### PR TITLE
6635: Add whitespace rule to JMC jcheck configuration

### DIFF
--- a/.jcheck/conf
+++ b/.jcheck/conf
@@ -38,7 +38,7 @@ project=jmc
 jbs=jmc
 
 [checks]
-error=author,reviewers,merge,message,issues,executable
+error=author,reviewers,merge,message,issues,executable,whitespace
 
 [census]
 version=0
@@ -54,3 +54,6 @@ message=Merge
 ; As soon as we wrap to five figures, add ^([1][0-9]{4})
 [checks "issues"]
 pattern=^([6-9][0-9]{3}): (\S.*)$
+
+[checks "whitespace"]
+files=.*\.java$|.*\.xml$|.*.\txt$


### PR DESCRIPTION
This is my first PR with skara :)

I think it would be nice if jcheck would also check for unnecessary whitespace.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

## Issue
[JMC-6635](https://bugs.openjdk.java.net/browse/JMC-6635): Add whitespace rule to JMC jcheck configuration
