### PR TITLE
6636: Adding spotless for core

### DIFF
--- a/core/coverage/pom.xml
+++ b/core/coverage/pom.xml
@@ -43,6 +43,10 @@
 	<name>Code coverage report jmc/core</name>
 	<packaging>pom</packaging>
 
+	<properties>
+		<spotless.config.path>${basedir}/../../configuration/ide/eclipse/formatting/formatting.xml</spotless.config.path>
+	</properties>
+
 	<dependencies>
 		<!-- First all the modules in core/ -->
 		<dependency>

--- a/core/org.openjdk.jmc.agent/pom.xml
+++ b/core/org.openjdk.jmc.agent/pom.xml
@@ -45,6 +45,7 @@
 		<asm.version>7.1</asm.version>
 		<junit.version>4.12</junit.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<spotless.config.path>${basedir}/../../configuration/ide/eclipse/formatting/formatting.xml</spotless.config.path>
 	</properties>
 	<build>
 		<plugins>

--- a/core/org.openjdk.jmc.common/pom.xml
+++ b/core/org.openjdk.jmc.common/pom.xml
@@ -39,4 +39,7 @@
 		<version>8.0.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>common</artifactId>
+	<properties>
+		<spotless.config.path>${basedir}/../../configuration/ide/eclipse/formatting/formatting.xml</spotless.config.path>
+	</properties>
 </project>

--- a/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/unit/UnitLookup.java
+++ b/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/unit/UnitLookup.java
@@ -448,7 +448,7 @@ final public class UnitLookup {
 
 		return memory;
 	}
-	
+
 	private static LinearKindOfQuantity createFrequency() {
 		LinearKindOfQuantity frequency = new LinearKindOfQuantity("frequency", "Hz", EnumSet.range(NONE, TERA),
 				EnumSet.range(YOCTO, YOTTA));
@@ -481,7 +481,7 @@ final public class UnitLookup {
 		// The Julian year (annum, symbol "a") is defined by UCUM for use with SI, since it is the basis for the light year (so this is exact).
 		LinearUnit year = timeSpan.makeUnit("a", hour.quantity(8766));
 		// A mean Julian month is 1/12 of a Julian year = 365.25*24/12 h = 730.5 h = 43 830 min (exactly).
-//		LinearUnit month = timeSpan.makeUnit("mo", minute.quantity(43830));
+		// LinearUnit month = timeSpan.makeUnit("mo", minute.quantity(43830));
 
 		LinearUnit[] units = {minute, hour, day, week, year};
 		for (LinearUnit unit : units) {

--- a/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/util/TypeHandling.java
+++ b/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/util/TypeHandling.java
@@ -233,17 +233,10 @@ public final class TypeHandling {
 	}
 
 	/**
-	 * Check for missing values, and return the numeric value in string format
-	 *
-	 * JMC-6256: JMC doesn't respect Long.MIN_VALUE as a missing value
-	 *
-	 * As per the bug report, the following values should be considered "missing"
-	 * - Integer.MIN_VALUE
-	 * - Long.MIN_VALUE
-	 * - Double.NaN
-	 * - Double.NEGATIVE_INFINITY
-	 * - Float.NaN
-	 * - Float.NEGATIVE_INFINITY
+	 * Check for missing values, and return the numeric value in string format JMC-6256: JMC doesn't
+	 * respect Long.MIN_VALUE as a missing value As per the bug report, the following values should
+	 * be considered "missing" - Integer.MIN_VALUE - Long.MIN_VALUE - Double.NaN -
+	 * Double.NEGATIVE_INFINITY - Float.NaN - Float.NEGATIVE_INFINITY
 	 *
 	 * @param value
 	 *            the numeric value to be converted to a string
@@ -261,16 +254,17 @@ public final class TypeHandling {
 			}
 		} else if (value.getClass() == Double.class) {
 			if (value.doubleValue() == Double.NEGATIVE_INFINITY) {
-				sb.append(MessageFormat.format(Messages.getString(Messages.MISSING_VALUE_TOOLTIP), DOUBLE_NEGATIVE_INFINITY));
+				sb.append(MessageFormat.format(Messages.getString(Messages.MISSING_VALUE_TOOLTIP),
+						DOUBLE_NEGATIVE_INFINITY));
 			} else if (Double.isNaN(value.doubleValue())) {
 				sb.append(MessageFormat.format(Messages.getString(Messages.MISSING_VALUE_TOOLTIP), DOUBLE_NAN));
 			}
 		} else if (value.getClass() == Float.class) {
 			if (Float.isNaN(value.floatValue())) {
 				sb.append(MessageFormat.format(Messages.getString(Messages.MISSING_VALUE_TOOLTIP), FLOAT_NAN));
-			}
-			else if (value.floatValue() == Float.NEGATIVE_INFINITY) {
-				sb.append(MessageFormat.format(Messages.getString(Messages.MISSING_VALUE_TOOLTIP), FLOAT_NEGATIVE_INFINITY));
+			} else if (value.floatValue() == Float.NEGATIVE_INFINITY) {
+				sb.append(MessageFormat.format(Messages.getString(Messages.MISSING_VALUE_TOOLTIP),
+						FLOAT_NEGATIVE_INFINITY));
 			}
 		}
 		if (sb.length() == 0) {

--- a/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/util/TypeHandling.java
+++ b/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/util/TypeHandling.java
@@ -233,10 +233,19 @@ public final class TypeHandling {
 	}
 
 	/**
-	 * Check for missing values, and return the numeric value in string format JMC-6256: JMC doesn't
-	 * respect Long.MIN_VALUE as a missing value As per the bug report, the following values should
-	 * be considered "missing" - Integer.MIN_VALUE - Long.MIN_VALUE - Double.NaN -
-	 * Double.NEGATIVE_INFINITY - Float.NaN - Float.NEGATIVE_INFINITY
+	 * Check for missing values, and return the numeric value in string format.
+	 * <p>
+	 * JMC-6256: JMC doesn't respect Long.MIN_VALUE as a missing value.
+	 * <p>
+	 * As per the bug report, the following values should be considered "missing"
+	 * <ul>
+	 * <li>Integer.MIN_VALUE</li>
+	 * <li>Long.MIN_VALUE</li>
+	 * <li>Double.NaN</li>
+	 * <li>Double.NEGATIVE_INFINITY</li>
+	 * <li>Float.NaN</li>
+	 * <li>Float.NEGATIVE_INFINITY</li>
+	 * </ul>
 	 *
 	 * @param value
 	 *            the numeric value to be converted to a string

--- a/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/version/JavaVersionSupport.java
+++ b/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/version/JavaVersionSupport.java
@@ -62,6 +62,6 @@ public class JavaVersionSupport {
 	public static final JavaVersion STRING_IS_BYTE_ARRAY = JDK_9;
 	public static final JavaVersion JDK_11_EA = new JavaVersion(true, 11);
 	public static final JavaVersion JFR_NOT_COMMERCIAL = JDK_11_EA;
-	public static final JavaVersion JDK_11 = new JavaVersion(11,0);
-	public static final JavaVersion JDK_12 = new JavaVersion(12,0);
+	public static final JavaVersion JDK_11 = new JavaVersion(11, 0);
+	public static final JavaVersion JDK_12 = new JavaVersion(12, 0);
 }

--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/pom.xml
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/pom.xml
@@ -39,6 +39,9 @@
 		<version>8.0.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>flightrecorder.rules.jdk</artifactId>
+	<properties>
+		<spotless.config.path>${basedir}/../../configuration/ide/eclipse/formatting/formatting.xml</spotless.config.path>
+	</properties>
 	<dependencies>
 		<dependency>
 			<groupId>org.openjdk.jmc</groupId>

--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/cpu/CompareCpuRule.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/cpu/CompareCpuRule.java
@@ -92,8 +92,8 @@ public class CompareCpuRule extends AbstractRule {
 		// FIXME: Could consider using the infoLimit for the span instead?
 		SpanLimit maxOtherCpu = SpanToolkit.getMaxSpanLimit(cpuItems, JdkAttributes.OTHER_CPU, JfrAttributes.END_TIME,
 				warningLimit);
-		SpanLimit maxOtherCpuRatio = SpanToolkit.getMaxSpanLimit(cpuItems, JdkAttributes.OTHER_CPU_RATIO, JfrAttributes.END_TIME,
-				warningLimit);
+		SpanLimit maxOtherCpuRatio = SpanToolkit.getMaxSpanLimit(cpuItems, JdkAttributes.OTHER_CPU_RATIO,
+				JfrAttributes.END_TIME, warningLimit);
 
 		if (maxOtherCpu == null || maxOtherCpuRatio == null) {
 			return RulesToolkit.getNotApplicableResult(this,

--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/dataproviders/JvmInternalsDataProvider.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/dataproviders/JvmInternalsDataProvider.java
@@ -57,7 +57,6 @@ public class JvmInternalsDataProvider {
 	private static final String[] OPTIONS = new String[] {"-XX", "-javaagent", "-agent"};
 	private static final Map<String, String> EQUIVALENT = new HashMap<>();
 
-
 	static {
 		putBiMap("-Xbatch", "BackgroundCompilation");
 		putBiMap("-Xmaxjitcodesize", "ReservedCodeCacheSize");
@@ -155,10 +154,9 @@ public class JvmInternalsDataProvider {
 				}
 				dupes.get(flag).add(fullArgument);
 
-			}
-			else {
+			} else {
 				seenFlags.put(flag, fullArgument);
-			}		
+			}
 		}
 		return dupes.values();
 	}

--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/exceptions/FatalErrorRule.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/exceptions/FatalErrorRule.java
@@ -54,12 +54,12 @@ import org.openjdk.jmc.flightrecorder.rules.util.RulesToolkit;
 import org.openjdk.jmc.flightrecorder.rules.util.RulesToolkit.EventAvailability;
 
 public class FatalErrorRule implements IRule {
-	
+
 	private static final String RESULT_ID = "Fatal Errors"; //$NON-NLS-1$
-	
+
 	private static final String ERROR_REASON = "VM Error"; //$NON-NLS-1$
 	private static final String INFO_REASON = "No remaining non-daemon Java threads"; //$NON-NLS-1$
-	
+
 	private FutureTask<Result> evaluationTask;
 
 	@Override
@@ -72,27 +72,28 @@ public class FatalErrorRule implements IRule {
 		});
 		return evaluationTask;
 	}
-	
+
 	private Result getResult(IItemCollection items, IPreferenceValueProvider valueProvider) {
 		EventAvailability eventAvailability = RulesToolkit.getEventAvailability(items, JdkTypeIDs.VM_SHUTDOWN);
 		if (eventAvailability != EventAvailability.AVAILABLE) {
 			return RulesToolkit.getEventAvailabilityResult(this, items, eventAvailability, JdkTypeIDs.VM_SHUTDOWN);
 		}
-		
+
 		IItemFilter shutdownFilter = ItemFilters.type(JdkTypeIDs.VM_SHUTDOWN);
 		IItemCollection shutdownItems = items.apply(shutdownFilter);
-		
+
 		if (shutdownItems.hasItems()) {
 			// Check the type of VM Shutdown, if it was a VM Error we should report it.
 			if (shutdownItems.apply(ItemFilters.contains(JdkAttributes.SHUTDOWN_REASON, ERROR_REASON)).hasItems()) {
 				String message = Messages.getString(Messages.FatalErrorRule_TEXT_WARN);
 				return new Result(this, 100, message);
-			} else if (shutdownItems.apply(ItemFilters.contains(JdkAttributes.SHUTDOWN_REASON, INFO_REASON)).hasItems()) {
+			} else if (shutdownItems.apply(ItemFilters.contains(JdkAttributes.SHUTDOWN_REASON, INFO_REASON))
+					.hasItems()) {
 				String message = Messages.getString(Messages.FatalErrorRule_TEXT_INFO);
 				return new Result(this, 25, message);
 			}
 		}
-		
+
 		return new Result(this, 0, Messages.getString(Messages.FatalErrorRule_TEXT_OK));
 	}
 

--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/general/DuplicateFlagsRule.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/general/DuplicateFlagsRule.java
@@ -74,9 +74,8 @@ public class DuplicateFlagsRule implements IRule {
 		// FIXME: Should we check if there are different jvm args in different chunks?
 		Set<String> args = jvmInfoItems.getAggregate(Aggregators.distinct(JdkAttributes.JVM_ARGUMENTS));
 		if (args != null && !args.isEmpty()) {
-			
-			Collection<ArrayList<String>> dupes = JvmInternalsDataProvider.
-					checkDuplicates(args.iterator().next());
+
+			Collection<ArrayList<String>> dupes = JvmInternalsDataProvider.checkDuplicates(args.iterator().next());
 
 			if (!dupes.isEmpty()) {
 				StringBuilder sb = new StringBuilder();

--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/general/FlightRecordingSupportRule.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/general/FlightRecordingSupportRule.java
@@ -79,7 +79,7 @@ public class FlightRecordingSupportRule implements IRule {
 		double timeConversionScore = timeConversionResult.getScore();
 
 		if (versionScore > 0 || timeConversionScore > 0) {
-			return versionResult.getScore() > timeConversionResult.getScore() ? versionResult : timeConversionResult;			
+			return versionResult.getScore() > timeConversionResult.getScore() ? versionResult : timeConversionResult;
 		}
 		// If no rule reported a warning or error, return the rule with the lowest score,
 		// meaning it was NotApplicable, Failed or Ignored.
@@ -122,7 +122,7 @@ public class FlightRecordingSupportRule implements IRule {
 
 		if (usedVersion == null) {
 			return RulesToolkit.getNotApplicableResult(this,
-                    Messages.getString(Messages.General_TEXT_COULD_NOT_DETERMINE_JAVA_VERSION));
+					Messages.getString(Messages.General_TEXT_COULD_NOT_DETERMINE_JAVA_VERSION));
 		}
 
 		if (!usedVersion.isGreaterOrEqualThan(JDK_7_U_40)) {

--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/latency/JavaBlockingRule.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/latency/JavaBlockingRule.java
@@ -129,11 +129,11 @@ public class JavaBlockingRule implements IRule {
 		String mostBlockingText;
 		if (byThread.compareTo(byInstance) > 0) {
 			List<IntEntry<IMCThread>> groupedByThread = RulesToolkit.calculateGroupingScore(
-					items.apply(ItemFilters.type(JdkTypeIDs.MONITOR_ENTER)),JfrAttributes.EVENT_THREAD);
+					items.apply(ItemFilters.type(JdkTypeIDs.MONITOR_ENTER)), JfrAttributes.EVENT_THREAD);
 			IntEntry<IMCThread> mostBlockedThread = groupedByThread.get(groupedByThread.size() - 1);
 
-			IItemCollection mostBlockedThreadOccurences = items.apply(
-					ItemFilters.equals(JfrAttributes.EVENT_THREAD, mostBlockedThread.getKey()));
+			IItemCollection mostBlockedThreadOccurences = items
+					.apply(ItemFilters.equals(JfrAttributes.EVENT_THREAD, mostBlockedThread.getKey()));
 			IQuantity mostBlockingTime = mostBlockedThreadOccurences.getAggregate(JdkAggregators.TOTAL_BLOCKED_TIME);
 
 			mostBlockingText = MessageFormat.format(
@@ -145,8 +145,8 @@ public class JavaBlockingRule implements IRule {
 					items.apply(ItemFilters.type(JdkTypeIDs.MONITOR_ENTER)), JdkAttributes.MONITOR_CLASS);
 			IntEntry<IMCType> mostBlockingClass = groupedByClass.get(groupedByClass.size() - 1);
 
-			IItemCollection mostBlockedClassOccurences = items.apply(
-					ItemFilters.equals(JdkAttributes.MONITOR_CLASS, mostBlockingClass.getKey()));
+			IItemCollection mostBlockedClassOccurences = items
+					.apply(ItemFilters.equals(JdkAttributes.MONITOR_CLASS, mostBlockingClass.getKey()));
 			IQuantity mostBlockingTime = mostBlockedClassOccurences.getAggregate(JdkAggregators.TOTAL_BLOCKED_TIME);
 
 			mostBlockingText = MessageFormat.format(

--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/latency/MethodProfilingRule.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/latency/MethodProfilingRule.java
@@ -152,7 +152,8 @@ public class MethodProfilingRule implements IRule {
 		IQuantity ratioOfActualSamples;
 		IRange<IQuantity> window;
 
-		public MethodProfilingWindowResult(IMCMethod method, IMCStackTrace path, IQuantity ratio, IQuantity actualRatio, IRange<IQuantity> window) {
+		public MethodProfilingWindowResult(IMCMethod method, IMCStackTrace path, IQuantity ratio, IQuantity actualRatio,
+				IRange<IQuantity> window) {
 			this.method = method;
 			this.path = path;
 			this.ratioOfAllPossibleSamples = ratio;
@@ -179,7 +180,8 @@ public class MethodProfilingRule implements IRule {
 			Messages.getString(Messages.MethodProfilingRule_EXCLUDED_PACKAGES),
 			Messages.getString(Messages.MethodProfilingRule_EXCLUDED_PACKAGES_DESC),
 			UnitLookup.PLAIN_TEXT.getPersister(), "java\\.(lang|util)"); //$NON-NLS-1$
-	private static final List<TypedPreference<?>> CONFIG_ATTRIBUTES = Arrays.<TypedPreference<?>> asList(WINDOW_SIZE, EXCLUDED_PACKAGE_REGEXP);
+	private static final List<TypedPreference<?>> CONFIG_ATTRIBUTES = Arrays.<TypedPreference<?>> asList(WINDOW_SIZE,
+			EXCLUDED_PACKAGE_REGEXP);
 
 	/**
 	 * Private Callable implementation specifically used to avoid storing the FutureTask as a field.
@@ -269,12 +271,10 @@ public class MethodProfilingRule implements IRule {
 					FormatToolkit.getHumanReadable(mostInterestingResult.path, false, false, true, true, true, false,
 							MAX_STACK_DEPTH, null, "<li>", //$NON-NLS-1$
 							"</li>" //$NON-NLS-1$
-							) + "</ul>"; //$NON-NLS-1$
+					) + "</ul>"; //$NON-NLS-1$
 			String longDescription = MessageFormat.format(
-					Messages.getString(Messages.HotMethodsRuleFactory_TEXT_INFO_LONG),
-					buildResultList(percentByMethod),
-					formattedPath
-					);
+					Messages.getString(Messages.HotMethodsRuleFactory_TEXT_INFO_LONG), buildResultList(percentByMethod),
+					formattedPath);
 			result = new Result(this, mappedScore, shortDescription, shortDescription + "<p>" + longDescription); //$NON-NLS-1$
 		}
 		return result;
@@ -339,16 +339,18 @@ public class MethodProfilingRule implements IRule {
 	 */
 	private IUnorderedWindowVisitor createWindowVisitor(
 		final PeriodRangeMap settings, final IItemFilter settingsFilter, final IQuantity windowSize,
-		final List<MethodProfilingWindowResult> rawScores, final FutureTask<Result> evaluationTask, final Pattern excludes) {
+		final List<MethodProfilingWindowResult> rawScores, final FutureTask<Result> evaluationTask,
+		final Pattern excludes) {
 		return new IUnorderedWindowVisitor() {
 			@Override
 			public void visitWindow(IItemCollection items, IQuantity startTime, IQuantity endTime) {
 				IRange<IQuantity> windowRange = QuantityRange.createWithEnd(startTime, endTime);
 				if (RulesToolkit.getSettingMaxPeriod(items, JdkTypeIDs.EXECUTION_SAMPLE) == null) {
-					Pair<Pair<IQuantity, IQuantity>, IMCStackTrace> resultPair = performCalculation(items, settings.getSetting(startTime));
+					Pair<Pair<IQuantity, IQuantity>, IMCStackTrace> resultPair = performCalculation(items,
+							settings.getSetting(startTime));
 					if (resultPair != null) {
-						rawScores.add(new MethodProfilingWindowResult(resultPair.right.getFrames().get(0).getMethod(), resultPair.right,
-								resultPair.left.left, resultPair.left.right, windowRange));
+						rawScores.add(new MethodProfilingWindowResult(resultPair.right.getFrames().get(0).getMethod(),
+								resultPair.right, resultPair.left.left, resultPair.left.right, windowRange));
 					}
 				} else {
 					Set<IQuantity> settingTimes = items.apply(settingsFilter)
@@ -367,8 +369,9 @@ public class MethodProfilingRule implements IRule {
 							if (scoresByMethod.get(score.right) == null) {
 								scoresByMethod.put(score.right, score.left);
 							} else {
-								scoresByMethod.put(score.right, new Pair<>(score.left.left.add(scoresByMethod.get(score.right).left),
-										score.left.right.add(scoresByMethod.get(score.right).right)));
+								scoresByMethod.put(score.right,
+										new Pair<>(score.left.left.add(scoresByMethod.get(score.right).left),
+												score.left.right.add(scoresByMethod.get(score.right).right)));
 							}
 						}
 					}
@@ -384,7 +387,8 @@ public class MethodProfilingRule implements IRule {
 					}
 					IQuantity averageOfAllPossibleSamples = sumScore.multiply(1d / scores.size());
 					IMCMethod hottestMethod = (hottestPath == null ? null : hottestPath.getFrames().get(0).getMethod());
-					rawScores.add(new MethodProfilingWindowResult(hottestMethod, hottestPath, averageOfAllPossibleSamples, actualScore, windowRange));
+					rawScores.add(new MethodProfilingWindowResult(hottestMethod, hottestPath,
+							averageOfAllPossibleSamples, actualScore, windowRange));
 				}
 			}
 
@@ -403,7 +407,8 @@ public class MethodProfilingRule implements IRule {
 			 * @return a double value in the interval [0,1] with 1 being a system in completely
 			 *         saturated load with only one method called
 			 */
-			private Pair<Pair<IQuantity, IQuantity>, IMCStackTrace> performCalculation(IItemCollection items, IQuantity period) {
+			private Pair<Pair<IQuantity, IQuantity>, IMCStackTrace> performCalculation(
+				IItemCollection items, IQuantity period) {
 				IItemCollection filteredItems = items.apply(JdkFilters.EXECUTION_SAMPLE);
 				final IMCMethod[] maxMethod = new IMCMethod[1];
 				final IMCStackTrace[] maxPath = new IMCStackTrace[1];
@@ -418,7 +423,8 @@ public class MethodProfilingRule implements IRule {
 							}
 
 							@Override
-							public IQuantity getValue(Iterable<? extends GroupEntry<IMCStackTrace, CountConsumer>> groupEntries) {
+							public IQuantity getValue(
+								Iterable<? extends GroupEntry<IMCStackTrace, CountConsumer>> groupEntries) {
 								HashMap<IMCMethod, IQuantity> map = new HashMap<>();
 								HashMap<IMCMethod, IMCStackTrace> pathMap = new HashMap<>();
 								int total = 0;
@@ -431,25 +437,29 @@ public class MethodProfilingRule implements IRule {
 									if (!trace.getFrames().isEmpty()) {
 										IMCMethod topFrameMethod = trace.getFrames().get(0).getMethod();
 										if (map.get(topFrameMethod) == null) {
-											map.put(topFrameMethod, UnitLookup.NUMBER_UNITY.quantity(group.getConsumer().getCount()));
+											map.put(topFrameMethod,
+													UnitLookup.NUMBER_UNITY.quantity(group.getConsumer().getCount()));
 											pathMap.put(topFrameMethod, trace);
 										} else {
 											IQuantity old = map.get(topFrameMethod);
-											map.put(topFrameMethod, old.add(UnitLookup.NUMBER_UNITY.quantity(group.getConsumer().getCount())));
+											map.put(topFrameMethod, old.add(
+													UnitLookup.NUMBER_UNITY.quantity(group.getConsumer().getCount())));
 										}
 									}
 								}
 								if (!pathMap.isEmpty() && !map.isEmpty()) {
-									Entry<IMCMethod, IQuantity> topEntry = Collections.max(map.entrySet(), new Comparator<Entry<IMCMethod, IQuantity>>() {
-										@Override
-										public int compare(Entry<IMCMethod, IQuantity> arg0,
-												Entry<IMCMethod, IQuantity> arg1) {
-											return arg0.getValue().compareTo(arg1.getValue());
-										}
-									});
+									Entry<IMCMethod, IQuantity> topEntry = Collections.max(map.entrySet(),
+											new Comparator<Entry<IMCMethod, IQuantity>>() {
+												@Override
+												public int compare(
+													Entry<IMCMethod, IQuantity> arg0,
+													Entry<IMCMethod, IQuantity> arg1) {
+													return arg0.getValue().compareTo(arg1.getValue());
+												}
+											});
 									maxPath[0] = pathMap.get(topEntry.getKey());
 									maxMethod[0] = topEntry.getKey();
-									return topEntry.getValue().multiply(1d/total);
+									return topEntry.getValue().multiply(1d / total);
 								}
 								return UnitLookup.NUMBER_UNITY.quantity(0);
 							}
@@ -471,7 +481,7 @@ public class MethodProfilingRule implements IRule {
 								frames.removeAll(framesToDrop);
 								return new MCStackTrace(frames, path.getTruncationState());
 							}
-				});
+						});
 
 				IQuantity maxRatio = filteredItems.getAggregate(aggregator);
 				Pair<Pair<IQuantity, IQuantity>, IMCStackTrace> result = null;

--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/memory/AutoBoxingRule.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/memory/AutoBoxingRule.java
@@ -68,7 +68,7 @@ import org.openjdk.jmc.flightrecorder.stacktrace.StacktraceModel.Branch;
  */
 // FIXME: Rename class (and message constants) from autoboxing to something more generic?
 public class AutoBoxingRule extends AbstractRule {
-	
+
 	private static final String VALUE_OF_METHOD_NAME = "valueOf";
 	private static final String SHORT = "java.lang.Short";
 	private static final String LONG = "java.lang.Long";
@@ -78,7 +78,7 @@ public class AutoBoxingRule extends AbstractRule {
 	private static final String CHARACTER = "java.lang.Character";
 	private static final String BYTE = "java.lang.Byte";
 	private static final String BOOLEAN = "java.lang.Boolean";
-	
+
 	private static final IPredicate<IMCMethod> IS_AUTOBOXED_PREDICATE = new IPredicate<IMCMethod>() {
 		@Override
 		public boolean evaluate(IMCMethod method) {
@@ -105,7 +105,7 @@ public class AutoBoxingRule extends AbstractRule {
 			return false;
 		}
 	};
-	
+
 	private static final TypedPreference<IQuantity> AUTOBOXING_RATIO_INFO_LIMIT = new TypedPreference<>(
 			"autoboxing.ratio.info.limit", //$NON-NLS-1$
 			Messages.getString(Messages.AutoboxingRule_AUTOBOXING_RATIO_INFO_LIMIT),
@@ -162,7 +162,8 @@ public class AutoBoxingRule extends AbstractRule {
 					} else if (firstBranch.getEndFork().getBranchCount() > 0) {
 						secondFrame = firstBranch.getEndFork().getBranch(0).getFirstFrame();
 					}
-					secondFrameFromMostAllocated = StacktraceFormatToolkit.formatFrame(secondFrame.getFrame(), sep, false, false, true, true, true, false);
+					secondFrameFromMostAllocated = StacktraceFormatToolkit.formatFrame(secondFrame.getFrame(), sep,
+							false, false, true, true, true, false);
 				}
 				allocationSizeByType.put(method.getType(), total);
 			}
@@ -185,7 +186,8 @@ public class AutoBoxingRule extends AbstractRule {
 					.format(Messages.getString(Messages.AutoboxingRule_RESULT_MOST_AUTOBOXED_TYPE), fullName);
 			mostAllocatedTypeInfoLong = "<p>" //$NON-NLS-1$
 					+ MessageFormat.format(Messages.getString(Messages.AutoboxingRule_RESULT_MOST_AUTOBOXED_TYPE_LONG),
-							fullName, largestAllocatedByType.displayUsing(IDisplayable.AUTO), secondFrameFromMostAllocated);
+							fullName, largestAllocatedByType.displayUsing(IDisplayable.AUTO),
+							secondFrameFromMostAllocated);
 		}
 
 		String shortIntro = MessageFormat.format(Messages.getString(Messages.AutoboxingRule_RESULT_AUTOBOXING_RATIO),

--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/memory/FullGcRule.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/memory/FullGcRule.java
@@ -73,47 +73,36 @@ public class FullGcRule implements IRule {
 			public Result call() throws Exception {
 				final CollectorType collectorType = CollectorType.getOldCollectorType(items);
 				if (!(CollectorType.CMS.equals(collectorType) || CollectorType.G1_OLD.equals(collectorType))) {
-					return RulesToolkit.getNotApplicableResult(
-							FullGcRule.this,
-							Messages.getString(Messages.FullGcRule_OTHER_COLLECTOR_IN_USE)
-							);
+					return RulesToolkit.getNotApplicableResult(FullGcRule.this,
+							Messages.getString(Messages.FullGcRule_OTHER_COLLECTOR_IN_USE));
 				}
 
 				final String[] eventTypes;
 				if (CollectorType.CMS.equals(collectorType)) {
-					eventTypes = new String[] { JdkTypeIDs.GC_COLLECTOR_OLD_GARBAGE_COLLECTION };
+					eventTypes = new String[] {JdkTypeIDs.GC_COLLECTOR_OLD_GARBAGE_COLLECTION};
 				} else {
 					eventTypes = G1Aggregator.EVENT_TYPES;
 				}
 				if (!hasAvailableEvents(items, eventTypes)) {
-					return RulesToolkit.getEventAvailabilityResult(
-							FullGcRule.this,
-							items,
-							RulesToolkit.getEventAvailability(items, eventTypes),
-							eventTypes
-							);
+					return RulesToolkit.getEventAvailabilityResult(FullGcRule.this, items,
+							RulesToolkit.getEventAvailability(items, eventTypes), eventTypes);
 				}
 
 				final int fullGCs;
 				if (CollectorType.CMS.equals(collectorType)) {
-					final IQuantity c = items.getAggregate(Aggregators.count(null, null, JdkFilters.OLD_GARBAGE_COLLECTION));
+					final IQuantity c = items
+							.getAggregate(Aggregators.count(null, null, JdkFilters.OLD_GARBAGE_COLLECTION));
 					fullGCs = c == null ? 0 : c.clampedIntFloorIn(NUMBER_UNITY);
 				} else {
 					fullGCs = items.getAggregate(new G1Aggregator()).fullGCs;
 				}
 
 				if (fullGCs > 0) {
-					return new Result(
-							FullGcRule.this, 100,
+					return new Result(FullGcRule.this, 100,
 							Messages.getString(Messages.FullGcRule_FULL_GC_OCCURRED_TITLE),
-							Messages.getString(Messages.FullGcRule_FULL_GC_OCCURRED_DESC)
-							);
+							Messages.getString(Messages.FullGcRule_FULL_GC_OCCURRED_DESC));
 				} else {
-					return new Result(
-							FullGcRule.this,
-							0,
-							Messages.getString(Messages.FullGcRule_NO_FULL_GC_OCCURRED)
-							);
+					return new Result(FullGcRule.this, 0, Messages.getString(Messages.FullGcRule_NO_FULL_GC_OCCURRED));
 				}
 			}
 		});
@@ -144,7 +133,7 @@ public class FullGcRule implements IRule {
 	}
 
 	private static class G1Aggregator extends MergingAggregator<G1FullGCInfo, G1FullGCInfo> {
-		static final String[] EVENT_TYPES = new String[] { JdkTypeIDs.GARBAGE_COLLECTION };
+		static final String[] EVENT_TYPES = new String[] {JdkTypeIDs.GARBAGE_COLLECTION};
 
 		G1Aggregator() {
 			super(null, null, UnitLookup.UNKNOWN);

--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/memory/GarbageCollectionsInfo.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/memory/GarbageCollectionsInfo.java
@@ -89,7 +89,8 @@ class GarbageCollectionsInfo implements IItemConsumer<GarbageCollectionsInfo> {
 			if (cause.contains("gclocker")) { //$NON-NLS-1$
 				gcLockers++;
 			}
-			if (!nonRequestedSerialOldGc && CollectorType.SERIAL_OLD.getCollectorName().equals(nameAccessor.getMember(item))) {
+			if (!nonRequestedSerialOldGc
+					&& CollectorType.SERIAL_OLD.getCollectorName().equals(nameAccessor.getMember(item))) {
 				nonRequestedSerialOldGc = true;
 			}
 		}

--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/memory/GcStallRule.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/memory/GcStallRule.java
@@ -97,8 +97,7 @@ public class GcStallRule implements IRule {
 
 		EventAvailability eventAvailability = RulesToolkit.getEventAvailability(items,
 				JdkTypeIDs.CONCURRENT_MODE_FAILURE, JdkTypeIDs.GC_CONF, JdkTypeIDs.GARBAGE_COLLECTION);
-		if (eventAvailability != EventAvailability.AVAILABLE
-				&& eventAvailability != EventAvailability.ENABLED) {
+		if (eventAvailability != EventAvailability.AVAILABLE && eventAvailability != EventAvailability.ENABLED) {
 			return RulesToolkit.getEventAvailabilityResult(this, items, eventAvailability,
 					JdkTypeIDs.CONCURRENT_MODE_FAILURE, JdkTypeIDs.GC_CONF, JdkTypeIDs.GARBAGE_COLLECTION);
 		}

--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/memory/HighGcRule.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/memory/HighGcRule.java
@@ -86,8 +86,8 @@ public class HighGcRule implements IRule {
 			String longMessage = message + " " + Messages.getString(Messages.HighGcRuleFactory_TEXT_INFO_LONG); //$NON-NLS-1$
 			if (!RulesToolkit.isEventsEnabled(items, JdkTypeIDs.ALLOC_INSIDE_TLAB, JdkTypeIDs.ALLOC_OUTSIDE_TLAB)) {
 				longMessage = longMessage + "<p>" //$NON-NLS-1$
-						+ RulesToolkit.getEnabledEventTypesRecommendation(items,
-								JdkTypeIDs.ALLOC_INSIDE_TLAB, JdkTypeIDs.ALLOC_OUTSIDE_TLAB);
+						+ RulesToolkit.getEnabledEventTypesRecommendation(items, JdkTypeIDs.ALLOC_INSIDE_TLAB,
+								JdkTypeIDs.ALLOC_OUTSIDE_TLAB);
 			}
 			return new Result(this, score, message, longMessage, JdkQueries.GC_PAUSE);
 		}

--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/memory/IncreasingLiveSetRule.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/memory/IncreasingLiveSetRule.java
@@ -95,8 +95,8 @@ public class IncreasingLiveSetRule implements IRule {
 			Messages.getString(Messages.IncreasingLiveSetRule_RELEVANCE_THRESHOLD_DESC), NUMBER,
 			NUMBER_UNITY.quantity(0.5d));
 	public static final TypedPreference<IQuantity> YOUNG_COLLECTION_THRESHOLD = new TypedPreference<IQuantity>(
-			"memleak.young.collections", Messages.getString(Messages.IncreasingLiveSetRule_YOUNG_COLLECTION_THRESHOLD), 
-			Messages.getString(Messages.IncreasingLiveSetRule_YOUNG_COLLECTION_THRESHOLD_DESC), NUMBER, 
+			"memleak.young.collections", Messages.getString(Messages.IncreasingLiveSetRule_YOUNG_COLLECTION_THRESHOLD),
+			Messages.getString(Messages.IncreasingLiveSetRule_YOUNG_COLLECTION_THRESHOLD_DESC), NUMBER,
 			NUMBER_UNITY.quantity(4));
 	private static final List<TypedPreference<?>> CONFIG_ATTRIBUTES = Arrays
 			.<TypedPreference<?>> asList(CLASSES_LOADED_PERCENT, RELEVANCE_THRESHOLD, YOUNG_COLLECTION_THRESHOLD);
@@ -133,13 +133,15 @@ public class IncreasingLiveSetRule implements IRule {
 			double relativeIncreasePerSecond = liveSetIncreasePerSecond.ratioTo(postWarmupHeapSize);
 			score = RulesToolkit.mapExp100(relativeIncreasePerSecond, PERCENT_OF_HEAP_INCREASE_PER_SECOND);
 		}
-		
-		IQuantity youngCollections = items.getAggregate(Aggregators.count(ItemFilters.type(JdkTypeIDs.GC_COLLECTOR_YOUNG_GARBAGE_COLLECTION)));
+
+		IQuantity youngCollections = items
+				.getAggregate(Aggregators.count(ItemFilters.type(JdkTypeIDs.GC_COLLECTOR_YOUNG_GARBAGE_COLLECTION)));
 		IQuantity oldCollections = items.getAggregate(Aggregators.count(JdkFilters.OLD_GARBAGE_COLLECTION));
-		if (oldCollections.longValue() == 0) { 
+		if (oldCollections.longValue() == 0) {
 			// If there are no old collections we cannot accurately determine whether or not there is a leak
 			// but a stable increase in live set over a recording is still interesting, since it could force a full GC eventually.
-			if (youngCollections.longValue() <= valueProvider.getPreferenceValue(YOUNG_COLLECTION_THRESHOLD).longValue()) {
+			if (youngCollections.longValue() <= valueProvider.getPreferenceValue(YOUNG_COLLECTION_THRESHOLD)
+					.longValue()) {
 				// If we have too few collections at all we shouldn't even try to guess at the live set
 				return RulesToolkit.getTooFewEventsResult(this);
 			}
@@ -151,7 +153,8 @@ public class IncreasingLiveSetRule implements IRule {
 		// FIXME: Should construct an message using memoryIncrease, not use a hard limit
 		if (ea == EventAvailability.DISABLED || ea == EventAvailability.UNKNOWN) {
 			if (score >= 25) {
-				IQuantity timeAfterJVMStart = items.getAggregate(JdkAggregators.FIRST_ITEM_START).subtract(items.getAggregate(JdkAggregators.JVM_START_TIME));
+				IQuantity timeAfterJVMStart = items.getAggregate(JdkAggregators.FIRST_ITEM_START)
+						.subtract(items.getAggregate(JdkAggregators.JVM_START_TIME));
 				String shortMessage = MessageFormat.format(
 						Messages.getString(Messages.IncreasingLiveSetRuleFactory_TEXT_INFO),
 						liveSetIncreasePerSecond.displayUsing(IDisplayable.AUTO));

--- a/core/org.openjdk.jmc.flightrecorder.rules/pom.xml
+++ b/core/org.openjdk.jmc.flightrecorder.rules/pom.xml
@@ -39,7 +39,9 @@
 		<version>8.0.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>flightrecorder.rules</artifactId>
-
+	<properties>
+		<spotless.config.path>${basedir}/../../configuration/ide/eclipse/formatting/formatting.xml</spotless.config.path>
+	</properties>
 	<dependencies>
 		<dependency>
 			<groupId>org.openjdk.jmc</groupId>

--- a/core/org.openjdk.jmc.flightrecorder.rules/src/main/java/org/openjdk/jmc/flightrecorder/rules/tree/ItemTreeBuilder.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules/src/main/java/org/openjdk/jmc/flightrecorder/rules/tree/ItemTreeBuilder.java
@@ -47,21 +47,21 @@ import org.openjdk.jmc.flightrecorder.JfrAttributes;
  * Helper for building item trees.
  */
 public class ItemTreeBuilder {
-	
+
 	/**
 	 * Interface used to allow interrupting slow builds of encapsulation trees.
 	 */
 	public interface IItemTreeBuilderCallback {
 		boolean shouldContinue();
 	}
-	
+
 	private static IItemTreeBuilderCallback DEFAULT_CALLBACK = new IItemTreeBuilderCallback() {
 		@Override
 		public boolean shouldContinue() {
 			return true;
 		}
 	};
-	
+
 	/**
 	 * Builds a tree where events that wrap other events, time wise, are higher up in the hierarchy.
 	 *
@@ -87,7 +87,8 @@ public class ItemTreeBuilder {
 	 *            level events. It's up to the caller to make sure this is safe to do.
 	 * @return the root node for the resulting tree.
 	 */
-	public static ITreeNode<IItem> buildEncapsulationTree(IItemCollection items, boolean allowInstants, boolean ignoreThread) {
+	public static ITreeNode<IItem> buildEncapsulationTree(
+		IItemCollection items, boolean allowInstants, boolean ignoreThread) {
 		return buildEncapsulationTree(items, allowInstants, ignoreThread, DEFAULT_CALLBACK);
 	}
 
@@ -102,7 +103,8 @@ public class ItemTreeBuilder {
 	 *            {@code true} to make the algorithm not care about event thread, can be used for VM
 	 *            level events. It's up to the caller to make sure this is safe to do.
 	 * @param callback
-	 *            callback used to determine whether or not to continue building the encapsulation tree
+	 *            callback used to determine whether or not to continue building the encapsulation
+	 *            tree
 	 * @return the root node for the resulting tree.
 	 */
 	public static ITreeNode<IItem> buildEncapsulationTree(
@@ -110,10 +112,14 @@ public class ItemTreeBuilder {
 		// FIXME: Consider introducing a maxdepth at which to stop adding nodes
 		TreeNode<IItem> root = new TreeNode<>(null);
 		for (IItemIterable itemIterable : items) {
-			IMemberAccessor<IQuantity, IItem> durationAccessor = JfrAttributes.DURATION.getAccessor(itemIterable.getType());
-			IMemberAccessor<IQuantity, IItem> startTimeAccessor = JfrAttributes.START_TIME.getAccessor(itemIterable.getType());
-			IMemberAccessor<IQuantity, IItem> endTimeAccessor = JfrAttributes.END_TIME.getAccessor(itemIterable.getType());
-			IMemberAccessor<IMCThread, IItem> threadAccessor = JfrAttributes.EVENT_THREAD.getAccessor(itemIterable.getType());
+			IMemberAccessor<IQuantity, IItem> durationAccessor = JfrAttributes.DURATION
+					.getAccessor(itemIterable.getType());
+			IMemberAccessor<IQuantity, IItem> startTimeAccessor = JfrAttributes.START_TIME
+					.getAccessor(itemIterable.getType());
+			IMemberAccessor<IQuantity, IItem> endTimeAccessor = JfrAttributes.END_TIME
+					.getAccessor(itemIterable.getType());
+			IMemberAccessor<IMCThread, IItem> threadAccessor = JfrAttributes.EVENT_THREAD
+					.getAccessor(itemIterable.getType());
 			for (IItem item : itemIterable) {
 				if (!callback.shouldContinue()) {
 					return root;
@@ -122,19 +128,17 @@ public class ItemTreeBuilder {
 				boolean hasDuration = duration.longValue() != 0;
 				IMCThread thread = threadAccessor == null ? null : threadAccessor.getMember(item);
 				if (hasDuration || allowInstants) {
-					addTimeSplitNode(root, item, hasDuration, startTimeAccessor.getMember(item), endTimeAccessor.getMember(item), thread, callback, ignoreThread);
+					addTimeSplitNode(root, item, hasDuration, startTimeAccessor.getMember(item),
+							endTimeAccessor.getMember(item), thread, callback, ignoreThread);
 				}
 			}
 		}
 		return root;
 	}
 
-	private static void addTimeSplitNode(TreeNode<IItem> node, IItem item,
-			boolean itemHasDuration,
-			IQuantity itemStartTime,
-			IQuantity itemEndTime,
-			IMCThread itemThread, 
-			IItemTreeBuilderCallback callback, boolean ignoreThread) {
+	private static void addTimeSplitNode(
+		TreeNode<IItem> node, IItem item, boolean itemHasDuration, IQuantity itemStartTime, IQuantity itemEndTime,
+		IMCThread itemThread, IItemTreeBuilderCallback callback, boolean ignoreThread) {
 		TreeNode<IItem> addedNode = null;
 		List<ITreeNode<IItem>> children = new ArrayList<>(node.getChildren());
 		for (ITreeNode<IItem> child : children) {
@@ -142,9 +146,11 @@ public class ItemTreeBuilder {
 				return;
 			}
 			if (treeItemEncloses((TreeNode<IItem>) child, itemStartTime, itemEndTime, itemThread, ignoreThread)) {
-				addTimeSplitNode((TreeNode<IItem>) child, item, itemHasDuration, itemStartTime, itemEndTime, itemThread, callback, ignoreThread);
+				addTimeSplitNode((TreeNode<IItem>) child, item, itemHasDuration, itemStartTime, itemEndTime, itemThread,
+						callback, ignoreThread);
 				return;
-			} else if (enclosesTreeItem(itemHasDuration, itemStartTime, itemEndTime, itemThread, (TreeNode<IItem>) child, ignoreThread)) {
+			} else if (enclosesTreeItem(itemHasDuration, itemStartTime, itemEndTime, itemThread,
+					(TreeNode<IItem>) child, ignoreThread)) {
 				((TreeNode<IItem>) child).detach();
 				if (addedNode == null) {
 					addedNode = new TreeNode<>(item, itemHasDuration, itemStartTime, itemEndTime, itemThread);
@@ -157,9 +163,10 @@ public class ItemTreeBuilder {
 			node.addChild(new TreeNode<>(item, itemHasDuration, itemStartTime, itemEndTime, itemThread));
 		}
 	}
-	
-	private static boolean enclosesTreeItem(boolean encloserHasDuration, IQuantity encloserStartTime, IQuantity encloserEndTime,
-			IMCThread encloserThread, TreeNode<IItem> enclosee, boolean ignoreThread) {
+
+	private static boolean enclosesTreeItem(
+		boolean encloserHasDuration, IQuantity encloserStartTime, IQuantity encloserEndTime, IMCThread encloserThread,
+		TreeNode<IItem> enclosee, boolean ignoreThread) {
 		if (encloserHasDuration) {
 			return encloserStartTime.compareTo(enclosee.getStartTime()) <= 0
 					&& encloserEndTime.compareTo(enclosee.getEndTime()) >= 0
@@ -167,8 +174,10 @@ public class ItemTreeBuilder {
 		}
 		return false;
 	}
-	
-	private static boolean treeItemEncloses(TreeNode<IItem> encloser, IQuantity encloseeStartTime, IQuantity encloseeEndTime, IMCThread encloseeThread, boolean ignoreThread) {
+
+	private static boolean treeItemEncloses(
+		TreeNode<IItem> encloser, IQuantity encloseeStartTime, IQuantity encloseeEndTime, IMCThread encloseeThread,
+		boolean ignoreThread) {
 		if (encloser.hasDuration()) {
 			return encloser.getStartTime().compareTo(encloseeStartTime) <= 0
 					&& encloser.getEndTime().compareTo(encloseeEndTime) >= 0

--- a/core/org.openjdk.jmc.flightrecorder.rules/src/main/java/org/openjdk/jmc/flightrecorder/rules/tree/TreeNode.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules/src/main/java/org/openjdk/jmc/flightrecorder/rules/tree/TreeNode.java
@@ -62,7 +62,7 @@ public class TreeNode<T> implements ITreeNode<T> {
 	public TreeNode(T item) {
 		this.item = item;
 	}
-	
+
 	public TreeNode(T item, boolean hasDuration, IQuantity startTime, IQuantity endTime, IMCThread thread) {
 		this.item = item;
 		this.hasDuration = hasDuration;
@@ -85,7 +85,7 @@ public class TreeNode<T> implements ITreeNode<T> {
 	public T getValue() {
 		return item;
 	}
-	
+
 	public boolean hasDuration() {
 		return hasDuration;
 	}
@@ -93,15 +93,15 @@ public class TreeNode<T> implements ITreeNode<T> {
 	public IQuantity getStartTime() {
 		return startTime;
 	}
-	
+
 	public IQuantity getEndTime() {
 		return endTime;
 	}
-	
+
 	public IMCThread getThread() {
 		return thread;
 	}
-	
+
 	@Override
 	public void accept(ITreeVisitor<T> visitor) {
 		visitor.visit(this);

--- a/core/org.openjdk.jmc.flightrecorder/pom.xml
+++ b/core/org.openjdk.jmc.flightrecorder/pom.xml
@@ -38,8 +38,10 @@
 		<artifactId>missioncontrol.core</artifactId>
 		<version>8.0.0-SNAPSHOT</version>
 	</parent>
-
 	<artifactId>flightrecorder</artifactId>
+	<properties>
+		<spotless.config.path>${basedir}/../../configuration/ide/eclipse/formatting/formatting.xml</spotless.config.path>
+	</properties>
 	<dependencies>
 		<dependency>
 			<groupId>org.openjdk.jmc</groupId>

--- a/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/JfrAttributes.java
+++ b/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/JfrAttributes.java
@@ -66,15 +66,16 @@ public interface JfrAttributes {
 			return MemberAccessorToolkit.constant(type);
 		}
 	});
-	
+
 	IAttribute<String> EVENT_TYPE_ID = Attribute.canonicalize(new Attribute<String>("(eventTypeId)", //$NON-NLS-1$
-			Messages.getString(Messages.ATTR_EVENT_TYPE_ID), Messages.getString(Messages.ATTR_EVENT_TYPE_ID_DESC), PLAIN_TEXT) {
+			Messages.getString(Messages.ATTR_EVENT_TYPE_ID), Messages.getString(Messages.ATTR_EVENT_TYPE_ID_DESC),
+			PLAIN_TEXT) {
 		@Override
 		public <U> IMemberAccessor<String, U> customAccessor(final IType<U> type) {
 			return MemberAccessorToolkit.constant(type.getIdentifier());
 		}
 	});
-	
+
 	IAttribute<IQuantity> END_TIME = Attribute.canonicalize(
 			new Attribute<IQuantity>("(endTime)", Messages.getString(Messages.ATTR_END_TIME), null, TIMESTAMP) { //$NON-NLS-1$
 				@Override

--- a/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/jdk/JdkAttributes.java
+++ b/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/jdk/JdkAttributes.java
@@ -370,26 +370,29 @@ public final class JdkAttributes {
 			};
 		}
 	});
-	public static final IAttribute<IQuantity> OTHER_CPU_RATIO = Attribute.canonicalize(new Attribute<IQuantity>("otherCpuRatio", //$NON-NLS-1$
-			Messages.getString(Messages.ATTR_OTHER_CPU_RATIO), Messages.getString(Messages.ATTR_OTHER_CPU_RATIO_DESC), PERCENTAGE) {
-		@Override
-		public <U> IMemberAccessor<IQuantity, U> customAccessor(IType<U> type) {
-			final IMemberAccessor<IQuantity, U> otherCpuAccessor = OTHER_CPU.getAccessor(type);
-			// Avoid possible future circularity by asking the type directly.
-			final IMemberAccessor<IQuantity, U> machineTotalAccessor = type.getAccessor(MACHINE_TOTAL.getKey());
-			if ((otherCpuAccessor == null) || (machineTotalAccessor == null)) {
-				return null;
-			}
-			return new IMemberAccessor<IQuantity, U>() {
+	public static final IAttribute<IQuantity> OTHER_CPU_RATIO = Attribute
+			.canonicalize(new Attribute<IQuantity>("otherCpuRatio", //$NON-NLS-1$
+					Messages.getString(Messages.ATTR_OTHER_CPU_RATIO),
+					Messages.getString(Messages.ATTR_OTHER_CPU_RATIO_DESC), PERCENTAGE) {
 				@Override
-				public IQuantity getMember(U i) {
-					IQuantity machineTotal = machineTotalAccessor.getMember(i);
-					IQuantity otherCpu = otherCpuAccessor.getMember(i);
-					return otherCpu != null && machineTotal != null ? otherCpu.multiply(machineTotal.doubleValue()) : null;
+				public <U> IMemberAccessor<IQuantity, U> customAccessor(IType<U> type) {
+					final IMemberAccessor<IQuantity, U> otherCpuAccessor = OTHER_CPU.getAccessor(type);
+					// Avoid possible future circularity by asking the type directly.
+					final IMemberAccessor<IQuantity, U> machineTotalAccessor = type.getAccessor(MACHINE_TOTAL.getKey());
+					if ((otherCpuAccessor == null) || (machineTotalAccessor == null)) {
+						return null;
+					}
+					return new IMemberAccessor<IQuantity, U>() {
+						@Override
+						public IQuantity getMember(U i) {
+							IQuantity machineTotal = machineTotalAccessor.getMember(i);
+							IQuantity otherCpu = otherCpuAccessor.getMember(i);
+							return otherCpu != null && machineTotal != null
+									? otherCpu.multiply(machineTotal.doubleValue()) : null;
+						}
+					};
 				}
-			};
-		}
-	});
+			});
 
 	public static final IAttribute<IQuantity> RECORDING_ID = attr("id", Messages.getString(Messages.ATTR_RECORDING_ID), //$NON-NLS-1$
 			NUMBER);

--- a/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/jdk/JdkFilters.java
+++ b/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/jdk/JdkFilters.java
@@ -79,7 +79,8 @@ public final class JdkFilters {
 			JdkTypeIDs.ALLOC_OUTSIDE_TLAB);
 	public static final IItemFilter REFERENCE_STATISTICS = ItemFilters.type(JdkTypeIDs.GC_REFERENCE_STATISTICS);
 	public static final IItemFilter GARBAGE_COLLECTION = ItemFilters.type(JdkTypeIDs.GARBAGE_COLLECTION);
-	public static final IItemFilter OLD_GARBAGE_COLLECTION = ItemFilters.type(JdkTypeIDs.GC_COLLECTOR_OLD_GARBAGE_COLLECTION);
+	public static final IItemFilter OLD_GARBAGE_COLLECTION = ItemFilters
+			.type(JdkTypeIDs.GC_COLLECTOR_OLD_GARBAGE_COLLECTION);
 	public static final IItemFilter CONCURRENT_MODE_FAILURE = ItemFilters.type(JdkTypeIDs.CONCURRENT_MODE_FAILURE);
 	public static final IItemFilter ERRORS = ItemFilters.type(JdkTypeIDs.ERRORS_THROWN);
 	public static final IItemFilter EXCEPTIONS = ItemFilters.type(JdkTypeIDs.EXCEPTIONS_THROWN);
@@ -91,7 +92,8 @@ public final class JdkFilters {
 	public static final IItemFilter CLASS_LOAD = ItemFilters.type(JdkTypeIDs.CLASS_LOAD);
 	public static final IItemFilter CLASS_LOAD_OR_UNLOAD = ItemFilters.or(CLASS_LOAD, CLASS_UNLOAD);
 	public static final IItemFilter CLASS_DEFINE = ItemFilters.type(JdkTypeIDs.CLASS_DEFINE);
-	public static final IItemFilter CLASS_LOADER_EVENTS = ItemFilters.or(CLASS_LOAD, CLASS_UNLOAD, CLASS_DEFINE, CLASS_LOADER_STATISTICS);
+	public static final IItemFilter CLASS_LOADER_EVENTS = ItemFilters.or(CLASS_LOAD, CLASS_UNLOAD, CLASS_DEFINE,
+			CLASS_LOADER_STATISTICS);
 	public static final IItemFilter MONITOR_ENTER = ItemFilters.type(JdkTypeIDs.MONITOR_ENTER);
 	public static final IItemFilter FILE_OR_SOCKET_IO = ItemFilters.type(JdkTypeIDs.SOCKET_READ,
 			JdkTypeIDs.SOCKET_WRITE, JdkTypeIDs.FILE_READ, JdkTypeIDs.FILE_WRITE);

--- a/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/jdk/JdkTypeIDs.java
+++ b/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/jdk/JdkTypeIDs.java
@@ -196,6 +196,6 @@ public final class JdkTypeIDs {
 
 	public static final String MODULE_EXPORT = PREFIX + "ModuleExport";
 	public static final String MODULE_REQUIRE = PREFIX + "ModuleRequire";
-	
-	public static final String NATIVE_LIBRARY = PREFIX + "NativeLibrary";	
+
+	public static final String NATIVE_LIBRARY = PREFIX + "NativeLibrary";
 }

--- a/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/jdk/messages/internal/Messages.java
+++ b/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/jdk/messages/internal/Messages.java
@@ -231,7 +231,7 @@ public class Messages {
 	public static final String ATTR_FLAG_NEW_VALUE_NUMBER = "ATTR_FLAG_NEW_VALUE_NUMBER"; //$NON-NLS-1$
 	public static final String ATTR_FLAG_NEW_VALUE_TEXT = "ATTR_FLAG_NEW_VALUE_TEXT"; //$NON-NLS-1$
 	public static final String ATTR_FLAG_OLD_VALUE_BOOLEAN = "ATTR_FLAG_OLD_VALUE_BOOLEAN"; //$NON-NLS-1$
-	public static final String ATTR_FLAG_OLD_VALUE_NUMBER= "ATTR_FLAG_OLD_VALUE_NUMBER"; //$NON-NLS-1$
+	public static final String ATTR_FLAG_OLD_VALUE_NUMBER = "ATTR_FLAG_OLD_VALUE_NUMBER"; //$NON-NLS-1$
 	public static final String ATTR_FLAG_OLD_VALUE_TEXT = "ATTR_FLAG_OLD_VALUE_TEXT"; //$NON-NLS-1$
 	public static final String ATTR_FLAG_ORIGIN = "ATTR_FLAG_ORIGIN"; //$NON-NLS-1$
 	public static final String ATTR_FLAG_VALUE_BOOLEAN = "ATTR_FLAG_VALUE_BOOLEAN"; //$NON-NLS-1$

--- a/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/memleak/ReferenceTreeModel.java
+++ b/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/memleak/ReferenceTreeModel.java
@@ -258,18 +258,19 @@ public class ReferenceTreeModel {
 
 	/**
 	 * A helper method to calculate number of Referenced Object within specified period.
+	 * 
 	 * @param timerange
 	 *            a range of time that specifies which root objects to retrieve
 	 * @param referenceTreeObject
 	 *            leak candidate
-	 * @return number of leaked object during the specified timerange for a given
-	 * 			  leak candidate
+	 * @return number of leaked object during the specified timerange for a given leak candidate
 	 */
 	public int getLeakCountInRange(IRange<IQuantity> timerange, ReferenceTreeObject referenceTreeObject) {
 		int referencecount = 0;
 		for (ReferenceTreeObject rtObject : leakObjects) {
-			if (rtObject.getRootObject().equals(referenceTreeObject.getRootObject()) &&
-					timerange.getStart().compareTo(rtObject.getTimestamp()) <= 0 && timerange.getEnd().compareTo(rtObject.getTimestamp()) >= 0) {
+			if (rtObject.getRootObject().equals(referenceTreeObject.getRootObject())
+					&& timerange.getStart().compareTo(rtObject.getTimestamp()) <= 0
+					&& timerange.getEnd().compareTo(rtObject.getTimestamp()) >= 0) {
 				++referencecount;
 			}
 		}
@@ -356,8 +357,7 @@ public class ReferenceTreeModel {
 					ReferenceTreeObject parent = node.getParent();
 					if (parent == null) {
 						node.updateOldObjectSamples(map.get(objectAccessor.getMember(item).getAddress()));
-					}
-					else {
+					} else {
 						while (parent.getParent() != null) {
 							parent = parent.getParent();
 						}

--- a/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/memleak/ReferenceTreeObject.java
+++ b/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/memleak/ReferenceTreeObject.java
@@ -305,11 +305,11 @@ public class ReferenceTreeObject implements IMCOldObject {
 	}
 
 	/**
-	 * This method updates the Root object's Map with allocationTime and its oldObjectReference object (leaves). 
-	 *  
+	 * This method updates the Root object's Map with allocationTime and its oldObjectReference
+	 * object (leaves).
+	 * 
 	 * @param oldobjectrefnode
 	 *            oldObjectReference leaf node
-	 *            
 	 */
 	public void updateOldObjectSamples(ReferenceTreeObject oldobjectrefnode) {
 		oldObjectSamples.put(oldobjectrefnode.getTimestamp(), oldobjectrefnode);

--- a/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/parser/synthetic/JdkTypeIDsPreJdk11.java
+++ b/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/parser/synthetic/JdkTypeIDsPreJdk11.java
@@ -207,7 +207,7 @@ final class JdkTypeIDsPreJdk11 {
 
 	final static String RECORDINGS = JFR_INFO_EVENT_ID_ROOT + "recordings/recording";
 	final static String RECORDING_SETTING = JFR_INFO_EVENT_ID_ROOT + "recordings/recording_setting";
-        final static String JDK9_RECORDING_SETTING = PREFIX_9_10 + "ActiveSetting";
+	final static String JDK9_RECORDING_SETTING = PREFIX_9_10 + "ActiveSetting";
 
 	/**
 	 * Translate a pre-JDK 11 type id into a JDK 11 type id.

--- a/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/parser/synthetic/SettingsTransformer.java
+++ b/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/parser/synthetic/SettingsTransformer.java
@@ -215,7 +215,7 @@ class SettingsTransformer implements IEventSink {
 		LabeledIdentifier type = (LabeledIdentifier) values[typeIndex];
 		if (type != null) {
 			type = new LabeledIdentifier(JdkTypeIDsPreJdk11.translate(type.getInterfaceId()),
-				type.getImplementationId(), type.getName(), type.getDeclaredDescription());
+					type.getImplementationId(), type.getName(), type.getDeclaredDescription());
 			if (endTimeIndex < 0) {
 				values[typeIndex] = type;
 				sink.addEvent(values);
@@ -278,14 +278,12 @@ class SettingsTransformer implements IEventSink {
 			public IEventSink create(
 				String identifier, String label, String[] category, String description,
 				List<ValueField> dataStructure) {
-				if (JdkTypeIDsPreJdk11.RECORDING_SETTING.equals(identifier) ||
-					JdkTypeIDsPreJdk11.JDK9_RECORDING_SETTING.equals(identifier)) {
+				if (JdkTypeIDsPreJdk11.RECORDING_SETTING.equals(identifier)
+						|| JdkTypeIDsPreJdk11.JDK9_RECORDING_SETTING.equals(identifier)) {
 					SettingsTransformer st = new SettingsTransformer(subFactory, label, category, description,
 							dataStructure);
-					if ((JdkTypeIDsPreJdk11.RECORDING_SETTING.equals(identifier) &&
-					     st.isValid()) ||
-						(JdkTypeIDsPreJdk11.JDK9_RECORDING_SETTING.equals(identifier) &&
-						 st.isValidV1())) {
+					if ((JdkTypeIDsPreJdk11.RECORDING_SETTING.equals(identifier) && st.isValid())
+							|| (JdkTypeIDsPreJdk11.JDK9_RECORDING_SETTING.equals(identifier) && st.isValidV1())) {
 						return st;
 					} else {
 						// FIXME: Avoid System.err.println

--- a/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/util/ChunkReader.java
+++ b/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/util/ChunkReader.java
@@ -69,7 +69,7 @@ public final class ChunkReader {
 	private ChunkReader() {
 		throw new UnsupportedOperationException("Not to be instantiated"); //$NON-NLS-1$
 	}
-	
+
 	/**
 	 * Chunk iterator for an uncompressed JFR file. Efficiently reads a JFR file, chunk by chunk,
 	 * into memory as byte arrays by memory mapping the JFR file, finding the chunk boundaries with

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -44,6 +44,8 @@
 		<maven.compiler.source>1.7</maven.compiler.source>
 		<maven.compiler.target>1.7</maven.compiler.target>
 		<manifest-location>META-INF</manifest-location>
+		<spotless.version>1.26.0</spotless.version>
+		<spotless.config.path>${basedir}/../configuration/ide/eclipse/formatting/formatting.xml</spotless.config.path>
 	</properties>
 
 	<modules>
@@ -81,6 +83,19 @@
 					<configuration>
 						<manifestLocation>${manifest-location}</manifestLocation>
 					</configuration>
+				</plugin>
+				<plugin>
+  				<groupId>com.diffplug.spotless</groupId>
+  					<artifactId>spotless-maven-plugin</artifactId>
+  					<version>${spotless.version}</version>
+  					<configuration>
+    				<java>
+      				<eclipse>
+        				<file>${spotless.config.path}</file>
+        				<version>4.8.0</version>
+      				</eclipse>
+    				</java>
+  				</configuration>
 				</plugin>
 			</plugins>
 		</pluginManagement>

--- a/core/tests/org.openjdk.jmc.common.test/pom.xml
+++ b/core/tests/org.openjdk.jmc.common.test/pom.xml
@@ -39,6 +39,9 @@
 		<version>8.0.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>common.test</artifactId>
+	<properties>
+		<spotless.config.path>${basedir}/../../../configuration/ide/eclipse/formatting/formatting.xml</spotless.config.path>
+	</properties>
 	<packaging>jar</packaging>
 	<dependencies>
 		<dependency>

--- a/core/tests/org.openjdk.jmc.common.test/src/test/java/org/openjdk/jmc/common/test/MCTestCase.java
+++ b/core/tests/org.openjdk.jmc.common.test/src/test/java/org/openjdk/jmc/common/test/MCTestCase.java
@@ -79,8 +79,8 @@ public class MCTestCase {
 	 */
 	static public void assertMaskedEquals(String message, long expected, long actual, long mask) {
 		if (((expected ^ actual) & mask) != 0) {
-			Assert.fail(((message != null) ? message + ' ' : "")
-					+ "masked with " + hex(mask) + " expected:<" + hex(expected) + "> was not:<" + hex(actual) + ">");
+			Assert.fail(((message != null) ? message + ' ' : "") + "masked with " + hex(mask) + " expected:<"
+					+ hex(expected) + "> was not:<" + hex(actual) + ">");
 		}
 	}
 
@@ -101,8 +101,8 @@ public class MCTestCase {
 	 */
 	static public <T extends Comparable<T>> void assertBetween(String message, T min, T max, T actual) {
 		if ((min.compareTo(actual) > 0) || (max.compareTo(actual) < 0)) {
-			Assert.fail(((message != null) ? message + ' ' : "")
-					+ "expected in:[" + min + ", " + max + "] was not:<" + actual + ">");
+			Assert.fail(((message != null) ? message + ' ' : "") + "expected in:[" + min + ", " + max + "] was not:<"
+					+ actual + ">");
 		}
 	}
 
@@ -119,8 +119,8 @@ public class MCTestCase {
 	 */
 	static public <T extends Comparable<T>> void assertMax(String message, T max, T actual) {
 		if (max.compareTo(actual) < 0) {
-			Assert.fail(((message != null) ? message + ' ' : "")
-					+ "expected max:<" + max + "> was not:<" + actual + ">");
+			Assert.fail(
+					((message != null) ? message + ' ' : "") + "expected max:<" + max + "> was not:<" + actual + ">");
 		}
 	}
 
@@ -137,8 +137,8 @@ public class MCTestCase {
 	 */
 	static public <T extends Comparable<T>> void assertMin(String message, T min, T actual) {
 		if (min.compareTo(actual) > 0) {
-			Assert.fail(((message != null) ? message + ' ' : "")
-					+ "expected min:<" + min + "> was not:<" + actual + ">");
+			Assert.fail(
+					((message != null) ? message + ' ' : "") + "expected min:<" + min + "> was not:<" + actual + ">");
 		}
 	}
 
@@ -155,8 +155,8 @@ public class MCTestCase {
 	 */
 	static public <T extends Comparable<T>> void assertLessThan(String message, T greaterVal, T actual) {
 		if (greaterVal.compareTo(actual) <= 0) {
-			Assert.fail(((message != null) ? message + ' ' : "")
-					+ "expected less than:<" + greaterVal + "> was not:<" + actual + ">");
+			Assert.fail(((message != null) ? message + ' ' : "") + "expected less than:<" + greaterVal + "> was not:<"
+					+ actual + ">");
 		}
 	}
 
@@ -173,8 +173,8 @@ public class MCTestCase {
 	 */
 	static public <T extends Comparable<? super T>> void assertGreaterThan(String message, T lesserVal, T actual) {
 		if (lesserVal.compareTo(actual) >= 0) {
-			Assert.fail(((message != null) ? message + ' ' : "")
-					+ "expected greater than:<" + lesserVal + "> was not:<" + actual + ">");
+			Assert.fail(((message != null) ? message + ' ' : "") + "expected greater than:<" + lesserVal + "> was not:<"
+					+ actual + ">");
 		}
 	}
 

--- a/core/tests/org.openjdk.jmc.common.test/src/test/java/org/openjdk/jmc/common/test/TestToolkit.java
+++ b/core/tests/org.openjdk.jmc.common.test/src/test/java/org/openjdk/jmc/common/test/TestToolkit.java
@@ -93,7 +93,7 @@ public final class TestToolkit {
 		}
 		return new IOResourceSet(resources);
 	}
-	
+
 	public static IOResource getNamedResource(Class<?> clazz, String directory, String fileName) throws IOException {
 		String resourceName = directory + '/' + fileName;
 		if (clazz.getClassLoader().getResource(resourceName) == null) {
@@ -157,7 +157,7 @@ public final class TestToolkit {
 	private static URL getLocation(Class<?> clazz) {
 		return clazz.getProtectionDomain().getCodeSource().getLocation();
 	}
-	
+
 	private static File createFile(URL url) throws IOException {
 		try {
 			return new File(url.toURI());

--- a/core/tests/org.openjdk.jmc.common.test/src/test/java/org/openjdk/jmc/common/test/unit/DeriveUnitTest.java
+++ b/core/tests/org.openjdk.jmc.common.test/src/test/java/org/openjdk/jmc/common/test/unit/DeriveUnitTest.java
@@ -69,7 +69,7 @@ public class DeriveUnitTest extends MCTestCase {
 		d = span.getUnit("d");
 		wk = span.getUnit("wk");
 		y = span.getUnit("a");
-		
+
 		Hz = UnitLookup.HERTZ;
 		LinearKindOfQuantity freq = UnitLookup.FREQUENCY;
 		kHz = freq.getUnit(DecimalPrefix.KILO);
@@ -106,7 +106,7 @@ public class DeriveUnitTest extends MCTestCase {
 
 		assertDerivedUnit(null, B.quantity(0.1));
 	}
-	
+
 	@Test
 	public void testFrequencies() throws Exception {
 		assertDerivedUnit(Hz, Hz.quantity(1));
@@ -114,7 +114,7 @@ public class DeriveUnitTest extends MCTestCase {
 		assertDerivedUnit(kHz, Hz.quantity(1000));
 		assertDerivedUnit(kHz, kHz.quantity(999));
 		assertDerivedUnit(MHz, kHz.quantity(1000));
-		
+
 		assertDerivedUnit(mHz, Hz.quantity(0.5));
 		assertDerivedUnit(uHz, mHz.quantity(0.5));
 	}

--- a/core/tests/org.openjdk.jmc.common.test/src/test/java/org/openjdk/jmc/common/version/JavaVersionTest.java
+++ b/core/tests/org.openjdk.jmc.common.test/src/test/java/org/openjdk/jmc/common/version/JavaVersionTest.java
@@ -189,7 +189,7 @@ public class JavaVersionTest {
 
 		assertTrue(version17u0.equals(version17));
 	}
-	
+
 	@Test
 	public void testNullStringArgument() {
 		JavaVersion nullVersion = new JavaVersion((String) null);

--- a/core/tests/org.openjdk.jmc.flightrecorder.rules.jdk.test/pom.xml
+++ b/core/tests/org.openjdk.jmc.flightrecorder.rules.jdk.test/pom.xml
@@ -39,7 +39,9 @@
 		<version>8.0.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>flightrecorder.rules.jdk.test</artifactId>
-
+	<properties>
+		<spotless.config.path>${basedir}/../../../configuration/ide/eclipse/formatting/formatting.xml</spotless.config.path>
+	</properties>
 	<dependencies>
 		<dependency>
 			<groupId>org.openjdk.jmc</groupId>

--- a/core/tests/org.openjdk.jmc.flightrecorder.rules.jdk.test/src/test/java/org/openjdk/jmc/flightrecorder/test/rules/dataproviders/TestJvmInternalsDataProvider.java
+++ b/core/tests/org.openjdk.jmc.flightrecorder.rules.jdk.test/src/test/java/org/openjdk/jmc/flightrecorder/test/rules/dataproviders/TestJvmInternalsDataProvider.java
@@ -12,27 +12,28 @@ public class TestJvmInternalsDataProvider {
 
 	@Test
 	public void testJavaAgentDuplicateFlags() {
-		assertEquals("same jar, no option", 1, JvmInternalsDataProvider.checkDuplicates(
-				"-javaagent:myjar.jar -javaagent:myjar.jar").toArray().length);
-		assertEquals("different jar, no option", 0, JvmInternalsDataProvider.checkDuplicates(
-				"-javaagent:myjar.jar -javaagent:anotherjar.jar").toArray().length);
+		assertEquals("same jar, no option", 1,
+				JvmInternalsDataProvider.checkDuplicates("-javaagent:myjar.jar -javaagent:myjar.jar").toArray().length);
+		assertEquals("different jar, no option", 0, JvmInternalsDataProvider
+				.checkDuplicates("-javaagent:myjar.jar -javaagent:anotherjar.jar").toArray().length);
 
-		assertEquals("same jar, same option", 1, JvmInternalsDataProvider.checkDuplicates(
-				"-javaagent:myjar.jar=option -javaagent:myjar.jar=option").toArray().length);
-		assertEquals("different jar, same option", 0, JvmInternalsDataProvider.checkDuplicates(
-				"-javaagent:myjar.jar=option -javaagent:anotherjar.jar=option").toArray().length);
+		assertEquals("same jar, same option", 1, JvmInternalsDataProvider
+				.checkDuplicates("-javaagent:myjar.jar=option -javaagent:myjar.jar=option").toArray().length);
+		assertEquals("different jar, same option", 0, JvmInternalsDataProvider
+				.checkDuplicates("-javaagent:myjar.jar=option -javaagent:anotherjar.jar=option").toArray().length);
 
-		assertEquals("same jar, different option", 1, JvmInternalsDataProvider.checkDuplicates(
-				"-javaagent:myjar.jar=option -javaagent:myjar.jar=anotheroption").toArray().length);
-		assertEquals("different jar, different option", 0, JvmInternalsDataProvider.checkDuplicates(
-				"-javaagent:myjar.jar=option -javaagent:anotherjar.jar=anotheroption").toArray().length);
+		assertEquals("same jar, different option", 1, JvmInternalsDataProvider
+				.checkDuplicates("-javaagent:myjar.jar=option -javaagent:myjar.jar=anotheroption").toArray().length);
+		assertEquals("different jar, different option", 0,
+				JvmInternalsDataProvider
+						.checkDuplicates("-javaagent:myjar.jar=option -javaagent:anotherjar.jar=anotheroption")
+						.toArray().length);
 	}
 
 	@Test
 	@SuppressWarnings("unchecked")
 	public void testJavaAgentPathIsParsedCorrectly() {
-		String arguments = "-javagent:c:/path/to/archive/myjar.jar "
-				+ "-javagent:c:/path/to/archive/myjar.jar";
+		String arguments = "-javagent:c:/path/to/archive/myjar.jar " + "-javagent:c:/path/to/archive/myjar.jar";
 		String expectedResult = "-javagent:c:/path/to/archive/myjar.jar";
 
 		Collection<ArrayList<String>> result = JvmInternalsDataProvider.checkDuplicates(arguments);

--- a/core/tests/org.openjdk.jmc.flightrecorder.rules.jdk.test/src/test/java/org/openjdk/jmc/flightrecorder/test/rules/jdk/TestRulesWithJfr.java
+++ b/core/tests/org.openjdk.jmc.flightrecorder.rules.jdk.test/src/test/java/org/openjdk/jmc/flightrecorder/test/rules/jdk/TestRulesWithJfr.java
@@ -105,7 +105,7 @@ public class TestRulesWithJfr {
 	static final String RECORDINGS_INDEXFILE = "index.txt";
 
 	private TimeZone defaultTimeZone;
-	
+
 	@Before
 	public void before() {
 		// empty the log before each test
@@ -114,7 +114,7 @@ public class TestRulesWithJfr {
 		defaultTimeZone = TimeZone.getDefault();
 		TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
 	}
-	
+
 	@After
 	public void after() {
 		// restore previous default time zone
@@ -133,7 +133,8 @@ public class TestRulesWithJfr {
 	}
 
 	private void verifyRuleResults(boolean onlyOneRecording) throws IOException {
-		IOResourceSet jfrs = TestToolkit.getResourcesInDirectory(TestRulesWithJfr.class, RECORDINGS_DIR, RECORDINGS_INDEXFILE);
+		IOResourceSet jfrs = TestToolkit.getResourcesInDirectory(TestRulesWithJfr.class, RECORDINGS_DIR,
+				RECORDINGS_INDEXFILE);
 		String reportName = null;
 		if (onlyOneRecording) {
 			IOResource firstJfr = jfrs.iterator().next();
@@ -241,8 +242,7 @@ public class TestRulesWithJfr {
 
 			for (IRule rule : RuleRegistry.getRules()) {
 				try {
-					RunnableFuture<Result> future = rule.evaluate(events,
-							IPreferenceValueProvider.DEFAULT_VALUES);
+					RunnableFuture<Result> future = rule.evaluate(events, IPreferenceValueProvider.DEFAULT_VALUES);
 					future.run();
 					Result result = future.get();
 //					for (Result result : results) {
@@ -530,8 +530,8 @@ public class TestRulesWithJfr {
 			boolean scoreEquals = Objects.equals(score, otherRule.score);
 			if (!scoreEquals) {
 				// determine if this is just a rounding error
-				scoreEquals = (Math.abs(Float.valueOf(score) - Float.valueOf(otherRule.score)) < 0.0000000000001f) ? true
-						: false;
+				scoreEquals = (Math.abs(Float.valueOf(score) - Float.valueOf(otherRule.score)) < 0.0000000000001f)
+						? true : false;
 				if (scoreEquals) {
 					// apparently a rounding issue. Print it out for informational purposes
 					System.out

--- a/core/tests/org.openjdk.jmc.flightrecorder.rules.test/pom.xml
+++ b/core/tests/org.openjdk.jmc.flightrecorder.rules.test/pom.xml
@@ -39,6 +39,9 @@
 		<version>8.0.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>flightrecorder.rules.test</artifactId>
+	<properties>
+		<spotless.config.path>${basedir}/../../../configuration/ide/eclipse/formatting/formatting.xml</spotless.config.path>
+	</properties>
 	<dependencies>
            <dependency>
                    <groupId>org.openjdk.jmc</groupId>

--- a/core/tests/org.openjdk.jmc.flightrecorder.test/pom.xml
+++ b/core/tests/org.openjdk.jmc.flightrecorder.test/pom.xml
@@ -39,6 +39,9 @@
 		<version>8.0.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>flightrecorder.test</artifactId>
+	<properties>
+		<spotless.config.path>${basedir}/../../../configuration/ide/eclipse/formatting/formatting.xml</spotless.config.path>
+	</properties>
 	<dependencies>
            <dependency>
                    <groupId>org.openjdk.jmc</groupId>

--- a/core/tests/org.openjdk.jmc.flightrecorder.test/src/test/java/org/openjdk/jmc/flightrecorder/test/JfrAttributesTest.java
+++ b/core/tests/org.openjdk.jmc.flightrecorder.test/src/test/java/org/openjdk/jmc/flightrecorder/test/JfrAttributesTest.java
@@ -50,12 +50,12 @@ import org.openjdk.jmc.flightrecorder.test.util.RecordingToolkit;
  * Class to test JfrAttributes
  */
 public class JfrAttributesTest {
-	
+
 	@Test
 	public void testGetEventTypes() throws IOException, CouldNotLoadRecordingException {
 		IItemCollection events = RecordingToolkit.getFlightRecording(RecordingToolkit.getRecordings());
 		String typesStr = events.getAggregate(Aggregators.distinctAsString(JfrAttributes.EVENT_TYPE_ID, ", "));
-		
+
 		IAggregator<Set<IType<?>>, ?> distinct = Aggregators.distinct(JfrAttributes.EVENT_TYPE);
 		Set<IType<?>> types = events.getAggregate(distinct);
 		assertEquals(types.size(), typesStr.split(",").length);

--- a/core/tests/org.openjdk.jmc.flightrecorder.test/src/test/java/org/openjdk/jmc/flightrecorder/test/util/RecordingToolkit.java
+++ b/core/tests/org.openjdk.jmc.flightrecorder.test/src/test/java/org/openjdk/jmc/flightrecorder/test/util/RecordingToolkit.java
@@ -67,14 +67,16 @@ public class RecordingToolkit {
 		return TestToolkit.getResourcesInDirectory(RecordingToolkit.class, RECORDINGS_DIRECTORY, RECORDINGS_INDEXFILE);
 	}
 
-	public static IItemCollection getNamedRecording(String recordingName) throws IOException, CouldNotLoadRecordingException {
-		return getFlightRecording(TestToolkit.getNamedResource(RecordingToolkit.class, RECORDINGS_DIRECTORY, recordingName));
+	public static IItemCollection getNamedRecording(String recordingName)
+			throws IOException, CouldNotLoadRecordingException {
+		return getFlightRecording(
+				TestToolkit.getNamedResource(RecordingToolkit.class, RECORDINGS_DIRECTORY, recordingName));
 	}
-	
+
 	public static InputStream getNamedRecordingResource(String recordingName) throws IOException {
 		return TestToolkit.getNamedResource(RecordingToolkit.class, RECORDINGS_DIRECTORY, recordingName).open();
 	}
-	
+
 	public static IItemCollection getFlightRecording(IOResourceSet resourceSet)
 			throws IOException, CouldNotLoadRecordingException {
 		return getFlightRecording(resourceSet.getResource(0));
@@ -94,7 +96,7 @@ public class RecordingToolkit {
 		IOToolkit.closeSilently(is);
 		return JfrLoaderToolkit.loadEvents(tmpRecording);
 	}
-	
+
 	public static File createResultFile(String prefix, String suffix, boolean deleteTempOnExit) throws IOException {
 		String resultDir = System.getProperty("results.dir");
 		File resultFile;

--- a/core/tests/pom.xml
+++ b/core/tests/pom.xml
@@ -53,6 +53,7 @@
 		<fail.if.no.tests>true</fail.if.no.tests>
 		<maven.compiler.source>1.7</maven.compiler.source>
 		<maven.compiler.target>1.7</maven.compiler.target>
+		<spotless.config.path>${basedir}/../../configuration/ide/eclipse/formatting/formatting.xml</spotless.config.path>
 	</properties>
 	<profiles>
 		<profile>


### PR DESCRIPTION
This is a test for adding spotless. After this change you can run mvn spotless:check in core, to see that everything is formatted ok. If it fails, you can run mvn spotless:apply, which will format your source automatically for you. If everyone is happy with spotless, I will make spotless available for all code in JMC, and make spotless checks part of the integration checks.

If there are any changes we'd like to do to the formatting template, now would be the time to make them. ;)
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

## Issue
[JMC-6636](https://bugs.openjdk.java.net/browse/JMC-6636): Introduce spotless for core


## Approvers
 * Henrik Dafgård ([hdafgard](@Gunde) - **Reviewer**)