### PR TITLE
5660: Lazy initialization of TimestampUnit description string

### DIFF
--- a/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/unit/TimestampUnit.java
+++ b/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/unit/TimestampUnit.java
@@ -225,7 +225,8 @@ public class TimestampUnit extends TypedUnit<TimestampUnit> {
 	public String getLocalizedDescription() {
 		if (unitDescription == null) {
 			String multiplier = timeOffsetUnit.asWellKnownQuantity().displayUsing(IDisplayable.EXACT);
-			unitDescription = MessageFormat.format(Messages.getString(Messages.TimestampKind_SINCE_1970_MSG), multiplier);
+			unitDescription = MessageFormat.format(Messages.getString(Messages.TimestampKind_SINCE_1970_MSG),
+					multiplier);
 		}
 		return unitDescription;
 	}

--- a/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/unit/TimestampUnit.java
+++ b/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/unit/TimestampUnit.java
@@ -47,13 +47,12 @@ import org.openjdk.jmc.common.messages.internal.Messages;
 public class TimestampUnit extends TypedUnit<TimestampUnit> {
 	private final LinearUnit timeOffsetUnit;
 	private final String unitId;
-	private final String unitDescription;
+	private String unitDescription;
 
 	TimestampUnit(LinearUnit timeOffsetUnit) {
 		this.timeOffsetUnit = timeOffsetUnit;
 		unitId = "epoch" + timeOffsetUnit.getIdentifier(); //$NON-NLS-1$
-		String multiplier = timeOffsetUnit.asWellKnownQuantity().displayUsing(IDisplayable.EXACT);
-		unitDescription = MessageFormat.format(Messages.getString(Messages.TimestampKind_SINCE_1970_MSG), multiplier);
+		unitDescription = null;
 	}
 
 	@Override
@@ -224,6 +223,10 @@ public class TimestampUnit extends TypedUnit<TimestampUnit> {
 
 	@Override
 	public String getLocalizedDescription() {
+		if (unitDescription == null) {
+			String multiplier = timeOffsetUnit.asWellKnownQuantity().displayUsing(IDisplayable.EXACT);
+			unitDescription = MessageFormat.format(Messages.getString(Messages.TimestampKind_SINCE_1970_MSG), multiplier);
+		}
 		return unitDescription;
 	}
 


### PR DESCRIPTION
Creating a string description for each timestamp unit instance is far too expensive since we have to create a new unit for e.g. each duration comparison. So rules that perform such comparisons cause a lot of unnecessary allocations, on my local machine I estimate that this will reduce total allocations by around 50% for rules evaluations.

This doesn't really fix JMC-5660, but will reduce the performance cost until we get a more proper fix for this bug.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [ ] Commit message must refer to an issue
- [ ] Change must be properly reviewed

## Issue
[JMC-5660](https://bugs.openjdk.java.net/browse/JMC-5660): Unnecessary creation of a new TimestampUnit instance for each add of timestamp quantities with different units
