### PR TITLE
6712: Make agent retransform classes when loaded dynamically

### DIFF
--- a/agent/src/main/java/org/openjdk/jmc/agent/Agent.java
+++ b/agent/src/main/java/org/openjdk/jmc/agent/Agent.java
@@ -38,7 +38,9 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.lang.instrument.Instrumentation;
 import java.lang.instrument.UnmodifiableClassException;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -144,18 +146,18 @@ public class Agent {
 	 * @param instrumentation
 	 *            the {@link Instrumentation} instance.
 	 */
-	private static void retransformClasses(List<String> clazzes, Instrumentation instrumentation) {
-		Class<?>[] classesToRetransform = new Class<?>[clazzes.size()];
-		for (int i = 0; i < clazzes.size(); i++) {
+	private static void retransformClasses(Set<String> clazzes, Instrumentation instrumentation) {
+		List<Class<?>> classesToRetransform = new ArrayList<Class<?>>();
+		for (String clazz : clazzes) {
 			try {
-				Class<?> classToRetransform = Class.forName(clazzes.get(i).replace('/', '.'));
-				classesToRetransform[i] = classToRetransform;
+				Class<?> classToRetransform = Class.forName(clazz.replace('/', '.'));
+				classesToRetransform.add(classToRetransform);
 			} catch (ClassNotFoundException cnfe) {
-				getLogger().log(Level.SEVERE, "Unable to find class: " + clazzes.get(i), cnfe);
+				getLogger().log(Level.SEVERE, "Unable to find class: " + clazz, cnfe);
 			}
 		}
 		try {
-			instrumentation.retransformClasses(classesToRetransform);
+			instrumentation.retransformClasses(classesToRetransform.toArray(new Class<?>[0]));
 		} catch (UnmodifiableClassException e) {
 			getLogger().log(Level.SEVERE, "Unable to retransform classes", e);
 		}

--- a/agent/src/main/java/org/openjdk/jmc/agent/TransformRegistry.java
+++ b/agent/src/main/java/org/openjdk/jmc/agent/TransformRegistry.java
@@ -33,6 +33,7 @@
 package org.openjdk.jmc.agent;
 
 import java.util.List;
+import java.util.Set;
 
 public interface TransformRegistry {
 	/**
@@ -56,9 +57,9 @@ public interface TransformRegistry {
 	/**
 	 * Returns the names of all classes stored in the registry.
 	 *
-	 * @return the list of class names.
+	 * @return the unmodifiable set of class names.
 	 */
-	List<String> getClassNames();
+	Set<String> getClassNames();
 
 	/**
 	 * Modifies class information in the registry according to the xml description.

--- a/agent/src/main/java/org/openjdk/jmc/agent/TransformRegistry.java
+++ b/agent/src/main/java/org/openjdk/jmc/agent/TransformRegistry.java
@@ -44,7 +44,7 @@ public interface TransformRegistry {
 	 */
 	boolean hasPendingTransforms(String className);
 
-	/**O
+	/**
 	 * Returns the list of {@link TransformDescriptor}s for the named class.
 	 *
 	 * @param className
@@ -52,6 +52,13 @@ public interface TransformRegistry {
 	 * @return the list of transformation metadata for the named class.
 	 */
 	List<TransformDescriptor> getTransformData(String className);
+
+	/**
+	 * Returns the names of all classes stored in the registry.
+	 *
+	 * @return the list of class names.
+	 */
+	List<String> getClassNames();
 
 	/**
 	 * Modifies class information in the registry according to the xml description.

--- a/agent/src/main/java/org/openjdk/jmc/agent/impl/DefaultTransformRegistry.java
+++ b/agent/src/main/java/org/openjdk/jmc/agent/impl/DefaultTransformRegistry.java
@@ -35,11 +35,13 @@ package org.openjdk.jmc.agent.impl;
 import java.io.InputStream;
 import java.io.StringReader;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -456,8 +458,8 @@ public class DefaultTransformRegistry implements TransformRegistry {
 		return classNames;
 	}
 
-	public List<String> getClassNames() {
-		return new ArrayList<>(transformData.keySet());
+	public Set<String> getClassNames() {
+		return Collections.unmodifiableSet(transformData.keySet());
 	}
 
 	public void setRevertInstrumentation(boolean shouldRevert) {

--- a/agent/src/main/java/org/openjdk/jmc/agent/impl/DefaultTransformRegistry.java
+++ b/agent/src/main/java/org/openjdk/jmc/agent/impl/DefaultTransformRegistry.java
@@ -456,6 +456,10 @@ public class DefaultTransformRegistry implements TransformRegistry {
 		return classNames;
 	}
 
+	public List<String> getClassNames() {
+		return new ArrayList<>(transformData.keySet());
+	}
+
 	public void setRevertInstrumentation(boolean shouldRevert) {
 		this.revertInstrumentation = shouldRevert;
 	}


### PR DESCRIPTION
This patch makes the Agent retransform all classes stored in the registry after it is loaded, when it is loaded dynamically.  Previously the transformations specified in the xml file path argument were not always being performed in this dynamic case.

Let me know what you think.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JMC-6712](https://bugs.openjdk.java.net/browse/JMC-6712): Transformations defined in agent args not applied when loading dynamically


### Reviewers
 * Marcus Hirt ([hirt](@thegreystone) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jmc pull/60/head:pull/60`
`$ git checkout pull/60`
