### PR TITLE
6660: Make JMX API not return classes

### DIFF
--- a/core/org.openjdk.jmc.agent/README.md
+++ b/core/org.openjdk.jmc.agent/README.md
@@ -26,7 +26,7 @@ java --add-opens java.base/jdk.internal.misc=ALL-UNNAMED -XX:+FlightRecorder -ja
 ```
 
 ## Interacting with the agent
-At runtime the agent can be used to modify the transformed state of a class. To specify a desired state, supply the setTransforms function with a XML description of transformations to keep or modify, and leave out all those that should be reverted to their preinstrumentation versions.
+At runtime the agent can be used to modify the transformed state of a class. To specify a desired state, supply the defineEventProbes function with a XML description of event probes to add, keep or modify, and leave out all those that should be reverted to their preinstrumentation versions.
 
 ## Known Issues
 * The full converter support is still to be merged into the open source repo

--- a/core/org.openjdk.jmc.agent/pom.xml
+++ b/core/org.openjdk.jmc.agent/pom.xml
@@ -99,7 +99,7 @@
 				<configuration>
 					<argLine> --add-opens java.base/jdk.internal.misc=ALL-UNNAMED
 						-XX:+FlightRecorder</argLine>
-					<excludes>TestSetTransforms.java</excludes>
+					<excludes>TestDefineEventProbes.java</excludes>
 				</configuration>
 			</plugin>
 			<plugin>
@@ -118,7 +118,7 @@
 					<argLine> --add-opens java.base/jdk.internal.misc=ALL-UNNAMED
 						-XX:+FlightRecorder -javaagent:target/org.openjdk.jmc.agent-1.0.0-SNAPSHOT.jar=target/test-classes/org/openjdk/jmc/agent/test/jfrprobes_template.xml
 						 -cp target/org.openjdk.jmc.agent-1.0.0-SNAPSHOT.jar:target/test-classes/ </argLine>
-					<includes>TestSetTransforms.java</includes>
+					<includes>TestDefineEventProbes.java</includes>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/core/org.openjdk.jmc.agent/src/main/java/org/openjdk/jmc/agent/jmx/AgentController.java
+++ b/core/org.openjdk.jmc.agent/src/main/java/org/openjdk/jmc/agent/jmx/AgentController.java
@@ -53,7 +53,7 @@ public class AgentController implements AgentControllerMBean {
 		this.registry = registry;
 	}
 
-	public Class<?>[] setTransforms(String xmlDescription) throws Exception{
+	public void defineEventProbes(String xmlDescription) throws Exception{
 		HashSet<Class<?>> classesToRetransform = new HashSet<Class<?>>();
 		boolean revertAll = xmlDescription == null ? true : xmlDescription.isEmpty();
 		if (revertAll) {
@@ -71,7 +71,7 @@ public class AgentController implements AgentControllerMBean {
 			boolean noDescriptors = descriptors == null ? true : descriptors.isEmpty();
 			if (noDescriptors) {
 				logger.log(Level.SEVERE, "Failed to identify transformations: " + xmlDescription);
-				return null;
+				return;
 			}
 			for (TransformDescriptor descriptor : descriptors) {
 				try {
@@ -88,7 +88,5 @@ public class AgentController implements AgentControllerMBean {
 		registry.setRevertInstrumentation(true);
 		instrumentation.retransformClasses(classesToRetransformArray);
 		registry.setRevertInstrumentation(false);
-
-		return classesToRetransformArray;
 	}
 }

--- a/core/org.openjdk.jmc.agent/src/main/java/org/openjdk/jmc/agent/jmx/AgentControllerMBean.java
+++ b/core/org.openjdk.jmc.agent/src/main/java/org/openjdk/jmc/agent/jmx/AgentControllerMBean.java
@@ -33,5 +33,5 @@
 package org.openjdk.jmc.agent.jmx;
 
 public interface AgentControllerMBean {
-	public Class<?>[] setTransforms(String xmlDescription) throws Exception;
+	public void defineEventProbes(String xmlDescription) throws Exception;
 }

--- a/core/org.openjdk.jmc.agent/src/test/java/org/openjdk/jmc/agent/test/TestDefineEventProbes.java
+++ b/core/org.openjdk.jmc.agent/src/test/java/org/openjdk/jmc/agent/test/TestDefineEventProbes.java
@@ -58,7 +58,7 @@ import org.openjdk.jmc.agent.jfr.JFRTransformDescriptor;
 import org.openjdk.jmc.agent.jfrnext.impl.JFRNextEventClassGenerator;
 import org.openjdk.jmc.agent.util.TypeUtils;
 
-public class TestSetTransforms {
+public class TestDefineEventProbes {
 
 	private static final String AGENT_OBJECT_NAME = "org.openjdk.jmc.jfr.agent:type=AgentController"; //$NON-NLS-1$
 	private static final String EVENT_ID = "demo.jfr.test6";
@@ -87,7 +87,7 @@ public class TestSetTransforms {
 			+ "</jfragent>";
 
 	@Test
-	public void testSetTransforms() throws Exception {
+	public void testDefineEventProbes() throws Exception {
 		boolean exceptionThrown = false;
 		try {
 			InstrumentMe.printHelloWorldJFR6();
@@ -98,7 +98,7 @@ public class TestSetTransforms {
 		assertFalse(exceptionThrown);
 
 		injectFailingEvent();
-		doSetTransforms(XML_DESCRIPTION);
+		doDefineEventProbes(XML_DESCRIPTION);
 		try {
 			InstrumentMe.printHelloWorldJFR6();
 		} catch (RuntimeException e) {
@@ -106,7 +106,7 @@ public class TestSetTransforms {
 		}
 		assertTrue(exceptionThrown);
 
-		doSetTransforms("");
+		doDefineEventProbes("");
 		try {
 			InstrumentMe.printHelloWorldJFR6();
 			exceptionThrown = false;
@@ -159,13 +159,13 @@ public class TestSetTransforms {
 				ClassLoader.getSystemClassLoader(), null);
 	}
 
-	private void doSetTransforms(String xmlDescription) throws Exception  {
+	private void doDefineEventProbes(String xmlDescription) throws Exception  {
 		ObjectName name = new ObjectName(AGENT_OBJECT_NAME);
 		Object[] parameters = {xmlDescription};
 		String[] signature = {String.class.getName()};
 
 		MBeanServer mbs = ManagementFactory.getPlatformMBeanServer();
-		mbs.invoke(name, "setTransforms", parameters, signature);
+		mbs.invoke(name, "defineEventProbes", parameters, signature);
 	}
 
 	public void test() {


### PR DESCRIPTION
This patch modifies the JMX API so that functions return void instead of class arrays.

The name of the function setTransforms was also changed to defineEventProbes as a result of this change because an mbean function whose name begins with "set", has one parameter and a return type of void, gets registered as a setter not an operation.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

## Issue
[JMC-6660](https://bugs.openjdk.java.net/browse/JMC-6660): Agent JMX API should not return classes


## Approvers
 * Marcus Hirt ([hirt](@thegreystone) - **Reviewer**)