### PR TITLE
6652: Relaxing issue number verification

### DIFF
--- a/.jcheck/conf
+++ b/.jcheck/conf
@@ -51,6 +51,5 @@ role=committer
 [checks "merge"]
 message=Merge
 
-; As soon as we wrap to five figures, add ^([1][0-9]{4})
 [checks "issues"]
-pattern=^([6-9][0-9]{3}): (\S.*)$
+pattern=^([1-9]?[0-9]{3}): (\S.*)$


### PR DESCRIPTION

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

## Issue
[JMC-6652](https://bugs.openjdk.java.net/browse/JMC-6652): JCheck bug number verification too stringent


## Approvers
 * Robin Westberg ([rwestberg](@rwestberg) - no project role)
 * Henrik Dafgård ([hdafgard](@Gunde) - **Reviewer**)