### PR TITLE
6661: Simplify Agent JMX tests

### DIFF
--- a/core/org.openjdk.jmc.agent/src/test/java/org/openjdk/jmc/agent/test/TestDefineEventProbes.java
+++ b/core/org.openjdk.jmc.agent/src/test/java/org/openjdk/jmc/agent/test/TestDefineEventProbes.java
@@ -41,7 +41,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 
-import javax.management.MBeanServer;
+import javax.management.JMX;
 import javax.management.ObjectName;
 
 import org.junit.Test;
@@ -56,6 +56,7 @@ import org.openjdk.jmc.agent.Parameter;
 import org.openjdk.jmc.agent.ReturnValue;
 import org.openjdk.jmc.agent.jfr.JFRTransformDescriptor;
 import org.openjdk.jmc.agent.jfrnext.impl.JFRNextEventClassGenerator;
+import org.openjdk.jmc.agent.jmx.AgentControllerMBean;
 import org.openjdk.jmc.agent.util.TypeUtils;
 
 public class TestDefineEventProbes {
@@ -160,12 +161,9 @@ public class TestDefineEventProbes {
 	}
 
 	private void doDefineEventProbes(String xmlDescription) throws Exception  {
-		ObjectName name = new ObjectName(AGENT_OBJECT_NAME);
-		Object[] parameters = {xmlDescription};
-		String[] signature = {String.class.getName()};
-
-		MBeanServer mbs = ManagementFactory.getPlatformMBeanServer();
-		mbs.invoke(name, "defineEventProbes", parameters, signature);
+		AgentControllerMBean mbean = JMX.newMXBeanProxy(ManagementFactory.getPlatformMBeanServer(),
+				new ObjectName(AGENT_OBJECT_NAME), AgentControllerMBean.class, false);
+		mbean.defineEventProbes(xmlDescription);
 	}
 
 	public void test() {


### PR DESCRIPTION
This patch simplifies mbean function calls for agent JMX tests.  

The proposed solution, which is outlined in the ticket's description, was to create an mbean object by calling ManagementFactory.newPlatformMXBeanProxy(...). However this function requires the  AgentControllerMBean class to be loaded by the platform class loader, which it is not.  So instead I have called the JMX.newMXBeanProxy(...) directly.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

## Issue
[JMC-6661](https://bugs.openjdk.java.net/browse/JMC-6661): Agent tests for the JMX API can probably be simplified


## Approvers
 * Marcus Hirt ([hirt](@thegreystone) - **Reviewer**)