### PR TITLE
6685: Parse more fields directly to primitive values

### DIFF
--- a/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/internal/parser/v1/StructTypes.java
+++ b/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/internal/parser/v1/StructTypes.java
@@ -78,11 +78,7 @@ class StructTypes {
 
 		@Override
 		public Long getThreadId() {
-			/*
-			 * NOTE: Parser currently creates thread ID as a quantity, which it probably shouldn't
-			 * be. See TypeManager.createFieldReader(FieldElement, String).
-			 */
-			return ((Number) javaThreadId).longValue();
+			return (Long) javaThreadId;
 		}
 
 		@Override
@@ -603,11 +599,7 @@ class StructTypes {
 
 		@Override
 		public Integer getModifier() {
-			/*
-			 * NOTE: Parser currently creates method modifier as a quantity, which it probably
-			 * shouldn't be. See TypeManager.createFieldReader(FieldElement, String).
-			 */
-			return ((Number) modifiers).intValue();
+			return (Integer) modifiers;
 		}
 
 		@Override
@@ -647,20 +639,12 @@ class StructTypes {
 
 		@Override
 		public Integer getFrameLineNumber() {
-			/*
-			 * NOTE: Parser currently creates frame line number as a quantity, which it probably
-			 * shouldn't be. See TypeManager.createFieldReader(FieldElement, String).
-			 */
-			return ((Number) lineNumber).intValue();
+			return (Integer) lineNumber;
 		}
 
 		@Override
 		public Integer getBCI() {
-			/*
-			 * NOTE: Parser currently creates byte code index as a quantity, which it probably
-			 * shouldn't be. See TypeManager.createFieldReader(FieldElement, String).
-			 */
-			return ((Number) bytecodeIndex).intValue();
+			return (Integer) bytecodeIndex;
 		}
 
 		@Override

--- a/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/internal/parser/v1/TypeManager.java
+++ b/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/internal/parser/v1/TypeManager.java
@@ -451,13 +451,15 @@ class TypeManager {
 			if (JfrInternalConstants.TYPE_IDENTIFIER_VALUE_INTERPRETATION.equals(valueType)) {
 				reader = new TypeIdentifierReader(typeIdentifier, f.unsigned);
 			} else {
-				IUnit unit = UnitLookup.getUnitOrNull(valueType);
-				/*
-				 * FIXME: Currently we convert all numbers to quantities. This might not be ideal,
-				 * for example for thread IDs. See multiple notes referring to this method in
-				 * StructTypes.
-				 */
-				reader = new QuantityReader(typeIdentifier, unit == null ? UnitLookup.NUMBER_UNITY : unit, f.unsigned);
+				if (JfrInternalConstants.LINE_NUMBER_ID.equals(f.fieldIdentifier) ||
+						JfrInternalConstants.BCI_ID.equals(f.fieldIdentifier) ||
+						JfrInternalConstants.MODIFIERS_ID.equals(f.fieldIdentifier) ||
+						JfrInternalConstants.JAVA_THREAD_ID_ID.equals(f.fieldIdentifier)) {
+					reader = new PrimitiveReader(typeIdentifier);
+				} else {
+					IUnit unit = UnitLookup.getUnitOrNull(valueType);
+					reader = new QuantityReader(typeIdentifier, unit == null ? UnitLookup.NUMBER_UNITY : unit, f.unsigned);
+				}
 			}
 		}
 		if (f.isStoredInPool()) {

--- a/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/internal/parser/v1/TypeManager.java
+++ b/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/internal/parser/v1/TypeManager.java
@@ -451,14 +451,15 @@ class TypeManager {
 			if (JfrInternalConstants.TYPE_IDENTIFIER_VALUE_INTERPRETATION.equals(valueType)) {
 				reader = new TypeIdentifierReader(typeIdentifier, f.unsigned);
 			} else {
-				if (JfrInternalConstants.LINE_NUMBER_ID.equals(f.fieldIdentifier) ||
-						JfrInternalConstants.BCI_ID.equals(f.fieldIdentifier) ||
-						JfrInternalConstants.MODIFIERS_ID.equals(f.fieldIdentifier) ||
-						JfrInternalConstants.JAVA_THREAD_ID_ID.equals(f.fieldIdentifier)) {
+				if (JfrInternalConstants.LINE_NUMBER_ID.equals(f.fieldIdentifier)
+						|| JfrInternalConstants.BCI_ID.equals(f.fieldIdentifier)
+						|| JfrInternalConstants.MODIFIERS_ID.equals(f.fieldIdentifier)
+						|| JfrInternalConstants.JAVA_THREAD_ID_ID.equals(f.fieldIdentifier)) {
 					reader = new PrimitiveReader(typeIdentifier);
 				} else {
 					IUnit unit = UnitLookup.getUnitOrNull(valueType);
-					reader = new QuantityReader(typeIdentifier, unit == null ? UnitLookup.NUMBER_UNITY : unit, f.unsigned);
+					reader = new QuantityReader(typeIdentifier, unit == null ? UnitLookup.NUMBER_UNITY : unit,
+							f.unsigned);
 				}
 			}
 		}

--- a/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/internal/util/JfrInternalConstants.java
+++ b/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/internal/util/JfrInternalConstants.java
@@ -39,7 +39,7 @@ public final class JfrInternalConstants {
 
 	public static final String BUFFER_LOST_TYPE_ID = "org.openjdk.jmc.flightrecorder.bufferlosttypeid"; //$NON-NLS-1$
 	public static final String TYPE_IDENTIFIER_VALUE_INTERPRETATION = "org.openjdk.jmc.flightrecorder.value_interpretation.type_identifier"; //$NON-NLS-1$
-	
+
 	public static final String LINE_NUMBER_ID = "lineNumber"; //$NON-NLS-1$
 	public static final String BCI_ID = "bytecodeIndex"; //$NON-NLS-1$
 	public static final String MODIFIERS_ID = "modifiers"; //$NON-NLS-1$

--- a/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/internal/util/JfrInternalConstants.java
+++ b/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/internal/util/JfrInternalConstants.java
@@ -39,5 +39,9 @@ public final class JfrInternalConstants {
 
 	public static final String BUFFER_LOST_TYPE_ID = "org.openjdk.jmc.flightrecorder.bufferlosttypeid"; //$NON-NLS-1$
 	public static final String TYPE_IDENTIFIER_VALUE_INTERPRETATION = "org.openjdk.jmc.flightrecorder.value_interpretation.type_identifier"; //$NON-NLS-1$
-
+	
+	public static final String LINE_NUMBER_ID = "lineNumber"; //$NON-NLS-1$
+	public static final String BCI_ID = "bytecodeIndex"; //$NON-NLS-1$
+	public static final String MODIFIERS_ID = "modifiers"; //$NON-NLS-1$
+	public static final String JAVA_THREAD_ID_ID = "javaThreadId"; //$NON-NLS-1$
 }


### PR DESCRIPTION
Currently the parser reads line numbers, byte code indexes, modifiers and java thread ids with a QuantityReader, while as soon as they're used converted into primitive values. This PR changes the parser to read those field values as primitives directly.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

## Issue
[JMC-6685](https://bugs.openjdk.java.net/browse/JMC-6685): Read primitives in parser when possible


## Approvers
 * Marcus Hirt ([hirt](@thegreystone) - **Reviewer**)