### PR TITLE
6583: Add filter and search table actions to EventBrowser page

### DIFF
--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/common/DataPageToolkit.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/common/DataPageToolkit.java
@@ -1113,6 +1113,7 @@ public class DataPageToolkit {
 		ItemList list = listBuilder.build(parent, tableSettings);
 		ColumnViewer viewer = list.getManager().getViewer();
 		MCContextMenuManager mm = MCContextMenuManager.create(viewer.getControl());
+		list.setMenuManager(mm);
 		ColumnMenusFactory.addDefaultMenus(list.getManager(), mm);
 		viewer.addSelectionChangedListener(
 				e -> pageContainer.showSelection(ItemCollectionToolkit.build(list.getSelection().get())));

--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/common/ItemList.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/common/ItemList.java
@@ -65,6 +65,7 @@ import org.openjdk.jmc.ui.accessibility.FocusTracker;
 import org.openjdk.jmc.ui.column.ColumnBuilder;
 import org.openjdk.jmc.ui.column.ColumnManager;
 import org.openjdk.jmc.ui.column.ColumnManager.ColumnComparator;
+import org.openjdk.jmc.ui.handlers.MCContextMenuManager;
 import org.openjdk.jmc.ui.column.IColumn;
 import org.openjdk.jmc.ui.column.TableSettings;
 
@@ -105,6 +106,7 @@ public class ItemList {
 	private final SimpleArray<IItem> tail = new SimpleArray<>(new IItem[1000]);
 
 	private ExtraRowTableViewer tableViewer;
+	private MCContextMenuManager menuManager;
 
 	private ItemList(Composite container, List<IColumn> columns, TableSettings tableSettings, int style) {
 		tableViewer = new ExtraRowTableViewer(container,
@@ -136,6 +138,14 @@ public class ItemList {
 
 	public ColumnManager getManager() {
 		return columnManager;
+	}
+
+	public void setMenuManager(MCContextMenuManager mm) {
+		menuManager = mm;
+	}
+
+	public MCContextMenuManager getMenuManager() {
+		return menuManager;
 	}
 
 	@SuppressWarnings("unchecked")

--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/EventBrowserPage.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/EventBrowserPage.java
@@ -176,6 +176,8 @@ public class EventBrowserPage extends AbstractDataPage {
 		private FlavorSelector flavorSelector;
 		private FilterComponent listFilter;
 		private Boolean showTypesWithoutEvents;
+		private Boolean showFilterAction;
+		private Boolean showSearchAction;
 
 		EventBrowserUI(Composite parent, FormToolkit toolkit, IState state, IPageContainer container) {
 			this.container = container;
@@ -332,6 +334,7 @@ public class EventBrowserPage extends AbstractDataPage {
 			});
 			listColumns.addAll(0, newColumns);
 
+			saveFilterActionStates();
 			Control oldListControl = list.getManager().getViewer().getControl();
 			Composite parent = listFilter != null ? listFilter.getComponent().getParent() : oldListControl.getParent();
 			for (Control c : parent.getChildren()) {
@@ -342,7 +345,11 @@ public class EventBrowserPage extends AbstractDataPage {
 					Messages.EventBrowserPage_EVENT_BROWSER_SELECTION);
 			listFilter = FilterComponent.createFilterComponent(list, flagsFilter, filteredItems,
 					container.getSelectionStore()::getSelections, this::onFilterChange);
-			listFilter.loadState(getState().getChild(LIST_FILTER));
+			if (showFilterAction == null) {
+				listFilter.loadState(getState().getChild(LIST_FILTER));
+			} else {
+				loadFilterActionStates();
+			}
 			onFilterChange(flagsFilter);
 
 			MCContextMenuManager mm = list.getMenuManager();
@@ -370,6 +377,20 @@ public class EventBrowserPage extends AbstractDataPage {
 			if (settings.getOrderBy() != null) {
 				listOrderBy = settings.getOrderBy();
 			}
+		}
+
+		private void saveFilterActionStates() {
+			if (listFilter != null) {
+				showFilterAction = listFilter.getShowFilterAction().isChecked();
+				showSearchAction = listFilter.getShowSearchAction().isChecked();
+			}
+		}
+
+		private void loadFilterActionStates() {
+			listFilter.getShowFilterAction().setChecked(showFilterAction);
+			listFilter.getShowSearchAction().setChecked(showSearchAction);
+			listFilter.getShowFilterAction().run();
+			listFilter.getShowSearchAction().run();
 		}
 
 		@Override


### PR DESCRIPTION
This patch addresses [JMC-6583](https://bugs.openjdk.java.net/browse/JMC-6583) : Should be possible to filter and search in the Event Browser.

I have added table search and filter actions in the Event Browser.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

## Issue
[JMC-6583](https://bugs.openjdk.java.net/browse/JMC-6583): Should be possible to filter and search in the Event Browser


## Approvers
 * Marcus Hirt ([hirt](@thegreystone) - **Reviewer**)