### PR TITLE
6671: Eagerly convert end time to the same unit as start time

### DIFF
--- a/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/internal/util/DisjointBuilder.java
+++ b/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/internal/util/DisjointBuilder.java
@@ -114,7 +114,7 @@ public class DisjointBuilder<T> {
 
 	public void add(T e) {
 		IQuantity start = startAccessor.getMember(e);
-		IQuantity end = endAccessor.getMember(e);
+		IQuantity end = endAccessor.getMember(e).in(start.getUnit());
 		if (noLanes == 0) {
 			addToNewLane(e, start, end);
 		} else if (!lanes[0].accept(e, start, end)) {


### PR DESCRIPTION
Set event end time to use the same unit as start time when accessing the values, rather than when comparing between them.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

## Issue
[JMC-6671](https://bugs.openjdk.java.net/browse/JMC-6671): DisjointBuilder is slow for large quantities of duration events


## Approvers
 * Marcus Hirt ([hirt](@thegreystone) - **Reviewer**)