### PR TITLE
6651: Securing exposed public static array

### DIFF
--- a/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/io/IOToolkit.java
+++ b/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/io/IOToolkit.java
@@ -65,12 +65,12 @@ public final class IOToolkit {
 	/**
 	 * Magic bytes for recognizing Zip.
 	 */
-	public static final int MAGIC_ZIP[] = new int[] {80, 75, 3, 4};
+	private static final int MAGIC_ZIP[] = new int[] {80, 75, 3, 4};
 
 	/**
 	 * Magic bytes for recognizing GZip.
 	 */
-	public static final int MAGIC_GZ[] = new int[] {31, 139};
+	private static final int MAGIC_GZ[] = new int[] {31, 139};
 
 	private IOToolkit() {
 		throw new Error("Don't"); //$NON-NLS-1$
@@ -226,6 +226,26 @@ public final class IOToolkit {
 	 */
 	public static boolean isZipFile(File file) throws IOException {
 		return hasMagic(file, MAGIC_ZIP);
+	}
+
+	/**
+	 * Returns the magic bytes for identifying Gzip. This is a defensive copy. It's up to the user
+	 * to cache this to avoid excessive allocations.
+	 * 
+	 * @return a copy of the magic bytes for Gzip.
+	 */
+	public static int[] getGzipMagic() {
+		return MAGIC_GZ.clone();
+	}
+
+	/**
+	 * Returns the magic bytes for identifying Zip. This is a defensive copy. It's up to the user to
+	 * cache this to avoid excessive allocations.
+	 * 
+	 * @return a copy of the magic bytes for Zip.
+	 */
+	public static int[] getZipMagic() {
+		return MAGIC_ZIP.clone();
 	}
 
 	/**

--- a/core/tests/org.openjdk.jmc.common.test/src/test/java/org/openjdk/jmc/common/util/IOToolkitTest.java
+++ b/core/tests/org.openjdk.jmc.common.test/src/test/java/org/openjdk/jmc/common/util/IOToolkitTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/core/tests/org.openjdk.jmc.common.test/src/test/java/org/openjdk/jmc/common/util/IOToolkitTest.java
+++ b/core/tests/org.openjdk.jmc.common.test/src/test/java/org/openjdk/jmc/common/util/IOToolkitTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * 
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * The contents of this file are subject to the terms of either the Universal Permissive License
+ * v 1.0 as shown at http://oss.oracle.com/licenses/upl
+ *
+ * or the following license:
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted
+ * provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions
+ * and the following disclaimer.
+ * 
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other materials provided with
+ * the distribution.
+ * 
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to
+ * endorse or promote products derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+ * WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.openjdk.jmc.common.util;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openjdk.jmc.common.io.IOToolkit;
+
+public class IOToolkitTest {
+	private static final int MAGIC_ZIP[] = new int[] {80, 75, 3, 4};
+	private static final int MAGIC_GZ[] = new int[] {31, 139};
+
+	@Test
+	public void testGetMagics() {
+		Assert.assertArrayEquals(MAGIC_ZIP, IOToolkit.getZipMagic());
+		Assert.assertArrayEquals(MAGIC_GZ, IOToolkit.getGzipMagic());
+	}
+}


### PR DESCRIPTION
A version not exposing the magic bytes to corruption by a malicious user
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

## Issue
[JMC-6651](https://bugs.openjdk.java.net/browse/JMC-6651): Expose the magic bytes for Zip and GZip from the IOToolkit


## Approvers
 * Erik Gahlin ([egahlin](@egahlin) - **Reviewer**)