### PR TITLE
6674: Use try-with-resource in more places and close un-closed resources

### DIFF
--- a/application/org.openjdk.jmc.console.jconsole/src/main/java/org/openjdk/jmc/console/jconsole/JConsolePluginLoader.java
+++ b/application/org.openjdk.jmc.console.jconsole/src/main/java/org/openjdk/jmc/console/jconsole/JConsolePluginLoader.java
@@ -92,8 +92,9 @@ public class JConsolePluginLoader {
 	private static void initPluginService(File file) throws IOException {
 		String[] files = file.list();
 		if (files != null && files.length > 0) {
-			pluginService = ServiceLoader.load(JConsolePlugin.class,
-					new URLClassLoader(getURLs(file), Activator.class.getClassLoader()));
+			try (URLClassLoader loader = new URLClassLoader(getURLs(file), Activator.class.getClassLoader())) {
+				pluginService = ServiceLoader.load(JConsolePlugin.class, loader);
+			}
 		}
 	}
 

--- a/application/org.openjdk.jmc.console.ui.notification/src/main/java/org/openjdk/jmc/console/ui/notification/action/TriggerActionStartTimeBoundRecording.java
+++ b/application/org.openjdk.jmc.console.ui.notification/src/main/java/org/openjdk/jmc/console/ui/notification/action/TriggerActionStartTimeBoundRecording.java
@@ -181,11 +181,8 @@ public class TriggerActionStartTimeBoundRecording extends TriggerAction implemen
 	private File dumpFile(
 		IProgressMonitor monitor, IFlightRecorderService service, IRecordingDescriptor descriptor, MCFile path)
 			throws IOException, FlightRecorderException {
-		InputStream stream = service.openStream(descriptor, false);
-		try {
+		try (InputStream stream = service.openStream(descriptor, false)) {
 			return IDESupportToolkit.writeToUniqueFile(path, stream, monitor);
-		} finally {
-			IOToolkit.closeSilently(stream);
 		}
 	}
 

--- a/application/org.openjdk.jmc.console.ui.notification/src/main/java/org/openjdk/jmc/console/ui/notification/action/WriteAndOpenRecordingJob.java
+++ b/application/org.openjdk.jmc.console.ui.notification/src/main/java/org/openjdk/jmc/console/ui/notification/action/WriteAndOpenRecordingJob.java
@@ -121,11 +121,8 @@ public class WriteAndOpenRecordingJob extends Job {
 
 	private File writeFile(IProgressMonitor monitor, IRecordingDescriptor descriptor, IQuantity duration)
 			throws FlightRecorderException, IOException {
-		InputStream stream = service.openStream(descriptor, duration, false);
-		try {
+		try (InputStream stream = service.openStream(descriptor, duration, false)) {
 			return IDESupportToolkit.writeToUniqueFile(path, stream, monitor);
-		} finally {
-			IOToolkit.closeSilently(stream);
 		}
 	}
 }

--- a/application/org.openjdk.jmc.console.ui.notification/src/main/java/org/openjdk/jmc/console/ui/notification/tab/TriggerToolkit.java
+++ b/application/org.openjdk.jmc.console.ui.notification/src/main/java/org/openjdk/jmc/console/ui/notification/tab/TriggerToolkit.java
@@ -103,11 +103,10 @@ public class TriggerToolkit {
 	 *         successfully
 	 */
 	public static IStatus resetTriggers(NotificationRegistry model) {
-		InputStream stream = null;
-		try {
-			// Load DOM for default triggers
-			stream = NotificationPlugin.class.getResourceAsStream(NotificationPlugin.DEFAULT_TRIGGER_FILE);
-			Document doc = XmlToolkit.loadDocumentFromStream(new BufferedInputStream(stream));
+		// Load DOM for default triggers
+		try (InputStream stream = NotificationPlugin.class.getResourceAsStream(NotificationPlugin.DEFAULT_TRIGGER_FILE);
+				BufferedInputStream bis = new BufferedInputStream(stream)) {
+			Document doc = XmlToolkit.loadDocumentFromStream(bis);
 			Collection<TriggerRule> c = model.getAvailableRules();
 
 			// Remove all rules
@@ -124,8 +123,6 @@ public class TriggerToolkit {
 		} catch (Exception exc) {
 			return StatusFactory.createErr(NLS.bind(Messages.TriggerToolkit_ERROR_COULD_NOT_READ_DEFAULT_TEMPLATE_FILE,
 					NotificationPlugin.DEFAULT_TRIGGER_FILE), exc, false);
-		} finally {
-			IOToolkit.closeSilently(stream);
 		}
 		return StatusFactory.createOk(Messages.TriggerToolkit_MESSAGE_DEFAULT_TRIGGERS_LOADED);
 	}

--- a/application/org.openjdk.jmc.flightrecorder.controlpanel.ui.configuration/src/main/java/org/openjdk/jmc/flightrecorder/controlpanel/ui/configuration/model/xml/XMLModel.java
+++ b/application/org.openjdk.jmc.flightrecorder.controlpanel.ui.configuration/src/main/java/org/openjdk/jmc/flightrecorder/controlpanel/ui/configuration/model/xml/XMLModel.java
@@ -259,9 +259,10 @@ public final class XMLModel extends Observable {
 		// NOTE: The pretty printer writes that the encoding is UTF-8, so we must make sure it is.
 		// Ensure charset exists before opening file for writing.
 		Charset charset = Charset.forName("UTF-8"); //$NON-NLS-1$
-		Writer osw = new OutputStreamWriter(new FileOutputStream(file), charset);
+		try (Writer osw = new OutputStreamWriter(new FileOutputStream(file), charset)) {
 		if (writeTo(osw)) {
 			setDirty(false);
+		}
 		}
 	}
 
@@ -275,15 +276,12 @@ public final class XMLModel extends Observable {
 	 * @return true iff the model was successfully written to the {@link Writer}.
 	 */
 	public boolean writeTo(Writer writer) {
-		PrintWriter pw = new PrintWriter(writer);
-		try {
+		try (PrintWriter pw = new PrintWriter(writer)) {
 			PrettyPrinter pp = new PrettyPrinter(pw, m_validator.getElementsTooKeepOnOneLine());
 			pp.print(this);
 			pw.flush();
 			// PrintWriter never throws any exceptions, so this is how we find out if something went wrong.
 			return !pw.checkError();
-		} finally {
-			IOToolkit.closeSilently(pw);
 		}
 	}
 

--- a/application/org.openjdk.jmc.flightrecorder.controlpanel.ui.configuration/src/main/java/org/openjdk/jmc/flightrecorder/controlpanel/ui/configuration/model/xml/XMLModel.java
+++ b/application/org.openjdk.jmc.flightrecorder.controlpanel.ui.configuration/src/main/java/org/openjdk/jmc/flightrecorder/controlpanel/ui/configuration/model/xml/XMLModel.java
@@ -260,9 +260,9 @@ public final class XMLModel extends Observable {
 		// Ensure charset exists before opening file for writing.
 		Charset charset = Charset.forName("UTF-8"); //$NON-NLS-1$
 		try (Writer osw = new OutputStreamWriter(new FileOutputStream(file), charset)) {
-		if (writeTo(osw)) {
-			setDirty(false);
-		}
+			if (writeTo(osw)) {
+				setDirty(false);
+			}
 		}
 	}
 

--- a/application/org.openjdk.jmc.flightrecorder.controlpanel.ui/src/main/java/org/openjdk/jmc/flightrecorder/controlpanel/ui/actions/DumpAnyRecordingAction.java
+++ b/application/org.openjdk.jmc.flightrecorder.controlpanel.ui/src/main/java/org/openjdk/jmc/flightrecorder/controlpanel/ui/actions/DumpAnyRecordingAction.java
@@ -62,7 +62,8 @@ public class DumpAnyRecordingAction extends AbstractWizardUserAction {
 
 	@Override
 	public IWizard doCreateWizard() throws Exception {
-		try (IConnectionHandle handle = flightRecorder.getServerHandle().connect(Messages.ACTION_DUMP_ANY_RECORDING_LABEL)) {
+		try (IConnectionHandle handle = flightRecorder.getServerHandle()
+				.connect(Messages.ACTION_DUMP_ANY_RECORDING_LABEL)) {
 			RecordingProvider recording = flightRecorder.getSnapshotRecording(handle);
 			if (recording != null) {
 				flightRecorder.resetWarning();

--- a/application/org.openjdk.jmc.flightrecorder.controlpanel.ui/src/main/java/org/openjdk/jmc/flightrecorder/controlpanel/ui/actions/DumpAnyRecordingAction.java
+++ b/application/org.openjdk.jmc.flightrecorder.controlpanel.ui/src/main/java/org/openjdk/jmc/flightrecorder/controlpanel/ui/actions/DumpAnyRecordingAction.java
@@ -62,9 +62,7 @@ public class DumpAnyRecordingAction extends AbstractWizardUserAction {
 
 	@Override
 	public IWizard doCreateWizard() throws Exception {
-		IConnectionHandle handle = null;
-		try {
-			handle = flightRecorder.getServerHandle().connect(Messages.ACTION_DUMP_ANY_RECORDING_LABEL);
+		try (IConnectionHandle handle = flightRecorder.getServerHandle().connect(Messages.ACTION_DUMP_ANY_RECORDING_LABEL)) {
 			RecordingProvider recording = flightRecorder.getSnapshotRecording(handle);
 			if (recording != null) {
 				flightRecorder.resetWarning();
@@ -77,8 +75,6 @@ public class DumpAnyRecordingAction extends AbstractWizardUserAction {
 		} catch (Exception e) {
 			flightRecorder.setWarning(e.getLocalizedMessage());
 			throw e;
-		} finally {
-			IOToolkit.closeSilently(handle);
 		}
 	}
 

--- a/application/org.openjdk.jmc.flightrecorder.controlpanel.ui/src/main/java/org/openjdk/jmc/flightrecorder/controlpanel/ui/actions/EditRecordingAction.java
+++ b/application/org.openjdk.jmc.flightrecorder.controlpanel.ui/src/main/java/org/openjdk/jmc/flightrecorder/controlpanel/ui/actions/EditRecordingAction.java
@@ -34,7 +34,6 @@ package org.openjdk.jmc.flightrecorder.controlpanel.ui.actions;
 
 import org.eclipse.jface.wizard.IWizard;
 
-import org.openjdk.jmc.common.io.IOToolkit;
 import org.openjdk.jmc.flightrecorder.controlpanel.ui.ControlPanel;
 import org.openjdk.jmc.flightrecorder.controlpanel.ui.ImageConstants;
 import org.openjdk.jmc.flightrecorder.controlpanel.ui.RecordingProvider;
@@ -60,14 +59,10 @@ public class EditRecordingAction extends AbstractWizardUserAction {
 
 	@Override
 	public IWizard doCreateWizard() throws Exception {
-		IConnectionHandle connection = null;
-		try {
-			connection = recording.getServerHandle().connect(Messages.ACTION_EDIT_RECORDING_LABEL);
+		try (IConnectionHandle connection = recording.getServerHandle().connect(Messages.ACTION_EDIT_RECORDING_LABEL)) {
 			return new EditRecordingWizard(recording,
 					new RecordingWizardModel(connection.getServiceOrThrow(IFlightRecorderService.class),
 							recording.getRecordingDescriptor(), recording.getDumpToFile()));
-		} finally {
-			IOToolkit.closeSilently(connection);
 		}
 	}
 

--- a/application/org.openjdk.jmc.flightrecorder.controlpanel.ui/src/main/java/org/openjdk/jmc/flightrecorder/controlpanel/ui/actions/StartRecordingAction.java
+++ b/application/org.openjdk.jmc.flightrecorder.controlpanel.ui/src/main/java/org/openjdk/jmc/flightrecorder/controlpanel/ui/actions/StartRecordingAction.java
@@ -60,9 +60,7 @@ public class StartRecordingAction extends AbstractWizardUserAction {
 
 	@Override
 	public IWizard doCreateWizard() throws Exception {
-		IConnectionHandle handle = null;
-		try {
-			handle = recorder.getServerHandle().connect(Messages.ACTION_START_RECORDING_LABEL);
+		try (IConnectionHandle handle = recorder.getServerHandle().connect(Messages.ACTION_START_RECORDING_LABEL)) {
 			IFlightRecorderService flrService = handle.getServiceOrNull(IFlightRecorderService.class);
 			if (flrService == null) {
 				throw new FlightRecorderException(JVMSupportToolkit.getNoFlightRecorderErrorMessage(handle, false));
@@ -78,8 +76,6 @@ public class StartRecordingAction extends AbstractWizardUserAction {
 		} catch (Exception e) {
 			recorder.setWarning(e.getLocalizedMessage());
 			throw e;
-		} finally {
-			IOToolkit.closeSilently(handle);
 		}
 	}
 

--- a/application/org.openjdk.jmc.flightrecorder.controlpanel.ui/src/main/java/org/openjdk/jmc/flightrecorder/controlpanel/ui/jobs/UpdateRecordingJob.java
+++ b/application/org.openjdk.jmc.flightrecorder.controlpanel.ui/src/main/java/org/openjdk/jmc/flightrecorder/controlpanel/ui/jobs/UpdateRecordingJob.java
@@ -69,9 +69,7 @@ public class UpdateRecordingJob extends Job {
 
 	@Override
 	protected IStatus run(IProgressMonitor monitor) {
-		IConnectionHandle connection = null;
-		try {
-			connection = m_server.connect(getName());
+		try (IConnectionHandle connection = m_server.connect(getName())) {
 			IFlightRecorderService flightRecorderService = connection.getServiceOrThrow(IFlightRecorderService.class);
 			flightRecorderService.updateRecordingOptions(m_recordingDescriptor, m_recordingOptions);
 			flightRecorderService.updateEventOptions(m_recordingDescriptor, m_recordingSettings);
@@ -80,8 +78,6 @@ public class UpdateRecordingJob extends Job {
 			ControlPanel.getDefault().getLogger().log(Level.WARNING, "Could not update recording", e); //$NON-NLS-1$
 			return StatusFactory.createErr(
 					NLS.bind(Messages.UPDATE_RECORDING_JOB_SERVICE_ERROR_MSG, m_recordingDescriptor.getName()));
-		} finally {
-			IOToolkit.closeSilently(connection);
 		}
 	}
 }

--- a/application/org.openjdk.jmc.flightrecorder.controlpanel.ui/src/main/java/org/openjdk/jmc/flightrecorder/controlpanel/ui/model/EventConfiguration.java
+++ b/application/org.openjdk.jmc.flightrecorder.controlpanel.ui/src/main/java/org/openjdk/jmc/flightrecorder/controlpanel/ui/model/EventConfiguration.java
@@ -116,7 +116,7 @@ public final class EventConfiguration implements IEventConfiguration {
 			if (schemaStream != null) {
 				SchemaFactory schemaFactory = SchemaFactory.newInstance("http://www.w3.org/2001/XMLSchema"); //$NON-NLS-1$
 				XMLModel.validate(xmlStream, streamName, schemaFactory.newSchema(new StreamSource(schemaStream)));
-	 		} else {
+			} else {
 				throw new IOException("Could not locate schema for version " + version); //$NON-NLS-1$
 			}
 		} catch (SAXException e) {

--- a/application/org.openjdk.jmc.flightrecorder.controlpanel.ui/src/main/java/org/openjdk/jmc/flightrecorder/controlpanel/ui/model/EventConfiguration.java
+++ b/application/org.openjdk.jmc.flightrecorder.controlpanel.ui/src/main/java/org/openjdk/jmc/flightrecorder/controlpanel/ui/model/EventConfiguration.java
@@ -112,18 +112,15 @@ public final class EventConfiguration implements IEventConfiguration {
 
 	public static void validate(InputStream xmlStream, String streamName, SchemaVersion version)
 			throws ParseException, IOException {
-		InputStream schemaStream = version.createSchemaStream();
-		if (schemaStream != null) {
-			try {
+		try (InputStream schemaStream = version.createSchemaStream()) {
+			if (schemaStream != null) {
 				SchemaFactory schemaFactory = SchemaFactory.newInstance("http://www.w3.org/2001/XMLSchema"); //$NON-NLS-1$
 				XMLModel.validate(xmlStream, streamName, schemaFactory.newSchema(new StreamSource(schemaStream)));
-			} catch (SAXException e) {
-				throw new IOException("Trouble parsing schema for version " + version, e); //$NON-NLS-1$
-			} finally {
-				IOToolkit.closeSilently(schemaStream);
+	 		} else {
+				throw new IOException("Could not locate schema for version " + version); //$NON-NLS-1$
 			}
-		} else {
-			throw new IOException("Could not locate schema for version " + version); //$NON-NLS-1$
+		} catch (SAXException e) {
+			throw new IOException("Trouble parsing schema for version " + version, e); //$NON-NLS-1$
 		}
 	}
 
@@ -141,7 +138,9 @@ public final class EventConfiguration implements IEventConfiguration {
 	}
 
 	public static XMLModel createModel(File file) throws FileNotFoundException, IOException, ParseException {
-		return createModel(new FileInputStream(file));
+		try (FileInputStream fis = new FileInputStream(file)) {
+			return createModel(fis);
+		}
 	}
 
 	public static XMLModel createModel(InputStream inStream) throws IOException, ParseException {

--- a/application/org.openjdk.jmc.flightrecorder.controlpanel.ui/src/main/java/org/openjdk/jmc/flightrecorder/controlpanel/ui/model/PrivateStorageDelegate.java
+++ b/application/org.openjdk.jmc.flightrecorder.controlpanel.ui/src/main/java/org/openjdk/jmc/flightrecorder/controlpanel/ui/model/PrivateStorageDelegate.java
@@ -90,12 +90,9 @@ public class PrivateStorageDelegate implements IConfigurationStorageDelegate {
 		try {
 			// Ensure charset exists before opening file for writing.
 			Charset charset = Charset.forName(CHARSET_UTF8);
-			Writer out = new OutputStreamWriter(new FileOutputStream(file), charset);
-			try {
+			try (Writer out = new OutputStreamWriter(new FileOutputStream(file), charset)) {
 				out.write(fileContent);
 				out.flush();
-			} finally {
-				IOToolkit.closeSilently(out);
 			}
 			return true;
 		} catch (IllegalCharsetNameException e) {

--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/RecordingLoader.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/RecordingLoader.java
@@ -166,17 +166,12 @@ public class RecordingLoader extends Job {
 		Runtime runtime = Runtime.getRuntime();
 		long availableMemory = runtime.maxMemory() - runtime.totalMemory() + runtime.freeMemory();
 		if (availableMemory > (zippedFileMemoryFactor * file.length())) { // Try load from stream
-			InputStream stream = IOToolkit.openUncompressedStream(file);
-			try {
+			try (InputStream stream = IOToolkit.openUncompressedStream(file)) {
 				boolean hideExperimentals = !FlightRecorderUI.getDefault().includeExperimentalEventsAndFields();
 				boolean ignoreTruncatedChunk = FlightRecorderUI.getDefault().allowIncompleteRecordingFile();
 				return FlightRecordingLoader.loadStream(stream, hideExperimentals, ignoreTruncatedChunk);
-			} catch (NotEnoughMemoryException e) {
+			} catch (NotEnoughMemoryException | OutOfMemoryError e) {
 				// Try to load part of the file
-			} catch (OutOfMemoryError e) {
-				// Try to load part of the file
-			} finally {
-				IOToolkit.closeSilently(stream);
 			}
 		}
 		String fileName = file.getName();
@@ -257,12 +252,9 @@ public class RecordingLoader extends Job {
 		boolean acceptUnzip = DialogToolkit.openQuestionOnUiThread(Messages.FILE_OPENER_ZIPPED_FILE_TITLE, MessageFormat
 				.format(Messages.FILE_OPENER_ZIPPED_FILE_TEXT, file.getName(), unzippedFile.getAbsolutePath()));
 		if (acceptUnzip) {
-			InputStream is = IOToolkit.openUncompressedStream(file);
-			try {
+			try (InputStream is = IOToolkit.openUncompressedStream(file)) {
 				IOToolkit.write(is, unzippedFile, false);
 				return unzippedFile;
-			} finally {
-				IOToolkit.closeSilently(is);
 			}
 		} else {
 			throw new OperationCanceledException();

--- a/application/org.openjdk.jmc.ide.launch/src/main/java/org/openjdk/jmc/ide/launch/JfrLaunchDelegateHelper.java
+++ b/application/org.openjdk.jmc.ide.launch/src/main/java/org/openjdk/jmc/ide/launch/JfrLaunchDelegateHelper.java
@@ -240,9 +240,7 @@ public class JfrLaunchDelegateHelper {
 	}
 
 	protected void scheduleOpenJfrJob() {
-		FileInputStream stream = null;
-		try {
-			stream = new FileInputStream(recordingFile);
+		try (FileInputStream stream = new FileInputStream(recordingFile)) {
 			boolean wrote = jfrPathToOpen.tryWriteStream(stream, null);
 			if (wrote) {
 				String info = recordingFile.getAbsolutePath() + " was written to " + jfrPathToOpen.getPath() //$NON-NLS-1$
@@ -252,8 +250,6 @@ public class JfrLaunchDelegateHelper {
 			WorkbenchToolkit.asyncOpenEditor(new MCPathEditorInput(recordingFile, false));
 			return;
 		} catch (IOException e) {
-		} finally {
-			IOToolkit.closeSilently(stream);
 		}
 		displayErrorMessage(NLS.bind(Messages.JfrLaunch_JFR_FILE_DID_NOT_EXIST, jfrPathToOpen));
 	}

--- a/application/org.openjdk.jmc.ide.launch/src/main/java/org/openjdk/jmc/ide/launch/model/JfrLaunchModel.java
+++ b/application/org.openjdk.jmc.ide.launch/src/main/java/org/openjdk/jmc/ide/launch/model/JfrLaunchModel.java
@@ -60,7 +60,6 @@ import org.eclipse.jdt.launching.IVMInstall;
 import org.eclipse.jdt.launching.IVMInstall2;
 import org.eclipse.jdt.launching.JavaRuntime;
 
-import org.openjdk.jmc.common.io.IOToolkit;
 import org.openjdk.jmc.common.unit.QuantityConversionException;
 import org.openjdk.jmc.common.version.JavaVersion;
 import org.openjdk.jmc.common.version.JavaVersionSupport;
@@ -326,28 +325,21 @@ public class JfrLaunchModel extends RecordingWizardModel {
 	}
 
 	private static String parseJavaVersionFromJre(File theJreRoot) {
-		FileInputStream fis = null;
-		JarInputStream jis = null;
-		try {
-			File rtJar = new File(theJreRoot, "jre/lib/rt.jar"); //$NON-NLS-1$
-			if (!rtJar.exists()) {
-				rtJar = new File(theJreRoot, "lib/rt.jar"); //$NON-NLS-1$
-			}
-			if (rtJar.exists()) {
-				fis = new FileInputStream(rtJar);
-				jis = new JarInputStream(fis);
+		File rtJar = new File(theJreRoot, "jre/lib/rt.jar"); //$NON-NLS-1$
+		if (!rtJar.exists()) {
+			rtJar = new File(theJreRoot, "lib/rt.jar"); //$NON-NLS-1$
+		}
+		if (rtJar.exists()) {
+			try (FileInputStream fis = new FileInputStream(rtJar);
+		JarInputStream jis = new JarInputStream(fis)) {
 				Manifest mf = jis.getManifest();
-				jis.close();
 				Attributes as = mf.getMainAttributes();
 				String impVer = as.getValue("Implementation-Version"); //$NON-NLS-1$
 				if (impVer != null) {
 					return new JavaVersion(impVer).toString();
 				}
+			} catch (IOException e) {
 			}
-		} catch (IOException e) {
-		} finally {
-			IOToolkit.closeSilently(jis);
-			IOToolkit.closeSilently(fis);
 		}
 		return null;
 	}

--- a/application/org.openjdk.jmc.ide.launch/src/main/java/org/openjdk/jmc/ide/launch/model/JfrLaunchModel.java
+++ b/application/org.openjdk.jmc.ide.launch/src/main/java/org/openjdk/jmc/ide/launch/model/JfrLaunchModel.java
@@ -330,8 +330,7 @@ public class JfrLaunchModel extends RecordingWizardModel {
 			rtJar = new File(theJreRoot, "lib/rt.jar"); //$NON-NLS-1$
 		}
 		if (rtJar.exists()) {
-			try (FileInputStream fis = new FileInputStream(rtJar);
-		JarInputStream jis = new JarInputStream(fis)) {
+			try (FileInputStream fis = new FileInputStream(rtJar); JarInputStream jis = new JarInputStream(fis)) {
 				Manifest mf = jis.getManifest();
 				Attributes as = mf.getMainAttributes();
 				String impVer = as.getValue("Implementation-Version"); //$NON-NLS-1$

--- a/application/org.openjdk.jmc.joverflow/src/main/java/org/openjdk/jmc/joverflow/heap/parser/ReadBuffer.java
+++ b/application/org.openjdk.jmc.joverflow/src/main/java/org/openjdk/jmc/joverflow/heap/parser/ReadBuffer.java
@@ -168,9 +168,7 @@ public abstract class ReadBuffer {
 			} finally {
 				IOToolkit.closeSilently(ch);
 				IOToolkit.closeSilently(file);
-
 			}
-
 			return new FileReadBuffer(file);
 		}
 	}

--- a/application/org.openjdk.jmc.joverflow/src/main/java/org/openjdk/jmc/joverflow/util/FileUtils.java
+++ b/application/org.openjdk.jmc.joverflow/src/main/java/org/openjdk/jmc/joverflow/util/FileUtils.java
@@ -107,11 +107,8 @@ public class FileUtils {
 	}
 
 	public static void writeBytesToFile(File file, byte[] bytes) throws IOException {
-		BufferedOutputStream out = new BufferedOutputStream(new FileOutputStream(file));
-		try {
+		try (BufferedOutputStream out = new BufferedOutputStream(new FileOutputStream(file))) {
 			out.write(bytes);
-		} finally {
-			IOToolkit.closeSilently(out);
 		}
 	}
 

--- a/application/org.openjdk.jmc.rcp.application/src/main/java/org/openjdk/jmc/rcp/logging/LoggingToolkit.java
+++ b/application/org.openjdk.jmc.rcp.application/src/main/java/org/openjdk/jmc/rcp/logging/LoggingToolkit.java
@@ -104,8 +104,10 @@ public final class LoggingToolkit {
 		} else {
 			try {
 				if (new File(file).exists()) {
-					readConfiguration(new FileInputStream(file));
-					getLogger().log(Level.INFO, "Loaded user specified logging settings from " + file + "."); //$NON-NLS-1$ //$NON-NLS-2$
+					try (FileInputStream fis = new FileInputStream(file)) {
+						readConfiguration(fis);
+						getLogger().log(Level.INFO, "Loaded user specified logging settings from " + file + "."); //$NON-NLS-1$ //$NON-NLS-2$
+					}
 				} else {
 					getLogger().log(Level.WARNING, "Could not find user specified logging settings at " + file + "."); //$NON-NLS-1$ //$NON-NLS-2$
 				}
@@ -145,13 +147,10 @@ public final class LoggingToolkit {
 	}
 
 	private static InputStream getAsInputStream(Properties props) throws IOException {
-		ByteArrayOutputStream baos = new ByteArrayOutputStream();
-		try {
+		try (ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
 			props.store(baos, ""); //$NON-NLS-1$
 			String newProps = baos.toString();
 			return new ByteArrayInputStream(newProps.getBytes("UTF-8")); //$NON-NLS-1$
-		} finally {
-			IOToolkit.closeSilently(baos);
 		}
 	}
 

--- a/application/org.openjdk.jmc.rjmx/src/main/java/org/openjdk/jmc/rjmx/persistence/internal/PersistenceFile.java
+++ b/application/org.openjdk.jmc.rjmx/src/main/java/org/openjdk/jmc/rjmx/persistence/internal/PersistenceFile.java
@@ -77,8 +77,7 @@ class PersistenceFile {
 
 	PersistenceFile(File file) throws IOException {
 		this.file = file;
-		RandomAccessFile raf = new RandomAccessFile(file, "r"); //$NON-NLS-1$
-		try {
+		try (RandomAccessFile raf = new RandomAccessFile(file, "r")) { //$NON-NLS-1$
 			mri = MRI.createFromQualifiedName(raf.readUTF());
 			fileLen = raf.length();
 			eventsStart = raf.getFilePointer();
@@ -91,8 +90,6 @@ class PersistenceFile {
 				start = Long.MAX_VALUE;
 				end = Long.MAX_VALUE;
 			}
-		} finally {
-			IOToolkit.closeSilently(raf);
 		}
 	}
 
@@ -104,11 +101,8 @@ class PersistenceFile {
 		if (events == null) {
 			// TODO: For now read all data
 			events = new ITimestampedData[eventCount];
-			RandomAccessFile raf = new RandomAccessFile(file, "r"); //$NON-NLS-1$
-			try {
+			try (RandomAccessFile raf = new RandomAccessFile(file, "r")) { //$NON-NLS-1$
 				readEvents(raf, 0, eventCount);
-			} finally {
-				IOToolkit.closeSilently(raf);
 			}
 		}
 		return events;

--- a/application/org.openjdk.jmc.rjmx/src/main/java/org/openjdk/jmc/rjmx/subscription/internal/FileMRIMetadata.java
+++ b/application/org.openjdk.jmc.rjmx/src/main/java/org/openjdk/jmc/rjmx/subscription/internal/FileMRIMetadata.java
@@ -77,9 +77,7 @@ class FileMRIMetadata {
 
 	static Map<MRI, Map<String, Object>> readDefaultsFromFile() {
 		FileMRIMetadata metadataLoader = new FileMRIMetadata();
-		InputStream is = null;
-		try {
-			is = FileMRIMetadata.class.getResourceAsStream("mrimetadata.xml"); //$NON-NLS-1$
+		try (InputStream is = FileMRIMetadata.class.getResourceAsStream("mrimetadata.xml")) { //$NON-NLS-1$
 			Document doc = XmlToolkit.loadDocumentFromStream(is);
 			List<Element> elems = XmlToolkit.getChildElementsByTag(doc.getDocumentElement(),
 					ELEMENT_METADATA_COLLECTION);
@@ -97,8 +95,6 @@ class FileMRIMetadata {
 			LOGGER.log(Level.WARNING, "Tried reading mrimetadata.xml, but an exception occurred: " + e.getMessage() //$NON-NLS-1$
 					+ "Extended information about attributes may not be available, " //$NON-NLS-1$
 					+ "and the console will not operate optimally.", e); //$NON-NLS-1$
-		} finally {
-			IOToolkit.closeSilently(is);
 		}
 		return metadataLoader.metadataMap;
 	}

--- a/application/org.openjdk.jmc.rjmx/src/main/java/org/openjdk/jmc/rjmx/triggers/internal/NotificationRuleBag.java
+++ b/application/org.openjdk.jmc.rjmx/src/main/java/org/openjdk/jmc/rjmx/triggers/internal/NotificationRuleBag.java
@@ -32,6 +32,7 @@
  */
 package org.openjdk.jmc.rjmx.triggers.internal;
 
+import java.io.IOException;
 import java.lang.ref.WeakReference;
 import java.util.Collection;
 import java.util.HashMap;
@@ -70,11 +71,12 @@ class NotificationRuleBag {
 	}
 
 	void deactivate() {
-		IConnectionHandle handle = handleRef.get();
-		for (Entry<TriggerRule, IMRIValueListener> rule : rules.entrySet()) {
-			deactivateRule(rule.getKey(), rule.getValue(), handle);
+		try (IConnectionHandle handle = handleRef.get()) {
+			for (Entry<TriggerRule, IMRIValueListener> rule : rules.entrySet()) {
+				deactivateRule(rule.getKey(), rule.getValue(), handle);
+			}
+		} catch (IOException e) {
 		}
-
 	}
 
 	Collection<TriggerRule> getAllRegisteredRules() {

--- a/application/org.openjdk.jmc.ui.common/src/main/java/org/openjdk/jmc/ui/common/util/MCVersion.java
+++ b/application/org.openjdk.jmc.ui.common/src/main/java/org/openjdk/jmc/ui/common/util/MCVersion.java
@@ -89,20 +89,18 @@ public class MCVersion {
 	private static Properties getVersionProperties() {
 		// Just one thread executing this when it gets executed.
 		Properties versionProperties = new Properties();
-		InputStream is = MCVersion.class.getResourceAsStream("/version.properties"); //$NON-NLS-1$
-		if (is == null) {
-			LOGGER.log(Level.SEVERE, "Could not open version.properties file."); //$NON-NLS-1$
-			return null;
-		}
-		try {
+		try (InputStream is = MCVersion.class.getResourceAsStream("/version.properties")) { //$NON-NLS-1$
+			if (is == null) {
+				LOGGER.log(Level.SEVERE, "Could not open version.properties file."); //$NON-NLS-1$
+				return null;
+			}
 			versionProperties.load(is);
 		} catch (IOException e) {
 			LOGGER.log(Level.SEVERE, "Error loading version.properties file.", e); //$NON-NLS-1$
 			return null;
-		} finally {
-			IOToolkit.closeSilently(is);
 		}
 		return versionProperties;
+	
 	}
 
 	public static String getFullVersion() {

--- a/application/org.openjdk.jmc.ui.common/src/main/java/org/openjdk/jmc/ui/common/util/MCVersion.java
+++ b/application/org.openjdk.jmc.ui.common/src/main/java/org/openjdk/jmc/ui/common/util/MCVersion.java
@@ -100,7 +100,7 @@ public class MCVersion {
 			return null;
 		}
 		return versionProperties;
-	
+
 	}
 
 	public static String getFullVersion() {

--- a/application/tests/org.openjdk.jmc.flightrecorder.controlpanel.ui.test/src/test/java/org/openjdk/jmc/flightrecorder/controlpanel/ui/model/test/EventConfigurationModelTest.java
+++ b/application/tests/org.openjdk.jmc.flightrecorder.controlpanel.ui.test/src/test/java/org/openjdk/jmc/flightrecorder/controlpanel/ui/model/test/EventConfigurationModelTest.java
@@ -72,9 +72,10 @@ public class EventConfigurationModelTest extends RjmxTestCase {
 	}
 
 	protected static IEventConfiguration loadConfig(String jfcName) throws Exception {
-		InputStream in = EventConfigurationModelTest.class.getResourceAsStream(jfcName);
-		XMLModel model = EventConfiguration.createModel(in);
-		return new EventConfiguration(model);
+		try (InputStream in = EventConfigurationModelTest.class.getResourceAsStream(jfcName)) {
+			XMLModel model = EventConfiguration.createModel(in);
+			return new EventConfiguration(model);
+		}
 	}
 
 	@Before

--- a/application/tests/org.openjdk.jmc.flightrecorder.controlpanel.ui.test/src/test/java/org/openjdk/jmc/flightrecorder/controlpanel/ui/model/test/EventConfigurationTest.java
+++ b/application/tests/org.openjdk.jmc.flightrecorder.controlpanel.ui.test/src/test/java/org/openjdk/jmc/flightrecorder/controlpanel/ui/model/test/EventConfigurationTest.java
@@ -48,14 +48,16 @@ import org.openjdk.jmc.flightrecorder.controlpanel.ui.model.EventConfiguration;
 public class EventConfigurationTest {
 
 	private IEventConfiguration loadConfig(String jfcName) throws Exception {
-		InputStream in = EventConfigurationTest.class.getResourceAsStream(jfcName);
-		XMLModel model = EventConfiguration.createModel(in);
-		return new EventConfiguration(model);
+		try (InputStream in = EventConfigurationTest.class.getResourceAsStream(jfcName)) {
+			XMLModel model = EventConfiguration.createModel(in);
+			return new EventConfiguration(model);
+		}
 	}
 
 	private void validateConfig(String jfcName, SchemaVersion version) throws Exception {
-		InputStream in = EventConfigurationTest.class.getResourceAsStream(jfcName);
-		EventConfiguration.validate(in, jfcName, version);
+		try (InputStream in = EventConfigurationTest.class.getResourceAsStream(jfcName)) {
+			EventConfiguration.validate(in, jfcName, version);
+		}
 	}
 
 	@Test

--- a/application/tests/org.openjdk.jmc.flightrecorder.controlpanel.ui.test/src/test/java/org/openjdk/jmc/flightrecorder/controlpanel/ui/model/test/JfrControlTestCase.java
+++ b/application/tests/org.openjdk.jmc.flightrecorder.controlpanel.ui.test/src/test/java/org/openjdk/jmc/flightrecorder/controlpanel/ui/model/test/JfrControlTestCase.java
@@ -41,8 +41,9 @@ import org.openjdk.jmc.rjmx.services.jfr.test.JfrTestCase;
 
 public class JfrControlTestCase extends JfrTestCase {
 	protected static IEventConfiguration loadConfig(String jfcName) throws Exception {
-		InputStream in = JfrControlTestCase.class.getResourceAsStream(jfcName);
-		XMLModel model = EventConfiguration.createModel(in);
-		return new EventConfiguration(model);
+		try (InputStream in = JfrControlTestCase.class.getResourceAsStream(jfcName)) {
+			XMLModel model = EventConfiguration.createModel(in);
+			return new EventConfiguration(model);
+		}
 	}
 }

--- a/application/tests/org.openjdk.jmc.rjmx.services.jfr.test/src/test/java/org/openjdk/jmc/rjmx/services/jfr/test/JfrPackageExampleTest.java
+++ b/application/tests/org.openjdk.jmc.rjmx.services.jfr.test/src/test/java/org/openjdk/jmc/rjmx/services/jfr/test/JfrPackageExampleTest.java
@@ -38,7 +38,6 @@ import java.io.IOException;
 import java.io.InputStream;
 
 import org.junit.Test;
-import org.openjdk.jmc.common.io.IOToolkit;
 import org.openjdk.jmc.common.unit.IConstrainedMap;
 import org.openjdk.jmc.common.unit.IDescribedMap;
 import org.openjdk.jmc.flightrecorder.configuration.events.EventOptionID;
@@ -65,14 +64,11 @@ public class JfrPackageExampleTest extends RjmxTestCase {
 	public void testPackageExample1FunctionalityVerbatim() throws Exception {
 		IConnectionDescriptor descriptor = new ConnectionDescriptorBuilder().hostName("localhost").port(0).build();
 		IServerHandle serverHandle = IServerHandle.create(descriptor);
-		IConnectionHandle handle = serverHandle.connect("Get JFR recording info");
-		try {
+		try (IConnectionHandle handle = serverHandle.connect("Get JFR recording info")) {
 			IFlightRecorderService jfr = handle.getServiceOrThrow(IFlightRecorderService.class);
 			for (IRecordingDescriptor desc : jfr.getAvailableRecordings()) {
 				System.out.println(desc.getName());
 			}
-		} finally {
-			IOToolkit.closeSilently(handle);
 		}
 	}
 
@@ -80,8 +76,7 @@ public class JfrPackageExampleTest extends RjmxTestCase {
 	public void testPackageExample2FunctionalityVerbatim() throws Exception {
 		IConnectionDescriptor descriptor = new ConnectionDescriptorBuilder().hostName("localhost").port(0).build();
 		IServerHandle serverHandle = IServerHandle.create(descriptor);
-		IConnectionHandle handle = serverHandle.connect("Start time bound flight recording");
-		try {
+		try (IConnectionHandle handle = serverHandle.connect("Start time bound flight recording")) {
 			IFlightRecorderService jfr = handle.getServiceOrThrow(IFlightRecorderService.class);
 
 			long duration = 5000;
@@ -94,10 +89,9 @@ public class JfrPackageExampleTest extends RjmxTestCase {
 				Thread.sleep(1000);
 				recording = jfr.getUpdatedRecordingDescription(recording);
 			}
-			InputStream is = jfr.openStream(recording, true);
-			writeStreamToFile(is);
-		} finally {
-			IOToolkit.closeSilently(handle);
+			try (InputStream is = jfr.openStream(recording, true)) {
+				writeStreamToFile(is);
+			}
 		}
 	}
 

--- a/application/tests/org.openjdk.jmc.rjmx.test/src/test/java/org/openjdk/jmc/rjmx/test/DefaultServicesTest.java
+++ b/application/tests/org.openjdk.jmc.rjmx.test/src/test/java/org/openjdk/jmc/rjmx/test/DefaultServicesTest.java
@@ -51,36 +51,38 @@ public class DefaultServicesTest extends ServerHandleTestCase {
 
 	@Test
 	public void testMBeanServerConnection() throws Exception {
-		IConnectionHandle handle = getDefaultServer().connect("Test");
-		MBeanServerConnection connection = handle.getServiceOrThrow(MBeanServerConnection.class);
-
-		String[] domains = connection.getDomains();
-		assertNotNull(connection.getDomains());
-		// At least java.lang, no matter what, or we're breaking J2SE compliance...
-		for (String domain : domains) {
-			if (domain.equals("java.lang")) {
-				return;
+		try (IConnectionHandle handle = getDefaultServer().connect("Test")) {
+			MBeanServerConnection connection = handle.getServiceOrThrow(MBeanServerConnection.class);
+	
+			String[] domains = connection.getDomains();
+			assertNotNull(connection.getDomains());
+			// At least java.lang, no matter what, or we're breaking J2SE compliance...
+			for (String domain : domains) {
+				if (domain.equals("java.lang")) {
+					return;
+				}
 			}
+			fail("Could not find java.lang.management among the domains!");
 		}
-		fail("Could not find java.lang.management among the domains!");
 	}
 
 	@Test
 	public void xtestMBeanHelperService() throws Exception {
-		IConnectionHandle handle = getDefaultServer().connect("Test");
-		IMBeanHelperService helper = handle.getServiceOrThrow(IMBeanHelperService.class);
-
-		// FIXME: JMC-4270 - Server time approximation is not reliable. Disabling until a solution is found.
-//		long time = System.currentTimeMillis();
-//
-//		// The server time calculations should not be this much off.
-//		long diff = time - helper.getApproximateServerTime(time);
-//		assertLessThan("Server time approximation off by more than five seconds", 5000L, Math.abs(diff));
-//		System.out.println("DefaultServicesTest.testMBeanHelperService(): Server time approximation difference = "
-//				+ Math.abs(diff) + " ms");
-
-		// Should at least contain the java.lang mbeans. Just testing for the Threading one.
-		assertTrue("Could not find the Threading MBean!",
-				helper.getMBeanNames().contains(new ObjectName("java.lang:type=Threading")));
+		try (IConnectionHandle handle = getDefaultServer().connect("Test")) {
+			IMBeanHelperService helper = handle.getServiceOrThrow(IMBeanHelperService.class);
+	
+			// FIXME: JMC-4270 - Server time approximation is not reliable. Disabling until a solution is found.
+//			long time = System.currentTimeMillis();
+//	
+//			// The server time calculations should not be this much off.
+//			long diff = time - helper.getApproximateServerTime(time);
+//			assertLessThan("Server time approximation off by more than five seconds", 5000L, Math.abs(diff));
+//			System.out.println("DefaultServicesTest.testMBeanHelperService(): Server time approximation difference = "
+//					+ Math.abs(diff) + " ms");
+	
+			// Should at least contain the java.lang mbeans. Just testing for the Threading one.
+			assertTrue("Could not find the Threading MBean!",
+					helper.getMBeanNames().contains(new ObjectName("java.lang:type=Threading")));
+		}
 	}
 }

--- a/application/tests/org.openjdk.jmc.rjmx.test/src/test/java/org/openjdk/jmc/rjmx/test/DefaultServicesTest.java
+++ b/application/tests/org.openjdk.jmc.rjmx.test/src/test/java/org/openjdk/jmc/rjmx/test/DefaultServicesTest.java
@@ -53,7 +53,7 @@ public class DefaultServicesTest extends ServerHandleTestCase {
 	public void testMBeanServerConnection() throws Exception {
 		try (IConnectionHandle handle = getDefaultServer().connect("Test")) {
 			MBeanServerConnection connection = handle.getServiceOrThrow(MBeanServerConnection.class);
-	
+
 			String[] domains = connection.getDomains();
 			assertNotNull(connection.getDomains());
 			// At least java.lang, no matter what, or we're breaking J2SE compliance...
@@ -70,7 +70,7 @@ public class DefaultServicesTest extends ServerHandleTestCase {
 	public void xtestMBeanHelperService() throws Exception {
 		try (IConnectionHandle handle = getDefaultServer().connect("Test")) {
 			IMBeanHelperService helper = handle.getServiceOrThrow(IMBeanHelperService.class);
-	
+
 			// FIXME: JMC-4270 - Server time approximation is not reliable. Disabling until a solution is found.
 //			long time = System.currentTimeMillis();
 //	
@@ -79,7 +79,7 @@ public class DefaultServicesTest extends ServerHandleTestCase {
 //			assertLessThan("Server time approximation off by more than five seconds", 5000L, Math.abs(diff));
 //			System.out.println("DefaultServicesTest.testMBeanHelperService(): Server time approximation difference = "
 //					+ Math.abs(diff) + " ms");
-	
+
 			// Should at least contain the java.lang mbeans. Just testing for the Threading one.
 			assertTrue("Could not find the Threading MBean!",
 					helper.getMBeanNames().contains(new ObjectName("java.lang:type=Threading")));

--- a/application/tests/org.openjdk.jmc.rjmx.test/src/test/java/org/openjdk/jmc/rjmx/test/PackageExampleTest.java
+++ b/application/tests/org.openjdk.jmc.rjmx.test/src/test/java/org/openjdk/jmc/rjmx/test/PackageExampleTest.java
@@ -76,8 +76,7 @@ public class PackageExampleTest {
 	public void testPackageExampleVerbatim() throws Exception {
 		IConnectionDescriptor descriptor = new ConnectionDescriptorBuilder().hostName("localhost").port(0).build();
 		IServerHandle serverHandle = IServerHandle.create(descriptor);
-		IConnectionHandle handle = serverHandle.connect("Usage description");
-		try {
+		try (IConnectionHandle handle = serverHandle.connect("Usage description")) {
 			ISubscriptionService service = handle.getServiceOrThrow(ISubscriptionService.class);
 			MRI attribute = new MRI(Type.ATTRIBUTE, "java.lang:type=Threading", "ThreadCount");
 			service.addMRIValueListener(attribute, new IMRIValueListener() {
@@ -88,19 +87,14 @@ public class PackageExampleTest {
 			});
 			IMRISubscription subscription = service.getMRISubscription(attribute);
 			subscription.setUpdatePolicy(PolicyFactory.createSimpleUpdatePolicy(1500));
-		} finally {
-			// Always close IConnectionHandle when done
-			IOToolkit.closeSilently(handle);
 		}
-
 	}
 
 	@Test
 	public void testPackageExampleFunctionality() throws Exception {
 		ConnectionDescriptorBuilder builder = new ConnectionDescriptorBuilder();
 		IConnectionDescriptor descriptor = builder.hostName("localhost").port(0).build();
-		IConnectionHandle handle = IServerHandle.create(descriptor).connect("Usage description");
-		try {
+		try (IConnectionHandle handle = IServerHandle.create(descriptor).connect("Usage description")) {
 			ISubscriptionService service = handle.getServiceOrThrow(ISubscriptionService.class);
 			gotEvent = false;
 			MRI attribute = new MRI(Type.ATTRIBUTE, "java.lang:type=Threading", "ThreadCount");
@@ -118,8 +112,6 @@ public class PackageExampleTest {
 			synchronized (PackageExampleTest.this) {
 				this.wait(4000);
 			}
-		} finally {
-			IOToolkit.closeSilently(handle);
 		}
 		assertTrue("Never got any event!", gotEvent);
 	}
@@ -131,12 +123,9 @@ public class PackageExampleTest {
 			IServerDescriptor descriptor = server.getServerHandle().getServerDescriptor();
 			if (descriptor.getJvmInfo() != null
 					&& Integer.valueOf(Environment.getThisPID()).equals(descriptor.getJvmInfo().getPid())) {
-				IConnectionHandle handle = server.getServerHandle().connect("Usage description");
-				try {
+				try (IConnectionHandle handle = server.getServerHandle().connect("Usage description")) {
 					handle.getServiceOrThrow(IMBeanHelperService.class).getMBeanNames().size();
 					return;
-				} finally {
-					IOToolkit.closeSilently(handle);
 				}
 			}
 		}

--- a/application/tests/org.openjdk.jmc.rjmx.test/src/test/java/org/openjdk/jmc/rjmx/test/services/ServicesPackageExampleTest.java
+++ b/application/tests/org.openjdk.jmc.rjmx.test/src/test/java/org/openjdk/jmc/rjmx/test/services/ServicesPackageExampleTest.java
@@ -56,8 +56,7 @@ public class ServicesPackageExampleTest extends RjmxTestCase {
 	public void packageExampleFunctionalityVerbatim() throws Exception {
 		IConnectionDescriptor descriptor = new ConnectionDescriptorBuilder().hostName("localhost").port(0).build();
 		IServerHandle handle = IServerHandle.create(descriptor);
-		try {
-			IConnectionHandle connection = handle.connect("Run Diagnostic commands");
+		try (IConnectionHandle connection = handle.connect("Run Diagnostic commands")) {
 			assumeHasDiagnosticCommandsService(connection);
 			IDiagnosticCommandService dcmd = connection.getServiceOrThrow(IDiagnosticCommandService.class);
 			for (IOperation operation : dcmd.getOperations()) {
@@ -72,8 +71,7 @@ public class ServicesPackageExampleTest extends RjmxTestCase {
 	public void testPackageExampleFunctionality() throws Exception {
 		IConnectionDescriptor descriptor = new ConnectionDescriptorBuilder().hostName("localhost").port(0).build();
 		IServerHandle handle = IServerHandle.create(descriptor);
-		try {
-			IConnectionHandle connection = handle.connect("Run Diagnostic commands");
+		try (IConnectionHandle connection = handle.connect("Run Diagnostic commands")) {
 			assumeHasDiagnosticCommandsService(connection);
 			IDiagnosticCommandService dcmd = connection.getServiceOrThrow(IDiagnosticCommandService.class);
 			for (IOperation operation : dcmd.getOperations()) {

--- a/application/tests/org.openjdk.jmc.rjmx.test/src/test/java/org/openjdk/jmc/rjmx/test/subscription/MRIMetadataServiceTest.java
+++ b/application/tests/org.openjdk.jmc.rjmx.test/src/test/java/org/openjdk/jmc/rjmx/test/subscription/MRIMetadataServiceTest.java
@@ -92,13 +92,14 @@ public class MRIMetadataServiceTest extends RjmxTestCase {
 
 	@Test
 	public void testGetExtendedProperties() throws Exception {
-		IConnectionHandle handle = IServerHandle.create(LocalRJMXTestToolkit.createDefaultDescriptor()).connect("Test");
-		IMRIMetadataService service = LocalRJMXTestToolkit.getInfoService(handle);
-		IMRIMetadata info = service
-				.getMetadata(new MRI(Type.ATTRIBUTE, "java.lang:type=Memory", "HeapMemoryUsage/used"));
-		assertNotNull(info);
-		assertTrue("Should be numerical", MRIMetadataToolkit.isNumerical(info));
-		assertNotNull(info.getMetadata("color"));
+		try (IConnectionHandle handle = IServerHandle.create(LocalRJMXTestToolkit.createDefaultDescriptor()).connect("Test")) {
+			IMRIMetadataService service = LocalRJMXTestToolkit.getInfoService(handle);
+			IMRIMetadata info = service
+					.getMetadata(new MRI(Type.ATTRIBUTE, "java.lang:type=Memory", "HeapMemoryUsage/used"));
+			assertNotNull(info);
+			assertTrue("Should be numerical", MRIMetadataToolkit.isNumerical(info));
+			assertNotNull(info.getMetadata("color"));
+		}
 	}
 
 	@Test

--- a/application/tests/org.openjdk.jmc.rjmx.test/src/test/java/org/openjdk/jmc/rjmx/test/subscription/MRIMetadataServiceTest.java
+++ b/application/tests/org.openjdk.jmc.rjmx.test/src/test/java/org/openjdk/jmc/rjmx/test/subscription/MRIMetadataServiceTest.java
@@ -92,7 +92,8 @@ public class MRIMetadataServiceTest extends RjmxTestCase {
 
 	@Test
 	public void testGetExtendedProperties() throws Exception {
-		try (IConnectionHandle handle = IServerHandle.create(LocalRJMXTestToolkit.createDefaultDescriptor()).connect("Test")) {
+		try (IConnectionHandle handle = IServerHandle.create(LocalRJMXTestToolkit.createDefaultDescriptor())
+				.connect("Test")) {
 			IMRIMetadataService service = LocalRJMXTestToolkit.getInfoService(handle);
 			IMRIMetadata info = service
 					.getMetadata(new MRI(Type.ATTRIBUTE, "java.lang:type=Memory", "HeapMemoryUsage/used"));

--- a/application/uitests/org.openjdk.jmc.flightrecorder.uitest/src/test/java/org/openjdk/jmc/flightrecorder/uitest/JfrMetadataToolkit.java
+++ b/application/uitests/org.openjdk.jmc.flightrecorder.uitest/src/test/java/org/openjdk/jmc/flightrecorder/uitest/JfrMetadataToolkit.java
@@ -48,9 +48,7 @@ public class JfrMetadataToolkit {
 
 	protected static SortedMap<String, SortedMap<String, String>> parseRecordingFile(File recordingFile) {
 		SortedMap<String, SortedMap<String, String>> eventTypeMap = new TreeMap<>();
-		InputStream stream = null;
-		try {
-			stream = IOToolkit.openUncompressedStream(recordingFile);
+		try (InputStream stream = IOToolkit.openUncompressedStream(recordingFile)) {
 			EventArray[] eventArrays = FlightRecordingLoader.loadStream(stream, false, false);
 			for (EventArray entry : eventArrays) {
 				SortedMap<String, String> attrs = new TreeMap<>();
@@ -61,7 +59,6 @@ public class JfrMetadataToolkit {
 				eventTypeMap.put(eventTypeId, attrs);
 			}
 		} catch (Exception e) {
-			IOToolkit.closeSilently(stream);
 			throw new RuntimeException(e);
 		}
 		return eventTypeMap;

--- a/application/uitests/org.openjdk.jmc.flightrecorder.uitest/src/test/java/org/openjdk/jmc/flightrecorder/uitest/MetadataTestBase.java
+++ b/application/uitests/org.openjdk.jmc.flightrecorder.uitest/src/test/java/org/openjdk/jmc/flightrecorder/uitest/MetadataTestBase.java
@@ -168,8 +168,10 @@ public abstract class MetadataTestBase extends MCJemmyTestBase {
 
 	protected void copyFile(File sourceFile, File destFile) {
 		prepareFile(destFile);
-		try (FileChannel source = new FileInputStream(sourceFile).getChannel();
-				FileChannel destination = new FileOutputStream(destFile).getChannel()) {
+		try (FileInputStream sourceFis = new FileInputStream(sourceFile);
+				FileOutputStream destinationFos = new FileOutputStream(destFile);
+				FileChannel source = sourceFis.getChannel();
+				FileChannel destination = destinationFos.getChannel()) {
 			destination.transferFrom(source, 0, source.size());
 		} catch (IOException e) {
 			e.printStackTrace();

--- a/core/org.openjdk.jmc.agent/src/main/java/org/openjdk/jmc/agent/Agent.java
+++ b/core/org.openjdk.jmc.agent/src/main/java/org/openjdk/jmc/agent/Agent.java
@@ -35,6 +35,7 @@ package org.openjdk.jmc.agent;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
+import java.io.IOException;
 import java.io.InputStream;
 import java.lang.instrument.Instrumentation;
 import java.util.logging.Level;
@@ -122,10 +123,9 @@ public class Agent {
 			agentArguments = DEFAULT_CONFIG;
 		}
 		File file = new File(agentArguments);
-		try {
-			InputStream stream = new FileInputStream(file);
+		try (InputStream stream = new FileInputStream(file)) {
 			initializeAgent(stream, instrumentation);
-		} catch (FileNotFoundException | XMLStreamException e) {
+		} catch (XMLStreamException | IOException e) {
 			getLogger().log(Level.SEVERE, "Failed to read jfr probe definitions from " + file.getPath(), e); //$NON-NLS-1$
 		}
 	}

--- a/core/org.openjdk.jmc.agent/src/test/java/org/openjdk/jmc/agent/test/util/TestToolkit.java
+++ b/core/org.openjdk.jmc.agent/src/test/java/org/openjdk/jmc/agent/test/util/TestToolkit.java
@@ -52,8 +52,9 @@ public final class TestToolkit {
 	}
 
 	public static byte[] getByteCode(Class<?> c) throws IOException {
-		InputStream is = c.getClassLoader().getResourceAsStream(c.getName().replace('.', '/') + ".class"); //$NON-NLS-1$
-		return readFully(is, -1, true);
+		try (InputStream is = c.getClassLoader().getResourceAsStream(c.getName().replace('.', '/') + ".class")) { //$NON-NLS-1$
+			return readFully(is, -1, true);
+		}
 	}
 
 	public static byte[] readFully(InputStream is, int length, boolean readAll) throws IOException {
@@ -106,10 +107,9 @@ public final class TestToolkit {
 	}
 
 	public static String readTemplate(Class<?> resouceClass, String templateName) throws IOException {
-		InputStream inputStream = resouceClass.getResourceAsStream(templateName); // $NON-NLS-1$
-		String s = readString(inputStream);
-		closeSilently(inputStream);
-		return s;
+		try (InputStream inputStream = resouceClass.getResourceAsStream(templateName)) {
+			return readString(inputStream);
+		}
 	}
 
 	public static String readString(InputStream in) throws IOException {

--- a/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/io/IOToolkit.java
+++ b/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/io/IOToolkit.java
@@ -171,12 +171,8 @@ public final class IOToolkit {
 	 *             if an error occurred when trying to read from the file
 	 */
 	public static boolean hasMagic(File file, int[] magic) throws IOException {
-		FileInputStream fis = null;
-		try {
-			fis = new FileInputStream(file);
+		try (FileInputStream fis = new FileInputStream(file)) {
 			return hasMagic(fis, magic);
-		} finally {
-			closeSilently(fis);
 		}
 	}
 
@@ -260,17 +256,13 @@ public final class IOToolkit {
 	 *             if an error occurred when trying to read from the file
 	 */
 	public static boolean isCompressedFile(File file) throws IOException {
-		BufferedInputStream is = null;
-		try {
-			is = new BufferedInputStream(new FileInputStream(file), MAGIC_ZIP.length + 1);
+		try (BufferedInputStream is = new BufferedInputStream(new FileInputStream(file), MAGIC_ZIP.length + 1)) {
 			is.mark(MAGIC_ZIP.length + 1);
 			if (hasMagic(is, MAGIC_GZ)) {
 				return true;
 			}
 			is.reset();
 			return hasMagic(is, MAGIC_ZIP);
-		} finally {
-			closeSilently(is);
 		}
 	}
 
@@ -285,23 +277,19 @@ public final class IOToolkit {
 	 *             on I/O error
 	 */
 	public static List<String> loadFromFile(File file) throws IOException {
-		FileReader fr = new FileReader(file);
-		try {
+		try (FileReader fr = new FileReader(file)) {
 			return loadFromReader(fr);
-		} catch (IOException e) {
-			throw e;
-		} finally {
-			closeSilently(fr);
 		}
 	}
 
 	private static List<String> loadFromReader(Reader reader) throws IOException {
 		List<String> lines = new ArrayList<>();
-		BufferedReader br = new BufferedReader(reader);
-		while (br.ready()) {
-			lines.add(br.readLine());
+		try (BufferedReader br = new BufferedReader(reader)) {
+			while (br.ready()) {
+				lines.add(br.readLine());
+			}
+			return lines;
 		}
-		return lines;
 	}
 
 	/**
@@ -316,14 +304,10 @@ public final class IOToolkit {
 	 *             on I/O error
 	 */
 	public static void saveToFile(File file, List<String> lines) throws IOException {
-		PrintWriter pr = null;
-		try {
-			pr = new PrintWriter(new FileWriter(file));
+		try (PrintWriter pr = new PrintWriter(new FileWriter(file))) {
 			for (String line : lines) {
 				pr.println(line);
 			}
-		} finally {
-			closeSilently(pr);
 		}
 	}
 
@@ -338,10 +322,8 @@ public final class IOToolkit {
 	 *             on I/O error
 	 */
 	public static List<String> loadFromStream(InputStream is) throws IOException {
-		try {
+		try (BufferedInputStream bis = new BufferedInputStream(is); BufferedReader r = new BufferedReader(new InputStreamReader(bis))) {
 			List<String> lines = new ArrayList<>();
-			BufferedInputStream bis = new BufferedInputStream(is);
-			BufferedReader r = new BufferedReader(new InputStreamReader(bis));
 			while (r.ready()) {
 				lines.add(r.readLine());
 			}
@@ -365,14 +347,8 @@ public final class IOToolkit {
 	 *             on I/O error
 	 */
 	public static void write(InputStream in, File toOutput, boolean append) throws IOException {
-		FileOutputStream fos = new FileOutputStream(toOutput, append);
-		BufferedOutputStream os = null;
-		try {
-			os = new BufferedOutputStream(fos);
+		try (FileOutputStream fos = new FileOutputStream(toOutput, append); BufferedOutputStream os = new BufferedOutputStream(fos)) {
 			copy(in, os);
-		} finally {
-			closeSilently(os);
-			closeSilently(fos);
 		}
 	}
 
@@ -437,8 +413,7 @@ public final class IOToolkit {
 	 *             if something goes wrong when reading file data
 	 */
 	public static String calculateFileHash(File file) throws IOException {
-		RandomAccessFile raf = new RandomAccessFile(file, "r"); //$NON-NLS-1$
-		try {
+		try (RandomAccessFile raf = new RandomAccessFile(file, "r")) { //$NON-NLS-1$
 			long seek = raf.length() / 10;
 			byte[] buffer = new byte[1024];
 			MessageDigest hash = MessageDigest.getInstance("MD5"); //$NON-NLS-1$
@@ -450,8 +425,6 @@ public final class IOToolkit {
 			return new BigInteger(1, hash.digest()).toString();
 		} catch (NoSuchAlgorithmException e) {
 			throw new RuntimeException(e);
-		} finally {
-			closeSilently(raf);
 		}
 	}
 }

--- a/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/io/IOToolkit.java
+++ b/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/io/IOToolkit.java
@@ -322,7 +322,8 @@ public final class IOToolkit {
 	 *             on I/O error
 	 */
 	public static List<String> loadFromStream(InputStream is) throws IOException {
-		try (BufferedInputStream bis = new BufferedInputStream(is); BufferedReader r = new BufferedReader(new InputStreamReader(bis))) {
+		try (BufferedInputStream bis = new BufferedInputStream(is);
+				BufferedReader r = new BufferedReader(new InputStreamReader(bis))) {
 			List<String> lines = new ArrayList<>();
 			while (r.ready()) {
 				lines.add(r.readLine());
@@ -347,7 +348,8 @@ public final class IOToolkit {
 	 *             on I/O error
 	 */
 	public static void write(InputStream in, File toOutput, boolean append) throws IOException {
-		try (FileOutputStream fos = new FileOutputStream(toOutput, append); BufferedOutputStream os = new BufferedOutputStream(fos)) {
+		try (FileOutputStream fos = new FileOutputStream(toOutput, append);
+				BufferedOutputStream os = new BufferedOutputStream(fos)) {
 			copy(in, os);
 		}
 	}

--- a/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/util/XmlToolkit.java
+++ b/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/util/XmlToolkit.java
@@ -397,14 +397,8 @@ public final class XmlToolkit {
 	 *             if the stream could not be read
 	 */
 	public static Document loadDocumentFromFile(File file) throws SAXException, IOException {
-		FileInputStream is = null;
-		try {
-			is = new FileInputStream(file);
+		try (FileInputStream is = new FileInputStream(file)) {
 			return XmlToolkit.loadDocumentFromStream(new BufferedInputStream(is));
-		} finally {
-			if (is != null) {
-				IOToolkit.closeSilently(is);
-			}
 		}
 	}
 
@@ -457,14 +451,8 @@ public final class XmlToolkit {
 	 *             if the file could not written
 	 */
 	public static void storeDocumentToFile(Document doc, File file) throws IOException {
-		PrintWriter pw = null;
-		try {
-			pw = new PrintWriter(file, "UTF-8"); //$NON-NLS-1$
+		try (PrintWriter pw = new PrintWriter(file, "UTF-8")) { //$NON-NLS-1$
 			prettyPrint(doc.getDocumentElement(), pw);
-		} finally {
-			if (pw != null) {
-				IOToolkit.closeSilently(pw);
-			}
 		}
 	}
 

--- a/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/JfrLoaderToolkit.java
+++ b/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/JfrLoaderToolkit.java
@@ -66,11 +66,8 @@ public class JfrLoaderToolkit {
 		for (File file : files) {
 			streams.add(IOToolkit.openUncompressedStream(file));
 		}
-		InputStream stream = new SequenceInputStream(Collections.enumeration(streams));
-		try {
+		try (InputStream stream = new SequenceInputStream(Collections.enumeration(streams))) {
 			return FlightRecordingLoader.loadStream(stream, extensions, false, true);
-		} finally {
-			IOToolkit.closeSilently(stream);
 		}
 	}
 
@@ -97,9 +94,10 @@ public class JfrLoaderToolkit {
 	 * @return the events in the recording
 	 */
 	public static IItemCollection loadEvents(InputStream stream, List<? extends IParserExtension> extensions)
-			throws IOException, CouldNotLoadRecordingException {
-		InputStream in = IOToolkit.openUncompressedStream(stream);
-		return EventCollection.build(FlightRecordingLoader.loadStream(in, extensions, false, true));
+			throws CouldNotLoadRecordingException, IOException {
+		try (InputStream in = IOToolkit.openUncompressedStream(stream)) {
+			return EventCollection.build(FlightRecordingLoader.loadStream(in, extensions, false, true));
+		}
 	}
 
 	/**

--- a/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/internal/EventAppearance.java
+++ b/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/internal/EventAppearance.java
@@ -78,18 +78,15 @@ public class EventAppearance {
 		// Might change to ResourceBundle, or do as FieldToolkit (or NLS),
 		// if localization is needed. (Which I doubt, since it would be confusing.)
 		Properties properties = new Properties();
-		InputStream in = EventAppearance.class.getResourceAsStream(fileName);
-		if (in != null) {
-			try {
+		try (InputStream in = EventAppearance.class.getResourceAsStream(fileName)) {
+			if (in != null) {
 				properties.load(in);
-			} catch (IOException e) {
-				System.err.println("Problem loading file '" + fileName + "'"); //$NON-NLS-1$ //$NON-NLS-2$
-				e.printStackTrace();
-			} finally {
-				IOToolkit.closeSilently(in);
+			} else {
+				System.err.println("Couldn't find file '" + fileName + "'"); //$NON-NLS-1$ //$NON-NLS-2$
 			}
-		} else {
-			System.err.println("Couldn't find file '" + fileName + "'"); //$NON-NLS-1$ //$NON-NLS-2$
+		} catch (IOException e) {
+			System.err.println("Problem loading file '" + fileName + "'"); //$NON-NLS-1$ //$NON-NLS-2$
+			e.printStackTrace();
 		}
 		return properties;
 	}

--- a/core/tests/org.openjdk.jmc.flightrecorder.rules.jdk.test/src/test/java/org/openjdk/jmc/flightrecorder/test/rules/jdk/TestRulesWithJfr.java
+++ b/core/tests/org.openjdk.jmc.flightrecorder.rules.jdk.test/src/test/java/org/openjdk/jmc/flightrecorder/test/rules/jdk/TestRulesWithJfr.java
@@ -166,9 +166,9 @@ public class TestRulesWithJfr {
 				+ (onlyOneRecording ? "Generated_One_" : "Generated_") + fileName;
 		File resultFile = new File(filePath);
 		prepareFile(resultFile);
-		try {
-			writeDomToStream(doc, new FileOutputStream(resultFile));
-		} catch (FileNotFoundException e) {
+		try (FileOutputStream resultFos = new FileOutputStream(resultFile)) {
+			writeDomToStream(doc, resultFos);
+		} catch (IOException e) {
 			e.printStackTrace();
 		}
 	}


### PR DESCRIPTION
This PR fixes a few places where we didn't close resources properly before and also changes a number of older usages of IOToolkit to instead use try-with-resource.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

## Issue
[JMC-6674](https://bugs.openjdk.java.net/browse/JMC-6674): Inefficient finding of first start time and first & last end times


## Approvers
 * Marcus Hirt ([hirt](@thegreystone) - **Reviewer**)