### PR TITLE
6572: Make mbean functions protected by permission checks

### DIFF
--- a/core/org.openjdk.jmc.agent/README.md
+++ b/core/org.openjdk.jmc.agent/README.md
@@ -29,7 +29,7 @@ java --add-opens java.base/jdk.internal.misc=ALL-UNNAMED -XX:+FlightRecorder -ja
 At runtime the agent can be used to modify the transformed state of a class. To specify a desired state, supply the defineEventProbes function with a XML description of event probes to add, keep or modify, and leave out all those that should be reverted to their preinstrumentation versions.
 
 ### Using a security manager
-To make MBean calls more secure, the agent can be run with a security manager. A manager can be enabled by adding the VM option `-Djava.security.manager` and by supplying a policy file of permissions to grant as such: `-Djava.security.policy=permissions.policy`. The 'control' Management Permission must be granted in order for MBean function calls to succeed.
+When running with a security manager, the 'control' Management Permission must be granted to control the agent through the MBean. To set fine grained permissions for authenticated remote users, see [here](https://docs.oracle.com/javadb/10.10.1.2/adminguide/radminjmxenablepolicy.html#radminjmxenablepolicy) and [here](https://docs.oracle.com/javase/7/docs/technotes/guides/management/agent.html#gdeup).
 
 ## Known Issues
 * The full converter support is still to be merged into the open source repo

--- a/core/org.openjdk.jmc.agent/README.md
+++ b/core/org.openjdk.jmc.agent/README.md
@@ -28,6 +28,9 @@ java --add-opens java.base/jdk.internal.misc=ALL-UNNAMED -XX:+FlightRecorder -ja
 ## Interacting with the agent
 At runtime the agent can be used to modify the transformed state of a class. To specify a desired state, supply the defineEventProbes function with a XML description of event probes to add, keep or modify, and leave out all those that should be reverted to their preinstrumentation versions.
 
+### Using a security manager
+To make MBean calls more secure, the agent can be run with a security manager. A manager can be enabled by adding the VM option `-Djava.security.manager` and by supplying a policy file of permissions to grant as such: `-Djava.security.policy=permissions.policy`. The 'control' Management Permission must be granted in order for MBean function calls to succeed.
+
 ## Known Issues
 * The full converter support is still to be merged into the open source repo
 * Support for emitting an event only on exception has yet to be implemented

--- a/core/org.openjdk.jmc.agent/pom.xml
+++ b/core/org.openjdk.jmc.agent/pom.xml
@@ -99,7 +99,10 @@
 				<configuration>
 					<argLine> --add-opens java.base/jdk.internal.misc=ALL-UNNAMED
 						-XX:+FlightRecorder</argLine>
-					<excludes>TestDefineEventProbes.java</excludes>
+					<excludes>
+						<exclude>TestDefineEventProbes.java</exclude>
+						<exclude>TestPermissionChecks.java</exclude>
+					</excludes>
 				</configuration>
 			</plugin>
 			<plugin>
@@ -107,19 +110,33 @@
 				<artifactId>maven-failsafe-plugin</artifactId>
 				<version>3.0.0-M3</version>
 				<executions>
+					<execution>
+					<id>test-permissions</id>
+					<goals>
+						<goal>integration-test</goal>
+						<goal>verify</goal>
+					</goals>
+						<configuration>
+							<argLine> -Djava.security.manager -Djava.security.policy=target/test-classes/org/openjdk/jmc/agent/test/failing_control_permission.policy --add-opens java.base/jdk.internal.misc=ALL-UNNAMED
+								-XX:+FlightRecorder -javaagent:target/org.openjdk.jmc.agent-1.0.0-SNAPSHOT.jar=target/test-classes/org/openjdk/jmc/agent/test/jfrprobes_template.xml
+								 -cp target/org.openjdk.jmc.agent-1.0.0-SNAPSHOT.jar:target/test-classes/ </argLine>
+							<includes>TestPermissionChecks.java</includes>
+						</configuration>
+					</execution>
           			<execution>
+						<id>test-retransform</id>
             			<goals>
               				<goal>integration-test</goal>
               				<goal>verify</goal>
             			</goals>
-          			</execution>
+						<configuration>
+							<argLine> --add-opens java.base/jdk.internal.misc=ALL-UNNAMED
+								-XX:+FlightRecorder -javaagent:target/org.openjdk.jmc.agent-1.0.0-SNAPSHOT.jar=target/test-classes/org/openjdk/jmc/agent/test/jfrprobes_template.xml
+								 -cp target/org.openjdk.jmc.agent-1.0.0-SNAPSHOT.jar:target/test-classes/ </argLine>
+							<includes>TestDefineEventProbes.java</includes>
+						</configuration>
+					</execution>
         		</executions>
-				<configuration>
-					<argLine> --add-opens java.base/jdk.internal.misc=ALL-UNNAMED
-						-XX:+FlightRecorder -javaagent:target/org.openjdk.jmc.agent-1.0.0-SNAPSHOT.jar=target/test-classes/org/openjdk/jmc/agent/test/jfrprobes_template.xml
-						 -cp target/org.openjdk.jmc.agent-1.0.0-SNAPSHOT.jar:target/test-classes/ </argLine>
-					<includes>TestDefineEventProbes.java</includes>
-				</configuration>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>

--- a/core/org.openjdk.jmc.agent/src/main/java/org/openjdk/jmc/agent/jmx/AgentController.java
+++ b/core/org.openjdk.jmc.agent/src/main/java/org/openjdk/jmc/agent/jmx/AgentController.java
@@ -33,6 +33,7 @@
 package org.openjdk.jmc.agent.jmx;
 
 import java.lang.instrument.Instrumentation;
+import java.lang.management.ManagementPermission;
 import java.util.HashSet;
 import java.util.List;
 import java.util.logging.Level;
@@ -54,6 +55,7 @@ public class AgentController implements AgentControllerMBean {
 	}
 
 	public void defineEventProbes(String xmlDescription) throws Exception{
+		checkSecurity();
 		HashSet<Class<?>> classesToRetransform = new HashSet<Class<?>>();
 		boolean revertAll = xmlDescription == null ? true : xmlDescription.isEmpty();
 		if (revertAll) {
@@ -89,4 +91,12 @@ public class AgentController implements AgentControllerMBean {
 		instrumentation.retransformClasses(classesToRetransformArray);
 		registry.setRevertInstrumentation(false);
 	}
+
+	private void checkSecurity() {
+		  SecurityManager secMan = System.getSecurityManager();
+		  if (secMan != null) {
+		    secMan.checkPermission(new ManagementPermission("control"));
+		  }
+	}
+
 }

--- a/core/org.openjdk.jmc.agent/src/test/java/org/openjdk/jmc/agent/test/TestPermissionChecks.java
+++ b/core/org.openjdk.jmc.agent/src/test/java/org/openjdk/jmc/agent/test/TestPermissionChecks.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Red Hat Inc. All rights reserved.
+ *
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * The contents of this file are subject to the terms of either the Universal Permissive License
+ * v 1.0 as shown at http://oss.oracle.com/licenses/upl
+ *
+ * or the following license:
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted
+ * provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions
+ * and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other materials provided with
+ * the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to
+ * endorse or promote products derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+ * WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.openjdk.jmc.agent.test;
+
+import static org.junit.Assert.assertTrue;
+import java.lang.management.ManagementFactory;
+
+import javax.management.JMX;
+import javax.management.ObjectName;
+
+import org.junit.Test;
+import org.openjdk.jmc.agent.jmx.AgentControllerMBean;
+
+public class TestPermissionChecks {
+
+	private static final String AGENT_OBJECT_NAME = "org.openjdk.jmc.jfr.agent:type=AgentController"; //$NON-NLS-1$
+
+	@Test
+	public void testPermissionChecks() throws Exception {
+		boolean exceptionThrown = false;
+		try {
+			doDefineEventProbes("");
+		} catch(SecurityException e) {
+			exceptionThrown = true;
+		}
+		assertTrue(exceptionThrown);
+	}
+
+	private void doDefineEventProbes(String xmlDescription) throws Exception  {
+		AgentControllerMBean mbean = JMX.newMXBeanProxy(ManagementFactory.getPlatformMBeanServer(),
+				new ObjectName(AGENT_OBJECT_NAME), AgentControllerMBean.class, false);
+		mbean.defineEventProbes(xmlDescription);
+	}
+
+	public void test() {
+		//Dummy method for instrumentation
+	}
+}

--- a/core/org.openjdk.jmc.agent/src/test/resources/org/openjdk/jmc/agent/test/failing_control_permission.policy
+++ b/core/org.openjdk.jmc.agent/src/test/resources/org/openjdk/jmc/agent/test/failing_control_permission.policy
@@ -1,0 +1,23 @@
+grant {
+	permission java.io.FilePermission "target/test-classes/org/openjdk/jmc/agent/test/jfrprobes_template.xml", "read";
+	permission java.io.FilePermission "target/surefire/*", "read";
+	permission java.lang.management.ManagementPermission "monitor";
+	permission java.lang.reflect.ReflectPermission "suppressAccessChecks";
+	permission java.lang.RuntimePermission "accessClassInPackage.jdk.internal.misc";
+	permission java.lang.RuntimePermission "accessDeclaredMembers";
+	permission java.lang.RuntimePermission "setIO";
+	permission java.lang.RuntimePermission "accessClassInPackage.jdk.jfr.internal.handlers";
+	permission java.util.PropertyPermission "basedir", "write";
+	permission java.util.PropertyPermission "user.dir", "write";
+	permission java.util.PropertyPermission "localRepository", "write";
+	permission java.util.PropertyPermission "java.class.path", "read";
+	permission java.util.PropertyPermission "surefire.real.class.path", "write";
+	permission java.util.PropertyPermission "java.class.path", "write";
+	permission java.util.PropertyPermission "surefire.test.class.path", "write";
+	permission java.util.PropertyPermission "surefire.junit4.upgradecheck", "read";
+	permission java.util.PropertyPermission "*", "read,write";
+	permission javax.management.MBeanPermission "org.openjdk.jmc.agent.jmx.AgentController#-[org.openjdk.jmc.jfr.agent:type=AgentController]","registerMBean";
+	permission javax.management.MBeanServerPermission "createMBeanServer";
+	permission javax.management.MBeanTrustPermission "register";
+	permission jdk.jfr.FlightRecorderPermission "registerEvent";
+};


### PR DESCRIPTION
This patch adds a permission check to Agent MBean functions for the 'control' management permission. 

I have also added a test "testPermissionChecks" to see if a security exception is fired when this permission is not given.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

## Issue
[JMC-6572](https://bugs.openjdk.java.net/browse/JMC-6572): MBean retransform should be protected by permission checks


## Approvers
 * Marcus Hirt ([hirt](@thegreystone) - **Reviewer**)