### PR TITLE
6725: Formalize agent probe definition XML schema and enforce validations

### DIFF
--- a/agent/.classpath
+++ b/agent/.classpath
@@ -6,18 +6,19 @@
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>
 	</classpathentry>
+	<classpathentry kind="src" path="src/main/resources"/>
 	<classpathentry kind="src" output="target/test-classes" path="src/test/java">
 		<attributes>
+			<attribute name="test" value="true"/>
 			<attribute name="optional" value="true"/>
 			<attribute name="maven.pomderived" value="true"/>
-			<attribute name="test" value="true"/>
 		</attributes>
 	</classpathentry>
 	<classpathentry excluding="**" kind="src" output="target/test-classes" path="src/test/resources">
 		<attributes>
+			<attribute name="test" value="true"/>
 			<attribute name="optional" value="true"/>
 			<attribute name="maven.pomderived" value="true"/>
-			<attribute name="test" value="true"/>
 		</attributes>
 	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.m2e.MAVEN2_CLASSPATH_CONTAINER">

--- a/agent/src/main/java/org/openjdk/jmc/agent/impl/DefaultTransformRegistry.java
+++ b/agent/src/main/java/org/openjdk/jmc/agent/impl/DefaultTransformRegistry.java
@@ -114,7 +114,7 @@ public class DefaultTransformRegistry implements TransformRegistry {
 		return new DefaultTransformRegistry();
 	}
 
-	private static void validateProbeDefinition(InputStream in) throws XMLStreamException {
+	public static void validateProbeDefinition(InputStream in) throws XMLStreamException {
 		try {
 			Validator validator = PROBE_SCHEMA.newValidator();
 			validator.validate(new StreamSource(in));
@@ -123,7 +123,7 @@ public class DefaultTransformRegistry implements TransformRegistry {
 		}
 	}
 
-	private static void validateProbeDefinition(String configuration) throws XMLStreamException {
+	public static void validateProbeDefinition(String configuration) throws XMLStreamException {
 		validateProbeDefinition(new ByteArrayInputStream(configuration.getBytes()));
 	}
 

--- a/agent/src/main/java/org/openjdk/jmc/agent/impl/DefaultTransformRegistry.java
+++ b/agent/src/main/java/org/openjdk/jmc/agent/impl/DefaultTransformRegistry.java
@@ -32,6 +32,8 @@
  */
 package org.openjdk.jmc.agent.impl;
 
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringReader;
 import java.util.ArrayList;
@@ -45,10 +47,15 @@ import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import javax.xml.XMLConstants;
 import javax.xml.namespace.QName;
 import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
+import javax.xml.transform.stream.StreamSource;
+import javax.xml.validation.Schema;
+import javax.xml.validation.SchemaFactory;
+import javax.xml.validation.Validator;
 
 import org.openjdk.jmc.agent.Method;
 import org.openjdk.jmc.agent.Parameter;
@@ -57,7 +64,9 @@ import org.openjdk.jmc.agent.TransformDescriptor;
 import org.openjdk.jmc.agent.TransformRegistry;
 import org.openjdk.jmc.agent.Field;
 import org.openjdk.jmc.agent.jfr.JFRTransformDescriptor;
+import org.openjdk.jmc.agent.util.IOToolkit;
 import org.openjdk.jmc.agent.util.TypeUtils;
+import org.xml.sax.SAXException;
 
 public class DefaultTransformRegistry implements TransformRegistry {
 	private static final String XML_ATTRIBUTE_NAME_ID = "id"; //$NON-NLS-1$
@@ -79,6 +88,19 @@ public class DefaultTransformRegistry implements TransformRegistry {
 
 	private volatile boolean revertInstrumentation = false;
 
+	private static final String PROBE_SCHEMA_XSD = "jfrprobes_schema.xsd"; //$NON-NLS-1$
+	private static final Schema PROBE_SCHEMA;
+
+	static {
+		try {
+			SchemaFactory factory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
+			PROBE_SCHEMA = factory
+					.newSchema(new StreamSource(DefaultTransformRegistry.class.getResourceAsStream(PROBE_SCHEMA_XSD)));
+		} catch (SAXException e) {
+			throw new ExceptionInInitializerError(e);
+		}
+	}
+
 	@Override
 	public boolean hasPendingTransforms(String className) {
 		List<TransformDescriptor> transforms = transformData.get(className);
@@ -92,11 +114,36 @@ public class DefaultTransformRegistry implements TransformRegistry {
 		return new DefaultTransformRegistry();
 	}
 
+	private static void validateProbeDefinition(InputStream in) throws XMLStreamException {
+		try {
+			Validator validator = PROBE_SCHEMA.newValidator();
+			validator.validate(new StreamSource(in));
+		} catch (IOException | SAXException e) {
+			throw new XMLStreamException(e);
+		}
+	}
+
+	private static void validateProbeDefinition(String configuration) throws XMLStreamException {
+		validateProbeDefinition(new ByteArrayInputStream(configuration.getBytes()));
+	}
+
 	public static TransformRegistry from(InputStream in) throws XMLStreamException {
+		byte[] buf;
+		InputStream configuration;
+		try {
+			buf = IOToolkit.readFully(in, -1, true);
+			configuration = new ByteArrayInputStream(buf);
+			configuration.mark(0);
+			validateProbeDefinition(configuration);
+			configuration.reset();
+		} catch (IOException e) {
+			throw new XMLStreamException(e);
+		}
+
 		HashMap<String, String> globalDefaults = new HashMap<>();
 		DefaultTransformRegistry registry = new DefaultTransformRegistry();
 		XMLInputFactory inputFactory = XMLInputFactory.newInstance();
-		XMLStreamReader streamReader = inputFactory.createXMLStreamReader(in);
+		XMLStreamReader streamReader = inputFactory.createXMLStreamReader(configuration);
 		while (streamReader.hasNext()) {
 			if (streamReader.isStartElement()) {
 				QName element = streamReader.getName();
@@ -422,6 +469,8 @@ public class DefaultTransformRegistry implements TransformRegistry {
 
 	public List<TransformDescriptor> modify(String xmlDescription) {
 		try  {
+			validateProbeDefinition(xmlDescription);
+
 			List<TransformDescriptor> tds = new ArrayList<TransformDescriptor>();
 			StringReader reader = new StringReader(xmlDescription);
 			XMLInputFactory inputFactory = XMLInputFactory.newInstance();

--- a/agent/src/main/java/org/openjdk/jmc/agent/util/IOToolkit.java
+++ b/agent/src/main/java/org/openjdk/jmc/agent/util/IOToolkit.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ *
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * The contents of this file are subject to the terms of either the Universal Permissive License
+ * v 1.0 as shown at http://oss.oracle.com/licenses/upl
+ *
+ * or the following license:
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted
+ * provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions
+ * and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other materials provided with
+ * the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to
+ * endorse or promote products derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+ * WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.openjdk.jmc.agent.util;
+
+import java.io.EOFException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Arrays;
+
+/**
+ * Helper methods for IO related operations.
+ */
+public final class IOToolkit {
+	public static byte[] readFully(InputStream is, int length, boolean readAll) throws IOException {
+		byte[] output = {};
+		if (length == -1) {
+			length = Integer.MAX_VALUE;
+		}
+		int pos = 0;
+		while (pos < length) {
+			int bytesToRead;
+			if (pos >= output.length) { // Only expand when there's no room
+				bytesToRead = Math.min(length - pos, output.length + 1024);
+				if (output.length < pos + bytesToRead) {
+					output = Arrays.copyOf(output, pos + bytesToRead);
+				}
+			} else {
+				bytesToRead = output.length - pos;
+			}
+			int cc = is.read(output, pos, bytesToRead);
+			if (cc < 0) {
+				if (readAll && length != Integer.MAX_VALUE) {
+					throw new EOFException("Detect premature EOF"); //$NON-NLS-1$
+				} else {
+					if (output.length != pos) {
+						output = Arrays.copyOf(output, pos);
+					}
+					break;
+				}
+			}
+			pos += cc;
+		}
+		return output;
+	}
+}

--- a/agent/src/main/resources/org/openjdk/jmc/agent/impl/jfrprobes_schema.xsd
+++ b/agent/src/main/resources/org/openjdk/jmc/agent/impl/jfrprobes_schema.xsd
@@ -1,0 +1,218 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xs:schema elementFormDefault="qualified" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+	<xs:element type="jfrAgentType" name="jfragent"/>
+
+	<xs:complexType name="jfrAgentType">
+		<xs:all>
+			<xs:element type="configType" name="config" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Global configuration options</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element type="eventsType" name="events" minOccurs="0"/>
+		</xs:all>
+	</xs:complexType>
+
+	<xs:complexType name="configType">
+		<xs:all>
+			<xs:element type="xs:string" name="classprefix" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>This is the prefix to use when generating event class names</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element type="xs:boolean" name="allowtostring" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>
+						Will allow the recording of arrays and object parameters as Strings. This will cause toString to
+						be called for array elements and objects other than strings, which in turn can cause trouble if
+						the toString method is badly implemented. Use with care.
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element type="xs:boolean" name="allowconverter" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>
+						Allows converters to be used. If a converter is badly implemented, you are on your own.
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:all>
+	</xs:complexType>
+
+	<xs:complexType name="eventsType">
+		<xs:sequence>
+			<xs:element type="eventType" name="event" maxOccurs="unbounded" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+
+	<xs:complexType name="eventType">
+		<xs:all>
+			<xs:element type="xs:string" name="name"/>
+			<xs:element type="classType" name="class"/>
+			<xs:element type="methodType" name="method"/>
+			<xs:element type="xs:string" name="description" minOccurs="0"/>
+			<xs:element type="pathType" name="path" minOccurs="0"/>
+			<xs:element type="xs:boolean" name="stacktrace" minOccurs="0"/>
+			<xs:element type="xs:boolean" name="rethrow" minOccurs="0"/>
+			<xs:element type="locationType" name="location" minOccurs="0"/>
+			<xs:element type="fieldsType" name="fields" minOccurs="0"/>
+		</xs:all>
+		<xs:attribute type="xs:string" name="id" use="required"/>
+	</xs:complexType>
+
+	<xs:simpleType name="classType">
+		<xs:annotation>
+			<xs:documentation>the fully qualified class name (FQCN) of the class to be transformed</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:normalizedString">
+			<xs:pattern value="([a-zA-Z_$][a-zA-Z0-9_$]*\.)*([a-zA-Z_$][a-zA-Z0-9_$]*)"/>
+			<xs:whiteSpace value="collapse"/>
+		</xs:restriction>
+	</xs:simpleType>
+
+	<xs:complexType name="methodType">
+		<xs:all>
+			<xs:element type="methodNameType" name="name"/>
+			<xs:element type="descriptorType" name="descriptor"/>
+			<xs:element type="parametersType" name="parameters" minOccurs="0"/>
+			<xs:element type="returnValueType" name="returnvalue" minOccurs="0"/>
+		</xs:all>
+	</xs:complexType>
+
+	<xs:simpleType name="methodNameType">
+		<xs:restriction base="xs:normalizedString">
+			<xs:pattern value="[a-zA-Z_$][a-zA-Z0-9_$]*"/>
+			<xs:whiteSpace value="collapse"/>
+		</xs:restriction>
+	</xs:simpleType>
+
+	<xs:simpleType name="descriptorType">
+		<xs:annotation>
+			<xs:documentation>see §4.3.3 in Java Virtual Machine Specification</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:normalizedString">
+			<xs:pattern
+					value="\((\[*([BCDFIJSZ]|L([a-zA-Z_$][a-zA-Z0-9_$]*/)*[a-zA-Z_$][a-zA-Z0-9_$]*;))*\)(V|\[*([BCDFIJSZ]|L([a-zA-Z_$][a-zA-Z0-9_$]*/)*[a-zA-Z_$][a-zA-Z0-9_$]*;))"/>
+			<xs:whiteSpace value="collapse"/>
+		</xs:restriction>
+	</xs:simpleType>
+
+	<xs:complexType name="parametersType">
+		<xs:annotation>
+			<xs:documentation>only if we allow toString</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element type="parameterType" name="parameter" maxOccurs="unbounded" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+
+	<xs:complexType name="parameterType">
+		<xs:all>
+			<xs:element type="xs:string" name="name"/>
+			<xs:element type="xs:string" name="description" minOccurs="0"/>
+			<xs:element type="contentTypeType" name="contenttype" minOccurs="0"/>
+			<xs:element type="relationKeyType" name="relationkey" minOccurs="0"/>
+			<xs:element type="converterType" name="converter" minOccurs="0"/>
+		</xs:all>
+		<xs:attribute type="xs:nonNegativeInteger" name="index" use="required"/>
+	</xs:complexType>
+
+	<xs:simpleType name="contentTypeType">
+		<xs:annotation>
+			<xs:documentation>see com.oracle.jrockit.jfr.ContentType</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:normalizedString">
+			<xs:enumeration value="None"/>
+			<xs:enumeration value="Bytes"/>
+			<xs:enumeration value="Timestamp"/>
+			<xs:enumeration value="Millis"/>
+			<xs:enumeration value="Nanos"/>
+			<xs:enumeration value="Ticks"/>
+			<xs:enumeration value="Address"/>
+			<xs:enumeration value="OSThread"/>
+			<xs:enumeration value="JavaThread"/>
+			<xs:enumeration value="StackTrace"/>
+			<xs:enumeration value="Class"/>
+			<xs:enumeration value="Percentage"/>
+			<xs:whiteSpace value="collapse"/>
+		</xs:restriction>
+	</xs:simpleType>
+
+	<xs:simpleType name="relationKeyType">
+		<xs:annotation>
+			<xs:documentation>
+				a unique URI signifying a relationship between different events based on the values of specific
+				fields
+			</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:anyURI"/>
+	</xs:simpleType>
+
+	<xs:simpleType name="converterType">
+		<xs:annotation>
+			<xs:documentation>the fully qualified class name (FQCN) of the converter used</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="classType"/>
+	</xs:simpleType>
+
+	<xs:complexType name="returnValueType">
+		<xs:annotation>
+			<xs:documentation>This will only work if we allow toString</xs:documentation>
+		</xs:annotation>
+		<xs:all>
+			<xs:element type="xs:string" name="description" minOccurs="0"/>
+			<xs:element type="contentTypeType" name="contenttype" minOccurs="0"/>
+			<xs:element type="relationKeyType" name="relationkey" minOccurs="0"/>
+			<xs:element type="converterType" name="converter" minOccurs="0"/>
+		</xs:all>
+	</xs:complexType>
+
+	<xs:simpleType name="pathType">
+		<xs:restriction base="xs:normalizedString">
+			<xs:pattern value="([^/]+/)*([^/]*)"/>
+			<xs:whiteSpace value="collapse"/>
+		</xs:restriction>
+	</xs:simpleType>
+
+	<xs:simpleType name="locationType">
+		<xs:annotation>
+			<xs:documentation>location {ENTRY, EXIT, WRAP}</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:normalizedString">
+			<xs:enumeration value="ENTRY"/>
+			<xs:enumeration value="EXIT"/>
+			<xs:enumeration value="WRAP"/>
+			<xs:whiteSpace value="collapse"/>
+		</xs:restriction>
+	</xs:simpleType>
+
+	<xs:complexType name="fieldsType">
+		<xs:sequence>
+			<xs:element type="fieldType" name="field" maxOccurs="unbounded" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+
+	<xs:complexType name="fieldType">
+		<xs:sequence>
+			<xs:element type="xs:string" name="name"/>
+			<xs:element type="xs:string" name="description"/>
+			<xs:element type="expressionType" name="expression"/>
+			<xs:element type="contentTypeType" name="contenttype" minOccurs="0"/>
+			<xs:element type="relationKeyType" name="relationkey" minOccurs="0"/>
+			<xs:element type="converterType" name="converter" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+
+	<xs:simpleType name="expressionType">
+		<xs:annotation>
+			<xs:documentation>
+				an expression in a subset of primary expressions (see §15.8 in Java Language Specification) to be
+				evaluated
+			</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:normalizedString">
+			<xs:pattern value="([a-zA-Z_$][a-zA-Z0-9_$]*\.)*([a-zA-Z_$][a-zA-Z0-9_$]*)(\.[a-zA-Z_$][a-zA-Z_$]*)*"/>
+			<xs:whiteSpace value="collapse"/>
+		</xs:restriction>
+	</xs:simpleType>
+</xs:schema>

--- a/agent/src/main/resources/org/openjdk/jmc/agent/impl/jfrprobes_schema.xsd
+++ b/agent/src/main/resources/org/openjdk/jmc/agent/impl/jfrprobes_schema.xsd
@@ -1,6 +1,6 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8" ?>
 <xs:schema elementFormDefault="qualified" xmlns:xs="http://www.w3.org/2001/XMLSchema">
-	<xs:element type="jfrAgentType" name="jfragent"/>
+	<xs:element type="jfrAgentType" name="jfragent" />
 
 	<xs:complexType name="jfrAgentType">
 		<xs:all>
@@ -9,7 +9,7 @@
 					<xs:documentation>Global configuration options</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element type="eventsType" name="events" minOccurs="0"/>
+			<xs:element type="eventsType" name="events" minOccurs="0" />
 		</xs:all>
 	</xs:complexType>
 
@@ -22,7 +22,7 @@
 			</xs:element>
 			<xs:element type="xs:boolean" name="allowtostring" minOccurs="0">
 				<xs:annotation>
-					<xs:documentation>
+					<xs:documentation> 
 						Will allow the recording of arrays and object parameters as Strings. This will cause toString to
 						be called for array elements and objects other than strings, which in turn can cause trouble if
 						the toString method is badly implemented. Use with care.
@@ -41,23 +41,23 @@
 
 	<xs:complexType name="eventsType">
 		<xs:sequence>
-			<xs:element type="eventType" name="event" maxOccurs="unbounded" minOccurs="0"/>
+			<xs:element type="eventType" name="event" maxOccurs="unbounded" minOccurs="0" />
 		</xs:sequence>
 	</xs:complexType>
 
 	<xs:complexType name="eventType">
 		<xs:all>
-			<xs:element type="xs:string" name="name"/>
-			<xs:element type="classType" name="class"/>
-			<xs:element type="methodType" name="method"/>
-			<xs:element type="xs:string" name="description" minOccurs="0"/>
-			<xs:element type="pathType" name="path" minOccurs="0"/>
-			<xs:element type="xs:boolean" name="stacktrace" minOccurs="0"/>
-			<xs:element type="xs:boolean" name="rethrow" minOccurs="0"/>
-			<xs:element type="locationType" name="location" minOccurs="0"/>
-			<xs:element type="fieldsType" name="fields" minOccurs="0"/>
+			<xs:element type="xs:string" name="name" />
+			<xs:element type="classType" name="class" />
+			<xs:element type="methodType" name="method" />
+			<xs:element type="xs:string" name="description" minOccurs="0" />
+			<xs:element type="pathType" name="path" minOccurs="0" />
+			<xs:element type="xs:boolean" name="stacktrace" minOccurs="0" />
+			<xs:element type="xs:boolean" name="rethrow" minOccurs="0" />
+			<xs:element type="locationType" name="location" minOccurs="0" />
+			<xs:element type="fieldsType" name="fields" minOccurs="0" />
 		</xs:all>
-		<xs:attribute type="xs:string" name="id" use="required"/>
+		<xs:attribute type="xs:string" name="id" use="required" />
 	</xs:complexType>
 
 	<xs:simpleType name="classType">
@@ -65,24 +65,24 @@
 			<xs:documentation>the fully qualified class name (FQCN) of the class to be transformed</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:normalizedString">
-			<xs:pattern value="([a-zA-Z_$][a-zA-Z0-9_$]*\.)*([a-zA-Z_$][a-zA-Z0-9_$]*)"/>
-			<xs:whiteSpace value="collapse"/>
+			<xs:pattern value="([a-zA-Z_$][a-zA-Z0-9_$]*\.)*([a-zA-Z_$][a-zA-Z0-9_$]*)" />
+			<xs:whiteSpace value="collapse" />
 		</xs:restriction>
 	</xs:simpleType>
 
 	<xs:complexType name="methodType">
 		<xs:all>
-			<xs:element type="methodNameType" name="name"/>
-			<xs:element type="descriptorType" name="descriptor"/>
-			<xs:element type="parametersType" name="parameters" minOccurs="0"/>
-			<xs:element type="returnValueType" name="returnvalue" minOccurs="0"/>
+			<xs:element type="methodNameType" name="name" />
+			<xs:element type="descriptorType" name="descriptor" />
+			<xs:element type="parametersType" name="parameters" minOccurs="0" />
+			<xs:element type="returnValueType" name="returnvalue" minOccurs="0" />
 		</xs:all>
 	</xs:complexType>
 
 	<xs:simpleType name="methodNameType">
 		<xs:restriction base="xs:normalizedString">
-			<xs:pattern value="[a-zA-Z_$][a-zA-Z0-9_$]*"/>
-			<xs:whiteSpace value="collapse"/>
+			<xs:pattern value="[a-zA-Z_$][a-zA-Z0-9_$]*" />
+			<xs:whiteSpace value="collapse" />
 		</xs:restriction>
 	</xs:simpleType>
 
@@ -91,9 +91,8 @@
 			<xs:documentation>see §4.3.3 in Java Virtual Machine Specification</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:normalizedString">
-			<xs:pattern
-					value="\((\[*([BCDFIJSZ]|L([a-zA-Z_$][a-zA-Z0-9_$]*/)*[a-zA-Z_$][a-zA-Z0-9_$]*;))*\)(V|\[*([BCDFIJSZ]|L([a-zA-Z_$][a-zA-Z0-9_$]*/)*[a-zA-Z_$][a-zA-Z0-9_$]*;))"/>
-			<xs:whiteSpace value="collapse"/>
+			<xs:pattern value="\((\[*([BCDFIJSZ]|L([a-zA-Z_$][a-zA-Z0-9_$]*/)*[a-zA-Z_$][a-zA-Z0-9_$]*;))*\)(V|\[*([BCDFIJSZ]|L([a-zA-Z_$][a-zA-Z0-9_$]*/)*[a-zA-Z_$][a-zA-Z0-9_$]*;))" />
+			<xs:whiteSpace value="collapse" />
 		</xs:restriction>
 	</xs:simpleType>
 
@@ -102,19 +101,19 @@
 			<xs:documentation>only if we allow toString</xs:documentation>
 		</xs:annotation>
 		<xs:sequence>
-			<xs:element type="parameterType" name="parameter" maxOccurs="unbounded" minOccurs="0"/>
+			<xs:element type="parameterType" name="parameter" maxOccurs="unbounded" minOccurs="0" />
 		</xs:sequence>
 	</xs:complexType>
 
 	<xs:complexType name="parameterType">
 		<xs:all>
-			<xs:element type="xs:string" name="name"/>
-			<xs:element type="xs:string" name="description" minOccurs="0"/>
-			<xs:element type="contentTypeType" name="contenttype" minOccurs="0"/>
-			<xs:element type="relationKeyType" name="relationkey" minOccurs="0"/>
-			<xs:element type="converterType" name="converter" minOccurs="0"/>
+			<xs:element type="xs:string" name="name" />
+			<xs:element type="xs:string" name="description" minOccurs="0" />
+			<xs:element type="contentTypeType" name="contenttype" minOccurs="0" />
+			<xs:element type="relationKeyType" name="relationkey" minOccurs="0" />
+			<xs:element type="converterType" name="converter" minOccurs="0" />
 		</xs:all>
-		<xs:attribute type="xs:nonNegativeInteger" name="index" use="required"/>
+		<xs:attribute type="xs:nonNegativeInteger" name="index" use="required" />
 	</xs:complexType>
 
 	<xs:simpleType name="contentTypeType">
@@ -122,19 +121,19 @@
 			<xs:documentation>see com.oracle.jrockit.jfr.ContentType</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:normalizedString">
-			<xs:enumeration value="None"/>
-			<xs:enumeration value="Bytes"/>
-			<xs:enumeration value="Timestamp"/>
-			<xs:enumeration value="Millis"/>
-			<xs:enumeration value="Nanos"/>
-			<xs:enumeration value="Ticks"/>
-			<xs:enumeration value="Address"/>
-			<xs:enumeration value="OSThread"/>
-			<xs:enumeration value="JavaThread"/>
-			<xs:enumeration value="StackTrace"/>
-			<xs:enumeration value="Class"/>
-			<xs:enumeration value="Percentage"/>
-			<xs:whiteSpace value="collapse"/>
+			<xs:enumeration value="None" />
+			<xs:enumeration value="Bytes" />
+			<xs:enumeration value="Timestamp" />
+			<xs:enumeration value="Millis" />
+			<xs:enumeration value="Nanos" />
+			<xs:enumeration value="Ticks" />
+			<xs:enumeration value="Address" />
+			<xs:enumeration value="OSThread" />
+			<xs:enumeration value="JavaThread" />
+			<xs:enumeration value="StackTrace" />
+			<xs:enumeration value="Class" />
+			<xs:enumeration value="Percentage" />
+			<xs:whiteSpace value="collapse" />
 		</xs:restriction>
 	</xs:simpleType>
 
@@ -145,14 +144,14 @@
 				fields
 			</xs:documentation>
 		</xs:annotation>
-		<xs:restriction base="xs:anyURI"/>
+		<xs:restriction base="xs:anyURI" />
 	</xs:simpleType>
 
 	<xs:simpleType name="converterType">
 		<xs:annotation>
 			<xs:documentation>the fully qualified class name (FQCN) of the converter used</xs:documentation>
 		</xs:annotation>
-		<xs:restriction base="classType"/>
+		<xs:restriction base="classType" />
 	</xs:simpleType>
 
 	<xs:complexType name="returnValueType">
@@ -160,17 +159,17 @@
 			<xs:documentation>This will only work if we allow toString</xs:documentation>
 		</xs:annotation>
 		<xs:all>
-			<xs:element type="xs:string" name="description" minOccurs="0"/>
-			<xs:element type="contentTypeType" name="contenttype" minOccurs="0"/>
-			<xs:element type="relationKeyType" name="relationkey" minOccurs="0"/>
-			<xs:element type="converterType" name="converter" minOccurs="0"/>
+			<xs:element type="xs:string" name="description" minOccurs="0" />
+			<xs:element type="contentTypeType" name="contenttype" minOccurs="0" />
+			<xs:element type="relationKeyType" name="relationkey" minOccurs="0" />
+			<xs:element type="converterType" name="converter" minOccurs="0" />
 		</xs:all>
 	</xs:complexType>
 
 	<xs:simpleType name="pathType">
 		<xs:restriction base="xs:normalizedString">
-			<xs:pattern value="([^/]+/)*([^/]*)"/>
-			<xs:whiteSpace value="collapse"/>
+			<xs:pattern value="([^/]+/)*([^/]*)" />
+			<xs:whiteSpace value="collapse" />
 		</xs:restriction>
 	</xs:simpleType>
 
@@ -179,28 +178,28 @@
 			<xs:documentation>location {ENTRY, EXIT, WRAP}</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:normalizedString">
-			<xs:enumeration value="ENTRY"/>
-			<xs:enumeration value="EXIT"/>
-			<xs:enumeration value="WRAP"/>
-			<xs:whiteSpace value="collapse"/>
+			<xs:enumeration value="ENTRY" />
+			<xs:enumeration value="EXIT" />
+			<xs:enumeration value="WRAP" />
+			<xs:whiteSpace value="collapse" />
 		</xs:restriction>
 	</xs:simpleType>
 
 	<xs:complexType name="fieldsType">
 		<xs:sequence>
-			<xs:element type="fieldType" name="field" maxOccurs="unbounded" minOccurs="0"/>
+			<xs:element type="fieldType" name="field" maxOccurs="unbounded" minOccurs="0" />
 		</xs:sequence>
 	</xs:complexType>
 
 	<xs:complexType name="fieldType">
-		<xs:sequence>
-			<xs:element type="xs:string" name="name"/>
-			<xs:element type="xs:string" name="description"/>
-			<xs:element type="expressionType" name="expression"/>
-			<xs:element type="contentTypeType" name="contenttype" minOccurs="0"/>
-			<xs:element type="relationKeyType" name="relationkey" minOccurs="0"/>
-			<xs:element type="converterType" name="converter" minOccurs="0"/>
-		</xs:sequence>
+		<xs:all>
+			<xs:element type="xs:string" name="name" />
+			<xs:element type="expressionType" name="expression" />
+			<xs:element type="xs:string" name="description" minOccurs="0" />
+			<xs:element type="contentTypeType" name="contenttype" minOccurs="0" />
+			<xs:element type="relationKeyType" name="relationkey" minOccurs="0" />
+			<xs:element type="converterType" name="converter" minOccurs="0" />
+		</xs:all>
 	</xs:complexType>
 
 	<xs:simpleType name="expressionType">
@@ -211,8 +210,8 @@
 			</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:normalizedString">
-			<xs:pattern value="([a-zA-Z_$][a-zA-Z0-9_$]*\.)*([a-zA-Z_$][a-zA-Z0-9_$]*)(\.[a-zA-Z_$][a-zA-Z_$]*)*"/>
-			<xs:whiteSpace value="collapse"/>
+			<xs:pattern value="([a-zA-Z_$][a-zA-Z0-9_$]*\.)*([a-zA-Z_$][a-zA-Z0-9_$]*)(\.[a-zA-Z_$][a-zA-Z_$]*)*" />
+			<xs:whiteSpace value="collapse" />
 		</xs:restriction>
 	</xs:simpleType>
 </xs:schema>

--- a/agent/src/test/java/org/openjdk/jmc/agent/test/AllTests.java
+++ b/agent/src/test/java/org/openjdk/jmc/agent/test/AllTests.java
@@ -38,7 +38,7 @@ import org.junit.runners.Suite.SuiteClasses;
 import org.openjdk.jmc.agent.converters.test.TestConverterTransforms;
 
 @RunWith(Suite.class)
-@SuiteClasses({TestDefaultTransformRegistry.class, TestUtils.class, TestJFRTransformer.class, TestConverterTransforms.class})
+@SuiteClasses({TestDefaultTransformRegistry.class, TestUtils.class, TestJFRTransformer.class, TestConverterTransforms.class, TestProbeDefinitionValidation.class})
 
 public class AllTests {
 }

--- a/agent/src/test/java/org/openjdk/jmc/agent/test/TestProbeDefinitionValidation.java
+++ b/agent/src/test/java/org/openjdk/jmc/agent/test/TestProbeDefinitionValidation.java
@@ -1,0 +1,184 @@
+package org.openjdk.jmc.agent.test;
+
+import org.junit.Test;
+import org.openjdk.jmc.agent.impl.DefaultTransformRegistry;
+
+import javax.xml.stream.XMLStreamException;
+import java.text.MessageFormat;
+import java.util.Arrays;
+
+public class TestProbeDefinitionValidation {
+	private final String GLOBAL_PREFIX = "<jfragent><events>";
+	private final String GLOBAL_POSTFIX = "</events></jfragent>";
+
+	@Test
+	public void testValidatingProbeDefinition() throws XMLStreamException {
+		// a partially defined event with all optional elements unset
+		String probe = "<event id=\"demo.event2\">\n" // 
+				+ "    <name>Event 2</name>\n" //
+				+ "    <class>org.company.project.MyDemoClass</class>\n" // 
+				+ "    <method>\n" // 
+				+ "        <name>targetFunction</name>\n" //
+				+ "        <descriptor>(Ljava/lang/String;)V</descriptor>\n" // 
+				+ "    </method>\n" //
+				+ "</event>";
+
+		DefaultTransformRegistry.validateProbeDefinition(GLOBAL_PREFIX + probe + GLOBAL_POSTFIX);
+	}
+
+	@Test
+	public void testValidatingFullyDefinedProbe() throws XMLStreamException {
+		// a fully defined event with all optional elements set
+		String probe = "<event id=\"demo.event1\">\n" + "            <name>Event 1</name>\n"
+				+ "            <class>com.company.project.MyDemoClass</class>\n"
+				+ "            <description>demo event #1</description>\n" + "            <path>demo</path>\n"
+				+ "            <stacktrace>true</stacktrace>\n" + "            <method>\n"
+				+ "                <name>targetFunction</name>\n"
+				+ "                <descriptor>(Ljava/lang/String;)I</descriptor>\n" + "                <parameters>\n"
+				+ "                    <parameter index=\"0\">\n" + "                        <name>param 0</name>\n"
+				+ "                        <description>the first parameter</description>\n"
+				+ "                        <contenttype>None</contenttype>\n"
+				+ "                        <relationkey>http://project.company.com/relation_id/parameter#0</relationkey>\n"
+				+ "                        <converter>com.company.project.MyConverter</converter>\n"
+				+ "                    </parameter>\n" + "                </parameters>\n"
+				+ "                <returnvalue>\n"
+				+ "                    <description>the return value</description>\n"
+				+ "                    <contenttype>None</contenttype>\n"
+				+ "                    <relationkey>http://project.company.com/relation_id/parameter#0</relationkey>\n"
+				+ "                    <converter>com.company.project.MyConverter</converter>\n"
+				+ "                </returnvalue>\n" + "            </method>\n"
+				+ "            <location>WRAP</location>\n" + "            <fields>\n" + "                <field>\n"
+				+ "                    <name>count</name>\n"
+				+ "                    <description>current value of 'count' member variable</description>\n"
+				+ "                    <expression>com.company.product.MyClass.this</expression>\n"
+				+ "                    <contenttype>None</contenttype>\n"
+				+ "                    <relationkey>http://project.company.com/relation_id/field#0</relationkey>\n"
+				+ "                    <converter>com.company.project.MyConverter</converter>\n"
+				+ "                </field>\n" + "            </fields>\n" + "        </event>";
+
+		DefaultTransformRegistry.validateProbeDefinition(GLOBAL_PREFIX + probe + GLOBAL_POSTFIX);
+	}
+
+	@Test(expected = XMLStreamException.class)
+	public void testValidatingEmptyString() throws XMLStreamException {
+		DefaultTransformRegistry.validateProbeDefinition("");
+	}
+
+	@Test(expected = XMLStreamException.class)
+	public void testValidatingNonXmlInput() throws XMLStreamException {
+		DefaultTransformRegistry.validateProbeDefinition("This is not an XML string");
+	}
+
+	@Test
+	public void testValidatingCorrectClassNames() throws XMLStreamException {
+		String probe = "<event id=\"demo.event2\">\n" // 
+				+ "    <name>Event 2</name>\n" //
+				+ "    <class>{0}</class>\n" // 
+				+ "    <method>\n" // 
+				+ "        <name>targetFunction</name>\n" //
+				+ "        <descriptor>(Ljava/lang/String;)V</descriptor>\n" // 
+				+ "    </method>\n" //
+				+ "</event>";
+
+		for (String clazz : Arrays
+				.asList("MyClass", "pkg_name.MyClass", "com.company.project.MyClass", "MyClass$MyInnerClass")) {
+			DefaultTransformRegistry.validateProbeDefinition(GLOBAL_PREFIX + MessageFormat.format(probe, clazz) + GLOBAL_POSTFIX);
+		}
+	}
+
+	@Test(expected = XMLStreamException.class)
+	public void testValidatingEmptyClassName() throws XMLStreamException {
+		String probe = "<event id=\"demo.event2\">\n" // 
+				+ "    <name>Event 2</name>\n" //
+				+ "    <method>\n" // 
+				+ "        <name>targetFunction</name>\n" //
+				+ "        <descriptor>(Ljava/lang/String;)V</descriptor>\n" // 
+				+ "    </method>\n" //
+				+ "</event>";
+
+		DefaultTransformRegistry.validateProbeDefinition(GLOBAL_PREFIX + probe + GLOBAL_POSTFIX);
+	}
+
+	@Test(expected = XMLStreamException.class)
+	public void testValidatingIncorrectClassPattern() throws XMLStreamException {
+		String probe = "<event id=\"demo.event2\">\n" // 
+				+ "    <name>Event 2</name>\n" //
+				+ "    <class>not a validate full-qualified-class-name</class>\n" //
+				+ "    <method>\n" // 
+				+ "        <name>targetFunction</name>\n" //
+				+ "        <descriptor>(Ljava/lang/String;)V</descriptor>\n" // 
+				+ "    </method>\n" //
+				+ "</event>";
+
+		DefaultTransformRegistry.validateProbeDefinition(GLOBAL_PREFIX + probe + GLOBAL_POSTFIX);
+	}
+
+	@Test
+	public void testValidatingMethodDescriptor() throws XMLStreamException {
+		String probe = "<event id=\"demo.event2\">\n" // 
+				+ "    <name>Event 2</name>\n" //
+				+ "    <class>org.company.project.MyDemoClass</class>\n" // 
+				+ "    <method>\n" // 
+				+ "        <name>targetFunction</name>\n" //
+				+ "        <descriptor>{0}</descriptor>\n" // 
+				+ "    </method>\n" //
+				+ "</event>";
+
+		for (String descriptor : Arrays.asList("()D", "()V", // 
+				"(Ljava/lang/String;)V", "(Ljava/lang/String;J)I", //
+				"([Lcom/company/project/MyClass;)V", "([[Lcom/company/project/MyClass;)V", //
+				"()[D", "()[[D")) {
+			DefaultTransformRegistry.validateProbeDefinition(GLOBAL_PREFIX + MessageFormat.format(probe, descriptor) + GLOBAL_POSTFIX);
+		}
+	}
+
+	@Test(expected = XMLStreamException.class)
+	public void testValidatingEmptyDescriptor() throws XMLStreamException {
+		String probe = "<event id=\"demo.event2\">\n" // 
+				+ "    <name>Event 2</name>\n" //
+				+ "    <class>org.company.project.MyDemoClass</class>" //
+				+ "    <method>\n" // 
+				+ "        <name>targetFunction</name>\n" //
+				+ "    </method>\n" //
+				+ "</event>";
+
+		DefaultTransformRegistry.validateProbeDefinition(GLOBAL_PREFIX + probe + GLOBAL_POSTFIX);
+	}
+
+	@Test(expected = XMLStreamException.class)
+	public void testValidatingIncorrectDescriptor() throws XMLStreamException {
+		String probe = "<event id=\"demo.event2\">\n" // 
+				+ "    <name>Event 2</name>\n" //
+				+ "    <class>org.company.project.MyDemoClass</class>" //
+				+ "    <method>\n" // 
+				+ "        <name>targetFunction</name>\n" //
+				+ "        <descriptor>not a valid descriptor</descriptor>\n" // 
+				+ "    </method>\n" //
+				+ "</event>";
+
+		DefaultTransformRegistry.validateProbeDefinition(GLOBAL_PREFIX + probe + GLOBAL_POSTFIX);
+	}
+
+	@Test
+	public void testValidatingExpressions() throws XMLStreamException {
+		String probe = "<event id=\"demo.event2\">\n" // 
+				+ "    <name>Event 2</name>\n" //
+				+ "    <class>org.company.project.MyDemoClass</class>\n" // 
+				+ "    <method>\n" // 
+				+ "        <name>targetFunction</name>\n" //
+				+ "        <descriptor>(Ljava/lang/String;)V</descriptor>\n" // 
+				+ "    </method>\n" //
+				+ "    <fields>" //
+				+ "        <field>" //
+				+ "            <name>a variable</name>" //
+				+ "            <expression>${0}</expression>" //
+				+ "        </field>" //
+				+ "    </fields>" //
+				+ "</event>";
+
+		for (String expression : Arrays
+				.asList("this", "this.field", "MyClass.this.field", "field", "super.field", "STATIC_FIELD")) {
+			DefaultTransformRegistry.validateProbeDefinition(GLOBAL_PREFIX + MessageFormat.format(probe, expression) + GLOBAL_POSTFIX);
+		}
+	}
+}

--- a/agent/src/test/java/org/openjdk/jmc/agent/test/util/TestToolkit.java
+++ b/agent/src/test/java/org/openjdk/jmc/agent/test/util/TestToolkit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/agent/src/test/java/org/openjdk/jmc/agent/test/util/TestToolkit.java
+++ b/agent/src/test/java/org/openjdk/jmc/agent/test/util/TestToolkit.java
@@ -32,14 +32,14 @@
  */
 package org.openjdk.jmc.agent.test.util;
 
+import org.openjdk.jmc.agent.util.IOToolkit;
+
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
 import java.io.Closeable;
-import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.util.Arrays;
 import java.util.Random;
 
 public final class TestToolkit {
@@ -53,40 +53,8 @@ public final class TestToolkit {
 
 	public static byte[] getByteCode(Class<?> c) throws IOException {
 		try (InputStream is = c.getClassLoader().getResourceAsStream(c.getName().replace('.', '/') + ".class")) { //$NON-NLS-1$
-			return readFully(is, -1, true);
+			return IOToolkit.readFully(is, -1, true);
 		}
-	}
-
-	public static byte[] readFully(InputStream is, int length, boolean readAll) throws IOException {
-		byte[] output = {};
-		if (length == -1) {
-			length = Integer.MAX_VALUE;
-		}
-		int pos = 0;
-		while (pos < length) {
-			int bytesToRead;
-			if (pos >= output.length) { // Only expand when there's no room
-				bytesToRead = Math.min(length - pos, output.length + 1024);
-				if (output.length < pos + bytesToRead) {
-					output = Arrays.copyOf(output, pos + bytesToRead);
-				}
-			} else {
-				bytesToRead = output.length - pos;
-			}
-			int cc = is.read(output, pos, bytesToRead);
-			if (cc < 0) {
-				if (readAll && length != Integer.MAX_VALUE) {
-					throw new EOFException("Detect premature EOF"); //$NON-NLS-1$
-				} else {
-					if (output.length != pos) {
-						output = Arrays.copyOf(output, pos);
-					}
-					break;
-				}
-			}
-			pos += cc;
-		}
-		return output;
 	}
 
 	public static long randomLong() {

--- a/agent/src/test/resources/org/openjdk/jmc/agent/converters/test/jfrprobes_template.xml
+++ b/agent/src/test/resources/org/openjdk/jmc/agent/converters/test/jfrprobes_template.xml
@@ -48,92 +48,110 @@
 	<events>
 		<event id="demo.jfr.convertertest.String">
 			<name>ConverterEventString-%TEST_NAME%</name>
-			<description>Defined in the xml file and added by the agent. Should transform the Gurka parameter to String.</description>
+			<description>Defined in the xml file and added by the agent. Should transform the Gurka parameter to
+				String.
+			</description>
 			<path>demo/converterevents/</path>
-			<kind>DURATION</kind>
 			<stacktrace>true</stacktrace>
 			<class>org.openjdk.jmc.agent.converters.test.InstrumentMeConverter
 			</class>
 			<method>
 				<name>printGurkaToString</name>
 				<descriptor>(Lorg/openjdk/jmc/bciagent/test/Gurka;)V</descriptor>
-				<parameter index="0">
-					<name>Gurka Attribute</name>
-					<description>The one and only converted Gurk-parameter</description>
-					<contenttype>None</contenttype>
-					<converter>org.openjdk.jmc.agent.converters.test.GurkConverterString</converter>
-				</parameter>
+				<parameters>
+					<parameter index="0">
+						<name>Gurka Attribute</name>
+						<description>The one and only converted Gurk-parameter</description>
+						<contenttype>None</contenttype>
+						<converter>org.openjdk.jmc.agent.converters.test.GurkConverterString</converter>
+					</parameter>
+				</parameters>
 			</method>
 		</event>
 		<event id="demo.jfr.convertertest.Int">
 			<name>ConverterEventInt-%TEST_NAME%</name>
-			<description>Defined in the xml file and added by the agent. Should transform the Gurka parameter to an int.</description>
+			<description>Defined in the xml file and added by the agent. Should transform the Gurka parameter to an
+				int.
+			</description>
 			<path>demo/converterevents</path>
 			<stacktrace>true</stacktrace>
 			<class>org.openjdk.jmc.agent.converters.test.InstrumentMeConverter</class>
 			<method>
 				<name>printGurkaToInt</name>
 				<descriptor>(Lorg/openjdk/jmc/bciagent/test/Gurka;)V</descriptor>
-				<parameter index="0">
-					<name>Gurka Attribute</name>
-					<description>The one and only converted Gurk-parameter</description>
-					<contenttype>None</contenttype>
-					<converter>org.openjdk.jmc.agent.converters.test.GurkConverterInt</converter>
-				</parameter>
+				<parameters>
+					<parameter index="0">
+						<name>Gurka Attribute</name>
+						<description>The one and only converted Gurk-parameter</description>
+						<contenttype>None</contenttype>
+						<converter>org.openjdk.jmc.agent.converters.test.GurkConverterInt</converter>
+					</parameter>
+				</parameters>
 			</method>
 			<location>WRAP</location>
 		</event>
 		<event id="demo.jfr.convertertest.Long">
 			<name>ConverterEventLong-%TEST_NAME%</name>
-			<description>Defined in the xml file and added by the agent. Should transform the Gurka parameter to a long.</description>
+			<description>Defined in the xml file and added by the agent. Should transform the Gurka parameter to a
+				long.
+			</description>
 			<path>demo/converterevents</path>
 			<stacktrace>true</stacktrace>
 			<class>org.openjdk.jmc.agent.converters.test.InstrumentMeConverter</class>
 			<method>
 				<name>printGurkaToLong</name>
 				<descriptor>(Lorg/openjdk/jmc/bciagent/test/Gurka;)V</descriptor>
-				<parameter index="0">
-					<name>Gurka Attribute</name>
-					<description>The one and only converted Gurk-parameter</description>
-					<contenttype>None</contenttype>
-					<converter>org.openjdk.jmc.agent.converters.test.GurkConverterLong</converter>
-				</parameter>
+				<parameters>
+					<parameter index="0">
+						<name>Gurka Attribute</name>
+						<description>The one and only converted Gurk-parameter</description>
+						<contenttype>None</contenttype>
+						<converter>org.openjdk.jmc.agent.converters.test.GurkConverterLong</converter>
+					</parameter>
+				</parameters>
 			</method>
 			<location>WRAP</location>
 		</event>
 		<event id="demo.jfr.convertertest.Float">
 			<name>ConverterEventFloat-%TEST_NAME%</name>
-			<description>Defined in the xml file and added by the agent. Should transform the Gurka parameter to a float.</description>
+			<description>Defined in the xml file and added by the agent. Should transform the Gurka parameter to a
+				float.
+			</description>
 			<path>demo/converterevents</path>
-			<thread>true</thread>
 			<class>org.openjdk.jmc.agent.converters.test.InstrumentMeConverter</class>
 			<method>
 				<name>printGurkaToFloat</name>
 				<descriptor>(Lorg/openjdk/jmc/bciagent/test/Gurka;)V</descriptor>
-				<parameter index="0">
-					<name>Gurka Attribute</name>
-					<description>The one and only converted Gurk-parameter</description>
-					<contenttype>None</contenttype>
-					<converter>org.openjdk.jmc.agent.converters.test.GurkConverterFloat</converter>
-				</parameter>
+				<parameters>
+					<parameter index="0">
+						<name>Gurka Attribute</name>
+						<description>The one and only converted Gurk-parameter</description>
+						<contenttype>None</contenttype>
+						<converter>org.openjdk.jmc.agent.converters.test.GurkConverterFloat</converter>
+					</parameter>
+				</parameters>
 			</method>
 			<location>WRAP</location>
 		</event>
 		<event id="demo.jfr.convertertest.Double">
 			<name>ConverterEventDouble-%TEST_NAME%</name>
-			<description>Defined in the xml file and added by the agent. Should transform the Gurka parameter to a float.</description>
+			<description>Defined in the xml file and added by the agent. Should transform the Gurka parameter to a
+				float.
+			</description>
 			<path>demo/converterevents</path>
 			<stacktrace>true</stacktrace>
 			<class>org.openjdk.jmc.agent.converters.test.InstrumentMeConverter</class>
 			<method>
 				<name>printGurkaToFloat</name>
 				<descriptor>(Lorg/openjdk/jmc/bciagent/test/Gurka;)V</descriptor>
-				<parameter index="0">
-					<name>Gurka Attribute</name>
-					<description>The one and only converted Gurk-parameter</description>
-					<contenttype>None</contenttype>
-					<converter>org.openjdk.jmc.agent.converters.test.GurkConverterFloat</converter>
-				</parameter>
+				<parameters>
+					<parameter index="0">
+						<name>Gurka Attribute</name>
+						<description>The one and only converted Gurk-parameter</description>
+						<contenttype>None</contenttype>
+						<converter>org.openjdk.jmc.agent.converters.test.GurkConverterFloat</converter>
+					</parameter>
+				</parameters>
 			</method>
 			<location>WRAP</location>
 		</event>

--- a/agent/src/test/resources/org/openjdk/jmc/agent/converters/test/jfrprobes_template.xml
+++ b/agent/src/test/resources/org/openjdk/jmc/agent/converters/test/jfrprobes_template.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--   
-   Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+   Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
    
    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
    

--- a/agent/src/test/resources/org/openjdk/jmc/agent/test/jfrprobes_simple.xml
+++ b/agent/src/test/resources/org/openjdk/jmc/agent/test/jfrprobes_simple.xml
@@ -45,11 +45,13 @@
 			</method>
 			<!-- location {ENTRY, EXIT, WRAP}-->
 			<location>WRAP</location>
-			<field>
-				<name>'InstrumentMe.STATIC_STRING_FIELD'</name>
-				<description>Capturing outer class field with class name prefixed field name</description>
-				<expression>InstrumentMe.STATIC_STRING_FIELD</expression>
-			</field>
+			<fields>
+				<field>
+					<name>'InstrumentMe.STATIC_STRING_FIELD'</name>
+					<description>Capturing outer class field with class name prefixed field name</description>
+					<expression>InstrumentMe.STATIC_STRING_FIELD</expression>
+				</field>
+			</fields>
 		</event>
 	</events>
 </jfragent>

--- a/agent/src/test/resources/org/openjdk/jmc/agent/test/jfrprobes_template.xml
+++ b/agent/src/test/resources/org/openjdk/jmc/agent/test/jfrprobes_template.xml
@@ -41,7 +41,7 @@
 		     method is badly implemented. Use with care. -->
 		<allowtostring>true</allowtostring>
 		<!-- Allows converters to be used. If a converter is badly implemented, you are on your own. -->
-		<allowconverter>true</allowconverter>		
+		<allowconverter>true</allowconverter>
 	</config>
 	<events>
 		<event id="demo.jfr.test1">
@@ -51,7 +51,7 @@
 			<stacktrace>true</stacktrace>
 			<class>org.openjdk.jmc.agent.test.InstrumentMe</class>
 			<method>
-				<name>printHelloWorldJFR1</name>						
+				<name>printHelloWorldJFR1</name>
 				<descriptor>()V</descriptor>
 			</method>
 			<!-- location {ENTRY, EXIT, WRAP}-->
@@ -64,23 +64,25 @@
 			<stacktrace>true</stacktrace>
 			<class>org.openjdk.jmc.agent.test.InstrumentMe</class>
 			<method>
-				<name>printHelloWorldJFR2</name>						
+				<name>printHelloWorldJFR2</name>
 				<descriptor>(Ljava/lang/String;J)I</descriptor>
-				<parameter index="0">
-					<name>String Attribute</name>
-					<description>The first parameter</description>
-					<!-- See com.oracle.jrockit.jfr.ContentType
-					     {None, Bytes, Timestamp, Millis, Nanos, Ticks, Address, OSThread, JavaThread, StackTrace, Class, Percentage} -->
-					<contenttype>None</contenttype>	
-				</parameter>
-				<parameter index="1">
-					<name>Long Attribute</name>
-					<description>The second parameter</description>
-					<contenttype>Bytes</contenttype>	
-				</parameter>
+				<parameters>
+					<parameter index="0">
+						<name>String Attribute</name>
+						<description>The first parameter</description>
+						<!-- See com.oracle.jrockit.jfr.ContentType
+							 {None, Bytes, Timestamp, Millis, Nanos, Ticks, Address, OSThread, JavaThread, StackTrace, Class, Percentage} -->
+						<contenttype>None</contenttype>
+					</parameter>
+					<parameter index="1">
+						<name>Long Attribute</name>
+						<description>The second parameter</description>
+						<contenttype>Bytes</contenttype>
+					</parameter>
+				</parameters>
 				<returnvalue>
 					<description>The return value</description>
-					<contenttype>None</contenttype>	
+					<contenttype>None</contenttype>
 				</returnvalue>
 			</method>
 			<!-- location {ENTRY, EXIT, WRAP}-->
@@ -88,7 +90,9 @@
 		</event>
 		<event id="demo.jfr.test11">
 			<name>JFR Hello World Event 11 %TEST_NAME%</name>
-			<description>Defined in the xml file and added by the agent. Should record the value of static reference 'STATIC_STRING_FIELD'</description>
+			<description>Defined in the xml file and added by the agent. Should record the value of static reference
+				'STATIC_STRING_FIELD'
+			</description>
 			<path>demo/jfrhelloworldevent11</path>
 			<stacktrace>true</stacktrace>
 			<class>org.openjdk.jmc.agent.test.InstrumentMe</class>
@@ -96,25 +100,29 @@
 				<name>printHelloWorldJFR11</name>
 				<descriptor>()V</descriptor>
 			</method>
-			<field>
-				<name>'STATIC_STRING_FIELD'</name>
-				<description>Capturing static field with simple field name</description>
-				<expression>STATIC_STRING_FIELD</expression>
-			</field>
-			<field>
-				<name>'InstrumentMe.STATIC_STRING_FIELD'</name>
-				<description>Capturing static field with class name prefixed field name</description>
-				<expression>InstrumentMe.STATIC_STRING_FIELD</expression>
-			</field>
-			<field>
-				<name>'org.openjdk.jmc.agent.test.InstrumentMe.STATIC_STRING_FIELD'</name>
-				<description>Capturing static field with full qualified class prefixed name</description>
-				<expression>org.openjdk.jmc.agent.test.InstrumentMe.STATIC_STRING_FIELD</expression>
-			</field>
+			<fields>
+				<field>
+					<name>'STATIC_STRING_FIELD'</name>
+					<description>Capturing static field with simple field name</description>
+					<expression>STATIC_STRING_FIELD</expression>
+				</field>
+				<field>
+					<name>'InstrumentMe.STATIC_STRING_FIELD'</name>
+					<description>Capturing static field with class name prefixed field name</description>
+					<expression>InstrumentMe.STATIC_STRING_FIELD</expression>
+				</field>
+				<field>
+					<name>'org.openjdk.jmc.agent.test.InstrumentMe.STATIC_STRING_FIELD'</name>
+					<description>Capturing static field with full qualified class prefixed name</description>
+					<expression>org.openjdk.jmc.agent.test.InstrumentMe.STATIC_STRING_FIELD</expression>
+				</field>
+			</fields>
 		</event>
 		<event id="demo.jfr.test12">
 			<name>JFR Hello World Event 12 %TEST_NAME%</name>
-			<description>Defined in the xml file and added by the agent. Should record the values of 'STATIC_OBJECT_FIELD.STATIC_STRING_FIELD' and 'STATIC_OBJECT_FIELD.instanceStringField'</description>
+			<description>Defined in the xml file and added by the agent. Should record the values of
+				'STATIC_OBJECT_FIELD.STATIC_STRING_FIELD' and 'STATIC_OBJECT_FIELD.instanceStringField'
+			</description>
 			<path>demo/jfrhelloworldevent12</path>
 			<stacktrace>true</stacktrace>
 			<class>org.openjdk.jmc.agent.test.InstrumentMe</class>
@@ -122,20 +130,24 @@
 				<name>printHelloWorldJFR12</name>
 				<descriptor>()V</descriptor>
 			</method>
-			<field>
-				<name>'STATIC_OBJECT_FIELD.STATIC_STRING_FIELD'</name>
-				<description>Capturing static field on a object reference</description>
-				<expression>STATIC_OBJECT_FIELD.STATIC_STRING_FIELD</expression>
-			</field>
-			<field>
-				<name>'STATIC_OBJECT_FIELD.instanceStringField'</name>
-				<description>Capturing non-static field on a object reference</description>
-				<expression>STATIC_OBJECT_FIELD.instanceStringField</expression>
-			</field>
+			<fields>
+				<field>
+					<name>'STATIC_OBJECT_FIELD.STATIC_STRING_FIELD'</name>
+					<description>Capturing static field on a object reference</description>
+					<expression>STATIC_OBJECT_FIELD.STATIC_STRING_FIELD</expression>
+				</field>
+				<field>
+					<name>'STATIC_OBJECT_FIELD.instanceStringField'</name>
+					<description>Capturing non-static field on a object reference</description>
+					<expression>STATIC_OBJECT_FIELD.instanceStringField</expression>
+				</field>
+			</fields>
 		</event>
 		<event id="demo.jfr.test13">
 			<name>JFR Hello World Event 13 %TEST_NAME%</name>
-			<description>Defined in the xml file and added by the agent. Should record the values of static 'STATIC_NULL_FIELD.STATIC_STRING_FIELD' and 'STATIC_NULL_FIELD.instanceStringField'</description>
+			<description>Defined in the xml file and added by the agent. Should record the values of static
+				'STATIC_NULL_FIELD.STATIC_STRING_FIELD' and 'STATIC_NULL_FIELD.instanceStringField'
+			</description>
 			<path>demo/jfrhelloworldevent13</path>
 			<stacktrace>true</stacktrace>
 			<class>org.openjdk.jmc.agent.test.InstrumentMe</class>
@@ -143,16 +155,18 @@
 				<name>printHelloWorldJFR11</name>
 				<descriptor>()V</descriptor>
 			</method>
-			<field>
-				<name>'STATIC_NULL_FIELD.STATIC_STRING_FIELD'</name>
-				<description>Capturing static field on a null object reference</description>
-				<expression>STATIC_NULL_FIELD.STATIC_STRING_FIELD</expression>
-			</field>
-			<field>
-				<name>'STATIC_NULL_FIELD.instanceStringField'</name>
-				<description>Capturing non-static field on a null object reference</description>
-				<expression>STATIC_NULL_FIELD.instanceStringField</expression>
-			</field>
+			<fields>
+				<field>
+					<name>'STATIC_NULL_FIELD.STATIC_STRING_FIELD'</name>
+					<description>Capturing static field on a null object reference</description>
+					<expression>STATIC_NULL_FIELD.STATIC_STRING_FIELD</expression>
+				</field>
+				<field>
+					<name>'STATIC_NULL_FIELD.instanceStringField'</name>
+					<description>Capturing non-static field on a null object reference</description>
+					<expression>STATIC_NULL_FIELD.instanceStringField</expression>
+				</field>
+			</fields>
 		</event>
 		<event id="demo.jfr.testI1">
 			<name>JFR Hello World Instance Event 1 %TEST_NAME%</name>
@@ -161,7 +175,7 @@
 			<stacktrace>true</stacktrace>
 			<class>org.openjdk.jmc.agent.test.InstrumentMe</class>
 			<method>
-				<name>printInstanceHelloWorldJFR1</name>						
+				<name>printInstanceHelloWorldJFR1</name>
 				<descriptor>()V</descriptor>
 			</method>
 			<!-- location {ENTRY, EXIT, WRAP}-->
@@ -174,21 +188,23 @@
 			<stacktrace>true</stacktrace>
 			<class>org.openjdk.jmc.agent.test.InstrumentMe</class>
 			<method>
-				<name>printInstanceHelloWorldJFR2</name>						
+				<name>printInstanceHelloWorldJFR2</name>
 				<descriptor>(Ljava/lang/String;J)I</descriptor>
-				<parameter index="0">
-					<name>String Attribute</name>
-					<description>The first parameter</description>
-					<contenttype>None</contenttype>	
-				</parameter>
-				<parameter index="1">
-					<name>Long Attribute</name>
-					<description>The second parameter</description>
-					<contenttype>Bytes</contenttype>	
-				</parameter>
+				<parameters>
+					<parameter index="0">
+						<name>String Attribute</name>
+						<description>The first parameter</description>
+						<contenttype>None</contenttype>
+					</parameter>
+					<parameter index="1">
+						<name>Long Attribute</name>
+						<description>The second parameter</description>
+						<contenttype>Bytes</contenttype>
+					</parameter>
+				</parameters>
 				<returnvalue>
 					<description>The return value</description>
-					<contenttype>None</contenttype>	
+					<contenttype>None</contenttype>
 				</returnvalue>
 			</method>
 		</event>
@@ -199,14 +215,16 @@
 			<stacktrace>true</stacktrace>
 			<class>org.openjdk.jmc.agent.test.InstrumentMe</class>
 			<method>
-				<name>printInstanceHelloWorldJFR3</name>						
+				<name>printInstanceHelloWorldJFR3</name>
 				<descriptor>(Lorg/openjdk/jmc/bciagent/test/Gurka;)V</descriptor>
 				<!-- Note that this will only work if we allow toString -->
-				<parameter index="0">
-					<name>Gurka Attribute</name>
-					<description>The one and only Gurk-parameter</description>
-					<contenttype>None</contenttype>	
-				</parameter>
+				<parameters>
+					<parameter index="0">
+						<name>Gurka Attribute</name>
+						<description>The one and only Gurk-parameter</description>
+						<contenttype>None</contenttype>
+					</parameter>
+				</parameters>
 			</method>
 		</event>
 		<event id="demo.jfr.testI4">
@@ -216,14 +234,16 @@
 			<stacktrace>true</stacktrace>
 			<class>org.openjdk.jmc.agent.test.InstrumentMe</class>
 			<method>
-				<name>printInstanceHelloWorldJFR4</name>						
+				<name>printInstanceHelloWorldJFR4</name>
 				<descriptor>([Lorg/openjdk/jmc/bciagent/test/Gurka;)V</descriptor>
 				<!-- Note that this will only work if we allow toString -->
-				<parameter index="0">
-					<name>Gurka Array Attribute</name>
-					<description>The one and only Gurk-array-parameter</description>
-					<contenttype>None</contenttype>	
-				</parameter>
+				<parameters>
+					<parameter index="0">
+						<name>Gurka Array Attribute</name>
+						<description>The one and only Gurk-array-parameter</description>
+						<contenttype>None</contenttype>
+					</parameter>
+				</parameters>
 			</method>
 		</event>
 		<event id="demo.jfr.testI5">
@@ -233,14 +253,16 @@
 			<stacktrace>true</stacktrace>
 			<class>org.openjdk.jmc.agent.test.InstrumentMe</class>
 			<method>
-				<name>printInstanceHelloWorldJFR5</name>						
+				<name>printInstanceHelloWorldJFR5</name>
 				<descriptor>(Ljava/util/Collection;)V</descriptor>
 				<!-- Note that this will only work if we allow toString -->
-				<parameter index="0">
-					<name>Gurka Collection Attribute</name>
-					<description>The one and only Gurk-collection</description>
-					<contenttype>None</contenttype>	
-				</parameter>
+				<parameters>
+					<parameter index="0">
+						<name>Gurka Collection Attribute</name>
+						<description>The one and only Gurk-collection</description>
+						<contenttype>None</contenttype>
+					</parameter>
+				</parameters>
 			</method>
 		</event>
 		<event id="demo.jfr.testI6">
@@ -250,18 +272,20 @@
 			<stacktrace>true</stacktrace>
 			<class>org.openjdk.jmc.agent.test.InstrumentMe</class>
 			<method>
-				<name>printInstanceHelloWorldJFR6</name>						
+				<name>printInstanceHelloWorldJFR6</name>
 				<descriptor>()D</descriptor>
 				<!-- Note that this will only work if we allow toString -->
 				<returnvalue>
 					<description>A value between 0 and 100 (double)</description>
-					<contenttype>Percentage</contenttype>	
+					<contenttype>Percentage</contenttype>
 				</returnvalue>
 			</method>
 		</event>
 		<event id="demo.jfr.testI7">
 			<name>JFR Hello World Instance Event 7 %TEST_NAME%</name>
-			<description>Defined in the xml file and added by the agent. The original method contains a try-catch clause.</description>
+			<description>Defined in the xml file and added by the agent. The original method contains a try-catch
+				clause.
+			</description>
 			<path>demo/jfrhelloworldeventI7</path>
 			<stacktrace>true</stacktrace>
 			<class>org.openjdk.jmc.agent.test.InstrumentMe</class>
@@ -272,7 +296,8 @@
 		</event>
 		<event id="demo.jfr.testI8">
 			<name>JFR Hello World Instance Event 8 %TEST_NAME%</name>
-			<description>Defined in the xml file and added by the agent. Should record even if an exception is raised.</description>
+			<description>Defined in the xml file and added by the agent. Should record even if an exception is raised.
+			</description>
 			<path>demo/jfrhelloworldeventI8</path>
 			<stacktrace>true</stacktrace>
 			<class>org.openjdk.jmc.agent.test.InstrumentMe</class>
@@ -284,7 +309,8 @@
 		</event>
 		<event id="demo.jfr.testI9">
 			<name>JFR Hello World Instance Event 9 %TEST_NAME%</name>
-			<description>Defined in the xml file and added by the agent. Should not record if an exception is raised.</description>
+			<description>Defined in the xml file and added by the agent. Should not record if an exception is raised.
+			</description>
 			<path>demo/jfrhelloworldeventI9</path>
 			<stacktrace>true</stacktrace>
 			<class>org.openjdk.jmc.agent.test.InstrumentMe</class>
@@ -295,7 +321,9 @@
 		</event>
 		<event id="demo.jfr.testI10">
 			<name>JFR Hello World Instance Event 10 %TEST_NAME%</name>
-			<description>Defined in the xml file and added by the agent. Should record even if an exception is raised, but should not overwrite the existing try-catch clause.</description>
+			<description>Defined in the xml file and added by the agent. Should record even if an exception is raised,
+				but should not overwrite the existing try-catch clause.
+			</description>
 			<path>demo/jfrhelloworldeventI10</path>
 			<stacktrace>true</stacktrace>
 			<class>org.openjdk.jmc.agent.test.InstrumentMe</class>
@@ -307,7 +335,9 @@
 		</event>
 		<event id="demo.jfr.testI11">
 			<name>JFR Hello World Instance Event 11 %TEST_NAME%</name>
-			<description>Defined in the xml file and added by the agent. Should record the value of instance reference 'instanceStringField'</description>
+			<description>Defined in the xml file and added by the agent. Should record the value of instance reference
+				'instanceStringField'
+			</description>
 			<path>demo/jfrhelloworldeventI11</path>
 			<stacktrace>true</stacktrace>
 			<class>org.openjdk.jmc.agent.test.InstrumentMe</class>
@@ -315,25 +345,29 @@
 				<name>printInstanceHelloWorldJFR11</name>
 				<descriptor>()V</descriptor>
 			</method>
-			<field>
-				<name>'instanceStringField'</name>
-				<description>Capturing instance field with simple field name</description>
-				<expression>instanceStringField</expression>
-			</field>
-			<field>
-				<name>'this.instanceStringField'</name>
-				<description>Capturing instance field with "this" prefixed field name</description>
-				<expression>this.instanceStringField</expression>
-			</field>
-			<field>
-				<name>'InstrumentMe.this.instanceStringField'</name>
-				<description>Capturing instance field with qualified "this" prefixed field name</description>
-				<expression>InstrumentMe.this.instanceStringField</expression>
-			</field>
+			<fields>
+				<field>
+					<name>'instanceStringField'</name>
+					<description>Capturing instance field with simple field name</description>
+					<expression>instanceStringField</expression>
+				</field>
+				<field>
+					<name>'this.instanceStringField'</name>
+					<description>Capturing instance field with "this" prefixed field name</description>
+					<expression>this.instanceStringField</expression>
+				</field>
+				<field>
+					<name>'InstrumentMe.this.instanceStringField'</name>
+					<description>Capturing instance field with qualified "this" prefixed field name</description>
+					<expression>InstrumentMe.this.instanceStringField</expression>
+				</field>
+			</fields>
 		</event>
 		<event id="demo.jfr.testI12">
 			<name>JFR Hello World Instance Event 12 %TEST_NAME%</name>
-			<description>Defined in the xml file and added by the agent. Should record the values of various references</description>
+			<description>Defined in the xml file and added by the agent. Should record the values of various
+				references
+			</description>
 			<path>demo/jfrhelloworldeventI12</path>
 			<stacktrace>true</stacktrace>
 			<class>org.openjdk.jmc.agent.test.InstrumentMe$MyInnerClass</class>
@@ -341,43 +375,45 @@
 				<name>instrumentationPoint</name>
 				<descriptor>()V</descriptor>
 			</method>
-			<field>
-				<name>'innerClassField'</name>
-				<description>Capturing inner class field with simple field name</description>
-				<expression>innerClassField</expression>
-			</field>
-			<field>
-				<name>'this.innerClassField'</name>
-				<description>Capturing inner class field with "this" prefixed field name</description>
-				<expression>this.innerClassField</expression>
-			</field>
+			<fields>
+				<field>
+					<name>'innerClassField'</name>
+					<description>Capturing inner class field with simple field name</description>
+					<expression>innerClassField</expression>
+				</field>
+				<field>
+					<name>'this.innerClassField'</name>
+					<description>Capturing inner class field with "this" prefixed field name</description>
+					<expression>this.innerClassField</expression>
+				</field>
 
-			<field>
-				<name>'instanceStringField'</name>
-				<description>Capturing outer class field with simple field name</description>
-				<expression>instanceStringField</expression>
-			</field>
-			<field>
-				<name>'InstrumentMe.this.instanceStringField'</name>
-				<description>Capturing outer class field with qualified "this" prefixed field name</description>
-				<expression>InstrumentMe.this.instanceStringField</expression>
-			</field>
-			<field>
-				<name>'super.instanceStringField'</name>
-				<description>Capturing super class field with "super" prefixed field name</description>
-				<expression>super.instanceStringField</expression>
-			</field>
+				<field>
+					<name>'instanceStringField'</name>
+					<description>Capturing outer class field with simple field name</description>
+					<expression>instanceStringField</expression>
+				</field>
+				<field>
+					<name>'InstrumentMe.this.instanceStringField'</name>
+					<description>Capturing outer class field with qualified "this" prefixed field name</description>
+					<expression>InstrumentMe.this.instanceStringField</expression>
+				</field>
+				<field>
+					<name>'super.instanceStringField'</name>
+					<description>Capturing super class field with "super" prefixed field name</description>
+					<expression>super.instanceStringField</expression>
+				</field>
 
-			<field>
-				<name>'STATIC_STRING_FIELD'</name>
-				<description>Capturing outer class field with simple field name</description>
-				<expression>STATIC_STRING_FIELD</expression>
-			</field>
-			<field>
-				<name>'InstrumentMe.STATIC_STRING_FIELD'</name>
-				<description>Capturing outer class field with class name prefixed field name</description>
-				<expression>InstrumentMe.STATIC_STRING_FIELD</expression>
-			</field>
+				<field>
+					<name>'STATIC_STRING_FIELD'</name>
+					<description>Capturing outer class field with simple field name</description>
+					<expression>STATIC_STRING_FIELD</expression>
+				</field>
+				<field>
+					<name>'InstrumentMe.STATIC_STRING_FIELD'</name>
+					<description>Capturing outer class field with class name prefixed field name</description>
+					<expression>InstrumentMe.STATIC_STRING_FIELD</expression>
+				</field>
+			</fields>
 		</event>
 	</events>
 </jfragent>

--- a/agent/src/test/resources/org/openjdk/jmc/agent/test/jfrprobes_template.xml
+++ b/agent/src/test/resources/org/openjdk/jmc/agent/test/jfrprobes_template.xml
@@ -36,17 +36,20 @@
 	<config>
 		<!-- This is the prefix to use when generating event class names -->
 		<classprefix>__JFREvent</classprefix>
-		<!-- Will allow the recording of arrays and object parameters as Strings. This will cause toString to be called
-		     for array elements and objects other than strings, which in turn can cause trouble if the toString 
-		     method is badly implemented. Use with care. -->
+		<!-- Will allow the recording of arrays and object parameters as Strings. 
+			This will cause toString to be called for array elements and objects other 
+			than strings, which in turn can cause trouble if the toString method is badly 
+			implemented. Use with care. -->
 		<allowtostring>true</allowtostring>
-		<!-- Allows converters to be used. If a converter is badly implemented, you are on your own. -->
+		<!-- Allows converters to be used. If a converter is badly implemented, 
+			you are on your own. -->
 		<allowconverter>true</allowconverter>
 	</config>
 	<events>
 		<event id="demo.jfr.test1">
 			<name>JFR Hello World Event 1 %TEST_NAME%</name>
-			<description>Defined in the xml file and added by the agent.</description>
+			<description>Defined in the xml file and added by the agent.
+			</description>
 			<path>demo/jfrhelloworldevent1</path>
 			<stacktrace>true</stacktrace>
 			<class>org.openjdk.jmc.agent.test.InstrumentMe</class>
@@ -54,12 +57,14 @@
 				<name>printHelloWorldJFR1</name>
 				<descriptor>()V</descriptor>
 			</method>
-			<!-- location {ENTRY, EXIT, WRAP}-->
+			<!-- location {ENTRY, EXIT, WRAP} -->
 			<location>WRAP</location>
 		</event>
 		<event id="demo.jfr.test2">
 			<name>JFR Hello World Event 2 %TEST_NAME%</name>
-			<description>Defined in the xml file and added by the agent. Should record the parameters.</description>
+			<description>Defined in the xml file and added by the agent. Should
+				record the parameters.
+			</description>
 			<path>demo/jfrhelloworldevent2</path>
 			<stacktrace>true</stacktrace>
 			<class>org.openjdk.jmc.agent.test.InstrumentMe</class>
@@ -70,8 +75,8 @@
 					<parameter index="0">
 						<name>String Attribute</name>
 						<description>The first parameter</description>
-						<!-- See com.oracle.jrockit.jfr.ContentType
-							 {None, Bytes, Timestamp, Millis, Nanos, Ticks, Address, OSThread, JavaThread, StackTrace, Class, Percentage} -->
+						<!-- See com.oracle.jrockit.jfr.ContentType {None, Bytes, Timestamp, 
+							Millis, Nanos, Ticks, Address, OSThread, JavaThread, StackTrace, Class, Percentage} -->
 						<contenttype>None</contenttype>
 					</parameter>
 					<parameter index="1">
@@ -85,12 +90,13 @@
 					<contenttype>None</contenttype>
 				</returnvalue>
 			</method>
-			<!-- location {ENTRY, EXIT, WRAP}-->
+			<!-- location {ENTRY, EXIT, WRAP} -->
 			<location>WRAP</location>
 		</event>
 		<event id="demo.jfr.test11">
 			<name>JFR Hello World Event 11 %TEST_NAME%</name>
-			<description>Defined in the xml file and added by the agent. Should record the value of static reference
+			<description>Defined in the xml file and added by the agent. Should
+				record the value of static reference
 				'STATIC_STRING_FIELD'
 			</description>
 			<path>demo/jfrhelloworldevent11</path>
@@ -103,25 +109,34 @@
 			<fields>
 				<field>
 					<name>'STATIC_STRING_FIELD'</name>
-					<description>Capturing static field with simple field name</description>
+					<description>Capturing static field with simple field name
+					</description>
 					<expression>STATIC_STRING_FIELD</expression>
 				</field>
 				<field>
 					<name>'InstrumentMe.STATIC_STRING_FIELD'</name>
-					<description>Capturing static field with class name prefixed field name</description>
+					<description>Capturing static field with class name prefixed field
+						name
+					</description>
 					<expression>InstrumentMe.STATIC_STRING_FIELD</expression>
 				</field>
 				<field>
-					<name>'org.openjdk.jmc.agent.test.InstrumentMe.STATIC_STRING_FIELD'</name>
-					<description>Capturing static field with full qualified class prefixed name</description>
-					<expression>org.openjdk.jmc.agent.test.InstrumentMe.STATIC_STRING_FIELD</expression>
+					<name>'org.openjdk.jmc.agent.test.InstrumentMe.STATIC_STRING_FIELD'
+					</name>
+					<description>Capturing static field with full qualified class
+						prefixed name
+					</description>
+					<expression>org.openjdk.jmc.agent.test.InstrumentMe.STATIC_STRING_FIELD
+					</expression>
 				</field>
 			</fields>
 		</event>
 		<event id="demo.jfr.test12">
 			<name>JFR Hello World Event 12 %TEST_NAME%</name>
-			<description>Defined in the xml file and added by the agent. Should record the values of
-				'STATIC_OBJECT_FIELD.STATIC_STRING_FIELD' and 'STATIC_OBJECT_FIELD.instanceStringField'
+			<description>Defined in the xml file and added by the agent. Should
+				record the values of
+				'STATIC_OBJECT_FIELD.STATIC_STRING_FIELD' and
+				'STATIC_OBJECT_FIELD.instanceStringField'
 			</description>
 			<path>demo/jfrhelloworldevent12</path>
 			<stacktrace>true</stacktrace>
@@ -133,20 +148,24 @@
 			<fields>
 				<field>
 					<name>'STATIC_OBJECT_FIELD.STATIC_STRING_FIELD'</name>
-					<description>Capturing static field on a object reference</description>
+					<description>Capturing static field on a object reference
+					</description>
 					<expression>STATIC_OBJECT_FIELD.STATIC_STRING_FIELD</expression>
 				</field>
 				<field>
 					<name>'STATIC_OBJECT_FIELD.instanceStringField'</name>
-					<description>Capturing non-static field on a object reference</description>
+					<description>Capturing non-static field on a object reference
+					</description>
 					<expression>STATIC_OBJECT_FIELD.instanceStringField</expression>
 				</field>
 			</fields>
 		</event>
 		<event id="demo.jfr.test13">
 			<name>JFR Hello World Event 13 %TEST_NAME%</name>
-			<description>Defined in the xml file and added by the agent. Should record the values of static
-				'STATIC_NULL_FIELD.STATIC_STRING_FIELD' and 'STATIC_NULL_FIELD.instanceStringField'
+			<description>Defined in the xml file and added by the agent. Should
+				record the values of static
+				'STATIC_NULL_FIELD.STATIC_STRING_FIELD'
+				and 'STATIC_NULL_FIELD.instanceStringField'
 			</description>
 			<path>demo/jfrhelloworldevent13</path>
 			<stacktrace>true</stacktrace>
@@ -158,19 +177,22 @@
 			<fields>
 				<field>
 					<name>'STATIC_NULL_FIELD.STATIC_STRING_FIELD'</name>
-					<description>Capturing static field on a null object reference</description>
+					<description>Capturing static field on a null object reference
+					</description>
 					<expression>STATIC_NULL_FIELD.STATIC_STRING_FIELD</expression>
 				</field>
 				<field>
 					<name>'STATIC_NULL_FIELD.instanceStringField'</name>
-					<description>Capturing non-static field on a null object reference</description>
+					<description>Capturing non-static field on a null object reference
+					</description>
 					<expression>STATIC_NULL_FIELD.instanceStringField</expression>
 				</field>
 			</fields>
 		</event>
 		<event id="demo.jfr.testI1">
 			<name>JFR Hello World Instance Event 1 %TEST_NAME%</name>
-			<description>Defined in the xml file and added by the agent.</description>
+			<description>Defined in the xml file and added by the agent.
+			</description>
 			<path>demo/jfrhelloworldeventI1</path>
 			<stacktrace>true</stacktrace>
 			<class>org.openjdk.jmc.agent.test.InstrumentMe</class>
@@ -178,12 +200,14 @@
 				<name>printInstanceHelloWorldJFR1</name>
 				<descriptor>()V</descriptor>
 			</method>
-			<!-- location {ENTRY, EXIT, WRAP}-->
+			<!-- location {ENTRY, EXIT, WRAP} -->
 			<location>WRAP</location>
 		</event>
 		<event id="demo.jfr.testI2">
 			<name>JFR Hello World Instance Event 2 %TEST_NAME%</name>
-			<description>Defined in the xml file and added by the agent. Should record the parameters.</description>
+			<description>Defined in the xml file and added by the agent. Should
+				record the parameters.
+			</description>
 			<path>demo/jfrhelloworldeventI2</path>
 			<stacktrace>true</stacktrace>
 			<class>org.openjdk.jmc.agent.test.InstrumentMe</class>
@@ -210,7 +234,9 @@
 		</event>
 		<event id="demo.jfr.testI3">
 			<name>JFR Hello World Instance Event 3 %TEST_NAME%</name>
-			<description>Defined in the xml file and added by the agent. Should record the parameters.</description>
+			<description>Defined in the xml file and added by the agent. Should
+				record the parameters.
+			</description>
 			<path>demo/jfrhelloworldeventI3</path>
 			<stacktrace>true</stacktrace>
 			<class>org.openjdk.jmc.agent.test.InstrumentMe</class>
@@ -229,7 +255,9 @@
 		</event>
 		<event id="demo.jfr.testI4">
 			<name>JFR Hello World Instance Event 4 %TEST_NAME%</name>
-			<description>Defined in the xml file and added by the agent. Should record the parameters.</description>
+			<description>Defined in the xml file and added by the agent. Should
+				record the parameters.
+			</description>
 			<path>demo/jfrhelloworldeventI4</path>
 			<stacktrace>true</stacktrace>
 			<class>org.openjdk.jmc.agent.test.InstrumentMe</class>
@@ -248,7 +276,9 @@
 		</event>
 		<event id="demo.jfr.testI5">
 			<name>JFR Hello World Instance Event 5 %TEST_NAME%</name>
-			<description>Defined in the xml file and added by the agent. Should record the parameters.</description>
+			<description>Defined in the xml file and added by the agent. Should
+				record the parameters.
+			</description>
 			<path>demo/jfrhelloworldeventI5</path>
 			<stacktrace>true</stacktrace>
 			<class>org.openjdk.jmc.agent.test.InstrumentMe</class>
@@ -267,7 +297,9 @@
 		</event>
 		<event id="demo.jfr.testI6">
 			<name>JFR Hello World Instance Event 6 %TEST_NAME%</name>
-			<description>Defined in the xml file and added by the agent. Should record the return value.</description>
+			<description>Defined in the xml file and added by the agent. Should
+				record the return value.
+			</description>
 			<path>demo/jfrhelloworldeventI6</path>
 			<stacktrace>true</stacktrace>
 			<class>org.openjdk.jmc.agent.test.InstrumentMe</class>
@@ -283,7 +315,8 @@
 		</event>
 		<event id="demo.jfr.testI7">
 			<name>JFR Hello World Instance Event 7 %TEST_NAME%</name>
-			<description>Defined in the xml file and added by the agent. The original method contains a try-catch
+			<description>Defined in the xml file and added by the agent. The
+				original method contains a try-catch
 				clause.
 			</description>
 			<path>demo/jfrhelloworldeventI7</path>
@@ -296,7 +329,8 @@
 		</event>
 		<event id="demo.jfr.testI8">
 			<name>JFR Hello World Instance Event 8 %TEST_NAME%</name>
-			<description>Defined in the xml file and added by the agent. Should record even if an exception is raised.
+			<description>Defined in the xml file and added by the agent. Should
+				record even if an exception is raised.
 			</description>
 			<path>demo/jfrhelloworldeventI8</path>
 			<stacktrace>true</stacktrace>
@@ -309,7 +343,8 @@
 		</event>
 		<event id="demo.jfr.testI9">
 			<name>JFR Hello World Instance Event 9 %TEST_NAME%</name>
-			<description>Defined in the xml file and added by the agent. Should not record if an exception is raised.
+			<description>Defined in the xml file and added by the agent. Should
+				not record if an exception is raised.
 			</description>
 			<path>demo/jfrhelloworldeventI9</path>
 			<stacktrace>true</stacktrace>
@@ -321,8 +356,10 @@
 		</event>
 		<event id="demo.jfr.testI10">
 			<name>JFR Hello World Instance Event 10 %TEST_NAME%</name>
-			<description>Defined in the xml file and added by the agent. Should record even if an exception is raised,
-				but should not overwrite the existing try-catch clause.
+			<description>Defined in the xml file and added by the agent. Should
+				record even if an exception is raised,
+				but should not overwrite the
+				existing try-catch clause.
 			</description>
 			<path>demo/jfrhelloworldeventI10</path>
 			<stacktrace>true</stacktrace>
@@ -335,7 +372,8 @@
 		</event>
 		<event id="demo.jfr.testI11">
 			<name>JFR Hello World Instance Event 11 %TEST_NAME%</name>
-			<description>Defined in the xml file and added by the agent. Should record the value of instance reference
+			<description>Defined in the xml file and added by the agent. Should
+				record the value of instance reference
 				'instanceStringField'
 			</description>
 			<path>demo/jfrhelloworldeventI11</path>
@@ -348,24 +386,30 @@
 			<fields>
 				<field>
 					<name>'instanceStringField'</name>
-					<description>Capturing instance field with simple field name</description>
+					<description>Capturing instance field with simple field name
+					</description>
 					<expression>instanceStringField</expression>
 				</field>
 				<field>
 					<name>'this.instanceStringField'</name>
-					<description>Capturing instance field with "this" prefixed field name</description>
+					<description>Capturing instance field with "this" prefixed field
+						name
+					</description>
 					<expression>this.instanceStringField</expression>
 				</field>
 				<field>
 					<name>'InstrumentMe.this.instanceStringField'</name>
-					<description>Capturing instance field with qualified "this" prefixed field name</description>
+					<description>Capturing instance field with qualified "this"
+						prefixed field name
+					</description>
 					<expression>InstrumentMe.this.instanceStringField</expression>
 				</field>
 			</fields>
 		</event>
 		<event id="demo.jfr.testI12">
 			<name>JFR Hello World Instance Event 12 %TEST_NAME%</name>
-			<description>Defined in the xml file and added by the agent. Should record the values of various
+			<description>Defined in the xml file and added by the agent. Should
+				record the values of various
 				references
 			</description>
 			<path>demo/jfrhelloworldeventI12</path>
@@ -378,39 +422,50 @@
 			<fields>
 				<field>
 					<name>'innerClassField'</name>
-					<description>Capturing inner class field with simple field name</description>
+					<description>Capturing inner class field with simple field name
+					</description>
 					<expression>innerClassField</expression>
 				</field>
 				<field>
 					<name>'this.innerClassField'</name>
-					<description>Capturing inner class field with "this" prefixed field name</description>
+					<description>Capturing inner class field with "this" prefixed field
+						name
+					</description>
 					<expression>this.innerClassField</expression>
 				</field>
 
 				<field>
 					<name>'instanceStringField'</name>
-					<description>Capturing outer class field with simple field name</description>
+					<description>Capturing outer class field with simple field name
+					</description>
 					<expression>instanceStringField</expression>
 				</field>
 				<field>
 					<name>'InstrumentMe.this.instanceStringField'</name>
-					<description>Capturing outer class field with qualified "this" prefixed field name</description>
+					<description>Capturing outer class field with qualified "this"
+						prefixed field name
+					</description>
 					<expression>InstrumentMe.this.instanceStringField</expression>
 				</field>
 				<field>
 					<name>'super.instanceStringField'</name>
-					<description>Capturing super class field with "super" prefixed field name</description>
+					<description>Capturing super class field with "super" prefixed
+						field name
+					</description>
 					<expression>super.instanceStringField</expression>
 				</field>
 
 				<field>
 					<name>'STATIC_STRING_FIELD'</name>
-					<description>Capturing outer class field with simple field name</description>
+					<description>Capturing outer class field with simple field name
+					</description>
 					<expression>STATIC_STRING_FIELD</expression>
 				</field>
 				<field>
 					<name>'InstrumentMe.STATIC_STRING_FIELD'</name>
-					<description>Capturing outer class field with class name prefixed field name</description>
+					<description>Capturing outer class field with class name prefixed
+						field name
+					</description>
 					<expression>InstrumentMe.STATIC_STRING_FIELD</expression>
 				</field>
 			</fields>


### PR DESCRIPTION
This pr implements [JMC-6725: Formalize agent probe definition XML schema and enforce validations](https://bugs.openjdk.java.net/browse/JMC-6725). XMLs supplied by users are validated against [`jfrprobes_schema.xsd`](https://github.com/tabjy/jmc/blob/a4da862b744f407f3262f006e302515c142e9482/agent/src/main/resources/org/openjdk/jmc/agent/impl/jfrprobes_schema.xsd) on registry creation and modification.

Notable changes in configuration probes format are:
- `<parameter>` elements now should be enclosed by a `<parameters>` element, and
- `<field>` elements now should be enclosed by a `<fields>` element

Type checking is enforced on most elements. Additionally, the following types are restricted with regular expressions checking elements' text node contents:
- `classType` for `<class>` and `<converter>` elements
- `methodNameType` for `<name>` elements
- `descriptorType` for `<descriptor>` elements
-  `pathType` for `<path>` elements, and
- `expressionType` for `<expression>` elements

Please test, especially on regex, as I'm not entirely confident they cover every cases and don't yield false negatives.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JMC-6725](https://bugs.openjdk.java.net/browse/JMC-6725): Formalize agent probe definition XML schema and enforce validations


### Reviewers
 * Alex Macdonald ([aptmac](@aptmac) - Committer)
 * Marcus Hirt ([hirt](@thegreystone) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jmc pull/66/head:pull/66`
`$ git checkout pull/66`
