### PR TITLE
6698: SAPJVM not recognized as known (hotspot) VM

### DIFF
--- a/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/version/JavaVMVersionToolkit.java
+++ b/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/version/JavaVMVersionToolkit.java
@@ -113,7 +113,7 @@ public class JavaVMVersionToolkit {
 		if (vmName == null) {
 			return false;
 		}
-		return vmName.startsWith("Java HotSpot") || vmName.startsWith("OpenJDK"); //$NON-NLS-1$ //$NON-NLS-2$;
+		return vmName.startsWith("Java HotSpot") || vmName.startsWith("OpenJDK") || vmName.startsWith("SAP"); //$NON-NLS-1$ //$NON-NLS-2$;
 	}
 
 }


### PR DESCRIPTION
Enhance JavaVMVersionToolkit::isHotspotJVMName to recognize SAP JVM.
This method checks System Property "java.vm.name" which is "SAP Java Server VM" for SAP JVM.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JMC-6698](https://bugs.openjdk.java.net/browse/JMC-6698): SAPJVM not recognized as known (hotspot) VM


### Reviewers
 * Marcus Hirt ([hirt](@thegreystone) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jmc pull/55/head:pull/55`
`$ git checkout pull/55`
