### PR TITLE
6659: Remove 'Showing X of Y events...' table message when not applicable

### DIFF
--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/common/ExtraRowTableViewer.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/common/ExtraRowTableViewer.java
@@ -60,6 +60,10 @@ public class ExtraRowTableViewer extends TableViewer {
 		this.message = message;
 	}
 
+	public long getNumRowsDisplayed() {
+		return getFilteredChildren(getInput()).length;
+	}
+
 	@Override
 	public void refresh(Object element) {
 		if (message == null) {
@@ -93,10 +97,6 @@ public class ExtraRowTableViewer extends TableViewer {
 	}
 
 	private void createExtraRow() {
-		long maxNumRows = FlightRecorderUI.getDefault().getItemListSize().longValue();
-		if (getFilteredChildren(getInput()).length < maxNumRows) {
-			return;
-		}
 		extraRow = new TableItem(getTable(), SWT.NO_BACKGROUND | SWT.NO_FOCUS);
 		extraRow.setText(message);
 	}

--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/common/ExtraRowTableViewer.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/common/ExtraRowTableViewer.java
@@ -93,6 +93,10 @@ public class ExtraRowTableViewer extends TableViewer {
 	}
 
 	private void createExtraRow() {
+		long maxNumRows = FlightRecorderUI.getDefault().getItemListSize().longValue();
+		if (getFilteredChildren(getInput()).length < maxNumRows) {
+			return;
+		}
 		extraRow = new TableItem(getTable(), SWT.NO_BACKGROUND | SWT.NO_FOCUS);
 		extraRow.setText(message);
 	}

--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/common/FilterComponent.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/common/FilterComponent.java
@@ -39,6 +39,8 @@ import java.util.stream.Stream;
 import org.eclipse.jface.action.IAction;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.SashForm;
+import org.eclipse.swt.events.ModifyEvent;
+import org.eclipse.swt.events.ModifyListener;
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.RGB;
 import org.eclipse.swt.layout.GridData;
@@ -88,8 +90,10 @@ public class FilterComponent {
 	public static FilterComponent createFilterComponent(
 		ItemList list, IItemFilter filter, IItemCollection items, Supplier<Stream<SelectionStoreEntry>> selections,
 		Consumer<IItemFilter> onSelect) {
-		return createFilterComponent(list.getManager().getViewer().getControl(), list.getManager(), filter, items,
+		FilterComponent fc = createFilterComponent(list.getManager().getViewer().getControl(), list.getManager(), filter, items,
 				selections, onSelect);
+		fc.addItemListSearchListener(list);
+		return fc;
 	}
 
 	public static FilterComponent createFilterComponent(
@@ -178,6 +182,15 @@ public class FilterComponent {
 
 	public SashForm getComponent() {
 		return mainSash;
+	}
+
+	private void addItemListSearchListener(ItemList itemList) {
+		searchText.addModifyListener(new ModifyListener() {
+			@Override
+			public void modifyText(ModifyEvent e) {
+				itemList.onSearchFilterChange();
+			}
+		});
 	}
 
 	private IAction createShowSearchAction() {

--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/common/FilterComponent.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/common/FilterComponent.java
@@ -90,8 +90,8 @@ public class FilterComponent {
 	public static FilterComponent createFilterComponent(
 		ItemList list, IItemFilter filter, IItemCollection items, Supplier<Stream<SelectionStoreEntry>> selections,
 		Consumer<IItemFilter> onSelect) {
-		FilterComponent fc = createFilterComponent(list.getManager().getViewer().getControl(), list.getManager(), filter, items,
-				selections, onSelect);
+		FilterComponent fc = createFilterComponent(list.getManager().getViewer().getControl(), list.getManager(),
+				filter, items, selections, onSelect);
 		fc.addItemListSearchListener(list);
 		return fc;
 	}

--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/common/ItemList.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/common/ItemList.java
@@ -207,6 +207,16 @@ public class ItemList {
 		tableViewer.setExtraMessage(null);
 	}
 
+	public void onSearchFilterChange() {
+		long numRows = tableViewer.getNumRowsDisplayed();
+		if (numRows < maxSize) {
+			clearEllipsisMessage();
+		} else {
+			setEllipsisMessage();
+		}
+		tableViewer.refresh();
+	}
+
 	/**
 	 * Construct an identifier that can be used when persisting column state.
 	 *


### PR DESCRIPTION
This patch addresses the following issue: 

When a table made with an itemList has more rows than the set maximum that can be shown, it displays a message "Showing X of Y events..." in its last row. This message is not removed if a search is performed on the table that results in fewer then the maximum number of events being displayed. For example, this is seen in the Exceptions page in the Event Log table.
![table-example](https://user-images.githubusercontent.com/29706926/72159945-6cf9c380-338b-11ea-9f32-0fd3a6654709.png)

This patch makes the 'Showing X of Y events...'  table message disappear when less than the maximum number of events that can be displayed populate a table.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

## Issue
[JMC-6659](https://bugs.openjdk.java.net/browse/JMC-6659): Update the "Showing X of Y events..." 


## Approvers
 * Marcus Hirt ([hirt](@thegreystone) - **Reviewer**)