### PR TITLE
6715: Create MXBean retrieveCurrentTransforms function

### DIFF
--- a/agent/pom.xml
+++ b/agent/pom.xml
@@ -102,6 +102,7 @@
 					<excludes>
 						<exclude>TestDefineEventProbes.java</exclude>
 						<exclude>TestPermissionChecks.java</exclude>
+						<exclude>TestRetrieveCurrentTransforms.java</exclude>
 					</excludes>
 				</configuration>
 			</plugin>
@@ -134,6 +135,19 @@
 								-XX:+FlightRecorder -javaagent:target/org.openjdk.jmc.agent-1.0.0-SNAPSHOT.jar=target/test-classes/org/openjdk/jmc/agent/test/jfrprobes_template.xml
 								 -cp target/org.openjdk.jmc.agent-1.0.0-SNAPSHOT.jar:target/test-classes/ </argLine>
 							<includes>TestDefineEventProbes.java</includes>
+						</configuration>
+					</execution>
+					<execution>
+						<id>test-retrieve-transforms</id>
+						<goals>
+							<goal>integration-test</goal>
+							<goal>verify</goal>
+						</goals>
+						<configuration>
+							<argLine> --add-opens java.base/jdk.internal.misc=ALL-UNNAMED
+								-XX:+FlightRecorder -javaagent:target/org.openjdk.jmc.agent-1.0.0-SNAPSHOT.jar=target/test-classes/org/openjdk/jmc/agent/test/jfrprobes_simple.xml
+								 -cp target/org.openjdk.jmc.agent-1.0.0-SNAPSHOT.jar:target/test-classes/ </argLine>
+							<includes>TestRetrieveCurrentTransforms.java</includes>
 						</configuration>
 					</execution>
         		</executions>

--- a/agent/src/main/java/org/openjdk/jmc/agent/Field.java
+++ b/agent/src/main/java/org/openjdk/jmc/agent/Field.java
@@ -35,6 +35,9 @@ package org.openjdk.jmc.agent;
 import org.openjdk.jmc.agent.util.expression.ExpressionResolver;
 import org.openjdk.jmc.agent.util.expression.IllegalSyntaxException;
 import org.openjdk.jmc.agent.util.expression.ReferenceChain;
+
+import javax.management.openmbean.CompositeData;
+
 import org.openjdk.jmc.agent.util.TypeUtils;
 
 public class Field implements Attribute {
@@ -59,6 +62,11 @@ public class Field implements Attribute {
 		this.relationKey = relationKey;
 		this.converterClassName = converterClassName;
 		this.fieldName = "field" + TypeUtils.deriveIdentifierPart(name);
+	}
+
+	public static Field from(CompositeData cd) {
+		return new Field((String) cd.get("name"), (String) cd.get("expression"), (String) cd.get("description"),
+				(String) cd.get("contentType"), (String) cd.get("relationKey"), (String) cd.get("converterClassName"));
 	}
 
 	@Override

--- a/agent/src/main/java/org/openjdk/jmc/agent/Method.java
+++ b/agent/src/main/java/org/openjdk/jmc/agent/Method.java
@@ -32,6 +32,8 @@
  */
 package org.openjdk.jmc.agent;
 
+import javax.management.openmbean.CompositeData;
+
 /**
  * Definition of a method to be logged by the agent.
  */
@@ -42,6 +44,10 @@ public class Method {
 	public Method(String name, String signature) {
 		this.name = name;
 		this.signature = signature;
+	}
+
+	public static Method from(CompositeData cd) {
+		return new Method((String) cd.get("name"), (String) cd.get("signature"));
 	}
 
 	public String getName() {

--- a/agent/src/main/java/org/openjdk/jmc/agent/Parameter.java
+++ b/agent/src/main/java/org/openjdk/jmc/agent/Parameter.java
@@ -32,6 +32,8 @@
  */
 package org.openjdk.jmc.agent;
 
+import javax.management.openmbean.CompositeData;
+
 import org.openjdk.jmc.agent.util.TypeUtils;
 
 /**
@@ -57,6 +59,11 @@ public final class Parameter implements Attribute {
 		this.relationKey = relationKey;
 		this.converterClassName = converterClassName;
 		this.fieldName = "field" + TypeUtils.deriveIdentifierPart(name); //$NON-NLS-1$
+	}
+
+	public static Parameter from(CompositeData cd) {
+		return new Parameter((int) cd.get("index"), (String) cd.get("name"), (String) cd.get("description"),
+				(String) cd.get("contentType"), (String) cd.get("relationKey"), (String) cd.get("converterClassName"));
 	}
 
 	public int getIndex() {

--- a/agent/src/main/java/org/openjdk/jmc/agent/ReturnValue.java
+++ b/agent/src/main/java/org/openjdk/jmc/agent/ReturnValue.java
@@ -32,6 +32,8 @@
  */
 package org.openjdk.jmc.agent;
 
+import javax.management.openmbean.CompositeData;
+
 import org.openjdk.jmc.agent.util.TypeUtils;
 
 /**
@@ -52,6 +54,14 @@ public final class ReturnValue implements Attribute {
 		this.relationKey = relationKey;
 		this.converterClassName = converterClassName;
 		this.fieldName = "field" + TypeUtils.deriveIdentifierPart(this.name); //$NON-NLS-1$
+	}
+
+	public static ReturnValue from(CompositeData cd) {
+		if (cd == null) {
+			return null;
+		}
+		return new ReturnValue((String) cd.get("name"), (String) cd.get("description"), (String) cd.get("contentType"),
+				(String) cd.get("relationKey"), (String) cd.get("converterClassName"));
 	}
 
 	public String getName() {

--- a/agent/src/main/java/org/openjdk/jmc/agent/jmx/AgentController.java
+++ b/agent/src/main/java/org/openjdk/jmc/agent/jmx/AgentController.java
@@ -34,15 +34,18 @@ package org.openjdk.jmc.agent.jmx;
 
 import java.lang.instrument.Instrumentation;
 import java.lang.management.ManagementPermission;
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import org.openjdk.jmc.agent.TransformDescriptor;
 import org.openjdk.jmc.agent.TransformRegistry;
+import org.openjdk.jmc.agent.jfr.JFRTransformDescriptor;
 
-public class AgentController implements AgentControllerMBean {
+public class AgentController implements AgentControllerMXBean {
 	
 	private static final Logger logger = Logger.getLogger(AgentController.class.getName());
 	
@@ -90,6 +93,21 @@ public class AgentController implements AgentControllerMBean {
 		registry.setRevertInstrumentation(true);
 		instrumentation.retransformClasses(classesToRetransformArray);
 		registry.setRevertInstrumentation(false);
+	}
+
+	public JFRTransformDescriptor[] retrieveCurrentTransforms() {
+		checkSecurity();
+		Set<String> classNames = registry.getClassNames();
+		List<TransformDescriptor> tds  = new ArrayList<>();
+		for (String className : classNames) {
+			tds.addAll(registry.getTransformData(className));
+		}
+
+		List<JFRTransformDescriptor> jfrTds = new ArrayList<>();
+		for (TransformDescriptor td :tds) {
+			jfrTds.add((JFRTransformDescriptor) td);
+		}
+		return (jfrTds.toArray(new JFRTransformDescriptor[0]));
 	}
 
 	private void checkSecurity() {

--- a/agent/src/main/java/org/openjdk/jmc/agent/jmx/AgentControllerMXBean.java
+++ b/agent/src/main/java/org/openjdk/jmc/agent/jmx/AgentControllerMXBean.java
@@ -32,6 +32,11 @@
  */
 package org.openjdk.jmc.agent.jmx;
 
-public interface AgentControllerMBean {
+import org.openjdk.jmc.agent.jfr.JFRTransformDescriptor;
+
+public interface AgentControllerMXBean {
+
 	public void defineEventProbes(String xmlDescription) throws Exception;
+
+	public JFRTransformDescriptor[] retrieveCurrentTransforms();
 }

--- a/agent/src/main/java/org/openjdk/jmc/agent/jmx/AgentManagementFactory.java
+++ b/agent/src/main/java/org/openjdk/jmc/agent/jmx/AgentManagementFactory.java
@@ -50,7 +50,7 @@ public final class AgentManagementFactory {
 
 	private static AgentController agentControllerMBean;
 
-	public static AgentControllerMBean getAgentControllerBean() {
+	public static AgentControllerMXBean getAgentControllerBean() {
 		return agentControllerMBean;
 	}
 

--- a/agent/src/test/java/org/openjdk/jmc/agent/test/TestDefineEventProbes.java
+++ b/agent/src/test/java/org/openjdk/jmc/agent/test/TestDefineEventProbes.java
@@ -57,7 +57,7 @@ import org.openjdk.jmc.agent.Parameter;
 import org.openjdk.jmc.agent.ReturnValue;
 import org.openjdk.jmc.agent.jfr.JFRTransformDescriptor;
 import org.openjdk.jmc.agent.jfrnext.impl.JFRNextEventClassGenerator;
-import org.openjdk.jmc.agent.jmx.AgentControllerMBean;
+import org.openjdk.jmc.agent.jmx.AgentControllerMXBean;
 import org.openjdk.jmc.agent.util.TypeUtils;
 
 public class TestDefineEventProbes {
@@ -162,8 +162,8 @@ public class TestDefineEventProbes {
 	}
 
 	private void doDefineEventProbes(String xmlDescription) throws Exception  {
-		AgentControllerMBean mbean = JMX.newMXBeanProxy(ManagementFactory.getPlatformMBeanServer(),
-				new ObjectName(AGENT_OBJECT_NAME), AgentControllerMBean.class, false);
+		AgentControllerMXBean mbean = JMX.newMXBeanProxy(ManagementFactory.getPlatformMBeanServer(),
+				new ObjectName(AGENT_OBJECT_NAME), AgentControllerMXBean.class, false);
 		mbean.defineEventProbes(xmlDescription);
 	}
 

--- a/agent/src/test/java/org/openjdk/jmc/agent/test/TestRetrieveCurrentTransforms.java
+++ b/agent/src/test/java/org/openjdk/jmc/agent/test/TestRetrieveCurrentTransforms.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2019, Red Hat Inc. All rights reserved.
+ * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020, Red Hat Inc. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -33,34 +33,38 @@
  */
 package org.openjdk.jmc.agent.test;
 
-import static org.junit.Assert.assertTrue;
 import java.lang.management.ManagementFactory;
 
 import javax.management.JMX;
 import javax.management.ObjectName;
 
+import org.junit.Assert;
 import org.junit.Test;
+import org.openjdk.jmc.agent.jfr.JFRTransformDescriptor;
 import org.openjdk.jmc.agent.jmx.AgentControllerMXBean;
 
-public class TestPermissionChecks {
+public class TestRetrieveCurrentTransforms {
 
 	private static final String AGENT_OBJECT_NAME = "org.openjdk.jmc.jfr.agent:type=AgentController"; //$NON-NLS-1$
+	private static final String EVENT_ID = "demo.jfr.test1"; //$NON-NLS-1$
+	private static final String METHOD_NAME = "printHelloWorldJFR1"; //$NON-NLS-1$
+	private static final String FIELD_NAME = "'InstrumentMe.STATIC_STRING_FIELD'"; //$NON-NLS-1$
 
 	@Test
-	public void testPermissionChecks() throws Exception {
-		boolean exceptionThrown = false;
-		try {
-			doDefineEventProbes("");
-		} catch(SecurityException e) {
-			exceptionThrown = true;
+	public void testRetreiveCurrentTransforms() throws Exception {
+		JFRTransformDescriptor[] jfrTds = doRetrieveCurrentTransforms();
+		Assert.assertTrue(jfrTds.length == 1);
+		for (JFRTransformDescriptor jfrTd : jfrTds) {
+			Assert.assertEquals(EVENT_ID, jfrTd.getId());
+			Assert.assertEquals(METHOD_NAME, jfrTd.getMethod().getName());
+			Assert.assertEquals(FIELD_NAME, jfrTd.getFields().get(0).getName());
 		}
-		assertTrue(exceptionThrown);
 	}
 
-	private void doDefineEventProbes(String xmlDescription) throws Exception  {
+	private JFRTransformDescriptor[] doRetrieveCurrentTransforms() throws Exception {
 		AgentControllerMXBean mbean = JMX.newMXBeanProxy(ManagementFactory.getPlatformMBeanServer(),
 				new ObjectName(AGENT_OBJECT_NAME), AgentControllerMXBean.class, false);
-		mbean.defineEventProbes(xmlDescription);
+		return mbean.retrieveCurrentTransforms();
 	}
 
 	public void test() {

--- a/agent/src/test/resources/org/openjdk/jmc/agent/test/jfrprobes_simple.xml
+++ b/agent/src/test/resources/org/openjdk/jmc/agent/test/jfrprobes_simple.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+
+   DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+
+   The contents of this file are subject to the terms of either the Universal Permissive License
+   v 1.0 as shown at http://oss.oracle.com/licenses/upl
+
+   or the following license:
+
+   Redistribution and use in source and binary forms, with or without modification, are permitted
+   provided that the following conditions are met:
+
+   1. Redistributions of source code must retain the above copyright notice, this list of conditions
+   and the following disclaimer.
+
+   2. Redistributions in binary form must reproduce the above copyright notice, this list of
+   conditions and the following disclaimer in the documentation and/or other materials provided with
+   the distribution.
+
+   3. Neither the name of the copyright holder nor the names of its contributors may be used to
+   endorse or promote products derived from this software without specific prior written permission.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+   IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+   FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+   DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+   DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+   WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+   WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+-->
+<jfragent>
+	<events>
+		<event id="demo.jfr.test1">
+			<name>JFR Hello World Event 1 %TEST_NAME%</name>
+			<description>Defined in the xml file and added by the agent.</description>
+			<path>demo/jfrhelloworldevent1</path>
+			<stacktrace>true</stacktrace>
+			<class>org.openjdk.jmc.agent.test.InstrumentMe</class>
+			<method>
+				<name>printHelloWorldJFR1</name>
+				<descriptor>()V</descriptor>
+			</method>
+			<!-- location {ENTRY, EXIT, WRAP}-->
+			<location>WRAP</location>
+			<field>
+				<name>'InstrumentMe.STATIC_STRING_FIELD'</name>
+				<description>Capturing outer class field with class name prefixed field name</description>
+				<expression>InstrumentMe.STATIC_STRING_FIELD</expression>
+			</field>
+		</event>
+	</events>
+</jfragent>


### PR DESCRIPTION
This patch adds the MXBean function retrieveCurrentTransforms to the agent.  This allows a user to get information about the transforms that are currently instrumented.  I have added a test "testRetrieveCurrentTransforms".

Let me know what you think!
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JMC-6715](https://bugs.openjdk.java.net/browse/JMC-6715): Create operation to identify currently instrumented transforms 


### Reviewers
 * Marcus Hirt ([hirt](@thegreystone) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jmc pull/68/head:pull/68`
`$ git checkout pull/68`
