### PR TITLE
6708: Add santiy check when allocating Object arrays in parser

### DIFF
--- a/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/internal/parser/v0/ArrayReader.java
+++ b/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/internal/parser/v0/ArrayReader.java
@@ -44,15 +44,20 @@ import org.openjdk.jmc.flightrecorder.internal.util.DataInputToolkit;
 final class ArrayReader implements IValueReader {
 
 	private final IValueReader reader;
+	private final ChunkStructure header;
 
-	ArrayReader(IValueReader reader) {
+	ArrayReader(IValueReader reader, ChunkStructure header) {
 		this.reader = reader;
+		this.header = header;
 	}
 
 	@Override
 	public Object readValue(byte[] bytes, Offset offset, long timestamp) throws InvalidJfrFileException {
 		int arraySize = readArraySize(bytes, offset.get());
 		offset.increase(DataType.INTEGER.getSize());
+		if (arraySize > header.getChunkSize()) {
+			throw new InvalidJfrFileException("Found array larger than chunk size"); //$NON-NLS-1$
+		}
 		Object[] array = new Object[arraySize];
 		for (int n = 0; n < arraySize; n++) {
 			array[n] = reader.readValue(bytes, offset, timestamp);

--- a/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/internal/parser/v0/ChunkLoaderV0.java
+++ b/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/internal/parser/v0/ChunkLoaderV0.java
@@ -59,7 +59,7 @@ public class ChunkLoaderV0 implements IChunkLoader {
 	@Override
 	public byte[] call() throws Exception {
 		// Read constants
-		ReaderFactory readerFactory = new ReaderFactory(metadata, data, context);
+		ReaderFactory readerFactory = new ReaderFactory(metadata, data, context, structure);
 
 		// Read events
 		EventParserManager eventParser = new EventParserManager(readerFactory, context, metadata.getProducers());

--- a/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/internal/parser/v0/ReaderFactory.java
+++ b/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/internal/parser/v0/ReaderFactory.java
@@ -55,9 +55,11 @@ class ReaderFactory {
 	private final FastAccessNumberMap<ConstantMap> constants = new FastAccessNumberMap<>(100, 5);
 	private final ChunkMetadata metadata;
 	private final FastAccessNumberMap<LabeledIdentifier> types = new FastAccessNumberMap<>();
+	private final ChunkStructure header;
 
-	ReaderFactory(ChunkMetadata metadata, byte[] chunkData, LoaderContext context) throws InvalidJfrFileException {
+	ReaderFactory(ChunkMetadata metadata, byte[] chunkData, LoaderContext context, ChunkStructure header) throws InvalidJfrFileException {
 		this.metadata = metadata;
+		this.header = header;
 		for (ProducerDescriptor pd : metadata.getProducers()) {
 			for (ContentTypeDescriptor ct : pd.getContentTypes()) {
 				IValueReader reader = createReader(ct.getDataStructure());
@@ -123,9 +125,9 @@ class ReaderFactory {
 		if (vd.getDataType().isPrimitive()) {
 			return createPrimitiveReader(vd.getDataType(), vd.getContentType(), valueType);
 		} else if (vd.getDataType() == DataType.ARRAY) {
-			return new ArrayReader(createPrimitiveReader(vd.getInnerDataType(), vd.getContentType(), valueType));
+			return new ArrayReader(createPrimitiveReader(vd.getInnerDataType(), vd.getContentType(), valueType), header);
 		} else if (vd.getDataType() == DataType.STRUCTARRAY) {
-			return new ArrayReader(createReader(vd.getChildren()));
+			return new ArrayReader(createReader(vd.getChildren()), header);
 		} else if (vd.getDataType() == DataType.STRUCT) {
 			return createReader(vd.getChildren());
 		} else {

--- a/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/internal/parser/v0/ReaderFactory.java
+++ b/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/internal/parser/v0/ReaderFactory.java
@@ -57,7 +57,8 @@ class ReaderFactory {
 	private final FastAccessNumberMap<LabeledIdentifier> types = new FastAccessNumberMap<>();
 	private final ChunkStructure header;
 
-	ReaderFactory(ChunkMetadata metadata, byte[] chunkData, LoaderContext context, ChunkStructure header) throws InvalidJfrFileException {
+	ReaderFactory(ChunkMetadata metadata, byte[] chunkData, LoaderContext context, ChunkStructure header)
+			throws InvalidJfrFileException {
 		this.metadata = metadata;
 		this.header = header;
 		for (ProducerDescriptor pd : metadata.getProducers()) {
@@ -125,7 +126,8 @@ class ReaderFactory {
 		if (vd.getDataType().isPrimitive()) {
 			return createPrimitiveReader(vd.getDataType(), vd.getContentType(), valueType);
 		} else if (vd.getDataType() == DataType.ARRAY) {
-			return new ArrayReader(createPrimitiveReader(vd.getInnerDataType(), vd.getContentType(), valueType), header);
+			return new ArrayReader(createPrimitiveReader(vd.getInnerDataType(), vd.getContentType(), valueType),
+					header);
 		} else if (vd.getDataType() == DataType.STRUCTARRAY) {
 			return new ArrayReader(createReader(vd.getChildren()), header);
 		} else if (vd.getDataType() == DataType.STRUCT) {

--- a/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/internal/parser/v1/ChunkLoaderV1.java
+++ b/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/internal/parser/v1/ChunkLoaderV1.java
@@ -85,7 +85,7 @@ public class ChunkLoaderV1 implements IChunkLoader {
 			int size = input.readInt();
 			long type = input.readLong();
 			if (size == 0) {
-				throw new CouldNotLoadRecordingException("Found event with invalid size (0)");
+				throw new CouldNotLoadRecordingException("Found event with invalid size (0)"); //$NON-NLS-1$
 			}
 			if (type != CONSTANT_POOL_EVENT_TYPE && type != ChunkMetadata.METADATA_EVENT_TYPE) {
 				manager.readEvent(type, input);

--- a/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/internal/parser/v1/TypeManager.java
+++ b/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/internal/parser/v1/TypeManager.java
@@ -469,7 +469,7 @@ class TypeManager {
 			}
 			reader = new PoolReader(fieldType.constants, reader.getContentType());
 		}
-		return f.isArray() ? new ArrayReader(reader) : reader;
+		return f.isArray() ? new ArrayReader(reader, header) : reader;
 	}
 
 	private static String buildLabel(String id, AnnotatedElement element) {

--- a/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/internal/parser/v1/ValueReaders.java
+++ b/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/internal/parser/v1/ValueReaders.java
@@ -116,15 +116,20 @@ class ValueReaders {
 
 	static class ArrayReader implements IValueReader {
 		private final IValueReader elementReader;
+		private final ChunkStructure header;
 
-		ArrayReader(IValueReader elementReader) {
+		ArrayReader(IValueReader elementReader, ChunkStructure header) {
 			this.elementReader = elementReader;
+			this.header = header;
 		}
 
 		@Override
 		public Object read(IDataInput in, boolean allowUnresolvedReference)
 				throws IOException, InvalidJfrFileException {
 			int size = in.readInt();
+			if (size > header.getChunkSize()) {
+				throw new InvalidJfrFileException("Found array larger than chunk size"); //$NON-NLS-1$
+			}
 			Object[] values = new Object[size];
 			for (int i = 0; i < values.length; i++) {
 				values[i] = elementReader.read(in, allowUnresolvedReference);


### PR DESCRIPTION
Checking the size of an array before allocating it is a decent sanity check so the parser doesn't end up reading massive arrays and causing OoMs due to incorrectly written recordings.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JMC-6708](https://bugs.openjdk.java.net/browse/JMC-6708): Set boundary for array size while parsing recording


### Reviewers
 * Marcus Hirt ([hirt](@thegreystone) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jmc pull/59/head:pull/59`
`$ git checkout pull/59`
