### PR TITLE
6663: Reloading the Flame Chart View in Linux displays file browser

### DIFF
--- a/application/org.openjdk.jmc.flightrecorder.flameview/src/main/java/org/openjdk/jmc/flightrecorder/flameview/views/FlameGraphView.java
+++ b/application/org.openjdk.jmc.flightrecorder.flameview/src/main/java/org/openjdk/jmc/flightrecorder/flameview/views/FlameGraphView.java
@@ -56,6 +56,8 @@ import org.eclipse.swt.browser.Browser;
 import org.eclipse.swt.browser.ProgressAdapter;
 import org.eclipse.swt.browser.ProgressEvent;
 import org.eclipse.swt.custom.SashForm;
+import org.eclipse.swt.events.MenuDetectEvent;
+import org.eclipse.swt.events.MenuDetectListener;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.ui.IMemento;
 import org.eclipse.ui.ISelectionListener;
@@ -162,6 +164,12 @@ public class FlameGraphView extends ViewPart implements ISelectionListener {
 		container = new SashForm(parent, SWT.HORIZONTAL);
 		browser = new Browser(container, SWT.NONE);
 		container.setMaximizedControl(browser);
+		browser.addMenuDetectListener(new MenuDetectListener() {
+			@Override
+			public void menuDetected(MenuDetectEvent e) {
+				e.doit = false;
+			}
+		});
 	}
 
 	@Override


### PR DESCRIPTION
The context menu to reload is disabled

The disable comes from looking at Webkit source that respects doit field:
https://github.com/eclipse/eclipse.platform.swt/blob/master/bundles/org.eclipse.swt/Eclipse%20SWT%20WebKit/gtk/org/eclipse/swt/browser/WebKit.java#L819

The issue occurs as we set Browser text to some HTML and no URL is set. The reload action seems to revisit the URL with the default result being the file system, I guess.

A bug against SWT was opened to respect HTML text set when refresh/reload.
https://bugs.eclipse.org/bugs/show_bug.cgi?id=558846
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

## Issue
[JMC-6663](https://bugs.openjdk.java.net/browse/JMC-6663): Reloading the Flame Chart View in Linux displays file browser


## Approvers
 * Marcus Hirt ([hirt](@thegreystone) - **Reviewer**)