### PR TITLE
6724: Agent argument as a path to a probe definition XML should be optional

### DIFF
--- a/agent/src/main/java/org/openjdk/jmc/agent/Agent.java
+++ b/agent/src/main/java/org/openjdk/jmc/agent/Agent.java
@@ -58,7 +58,6 @@ public class Agent {
 	 * This should be generated as part of the build later.
 	 */
 	public final static String VERSION = "0.0.2"; //$NON-NLS-1$
-	private final static String DEFAULT_CONFIG = "jfrprobes.xml"; //$NON-NLS-1$
 	private static boolean loadedDynamically = false;
 
 	/**
@@ -102,7 +101,8 @@ public class Agent {
 	 */
 	public static void initializeAgent(InputStream configuration, Instrumentation instrumentation)
 			throws XMLStreamException {
-		TransformRegistry registry = DefaultTransformRegistry.from(configuration);
+		TransformRegistry registry =
+				configuration != null ? DefaultTransformRegistry.from(configuration) : DefaultTransformRegistry.empty();
 		instrumentation.addTransformer(new Transformer(registry), true);
 		AgentManagementFactory.createAndRegisterAgentControllerMBean(instrumentation, registry);
 		if (loadedDynamically) {
@@ -128,8 +128,14 @@ public class Agent {
 	 */
 	private static void initializeAgent(String agentArguments, Instrumentation instrumentation) {
 		if (agentArguments == null || agentArguments.trim().length() == 0) {
-			agentArguments = DEFAULT_CONFIG;
+			try {
+				initializeAgent((InputStream) null, instrumentation);
+			} catch (XMLStreamException e) {
+				// noop
+			}
+			return;
 		}
+
 		File file = new File(agentArguments);
 		try (InputStream stream = new FileInputStream(file)) {
 			initializeAgent(stream, instrumentation);

--- a/agent/src/main/java/org/openjdk/jmc/agent/Agent.java
+++ b/agent/src/main/java/org/openjdk/jmc/agent/Agent.java
@@ -94,6 +94,7 @@ public class Agent {
 	 *
 	 * @param configuration
 	 *            the configuration options, as XML. The stream will be fully read, but not closed.
+	 *            An empty configuration will be used if this argument is <code>null</code>.
 	 * @param instrumentation
 	 *            the {@link Instrumentation} instance.
 	 * @throws XMLStreamException
@@ -131,7 +132,7 @@ public class Agent {
 			try {
 				initializeAgent((InputStream) null, instrumentation);
 			} catch (XMLStreamException e) {
-				// noop
+				// noop: null as InputStream causes defaults to be used - the stream will not be used
 			}
 			return;
 		}

--- a/agent/src/main/java/org/openjdk/jmc/agent/impl/DefaultTransformRegistry.java
+++ b/agent/src/main/java/org/openjdk/jmc/agent/impl/DefaultTransformRegistry.java
@@ -88,6 +88,10 @@ public class DefaultTransformRegistry implements TransformRegistry {
 		return true;
 	}
 
+	public static TransformRegistry empty() {
+		return new DefaultTransformRegistry();
+	}
+
 	public static TransformRegistry from(InputStream in) throws XMLStreamException {
 		HashMap<String, String> globalDefaults = new HashMap<>();
 		DefaultTransformRegistry registry = new DefaultTransformRegistry();

--- a/agent/src/test/java/org/openjdk/jmc/agent/test/TestDefaultTransformRegistry.java
+++ b/agent/src/test/java/org/openjdk/jmc/agent/test/TestDefaultTransformRegistry.java
@@ -77,6 +77,12 @@ public class TestDefaultTransformRegistry {
 	}
 
 	@Test
+	public void testEmpty() {
+		TransformRegistry registry = DefaultTransformRegistry.empty();
+		assertNotNull(registry);
+	}
+
+	@Test
 	public void testFrom() throws XMLStreamException, IOException {
 		TransformRegistry registry = DefaultTransformRegistry
 				.from(TestToolkit.getProbesXMLFromTemplate(getTemplate(), "From")); //$NON-NLS-1$


### PR DESCRIPTION
This patch addresses [JMC-6724: Agent argument as a path to a probe definition XML should be optional](https://bugs.openjdk.java.net/browse/JMC-6724). It makes the agent argument optional and probes can always be defined later via JMX. If such an argument is missing, an empty registry is created with no transform descriptor.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JMC-6724](https://bugs.openjdk.java.net/browse/JMC-6724): Agent argument as a path to a probe definition XML should be optional


### Reviewers
 * Marcus Hirt ([hirt](@thegreystone) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jmc pull/63/head:pull/63`
`$ git checkout pull/63`
