### PR TITLE
6693: Eclipse projects core/org.openjdk.jmc.jdp* should have the correct JRE target level

### DIFF
--- a/core/org.openjdk.jmc.jdp/.classpath
+++ b/core/org.openjdk.jmc.jdp/.classpath
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" output="target/classes" path="src/main/java"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/core/tests/org.openjdk.jmc.jdp.test/.classpath
+++ b/core/tests/org.openjdk.jmc.jdp.test/.classpath
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" output="target/test-classes" path="src/test/java"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="output" path="target/test-classes"/>
 </classpath>


### PR DESCRIPTION

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

## Issue
[JMC-6693](https://bugs.openjdk.java.net/browse/JMC-6693): Eclipse projects core/org.openjdk.jmc.jdp* should have the correct JRE target level


## Approvers
 * Marcus Hirt ([hirt](@thegreystone) - **Reviewer**)