### PR TITLE
6658: Remove unnecessary storing of pre-instrumented bytecode

### DIFF
--- a/core/org.openjdk.jmc.agent/src/main/java/org/openjdk/jmc/agent/TransformRegistry.java
+++ b/core/org.openjdk.jmc.agent/src/main/java/org/openjdk/jmc/agent/TransformRegistry.java
@@ -71,23 +71,6 @@ public interface TransformRegistry {
 	List<String> clearAllTransformData();
 
 	/**
-	 * Stores the pre instrumentation byte array of a class.
-	 * @param className
-	 *           the class for which to store the pre instrumentation data.
-	 * @param classPreInstrumentation
-	 *           the pre instrumentation byte array of the class to store.
-	 */
-	void storeClassPreInstrumentation(String className, byte[] classPreInstrumentation);
-
-	/**
-	 * Returns a byte array associated with a class pre instrumentation.
-	 * @param className
-	 *           the name of the class to get pre instrumentation data for.
-	 * @return a byte array of a class pre instrumentation.
-	 */
-	byte[] getClassPreInstrumentation(String className);
-
-	/**
 	 * Signify classes are or are not being reverted to their pre instrumentation versions.
 	 * @param shouldRevert
 	 *           true if class instrumentation should be reverted, false otherwise.

--- a/core/org.openjdk.jmc.agent/src/main/java/org/openjdk/jmc/agent/Transformer.java
+++ b/core/org.openjdk.jmc.agent/src/main/java/org/openjdk/jmc/agent/Transformer.java
@@ -60,12 +60,9 @@ public class Transformer implements ClassFileTransformer {
 		ClassLoader loader, String className, Class<?> classBeingRedefined, ProtectionDomain protectionDomain,
 		byte[] classfileBuffer) throws IllegalClassFormatException {
 		if (!registry.hasPendingTransforms(className)) {
-			return registry.isRevertIntrumentation() ? registry.getClassPreInstrumentation(className) : null;
+			return registry.isRevertIntrumentation() ? classfileBuffer : null;
 		}
-		registry.storeClassPreInstrumentation(className, classfileBuffer);
-		byte[] instrumentedClassfileBuffer = registry.isRevertIntrumentation() ?
-				registry.getClassPreInstrumentation(className) : classfileBuffer;
-		return doTransforms(registry.getTransformData(className), instrumentedClassfileBuffer, loader, protectionDomain);
+		return doTransforms(registry.getTransformData(className), classfileBuffer, loader, protectionDomain);
 	}
 
 	private byte[] doTransforms(

--- a/core/org.openjdk.jmc.agent/src/main/java/org/openjdk/jmc/agent/impl/DefaultTransformRegistry.java
+++ b/core/org.openjdk.jmc.agent/src/main/java/org/openjdk/jmc/agent/impl/DefaultTransformRegistry.java
@@ -72,8 +72,6 @@ public class DefaultTransformRegistry implements TransformRegistry {
 	// First step in update should be to check if we even have transformations for the given class
 	private final HashMap<String, List<TransformDescriptor>> transformData = new HashMap<>();
 
-	// Maps class name -> pre instrumentation version of a class
-	private final HashMap<String, byte[]> preInstrumentedClasses = new HashMap<>();
 	private volatile boolean revertInstrumentation = false;
 
 	@Override
@@ -404,16 +402,6 @@ public class DefaultTransformRegistry implements TransformRegistry {
 		List<String> classNames = new ArrayList<>(transformData.keySet());
 		transformData.clear();
 		return classNames;
-	}
-
-	public void storeClassPreInstrumentation(String className, byte[] classPreInstrumentation) {
-		if(!preInstrumentedClasses.containsKey(className)) {
-			preInstrumentedClasses.put(className, classPreInstrumentation.clone());
-		}
-	}
-
-	public byte[] getClassPreInstrumentation(String className) {
-		return preInstrumentedClasses.get(className);
 	}
 
 	public void setRevertInstrumentation(boolean shouldRevert) {

--- a/core/org.openjdk.jmc.agent/src/test/java/org/openjdk/jmc/agent/test/TestSetTransforms.java
+++ b/core/org.openjdk.jmc.agent/src/test/java/org/openjdk/jmc/agent/test/TestSetTransforms.java
@@ -33,37 +33,53 @@
  */
 package org.openjdk.jmc.agent.test;
 
-import static org.junit.Assert.assertNotNull;
-
-import java.io.PrintWriter;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import java.lang.management.ManagementFactory;
-import java.util.logging.Level;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
 
 import javax.management.MBeanServer;
 import javax.management.ObjectName;
 
 import org.junit.Test;
 import org.objectweb.asm.ClassReader;
-import org.objectweb.asm.util.CheckClassAdapter;
-import org.objectweb.asm.util.TraceClassVisitor;
-import org.openjdk.jmc.agent.Agent;
-import org.openjdk.jmc.agent.test.util.TestToolkit;
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.commons.AdviceAdapter;
+import org.openjdk.jmc.agent.Method;
+import org.openjdk.jmc.agent.Parameter;
+import org.openjdk.jmc.agent.ReturnValue;
+import org.openjdk.jmc.agent.jfr.JFRTransformDescriptor;
+import org.openjdk.jmc.agent.jfrnext.impl.JFRNextEventClassGenerator;
+import org.openjdk.jmc.agent.util.TypeUtils;
 
 public class TestSetTransforms {
 
 	private static final String AGENT_OBJECT_NAME = "org.openjdk.jmc.jfr.agent:type=AgentController"; //$NON-NLS-1$
+	private static final String EVENT_ID = "demo.jfr.test6";
+	private static final String EVENT_NAME = "JFR Hello World Event 6 %TEST_NAME%";
+	private static final String EVENT_DESCRIPTION = "JFR Hello World Event 6 %TEST_NAME%";
+	private static final String EVENT_PATH = "demo/jfrhelloworldevent6";
+	private static final String EVENT_CLASS_NAME = "org.openjdk.jmc.agent.test.InstrumentMe";
+	private static final String METHOD_NAME = "printHelloWorldJFR6";
+	private static final String METHOD_DESCRIPTOR = "()D";
 
 	private static final String XML_DESCRIPTION = "<jfragent>"
 			+ "<events>"
-			+ "<event id=\"demo.jfr.test1\">"
-			+ "<name>JFR Hello World Event 1 %TEST_NAME%</name>"
-			+ "<description>Defined in the xml file and added by the agent.</description>"
-			+ "<path>demo/jfrhelloworldevent1</path>"
+			+ "<event id=\"" + EVENT_ID + "\">"
+			+ "<name>" + EVENT_NAME + "</name>"
+			+ "<description>" + EVENT_DESCRIPTION + "</description>"
+			+ "<path>" + EVENT_PATH + "</path>"
 			+ "<stacktrace>true</stacktrace>"
-			+ "<class>org.openjdk.jmc.agent.test.InstrumentMe</class>"
+			+ "<class>" + EVENT_CLASS_NAME + "</class>"
 			+ "<method>"
-			+ "<name>printHelloWorldJFR1</name>"
-			+ "<descriptor>()V</descriptor>"
+			+ "<name>" + METHOD_NAME + "</name>"
+			+ "<descriptor>" + METHOD_DESCRIPTOR + "</descriptor>"
 			+ "</method>"
 			+ "<location>WRAP</location>"
 			+ "</event>"
@@ -72,40 +88,84 @@ public class TestSetTransforms {
 
 	@Test
 	public void testSetTransforms() throws Exception {
-		// Invoke retransform
-		MBeanServer mbs = ManagementFactory.getPlatformMBeanServer();
-		ObjectName name = new ObjectName(AGENT_OBJECT_NAME);
-		Object[] parameters = {XML_DESCRIPTION};
-		String[] signature = {String.class.getName()};
-		Class<?>[] clazzes = (Class<?>[]) mbs.invoke(name, "setTransforms", parameters, signature);
-		assertNotNull(clazzes);
-		if (Agent.getLogger().isLoggable(Level.FINE)) {
-			for (Class<?> clazz : clazzes) {
-				// If we've asked for verbose information, we write the generated class
-				TraceClassVisitor visitor = new TraceClassVisitor(new PrintWriter(System.out));
-				new CheckClassAdapter(visitor);
-				new ClassReader(TestToolkit.getByteCode(clazz));
-			}
+		boolean excpetionThrown = false;
+		try {
+			InstrumentMe.printHelloWorldJFR6();
+		} catch (Exception e) {
+			e.printStackTrace(System.err);
+			excpetionThrown = true;
 		}
+		assertFalse(excpetionThrown);
+
+		injectFailingEvent();
+		doSetTransfroms(XML_DESCRIPTION);
+		try {
+			InstrumentMe.printHelloWorldJFR6();
+		} catch (RuntimeException e) {
+			excpetionThrown = true;
+		}
+		assertTrue(excpetionThrown);
+
+		doSetTransfroms("");
+		try {
+			InstrumentMe.printHelloWorldJFR6();
+			excpetionThrown = false;
+		} catch (Exception e) {
+			e.printStackTrace(System.err);
+		}
+		assertFalse(excpetionThrown);
 	}
 
-	@Test
-	public void testClearAllTransforms() throws Exception {
-		// Invoke retransform
-		MBeanServer mbs = ManagementFactory.getPlatformMBeanServer();
-		ObjectName name = new ObjectName(AGENT_OBJECT_NAME);
-		Object[] parameters = {""};
-		String[] signature = {String.class.getName()};
-		Class<?>[] clazzes = (Class<?>[]) mbs.invoke(name, "setTransforms", parameters, signature);
-		assertNotNull(clazzes);
-		if (Agent.getLogger().isLoggable(Level.FINE)) {
-			for (Class<?> clazz : clazzes) {
-				// If we've asked for verbose information, we write the generated class
-				TraceClassVisitor visitor = new TraceClassVisitor(new PrintWriter(System.out));
-				new CheckClassAdapter(visitor);
-				new ClassReader(TestToolkit.getByteCode(clazz));
+	private void injectFailingEvent() throws Exception {
+		Method method = new Method(METHOD_NAME, METHOD_DESCRIPTOR);
+		Map<String, String> attributes = new HashMap<String, String>();
+		attributes.put("path", EVENT_PATH);
+		attributes.put("name", EVENT_NAME);
+		attributes.put("description", EVENT_DESCRIPTION);
+		ReturnValue retVal = new ReturnValue(null, "", null);
+		JFRTransformDescriptor eventTd = new JFRTransformDescriptor(EVENT_ID,
+				EVENT_CLASS_NAME.replace(".", "/"), method, attributes, new ArrayList<Parameter>(), retVal);
+
+		ClassWriter classWriter = new ClassWriter(ClassWriter.COMPUTE_MAXS);
+		ClassVisitor classVisitor = new ClassVisitor(Opcodes.ASM5, classWriter) {
+			@Override
+			public MethodVisitor visitMethod(int access, String name, String desc, String signature,
+					String[] exceptions) {
+				MethodVisitor mv = super.visitMethod(access, name, desc, signature, exceptions);
+				if (!name.equals("<init>")) {
+					return mv;
+				}
+				return new AdviceAdapter(Opcodes.ASM5, mv, access, name, "()V") {
+					@Override
+					protected void onMethodExit(int opcode) {
+						mv.visitTypeInsn(Opcodes.NEW, "java/lang/RuntimeException");
+						mv.visitInsn(Opcodes.DUP);
+						mv.visitMethodInsn(Opcodes.INVOKESPECIAL, "java/lang/RuntimeException", "<init>", "()V", false); //$NON-NLS-1$ //$NON-NLS-2$
+						mv.visitInsn(Opcodes.ATHROW);
+
+						mv.visitFrame(F_NEW, 0, new Object[0], 0, new Object[0]);
+						mv.visitInsn(Opcodes.ACONST_NULL);
+					}
+				};
 			}
-		}
+		};
+
+		byte[] eventClass = JFRNextEventClassGenerator.generateEventClass(eventTd);
+		ClassReader reader = new ClassReader(eventClass);
+		reader.accept(classVisitor, 0);
+		byte[] modifiedEvent = classWriter.toByteArray();
+
+		TypeUtils.defineClass(eventTd.getEventClassName(), modifiedEvent, 0, modifiedEvent.length,
+				ClassLoader.getSystemClassLoader(), null);
+	}
+
+	private void doSetTransfroms(String xmlDescription) throws Exception  {
+		ObjectName name = new ObjectName(AGENT_OBJECT_NAME);
+		Object[] parameters = {xmlDescription};
+		String[] signature = {String.class.getName()};
+
+		MBeanServer mbs = ManagementFactory.getPlatformMBeanServer();
+		mbs.invoke(name, "setTransforms", parameters, signature);
 	}
 
 	public void test() {

--- a/core/org.openjdk.jmc.agent/src/test/java/org/openjdk/jmc/agent/test/TestSetTransforms.java
+++ b/core/org.openjdk.jmc.agent/src/test/java/org/openjdk/jmc/agent/test/TestSetTransforms.java
@@ -88,32 +88,32 @@ public class TestSetTransforms {
 
 	@Test
 	public void testSetTransforms() throws Exception {
-		boolean excpetionThrown = false;
+		boolean exceptionThrown = false;
 		try {
 			InstrumentMe.printHelloWorldJFR6();
 		} catch (Exception e) {
 			e.printStackTrace(System.err);
-			excpetionThrown = true;
+			exceptionThrown = true;
 		}
-		assertFalse(excpetionThrown);
+		assertFalse(exceptionThrown);
 
 		injectFailingEvent();
-		doSetTransfroms(XML_DESCRIPTION);
+		doSetTransforms(XML_DESCRIPTION);
 		try {
 			InstrumentMe.printHelloWorldJFR6();
 		} catch (RuntimeException e) {
-			excpetionThrown = true;
+			exceptionThrown = true;
 		}
-		assertTrue(excpetionThrown);
+		assertTrue(exceptionThrown);
 
-		doSetTransfroms("");
+		doSetTransforms("");
 		try {
 			InstrumentMe.printHelloWorldJFR6();
-			excpetionThrown = false;
+			exceptionThrown = false;
 		} catch (Exception e) {
 			e.printStackTrace(System.err);
 		}
-		assertFalse(excpetionThrown);
+		assertFalse(exceptionThrown);
 	}
 
 	private void injectFailingEvent() throws Exception {
@@ -159,7 +159,7 @@ public class TestSetTransforms {
 				ClassLoader.getSystemClassLoader(), null);
 	}
 
-	private void doSetTransfroms(String xmlDescription) throws Exception  {
+	private void doSetTransforms(String xmlDescription) throws Exception  {
 		ObjectName name = new ObjectName(AGENT_OBJECT_NAME);
 		Object[] parameters = {xmlDescription};
 		String[] signature = {String.class.getName()};


### PR DESCRIPTION
This patch addresses [JMC-6658](https://bugs.openjdk.java.net/browse/JMC-6658) and removes the unnecessary storing of pre-instrumented bytecode that was implemented in [JMC-5458](https://bugs.openjdk.java.net/browse/JMC-5458).
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

## Issue
[JMC-6658](https://bugs.openjdk.java.net/browse/JMC-6658): Remove unnecessary storing of pre-instrumented bytecode


## Approvers
 * Marcus Hirt ([hirt](@thegreystone) - **Reviewer**)