### PR TITLE
6554: Support JFR in OpenJDK 8

### DIFF
--- a/application/org.openjdk.jmc.browser.attach/src/main/java/org/openjdk/jmc/browser/attach/LocalJVMToolkit.java
+++ b/application/org.openjdk.jmc.browser.attach/src/main/java/org/openjdk/jmc/browser/attach/LocalJVMToolkit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/application/org.openjdk.jmc.browser.attach/src/main/java/org/openjdk/jmc/browser/attach/LocalJVMToolkit.java
+++ b/application/org.openjdk.jmc.browser.attach/src/main/java/org/openjdk/jmc/browser/attach/LocalJVMToolkit.java
@@ -199,6 +199,8 @@ public class LocalJVMToolkit {
 					String address = null;
 					String version = null;
 					String jvmArgs = null;
+					String jvmVendor = null;
+
 					try {
 						// This used to leak one \BaseNamedObjects\hsperfdata_* Section handle on Windows
 						MonitoredVm mvm = host.getMonitoredVm(new VmIdentifier(name));
@@ -235,6 +237,12 @@ public class LocalJVMToolkit {
 							if (sm != null) {
 								isDebug = isDebug(sm.stringValue());
 							}
+
+							sm = (StringMonitor) mvm.findByName("java.property.java.vm.vendor"); //$NON-NLS-1$
+							if (sm != null) {
+								jvmVendor = sm.stringValue();
+							}
+
 							// NOTE: isAttachable seems to return true even if a real attach is not possible.
 							// attachable = MonitoredVmUtil.isAttachable(mvm);
 
@@ -260,8 +268,8 @@ public class LocalJVMToolkit {
 					} catch (Exception x) {
 						// ignore
 					}
-					connDesc = createDescriptor(name, jvmArgs, vmid, connectable, type, jvmArch, address, version,
-							isDebug);
+					connDesc = createDescriptor(name, jvmArgs, jvmVendor, vmid, connectable, type, jvmArch, address,
+							version, isDebug);
 					return connDesc;
 				}
 			});
@@ -361,6 +369,7 @@ public class LocalJVMToolkit {
 					String javaArgs = null;
 					String jvmArgs = null;
 					String jvmVersion = null;
+					String jvmVendor = null;
 					VirtualMachine vm = null;
 					try {
 						// Attach creates one process handle on Windows.
@@ -381,6 +390,7 @@ public class LocalJVMToolkit {
 							jvmType = getJVMType(vmName);
 							version = props.getProperty("java.version"); //$NON-NLS-1$
 							jvmVersion = props.getProperty("java.vm.version"); //$NON-NLS-1$
+							jvmVendor = props.getProperty("java.vm.vendor");
 							isDebug = isDebug(jvmVersion);
 							jvmArch = JVMArch.getJVMArch(props);
 						}
@@ -398,8 +408,8 @@ public class LocalJVMToolkit {
 						}
 					}
 					if (connectable.isAttachable()) {
-						connDesc = createDescriptor(javaArgs, jvmArgs, Integer.parseInt(vmd.id()), connectable, jvmType,
-								jvmArch, address, version, isDebug);
+						connDesc = createDescriptor(javaArgs, jvmArgs, jvmVendor, Integer.parseInt(vmd.id()),
+								connectable, jvmType, jvmArch, address, version, isDebug);
 					}
 					BrowserAttachPlugin.getPluginLogger().info("Done resolving PID " + vmd); //$NON-NLS-1$
 					return connDesc;
@@ -463,9 +473,10 @@ public class LocalJVMToolkit {
 	}
 
 	private static DiscoveryEntry createDescriptor(
-		String javaCommand, String jvmArgs, int pid, Connectable connectable, JVMType type, JVMArch arch,
-		String address, String version, boolean isDebug) {
-		JVMDescriptor jvmInfo = new JVMDescriptor(version, type, arch, javaCommand, jvmArgs, pid, isDebug, connectable);
+		String javaCommand, String jvmArgs, String jvmVendor, int pid, Connectable connectable, JVMType type,
+		JVMArch arch, String address, String version, boolean isDebug) {
+		JVMDescriptor jvmInfo = new JVMDescriptor(version, type, arch, javaCommand, jvmArgs, jvmVendor, pid, isDebug,
+				connectable);
 		LocalConnectionDescriptor lcd = new LocalConnectionDescriptor(pid, address, connectable == ATTACHABLE);
 		String guid = "Local-[PID:" + pid + ", seq:" + (SEQ_NUMBER++) + "]"; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
 		IServerDescriptor sd = IServerDescriptor.create(guid, null, jvmInfo);

--- a/application/org.openjdk.jmc.browser.jdp/src/main/java/org/openjdk/jmc/browser/jdp/JDPDescriptorProvider.java
+++ b/application/org.openjdk.jmc.browser.jdp/src/main/java/org/openjdk/jmc/browser/jdp/JDPDescriptorProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -89,9 +89,9 @@ public class JDPDescriptorProvider extends AbstractDescriptorProvider implements
 				String url = map.get(JMXDataKeys.KEY_JMX_SERVICE_URL);
 				String commandLine = map.get(JMXDataKeys.KEY_JAVA_COMMAND);
 				String pid = map.get(JMXDataKeys.KEY_PID);
-				// NOTE: We would like to have the JVM type and architecture included in the JDP payload. We should probably file an enhancement request on JDK for this.
+				// NOTE: We would like to have the JVM type, architecture and vendor included in the JDP payload. We should probably file an enhancement request on JDK for this.
 				JVMDescriptor jvmInfo = new JVMDescriptor(null, JVMType.UNKNOWN, JVMArch.UNKNOWN, commandLine, null,
-						pid == null ? null : Integer.parseInt(pid), false, Connectable.MGMNT_AGENT_STARTED);
+						null, pid == null ? null : Integer.parseInt(pid), false, Connectable.MGMNT_AGENT_STARTED);
 				String path = null;
 				if (name == null) {
 				} else if (name.endsWith(PATH_SEPARATOR)) {

--- a/application/org.openjdk.jmc.rjmx.services.jfr/src/main/java/org/openjdk/jmc/rjmx/services/jfr/internal/FlightRecorderServiceV2.java
+++ b/application/org.openjdk.jmc.rjmx.services.jfr/src/main/java/org/openjdk/jmc/rjmx/services/jfr/internal/FlightRecorderServiceV2.java
@@ -104,17 +104,14 @@ public class FlightRecorderServiceV2 implements IFlightRecorderService {
 	}
 
 	private boolean isDynamicFlightRecorderSupported(IConnectionHandle handle) {
-		return ConnectionToolkit.isHotSpot(handle)
-				&& ConnectionToolkit.isJavaVersionAboveOrEqual(handle, JavaVersionSupport.DYNAMIC_JFR_SUPPORTED);
-	}
-
-	private boolean isFlightRecorderCommercial() {
-		return ConnectionToolkit.isHotSpot(connection)
-				&& !ConnectionToolkit.isJavaVersionAboveOrEqual(connection, JavaVersionSupport.JFR_NOT_COMMERCIAL);
+		// All OpenJDK versions of JFR support dynamic enablement of JFR, so if there are no commercial features in play
+		// all is A-OK.
+		return !cfs.hasCommercialFeatures() || (ConnectionToolkit.isHotSpot(handle)
+				&& ConnectionToolkit.isJavaVersionAboveOrEqual(handle, JavaVersionSupport.DYNAMIC_JFR_SUPPORTED));
 	}
 
 	private boolean isFlightRecorderDisabled(IConnectionHandle handle) {
-		if (cfs != null && isFlightRecorderCommercial()) {
+		if (cfs != null && cfs.hasCommercialFeatures()) {
 			return !cfs.isCommercialFeaturesEnabled() || JVMSupportToolkit.isFlightRecorderDisabled(handle, false);
 		} else {
 			return JVMSupportToolkit.isFlightRecorderDisabled(handle, false);
@@ -127,6 +124,7 @@ public class FlightRecorderServiceV2 implements IFlightRecorderService {
 
 	public FlightRecorderServiceV2(IConnectionHandle handle) throws ConnectionException, ServiceNotAvailableException {
 		cfs = handle.getServiceOrThrow(ICommercialFeaturesService.class);
+
 		if (!isDynamicFlightRecorderSupported(handle) && isFlightRecorderDisabled(handle)) {
 			throw new ServiceNotAvailableException(""); //$NON-NLS-1$
 		}
@@ -481,7 +479,7 @@ public class FlightRecorderServiceV2 implements IFlightRecorderService {
 	@Override
 	public boolean isEnabled() {
 		if (!wasEnabled) {
-			boolean isEnabled = isFlightRecorderCommercial() ? cfs.isCommercialFeaturesEnabled()
+			boolean isEnabled = cfs.hasCommercialFeatures() ? cfs.isCommercialFeaturesEnabled()
 					: isAvailable(connection);
 			if (isEnabled) {
 				wasEnabled = true;

--- a/application/org.openjdk.jmc.rjmx.services.jfr/src/main/java/org/openjdk/jmc/rjmx/services/jfr/internal/FlightRecorderServiceV2.java
+++ b/application/org.openjdk.jmc.rjmx.services.jfr/src/main/java/org/openjdk/jmc/rjmx/services/jfr/internal/FlightRecorderServiceV2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/application/org.openjdk.jmc.rjmx/src/main/java/org/openjdk/jmc/rjmx/ConnectionToolkit.java
+++ b/application/org.openjdk.jmc.rjmx/src/main/java/org/openjdk/jmc/rjmx/ConnectionToolkit.java
@@ -367,8 +367,12 @@ public final class ConnectionToolkit {
 
 	/**
 	 * Returns {@code true} if the connection handle is associated with an Oracle built JVM,
-	 * {@code false} otherwise. This method <b>does not</b> require the connection handle to be
-	 * connected.
+	 * {@code false} otherwise. If the information is already present in the {@link JVMDescriptor},
+	 * this method will not cause any JMXRMI calls. If the information is lacking, an attempt will
+	 * be made to look it up in the connected JVM. If the attempt fails, false will be returned.
+	 *
+	 * @return {@code true} if the connection handle describes an Oracle JVM, or {@code false}
+	 *         otherwise or if it could not be determined.
 	 */
 	public static boolean isOracle(IConnectionHandle handle) {
 		JVMDescriptor descriptor = handle.getServerDescriptor().getJvmInfo();

--- a/application/org.openjdk.jmc.rjmx/src/main/java/org/openjdk/jmc/rjmx/ConnectionToolkit.java
+++ b/application/org.openjdk.jmc.rjmx/src/main/java/org/openjdk/jmc/rjmx/ConnectionToolkit.java
@@ -346,7 +346,6 @@ public final class ConnectionToolkit {
 	 *         otherwise.
 	 */
 	public static boolean isJRockit(IConnectionHandle connectionHandle) {
-
 		String vmName = getVMName(connectionHandle);
 		return JavaVMVersionToolkit.isJRockitJVMName(vmName);
 	}
@@ -363,6 +362,16 @@ public final class ConnectionToolkit {
 	public static boolean isHotSpot(IConnectionHandle connectionHandle) {
 		String vmName = getVMName(connectionHandle);
 		return vmName != null && JavaVMVersionToolkit.isHotspotJVMName(vmName);
+	}
+
+	/**
+	 * Returns {@code true} if the connection handle is associated with an Oracle built JVM,
+	 * {@code false} otherwise. This method <b>does not</b> require the connection handle to be
+	 * connected.
+	 */
+	public static boolean isOracle(IConnectionHandle handle) {
+		String vendor = handle.getServerDescriptor().getJvmInfo().getJvmVendor();
+		return vendor != null && vendor.contains("Oracle");
 	}
 
 	/**
@@ -411,5 +420,4 @@ public final class ConnectionToolkit {
 		}
 		return null;
 	}
-
 }

--- a/application/org.openjdk.jmc.rjmx/src/main/java/org/openjdk/jmc/rjmx/ConnectionToolkit.java
+++ b/application/org.openjdk.jmc.rjmx/src/main/java/org/openjdk/jmc/rjmx/ConnectionToolkit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/application/org.openjdk.jmc.rjmx/src/main/java/org/openjdk/jmc/rjmx/JVMSupportToolkit.java
+++ b/application/org.openjdk.jmc.rjmx/src/main/java/org/openjdk/jmc/rjmx/JVMSupportToolkit.java
@@ -137,7 +137,7 @@ public final class JVMSupportToolkit {
 	}
 
 	/**
-	 * Returns information about whether to server denoted by the handle supports Flight Recorder
+	 * Returns information about whether the server supports Flight Recorder.
 	 *
 	 * @param handle
 	 *            the server to check

--- a/application/org.openjdk.jmc.rjmx/src/main/java/org/openjdk/jmc/rjmx/JVMSupportToolkit.java
+++ b/application/org.openjdk.jmc.rjmx/src/main/java/org/openjdk/jmc/rjmx/JVMSupportToolkit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/application/org.openjdk.jmc.rjmx/src/main/java/org/openjdk/jmc/rjmx/services/ICommercialFeaturesService.java
+++ b/application/org.openjdk.jmc.rjmx/src/main/java/org/openjdk/jmc/rjmx/services/ICommercialFeaturesService.java
@@ -52,4 +52,9 @@ public interface ICommercialFeaturesService {
 	 */
 	void enableCommercialFeatures() throws Exception;
 
+	/**
+	 * @return true if there are commercial features available, or false if this JVM doesn't have
+	 *         commercial features.
+	 */
+	boolean hasCommercialFeatures();
 }

--- a/application/org.openjdk.jmc.rjmx/src/main/java/org/openjdk/jmc/rjmx/services/ICommercialFeaturesService.java
+++ b/application/org.openjdk.jmc.rjmx/src/main/java/org/openjdk/jmc/rjmx/services/ICommercialFeaturesService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/application/org.openjdk.jmc.rjmx/src/main/java/org/openjdk/jmc/rjmx/services/internal/CommercialFeaturesServiceFactory.java
+++ b/application/org.openjdk.jmc.rjmx/src/main/java/org/openjdk/jmc/rjmx/services/internal/CommercialFeaturesServiceFactory.java
@@ -34,6 +34,7 @@ package org.openjdk.jmc.rjmx.services.internal;
 
 import org.openjdk.jmc.common.version.JavaVersion;
 import org.openjdk.jmc.rjmx.ConnectionException;
+import org.openjdk.jmc.rjmx.ConnectionToolkit;
 import org.openjdk.jmc.rjmx.IConnectionHandle;
 import org.openjdk.jmc.rjmx.ServiceNotAvailableException;
 import org.openjdk.jmc.rjmx.services.ICommercialFeaturesService;
@@ -52,10 +53,16 @@ public class CommercialFeaturesServiceFactory implements IServiceFactory<ICommer
 		if (descriptor != null) {
 			JavaVersion version = new JavaVersion(descriptor.getJavaVersion());
 			if (version.getMajorVersion() >= 11) {
-				return new Jdk11CommercialFeaturesService();
+				return new NoCommercialFeaturesService();
 			}
 		}
-		return new HotSpot23CommercialFeaturesService(handle);
+
+		// Funnily enough, OpenJDK built JVMs for unknown reasons also have the unlock commercial features flag,
+		// so we'll just check if Oracle is the JVM vendor. Any other vendor will not have JFR protected by commercial flags.
+		if (ConnectionToolkit.isOracle(handle)) {
+			return new HotSpot23CommercialFeaturesService(handle);
+		}
+		return new NoCommercialFeaturesService();
 	}
 
 	@Override

--- a/application/org.openjdk.jmc.rjmx/src/main/java/org/openjdk/jmc/rjmx/services/internal/CommercialFeaturesServiceFactory.java
+++ b/application/org.openjdk.jmc.rjmx/src/main/java/org/openjdk/jmc/rjmx/services/internal/CommercialFeaturesServiceFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/application/org.openjdk.jmc.rjmx/src/main/java/org/openjdk/jmc/rjmx/services/internal/HotSpot23CommercialFeaturesService.java
+++ b/application/org.openjdk.jmc.rjmx/src/main/java/org/openjdk/jmc/rjmx/services/internal/HotSpot23CommercialFeaturesService.java
@@ -43,7 +43,7 @@ import org.openjdk.jmc.rjmx.services.IDiagnosticCommandService;
 import javax.management.ObjectName;
 
 public class HotSpot23CommercialFeaturesService implements ICommercialFeaturesService {
-	private final static String VM_FLAG = "UnlockCommercialFeatures"; //$NON-NLS-1$
+	private final static String UNLOCK_COMMERCIAL_FEATURES_FLAG = "UnlockCommercialFeatures"; //$NON-NLS-1$
 	private final static String UNLOCK_COMMAND = "VM.unlock_commercial_features"; //$NON-NLS-1$
 	private final MBeanServerConnection server;
 	private final IDiagnosticCommandService dcs;
@@ -54,7 +54,7 @@ public class HotSpot23CommercialFeaturesService implements ICommercialFeaturesSe
 		server = handle.getServiceOrThrow(MBeanServerConnection.class);
 		dcs = handle.getServiceOrNull(IDiagnosticCommandService.class);
 		try {
-			HotspotManagementToolkit.getVMOption(server, VM_FLAG); // Will fail if option is not available
+			HotspotManagementToolkit.getVMOption(server, UNLOCK_COMMERCIAL_FEATURES_FLAG); // Will fail if option is not available
 		} catch (Exception e) {
 			// Commercial Feature option is not available but Flight Recorder is.
 			if (!isJfrMBeanAvailable()) {
@@ -66,7 +66,7 @@ public class HotSpot23CommercialFeaturesService implements ICommercialFeaturesSe
 	@Override
 	public boolean isCommercialFeaturesEnabled() {
 		try {
-			return ((String) HotspotManagementToolkit.getVMOption(server, VM_FLAG)).contains("true"); //$NON-NLS-1$
+			return ((String) HotspotManagementToolkit.getVMOption(server, UNLOCK_COMMERCIAL_FEATURES_FLAG)).contains("true"); //$NON-NLS-1$
 		} catch (Exception e) {
 			return false;
 		}
@@ -78,7 +78,7 @@ public class HotSpot23CommercialFeaturesService implements ICommercialFeaturesSe
 			dcs.runCtrlBreakHandlerWithResult(UNLOCK_COMMAND);
 		}
 		if (!isCommercialFeaturesEnabled()) {
-			HotspotManagementToolkit.setVMOption(server, VM_FLAG, "true"); //$NON-NLS-1$
+			HotspotManagementToolkit.setVMOption(server, UNLOCK_COMMERCIAL_FEATURES_FLAG, "true"); //$NON-NLS-1$
 		}
 	}
 
@@ -95,5 +95,10 @@ public class HotSpot23CommercialFeaturesService implements ICommercialFeaturesSe
 		ObjectName candidateObjectName = ConnectionToolkit.createObjectName(JDK_MANAGEMENT_JFR_MBEAN_NAME);
 		server.getMBeanInfo(candidateObjectName);
 		return candidateObjectName;
+	}
+
+	@Override
+	public boolean hasCommercialFeatures() {
+		return true;
 	}
 }

--- a/application/org.openjdk.jmc.rjmx/src/main/java/org/openjdk/jmc/rjmx/services/internal/HotSpot23CommercialFeaturesService.java
+++ b/application/org.openjdk.jmc.rjmx/src/main/java/org/openjdk/jmc/rjmx/services/internal/HotSpot23CommercialFeaturesService.java
@@ -66,7 +66,8 @@ public class HotSpot23CommercialFeaturesService implements ICommercialFeaturesSe
 	@Override
 	public boolean isCommercialFeaturesEnabled() {
 		try {
-			return ((String) HotspotManagementToolkit.getVMOption(server, UNLOCK_COMMERCIAL_FEATURES_FLAG)).contains("true"); //$NON-NLS-1$
+			return ((String) HotspotManagementToolkit.getVMOption(server, UNLOCK_COMMERCIAL_FEATURES_FLAG))
+					.contains("true"); //$NON-NLS-1$
 		} catch (Exception e) {
 			return false;
 		}

--- a/application/org.openjdk.jmc.rjmx/src/main/java/org/openjdk/jmc/rjmx/services/internal/HotSpot23CommercialFeaturesService.java
+++ b/application/org.openjdk.jmc.rjmx/src/main/java/org/openjdk/jmc/rjmx/services/internal/HotSpot23CommercialFeaturesService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/application/org.openjdk.jmc.rjmx/src/main/java/org/openjdk/jmc/rjmx/services/internal/NoCommercialFeaturesService.java
+++ b/application/org.openjdk.jmc.rjmx/src/main/java/org/openjdk/jmc/rjmx/services/internal/NoCommercialFeaturesService.java
@@ -34,7 +34,10 @@ package org.openjdk.jmc.rjmx.services.internal;
 
 import org.openjdk.jmc.rjmx.services.ICommercialFeaturesService;
 
-public class Jdk11CommercialFeaturesService implements ICommercialFeaturesService {
+/**
+ * Used by JVMs with no commercial features, e.g. OpenJDK 8 and JDK 11+ JVMs.
+ */
+public class NoCommercialFeaturesService implements ICommercialFeaturesService {
 
 	@Override
 	public boolean isCommercialFeaturesEnabled() {
@@ -44,5 +47,10 @@ public class Jdk11CommercialFeaturesService implements ICommercialFeaturesServic
 	@Override
 	public void enableCommercialFeatures() throws Exception {
 		// Noop
+	}
+
+	@Override
+	public boolean hasCommercialFeatures() {
+		return false;
 	}
 }

--- a/application/org.openjdk.jmc.rjmx/src/main/java/org/openjdk/jmc/rjmx/services/internal/NoCommercialFeaturesService.java
+++ b/application/org.openjdk.jmc.rjmx/src/main/java/org/openjdk/jmc/rjmx/services/internal/NoCommercialFeaturesService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/application/org.openjdk.jmc.ui.common/src/main/java/org/openjdk/jmc/ui/common/jvm/JVMDescriptor.java
+++ b/application/org.openjdk.jmc.ui.common/src/main/java/org/openjdk/jmc/ui/common/jvm/JVMDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/application/org.openjdk.jmc.ui.common/src/main/java/org/openjdk/jmc/ui/common/jvm/JVMDescriptor.java
+++ b/application/org.openjdk.jmc.ui.common/src/main/java/org/openjdk/jmc/ui/common/jvm/JVMDescriptor.java
@@ -38,6 +38,7 @@ package org.openjdk.jmc.ui.common.jvm;
 public class JVMDescriptor {
 	private final String javaVersion;
 	private final JVMType jvmType;
+	private final String jvmVendor;
 	private final JVMArch jvmArch;
 	private final String javaCommand;
 	private final String jvmArguments;
@@ -46,13 +47,14 @@ public class JVMDescriptor {
 	private final Connectable connectable;
 
 	public JVMDescriptor(String javaVersion, JVMType jvmType, JVMArch jvmArch, String javaCommand, String jvmArguments,
-			Integer pid, boolean debug, Connectable attachable) {
+			String jvmVendor, Integer pid, boolean debug, Connectable attachable) {
 		super();
 		this.javaVersion = javaVersion;
 		this.jvmType = jvmType;
 		this.jvmArch = jvmArch;
 		this.javaCommand = javaCommand;
 		this.jvmArguments = jvmArguments;
+		this.jvmVendor = jvmVendor;
 		this.pid = pid;
 		this.debug = debug;
 		connectable = attachable;
@@ -76,6 +78,10 @@ public class JVMDescriptor {
 
 	public String getJVMArguments() {
 		return jvmArguments;
+	}
+
+	public String getJvmVendor() {
+		return jvmVendor;
 	}
 
 	public Integer getPid() {

--- a/application/tests/org.openjdk.jmc.rjmx.test/src/test/java/org/openjdk/jmc/rjmx/test/JVMSupportToolkitTest.java
+++ b/application/tests/org.openjdk.jmc.rjmx.test/src/test/java/org/openjdk/jmc/rjmx/test/JVMSupportToolkitTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -33,6 +33,7 @@
 package org.openjdk.jmc.rjmx.test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 import org.junit.Test;
 import org.openjdk.jmc.rjmx.ConnectionDescriptorBuilder;
@@ -46,7 +47,7 @@ import org.openjdk.jmc.ui.common.jvm.JVMType;
 
 @SuppressWarnings("nls")
 public class JVMSupportToolkitTest {
-
+	private static final String ORACLE = "Oracle";
 	// FIXME: Add tests for the methods that take IConnectionHandle as a parameter.
 
 	private static final String SUPPORTED_MESSAGE = null;
@@ -63,7 +64,7 @@ public class JVMSupportToolkitTest {
 	public void testJfr17U40HotSpotSupported() {
 		ServerHandle server = new ServerHandle(
 				new ServerDescriptor(null, null,
-						new JVMDescriptor("1.7.0_40", JVMType.HOTSPOT, JVMArch.UNKNOWN, null, null, null, false, null)),
+						new JVMDescriptor("1.7.0_40", JVMType.HOTSPOT, JVMArch.UNKNOWN, ORACLE, null, null, null, false, null)),
 				new ConnectionDescriptorBuilder().hostName("localhost").port(0).build(), null);
 		String errorMessage = JVMSupportToolkit.checkFlightRecorderSupport(server, false);
 		assertEquals(SUPPORTED_MESSAGE, errorMessage);
@@ -73,7 +74,7 @@ public class JVMSupportToolkitTest {
 	public void testJfr17U4HotSpotNotFullySupported() {
 		ServerHandle server = new ServerHandle(
 				new ServerDescriptor(null, null,
-						new JVMDescriptor("1.7.0_04", JVMType.HOTSPOT, JVMArch.UNKNOWN, null, null, null, false, null)),
+						new JVMDescriptor("1.7.0_04", JVMType.HOTSPOT, JVMArch.UNKNOWN, ORACLE, null, null, null, false, null)),
 				new ConnectionDescriptorBuilder().hostName("localhost").port(0).build(), null);
 		String errorMessage = JVMSupportToolkit.checkFlightRecorderSupport(server, false);
 		assertEquals(Messages.JVMSupport_FLIGHT_RECORDER_NOT_FULLY_SUPPORTED_OLD_HOTSPOT, errorMessage);
@@ -83,7 +84,7 @@ public class JVMSupportToolkitTest {
 	public void testJfr17HotSpotNotSupported() {
 		ServerHandle server = new ServerHandle(
 				new ServerDescriptor(null, null,
-						new JVMDescriptor("1.7.0", JVMType.HOTSPOT, JVMArch.UNKNOWN, null, null, null, false, null)),
+						new JVMDescriptor("1.7.0", JVMType.HOTSPOT, JVMArch.UNKNOWN, ORACLE, null, null, null, false, null)),
 				new ConnectionDescriptorBuilder().hostName("localhost").port(0).build(), null);
 		String errorMessage = JVMSupportToolkit.checkFlightRecorderSupport(server, false);
 		assertEquals(Messages.JVMSupport_FLIGHT_RECORDER_NOT_SUPPORTED_OLD_HOTSPOT, errorMessage);
@@ -93,7 +94,7 @@ public class JVMSupportToolkitTest {
 	public void testJfrJRockitNotSupported() {
 		ServerHandle server = new ServerHandle(
 				new ServerDescriptor(null, null,
-						new JVMDescriptor("1.6", JVMType.JROCKIT, JVMArch.UNKNOWN, null, null, null, false, null)),
+						new JVMDescriptor("1.6", JVMType.JROCKIT, JVMArch.UNKNOWN, ORACLE, null, null, null, false, null)),
 				new ConnectionDescriptorBuilder().hostName("localhost").port(0).build(), null);
 		String errorMessage = JVMSupportToolkit.checkFlightRecorderSupport(server, false);
 		assertEquals(Messages.JVMSupport_JROCKIT_NO_LONGER_SUPPORTED, errorMessage);
@@ -103,7 +104,7 @@ public class JVMSupportToolkitTest {
 	public void testJfrOldHotSpotNotSupported() {
 		ServerHandle server = new ServerHandle(
 				new ServerDescriptor(null, null,
-						new JVMDescriptor("1.6", JVMType.HOTSPOT, JVMArch.UNKNOWN, null, null, null, false, null)),
+						new JVMDescriptor("1.6", JVMType.HOTSPOT, JVMArch.UNKNOWN, ORACLE, null, null, null, false, null)),
 				new ConnectionDescriptorBuilder().hostName("localhost").port(0).build(), null);
 		String errorMessage = JVMSupportToolkit.checkFlightRecorderSupport(server, false);
 		assertEquals(Messages.JVMSupport_FLIGHT_RECORDER_NOT_SUPPORTED_OLD_HOTSPOT, errorMessage);
@@ -113,7 +114,7 @@ public class JVMSupportToolkitTest {
 	public void testJfrNonHotSpotNotSupported() {
 		ServerHandle server = new ServerHandle(
 				new ServerDescriptor(null, null,
-						new JVMDescriptor("1.7", JVMType.OTHER, JVMArch.UNKNOWN, null, null, null, false, null)),
+						new JVMDescriptor("1.7", JVMType.OTHER, JVMArch.UNKNOWN, ORACLE, null, null, null, false, null)),
 				new ConnectionDescriptorBuilder().hostName("localhost").port(0).build(), null);
 		String errorMessage = JVMSupportToolkit.checkFlightRecorderSupport(server, false);
 		assertEquals(Messages.JVMSupport_FLIGHT_RECORDER_NOT_SUPPORTED_NOT_HOTSPOT, errorMessage);
@@ -123,10 +124,29 @@ public class JVMSupportToolkitTest {
 	public void testJfrUnknownNoWarning() {
 		ServerHandle server = new ServerHandle(
 				new ServerDescriptor(null, null,
-						new JVMDescriptor("1.7", JVMType.UNKNOWN, JVMArch.UNKNOWN, null, null, null, false, null)),
+						new JVMDescriptor("1.7", JVMType.UNKNOWN, JVMArch.UNKNOWN, ORACLE, null, null, null, false, null)),
 				new ConnectionDescriptorBuilder().hostName("localhost").port(0).build(), null);
 		String errorMessage = JVMSupportToolkit.checkFlightRecorderSupport(server, false);
 		assertEquals(SUPPORTED_MESSAGE, errorMessage);
 	}
 
+	@Test
+	public void testJfr8HotSpotOpenJDKSupported() {
+		ServerHandle server = new ServerHandle(
+				new ServerDescriptor(null, null,
+						new JVMDescriptor("1.8.0", JVMType.HOTSPOT, JVMArch.UNKNOWN, "OpenJDK", null, null, null, false, null)),
+				new ConnectionDescriptorBuilder().hostName("localhost").port(0).build(), null);
+		String errorMessage = JVMSupportToolkit.checkFlightRecorderSupport(server, false);
+		assertEquals(SUPPORTED_MESSAGE, errorMessage);
+	}
+	
+	@Test
+	public void testJdk7HotSpotOpenJDKNotSupported() {
+		ServerHandle server = new ServerHandle(
+				new ServerDescriptor(null, null,
+						new JVMDescriptor("1.7.0", JVMType.HOTSPOT, JVMArch.UNKNOWN, "OpenJDK", null, null, null, false, null)),
+				new ConnectionDescriptorBuilder().hostName("localhost").port(0).build(), null);
+		String errorMessage = JVMSupportToolkit.checkFlightRecorderSupport(server, false);
+		assertNotNull(errorMessage);
+	}
 }

--- a/application/tests/org.openjdk.jmc.rjmx.test/src/test/java/org/openjdk/jmc/rjmx/test/JVMSupportToolkitTest.java
+++ b/application/tests/org.openjdk.jmc.rjmx.test/src/test/java/org/openjdk/jmc/rjmx/test/JVMSupportToolkitTest.java
@@ -63,8 +63,8 @@ public class JVMSupportToolkitTest {
 	@Test
 	public void testJfr17U40HotSpotSupported() {
 		ServerHandle server = new ServerHandle(
-				new ServerDescriptor(null, null,
-						new JVMDescriptor("1.7.0_40", JVMType.HOTSPOT, JVMArch.UNKNOWN, ORACLE, null, null, null, false, null)),
+				new ServerDescriptor(null, null, new JVMDescriptor("1.7.0_40", JVMType.HOTSPOT, JVMArch.UNKNOWN, ORACLE,
+						null, null, null, false, null)),
 				new ConnectionDescriptorBuilder().hostName("localhost").port(0).build(), null);
 		String errorMessage = JVMSupportToolkit.checkFlightRecorderSupport(server, false);
 		assertEquals(SUPPORTED_MESSAGE, errorMessage);
@@ -73,8 +73,8 @@ public class JVMSupportToolkitTest {
 	@Test
 	public void testJfr17U4HotSpotNotFullySupported() {
 		ServerHandle server = new ServerHandle(
-				new ServerDescriptor(null, null,
-						new JVMDescriptor("1.7.0_04", JVMType.HOTSPOT, JVMArch.UNKNOWN, ORACLE, null, null, null, false, null)),
+				new ServerDescriptor(null, null, new JVMDescriptor("1.7.0_04", JVMType.HOTSPOT, JVMArch.UNKNOWN, ORACLE,
+						null, null, null, false, null)),
 				new ConnectionDescriptorBuilder().hostName("localhost").port(0).build(), null);
 		String errorMessage = JVMSupportToolkit.checkFlightRecorderSupport(server, false);
 		assertEquals(Messages.JVMSupport_FLIGHT_RECORDER_NOT_FULLY_SUPPORTED_OLD_HOTSPOT, errorMessage);
@@ -83,8 +83,8 @@ public class JVMSupportToolkitTest {
 	@Test
 	public void testJfr17HotSpotNotSupported() {
 		ServerHandle server = new ServerHandle(
-				new ServerDescriptor(null, null,
-						new JVMDescriptor("1.7.0", JVMType.HOTSPOT, JVMArch.UNKNOWN, ORACLE, null, null, null, false, null)),
+				new ServerDescriptor(null, null, new JVMDescriptor("1.7.0", JVMType.HOTSPOT, JVMArch.UNKNOWN, ORACLE,
+						null, null, null, false, null)),
 				new ConnectionDescriptorBuilder().hostName("localhost").port(0).build(), null);
 		String errorMessage = JVMSupportToolkit.checkFlightRecorderSupport(server, false);
 		assertEquals(Messages.JVMSupport_FLIGHT_RECORDER_NOT_SUPPORTED_OLD_HOTSPOT, errorMessage);
@@ -93,8 +93,8 @@ public class JVMSupportToolkitTest {
 	@Test
 	public void testJfrJRockitNotSupported() {
 		ServerHandle server = new ServerHandle(
-				new ServerDescriptor(null, null,
-						new JVMDescriptor("1.6", JVMType.JROCKIT, JVMArch.UNKNOWN, ORACLE, null, null, null, false, null)),
+				new ServerDescriptor(null, null, new JVMDescriptor("1.6", JVMType.JROCKIT, JVMArch.UNKNOWN, ORACLE,
+						null, null, null, false, null)),
 				new ConnectionDescriptorBuilder().hostName("localhost").port(0).build(), null);
 		String errorMessage = JVMSupportToolkit.checkFlightRecorderSupport(server, false);
 		assertEquals(Messages.JVMSupport_JROCKIT_NO_LONGER_SUPPORTED, errorMessage);
@@ -103,8 +103,8 @@ public class JVMSupportToolkitTest {
 	@Test
 	public void testJfrOldHotSpotNotSupported() {
 		ServerHandle server = new ServerHandle(
-				new ServerDescriptor(null, null,
-						new JVMDescriptor("1.6", JVMType.HOTSPOT, JVMArch.UNKNOWN, ORACLE, null, null, null, false, null)),
+				new ServerDescriptor(null, null, new JVMDescriptor("1.6", JVMType.HOTSPOT, JVMArch.UNKNOWN, ORACLE,
+						null, null, null, false, null)),
 				new ConnectionDescriptorBuilder().hostName("localhost").port(0).build(), null);
 		String errorMessage = JVMSupportToolkit.checkFlightRecorderSupport(server, false);
 		assertEquals(Messages.JVMSupport_FLIGHT_RECORDER_NOT_SUPPORTED_OLD_HOTSPOT, errorMessage);
@@ -113,8 +113,8 @@ public class JVMSupportToolkitTest {
 	@Test
 	public void testJfrNonHotSpotNotSupported() {
 		ServerHandle server = new ServerHandle(
-				new ServerDescriptor(null, null,
-						new JVMDescriptor("1.7", JVMType.OTHER, JVMArch.UNKNOWN, ORACLE, null, null, null, false, null)),
+				new ServerDescriptor(null, null, new JVMDescriptor("1.7", JVMType.OTHER, JVMArch.UNKNOWN, ORACLE, null,
+						null, null, false, null)),
 				new ConnectionDescriptorBuilder().hostName("localhost").port(0).build(), null);
 		String errorMessage = JVMSupportToolkit.checkFlightRecorderSupport(server, false);
 		assertEquals(Messages.JVMSupport_FLIGHT_RECORDER_NOT_SUPPORTED_NOT_HOTSPOT, errorMessage);
@@ -123,8 +123,8 @@ public class JVMSupportToolkitTest {
 	@Test
 	public void testJfrUnknownNoWarning() {
 		ServerHandle server = new ServerHandle(
-				new ServerDescriptor(null, null,
-						new JVMDescriptor("1.7", JVMType.UNKNOWN, JVMArch.UNKNOWN, ORACLE, null, null, null, false, null)),
+				new ServerDescriptor(null, null, new JVMDescriptor("1.7", JVMType.UNKNOWN, JVMArch.UNKNOWN, ORACLE,
+						null, null, null, false, null)),
 				new ConnectionDescriptorBuilder().hostName("localhost").port(0).build(), null);
 		String errorMessage = JVMSupportToolkit.checkFlightRecorderSupport(server, false);
 		assertEquals(SUPPORTED_MESSAGE, errorMessage);
@@ -133,18 +133,18 @@ public class JVMSupportToolkitTest {
 	@Test
 	public void testJfr8HotSpotOpenJDKSupported() {
 		ServerHandle server = new ServerHandle(
-				new ServerDescriptor(null, null,
-						new JVMDescriptor("1.8.0", JVMType.HOTSPOT, JVMArch.UNKNOWN, "OpenJDK", null, null, null, false, null)),
+				new ServerDescriptor(null, null, new JVMDescriptor("1.8.0", JVMType.HOTSPOT, JVMArch.UNKNOWN, "OpenJDK",
+						null, null, null, false, null)),
 				new ConnectionDescriptorBuilder().hostName("localhost").port(0).build(), null);
 		String errorMessage = JVMSupportToolkit.checkFlightRecorderSupport(server, false);
 		assertEquals(SUPPORTED_MESSAGE, errorMessage);
 	}
-	
+
 	@Test
 	public void testJdk7HotSpotOpenJDKNotSupported() {
 		ServerHandle server = new ServerHandle(
-				new ServerDescriptor(null, null,
-						new JVMDescriptor("1.7.0", JVMType.HOTSPOT, JVMArch.UNKNOWN, "OpenJDK", null, null, null, false, null)),
+				new ServerDescriptor(null, null, new JVMDescriptor("1.7.0", JVMType.HOTSPOT, JVMArch.UNKNOWN, "OpenJDK",
+						null, null, null, false, null)),
 				new ConnectionDescriptorBuilder().hostName("localhost").port(0).build(), null);
 		String errorMessage = JVMSupportToolkit.checkFlightRecorderSupport(server, false);
 		assertNotNull(errorMessage);

--- a/application/tests/org.openjdk.jmc.rjmx.test/src/test/java/org/openjdk/jmc/rjmx/test/JVMSupportToolkitTest.java
+++ b/application/tests/org.openjdk.jmc.rjmx.test/src/test/java/org/openjdk/jmc/rjmx/test/JVMSupportToolkitTest.java
@@ -47,7 +47,8 @@ import org.openjdk.jmc.ui.common.jvm.JVMType;
 
 @SuppressWarnings("nls")
 public class JVMSupportToolkitTest {
-	private static final String ORACLE = "Oracle";
+	private static final String VENDOR_OPEN_JDK = "OpenJDK";
+	private static final String VENDOR_ORACLE = "Oracle";
 	// FIXME: Add tests for the methods that take IConnectionHandle as a parameter.
 
 	private static final String SUPPORTED_MESSAGE = null;
@@ -63,8 +64,9 @@ public class JVMSupportToolkitTest {
 	@Test
 	public void testJfr17U40HotSpotSupported() {
 		ServerHandle server = new ServerHandle(
-				new ServerDescriptor(null, null, new JVMDescriptor("1.7.0_40", JVMType.HOTSPOT, JVMArch.UNKNOWN, ORACLE,
-						null, null, null, false, null)),
+				new ServerDescriptor(null, null,
+						new JVMDescriptor("1.7.0_40", JVMType.HOTSPOT, JVMArch.UNKNOWN, VENDOR_ORACLE, null, null, null,
+								false, null)),
 				new ConnectionDescriptorBuilder().hostName("localhost").port(0).build(), null);
 		String errorMessage = JVMSupportToolkit.checkFlightRecorderSupport(server, false);
 		assertEquals(SUPPORTED_MESSAGE, errorMessage);
@@ -73,8 +75,9 @@ public class JVMSupportToolkitTest {
 	@Test
 	public void testJfr17U4HotSpotNotFullySupported() {
 		ServerHandle server = new ServerHandle(
-				new ServerDescriptor(null, null, new JVMDescriptor("1.7.0_04", JVMType.HOTSPOT, JVMArch.UNKNOWN, ORACLE,
-						null, null, null, false, null)),
+				new ServerDescriptor(null, null,
+						new JVMDescriptor("1.7.0_04", JVMType.HOTSPOT, JVMArch.UNKNOWN, VENDOR_ORACLE, null, null, null,
+								false, null)),
 				new ConnectionDescriptorBuilder().hostName("localhost").port(0).build(), null);
 		String errorMessage = JVMSupportToolkit.checkFlightRecorderSupport(server, false);
 		assertEquals(Messages.JVMSupport_FLIGHT_RECORDER_NOT_FULLY_SUPPORTED_OLD_HOTSPOT, errorMessage);
@@ -83,8 +86,9 @@ public class JVMSupportToolkitTest {
 	@Test
 	public void testJfr17HotSpotNotSupported() {
 		ServerHandle server = new ServerHandle(
-				new ServerDescriptor(null, null, new JVMDescriptor("1.7.0", JVMType.HOTSPOT, JVMArch.UNKNOWN, ORACLE,
-						null, null, null, false, null)),
+				new ServerDescriptor(null, null,
+						new JVMDescriptor("1.7.0", JVMType.HOTSPOT, JVMArch.UNKNOWN, VENDOR_ORACLE, null, null, null,
+								false, null)),
 				new ConnectionDescriptorBuilder().hostName("localhost").port(0).build(), null);
 		String errorMessage = JVMSupportToolkit.checkFlightRecorderSupport(server, false);
 		assertEquals(Messages.JVMSupport_FLIGHT_RECORDER_NOT_SUPPORTED_OLD_HOTSPOT, errorMessage);
@@ -93,8 +97,9 @@ public class JVMSupportToolkitTest {
 	@Test
 	public void testJfrJRockitNotSupported() {
 		ServerHandle server = new ServerHandle(
-				new ServerDescriptor(null, null, new JVMDescriptor("1.6", JVMType.JROCKIT, JVMArch.UNKNOWN, ORACLE,
-						null, null, null, false, null)),
+				new ServerDescriptor(null, null,
+						new JVMDescriptor("1.6", JVMType.JROCKIT, JVMArch.UNKNOWN, VENDOR_ORACLE, null, null, null,
+								false, null)),
 				new ConnectionDescriptorBuilder().hostName("localhost").port(0).build(), null);
 		String errorMessage = JVMSupportToolkit.checkFlightRecorderSupport(server, false);
 		assertEquals(Messages.JVMSupport_JROCKIT_NO_LONGER_SUPPORTED, errorMessage);
@@ -103,8 +108,9 @@ public class JVMSupportToolkitTest {
 	@Test
 	public void testJfrOldHotSpotNotSupported() {
 		ServerHandle server = new ServerHandle(
-				new ServerDescriptor(null, null, new JVMDescriptor("1.6", JVMType.HOTSPOT, JVMArch.UNKNOWN, ORACLE,
-						null, null, null, false, null)),
+				new ServerDescriptor(null, null,
+						new JVMDescriptor("1.6", JVMType.HOTSPOT, JVMArch.UNKNOWN, VENDOR_ORACLE, null, null, null,
+								false, null)),
 				new ConnectionDescriptorBuilder().hostName("localhost").port(0).build(), null);
 		String errorMessage = JVMSupportToolkit.checkFlightRecorderSupport(server, false);
 		assertEquals(Messages.JVMSupport_FLIGHT_RECORDER_NOT_SUPPORTED_OLD_HOTSPOT, errorMessage);
@@ -113,8 +119,8 @@ public class JVMSupportToolkitTest {
 	@Test
 	public void testJfrNonHotSpotNotSupported() {
 		ServerHandle server = new ServerHandle(
-				new ServerDescriptor(null, null, new JVMDescriptor("1.7", JVMType.OTHER, JVMArch.UNKNOWN, ORACLE, null,
-						null, null, false, null)),
+				new ServerDescriptor(null, null, new JVMDescriptor("1.7", JVMType.OTHER, JVMArch.UNKNOWN, VENDOR_ORACLE,
+						null, null, null, false, null)),
 				new ConnectionDescriptorBuilder().hostName("localhost").port(0).build(), null);
 		String errorMessage = JVMSupportToolkit.checkFlightRecorderSupport(server, false);
 		assertEquals(Messages.JVMSupport_FLIGHT_RECORDER_NOT_SUPPORTED_NOT_HOTSPOT, errorMessage);
@@ -123,8 +129,9 @@ public class JVMSupportToolkitTest {
 	@Test
 	public void testJfrUnknownNoWarning() {
 		ServerHandle server = new ServerHandle(
-				new ServerDescriptor(null, null, new JVMDescriptor("1.7", JVMType.UNKNOWN, JVMArch.UNKNOWN, ORACLE,
-						null, null, null, false, null)),
+				new ServerDescriptor(null, null,
+						new JVMDescriptor("1.7", JVMType.UNKNOWN, JVMArch.UNKNOWN, VENDOR_ORACLE, null, null, null,
+								false, null)),
 				new ConnectionDescriptorBuilder().hostName("localhost").port(0).build(), null);
 		String errorMessage = JVMSupportToolkit.checkFlightRecorderSupport(server, false);
 		assertEquals(SUPPORTED_MESSAGE, errorMessage);
@@ -133,8 +140,9 @@ public class JVMSupportToolkitTest {
 	@Test
 	public void testJfr8HotSpotOpenJDKSupported() {
 		ServerHandle server = new ServerHandle(
-				new ServerDescriptor(null, null, new JVMDescriptor("1.8.0", JVMType.HOTSPOT, JVMArch.UNKNOWN, "OpenJDK",
-						null, null, null, false, null)),
+				new ServerDescriptor(null, null,
+						new JVMDescriptor("1.8.0", JVMType.HOTSPOT, JVMArch.UNKNOWN, VENDOR_OPEN_JDK, null, null, null,
+								false, null)),
 				new ConnectionDescriptorBuilder().hostName("localhost").port(0).build(), null);
 		String errorMessage = JVMSupportToolkit.checkFlightRecorderSupport(server, false);
 		assertEquals(SUPPORTED_MESSAGE, errorMessage);
@@ -143,8 +151,9 @@ public class JVMSupportToolkitTest {
 	@Test
 	public void testJdk7HotSpotOpenJDKNotSupported() {
 		ServerHandle server = new ServerHandle(
-				new ServerDescriptor(null, null, new JVMDescriptor("1.7.0", JVMType.HOTSPOT, JVMArch.UNKNOWN, "OpenJDK",
-						null, null, null, false, null)),
+				new ServerDescriptor(null, null,
+						new JVMDescriptor("1.7.0", JVMType.HOTSPOT, JVMArch.UNKNOWN, VENDOR_OPEN_JDK, null, null, null,
+								false, null)),
 				new ConnectionDescriptorBuilder().hostName("localhost").port(0).build(), null);
 		String errorMessage = JVMSupportToolkit.checkFlightRecorderSupport(server, false);
 		assertNotNull(errorMessage);

--- a/application/tests/org.openjdk.jmc.rjmx.test/src/test/java/org/openjdk/jmc/rjmx/test/services/CommercialFeaturesServiceTest.java
+++ b/application/tests/org.openjdk.jmc.rjmx.test/src/test/java/org/openjdk/jmc/rjmx/test/services/CommercialFeaturesServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -36,7 +36,6 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
-
 import org.openjdk.jmc.rjmx.ConnectionException;
 import org.openjdk.jmc.rjmx.IConnectionHandle;
 import org.openjdk.jmc.rjmx.services.ICommercialFeaturesService;
@@ -63,18 +62,17 @@ public class CommercialFeaturesServiceTest extends ServerHandleTestCase {
 	public void testSetCommercialFeaturesState() throws Exception {
 		ICommercialFeaturesService service = getCommercialFeaturesService();
 		// Check state. Any state is okay, but we want to catch exceptions.
-		if (!service.isCommercialFeaturesEnabled()) {
+		if (service.hasCommercialFeatures() && !service.isCommercialFeaturesEnabled()) {
 			service.enableCommercialFeatures();
 		}
-		assertTrue("Commercial features should now be enabled!", service.isCommercialFeaturesEnabled());
+		if (service.hasCommercialFeatures()) {
+			assertTrue("Commercial features should now be enabled!", service.isCommercialFeaturesEnabled());
+		}
 	}
 
 	private ICommercialFeaturesService getCommercialFeaturesService() throws ConnectionException {
-		IConnectionHandle handle = getConnectionHandle();
-
-		// LocalRJMXTestToolkit.createDefaultConnectionHandle(getConnectionManager());
+		IConnectionHandle handle = getDefaultServer().connect("Connection handle for test");
 		assumeHotSpot7u4OrLater(handle);
-
 		ICommercialFeaturesService service = handle.getServiceOrNull(ICommercialFeaturesService.class);
 
 		assertNotNull(

--- a/configuration/spotbugs/spotbugs-exclude.xml
+++ b/configuration/spotbugs/spotbugs-exclude.xml
@@ -566,6 +566,13 @@
 		<Bug pattern="ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD" />
 	</Match>
 
+	<!-- Spotbugs says exception can't be thrown, but many of the attach API calls 
+	     before are declaring exceptions. -->
+	<Match>
+		<Class name="org.openjdk.jmc.browser.attach.LocalJVMToolkit$2" />
+		<Bug pattern="REC_CATCH_EXCEPTION" />
+	</Match>
+
 	<!-- Spotbugs says vm is guaranteed to be null at L394. Perhaps it depends on 
 		JDK version, but it should indeed be able to be non-null. -->
 	<Match>


### PR DESCRIPTION
This is for OpenJDK 8 implementations that have backported JFR, e.g. Azul's JDK. There is also a backport effort for OpenJDK 8 in general.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

## Issue
[JMC-6554](https://bugs.openjdk.java.net/browse/JMC-6554): Support JFR in OpenJDK 8


## Approvers
 * Henrik Dafgård ([hdafgard](@Gunde) - **Reviewer**)