### PR TITLE
6246: Making the agent stop using Unsafe

### DIFF
--- a/core/org.openjdk.jmc.agent/src/main/java/org/openjdk/jmc/agent/generated_events/Dummy.java
+++ b/core/org.openjdk.jmc.agent/src/main/java/org/openjdk/jmc/agent/generated_events/Dummy.java
@@ -1,0 +1,4 @@
+package org.openjdk.jmc.agent.generated_events;
+
+public final class Dummy {
+}

--- a/core/org.openjdk.jmc.agent/src/main/java/org/openjdk/jmc/agent/jfr/JFRTransformDescriptor.java
+++ b/core/org.openjdk.jmc.agent/src/main/java/org/openjdk/jmc/agent/jfr/JFRTransformDescriptor.java
@@ -42,6 +42,7 @@ import org.openjdk.jmc.agent.Method;
 import org.openjdk.jmc.agent.Parameter;
 import org.openjdk.jmc.agent.ReturnValue;
 import org.openjdk.jmc.agent.TransformDescriptor;
+import org.openjdk.jmc.agent.generated_events.Dummy;
 import org.openjdk.jmc.agent.util.TypeUtils;
 
 public class JFRTransformDescriptor extends TransformDescriptor {
@@ -143,7 +144,7 @@ public class JFRTransformDescriptor extends TransformDescriptor {
 	}
 
 	private String initializeEventClassName() {
-		return TypeUtils.getPathPart(getClassName()) + getClassPrefix()
+		return TypeUtils.getPathPart(Dummy.class.getName().replace('.', '/')) + getClassPrefix()
 				+ TypeUtils.deriveIdentifierPart(getEventName());
 	}
 

--- a/core/org.openjdk.jmc.agent/src/main/java/org/openjdk/jmc/agent/jfrnext/impl/JFRNextClassVisitor.java
+++ b/core/org.openjdk.jmc.agent/src/main/java/org/openjdk/jmc/agent/jfrnext/impl/JFRNextClassVisitor.java
@@ -87,7 +87,7 @@ public class JFRNextClassVisitor extends ClassVisitor {
 
 	private Class<?> generateEventClass() throws Exception {
 		try {
-			return Class.forName(transformDescriptor.getEventClassName().replace('/', '.'));
+			return Class.forName(transformDescriptor.getEventClassName().replace('/', '.'), false, definingClassLoader);
 		} catch (ClassNotFoundException e) {
 			byte[] eventClass = JFRNextEventClassGenerator.generateEventClass(transformDescriptor);
 			return TypeUtils.defineClass(transformDescriptor.getEventClassName(), eventClass, 0, eventClass.length,

--- a/core/org.openjdk.jmc.agent/src/main/java/org/openjdk/jmc/agent/jfrnext/impl/JFRNextEventClassGenerator.java
+++ b/core/org.openjdk.jmc.agent/src/main/java/org/openjdk/jmc/agent/jfrnext/impl/JFRNextEventClassGenerator.java
@@ -85,7 +85,7 @@ public class JFRNextEventClassGenerator {
 
 		String fieldType = getFieldType(type);
 
-		FieldVisitor fv = cw.visitField(Opcodes.ACC_PROTECTED, param.getFieldName(), fieldType, null, null);
+		FieldVisitor fv = cw.visitField(Opcodes.ACC_PUBLIC, param.getFieldName(), fieldType, null, null);
 
 		// Name
 		AnnotationVisitor av = fv.visitAnnotation("Ljdk/jfr/Label;", true);
@@ -125,7 +125,7 @@ public class JFRNextEventClassGenerator {
 
 		String fieldType = getFieldType(type);
 
-		FieldVisitor fv = cw.visitField(Opcodes.ACC_PROTECTED, returnValue.getFieldName(), fieldType, null, null);
+		FieldVisitor fv = cw.visitField(Opcodes.ACC_PUBLIC, returnValue.getFieldName(), fieldType, null, null);
 
 		// Name
 		AnnotationVisitor av = fv.visitAnnotation("Ljdk/jfr/Label;", true);


### PR DESCRIPTION
This patch addresses [JMC-6246](https://bugs.openjdk.java.net/browse/JMC-6246).

The usage of `Unsafe.defineClass()` is replaced with:
- for pre-Java 9, reflective access on `ClassLoader.getSystemClassLoader().defineClass()`
- for Java 9 and later, `MethodHandles.Lookup.defineClass()`

Please note that `LookUp.defineClass()` can only define classes within the same package of the lookup. Therefore generated events classes will be in the dedicated package `org.openjdk.jmc.agent.generated_events`, instead of being in the same package of the instrumented class.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

## Issue
[JMC-6246](https://bugs.openjdk.java.net/browse/JMC-6246): Making the agent stop using Unsafe
