### PR TITLE
6744: Adding Eclipse RCP 2020-03 platform

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,7 @@
 	</distributionManagement>
 	<profiles>
 		<profile>
-			<id>2019-12</id>
+			<id>2020-03</id>
 			<activation>
 				<activeByDefault>true</activeByDefault>
 			</activation>
@@ -124,7 +124,7 @@
 							<target>
 								<artifact>
 									<groupId>org.openjdk.jmc</groupId>
-									<artifactId>platform-definition-2019-12</artifactId>
+									<artifactId>platform-definition-2020-03</artifactId>
 									<version>8.0.0-SNAPSHOT</version>
 								</artifact>
 							</target>
@@ -134,7 +134,7 @@
 			</build>
 		</profile>
 		<profile>
-			<id>2019-09</id>
+			<id>2019-12</id>
 			<build>
 				<plugins>
 					<plugin>
@@ -145,7 +145,7 @@
 							<target>
 								<artifact>
 									<groupId>org.openjdk.jmc</groupId>
-									<artifactId>platform-definition-2019-09</artifactId>
+									<artifactId>platform-definition-2019-12</artifactId>
 									<version>8.0.0-SNAPSHOT</version>
 								</artifact>
 							</target>

--- a/pom.xml
+++ b/pom.xml
@@ -111,9 +111,6 @@
 	<profiles>
 		<profile>
 			<id>2020-03</id>
-			<activation>
-				<activeByDefault>true</activeByDefault>
-			</activation>
 			<build>
 				<plugins>
 					<plugin>
@@ -135,6 +132,9 @@
 		</profile>
 		<profile>
 			<id>2019-12</id>
+			<activation>
+				<activeByDefault>true</activeByDefault>
+			</activation>
 			<build>
 				<plugins>
 					<plugin>

--- a/releng/platform-definitions/platform-definition-2019-12/platform-definition-2019-12.target
+++ b/releng/platform-definitions/platform-definition-2019-12/platform-definition-2019-12.target
@@ -56,9 +56,9 @@
             <repository location="http://download.eclipse.org/releases/2019-12/"/>
         </location>
         <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-            <unit id="org.eclipse.babel.nls_eclipse_ja.feature.group" version="4.12.0.v20190713060001"/>
-            <unit id="org.eclipse.babel.nls_eclipse_zh.feature.group" version="4.12.0.v20190713060001"/>
-            <repository location="https://archive.eclipse.org/technology/babel/update-site/R0.17.0/2019-06/"/>
+            <unit id="org.eclipse.babel.nls_eclipse_ja.feature.group" version="4.14.0.v20200113020001"/>
+            <unit id="org.eclipse.babel.nls_eclipse_zh.feature.group" version="4.14.0.v20200113020001"/>
+            <repository location="https://archive.eclipse.org/technology/babel/update-site/R0.17.1/2019-12/"/>
         </location>
     </locations>
     <targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>

--- a/releng/platform-definitions/platform-definition-2020-03/.project
+++ b/releng/platform-definitions/platform-definition-2020-03/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>platform-definition-2019-09</name>
+	<name>platform-definition-2020-03</name>
 	<comment></comment>
 	<projects>
 	</projects>

--- a/releng/platform-definitions/platform-definition-2020-03/platform-definition-2020-03.target
+++ b/releng/platform-definitions/platform-definition-2020-03/platform-definition-2020-03.target
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
-   Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+   Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+   Copyright (c) 2019, Datadog, Inc. All rights reserved.
 
    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
@@ -32,7 +33,7 @@
    WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 -->
 <?pde version="3.8"?>
-<target name="jmc-target-2019-09" sequenceNumber="47">
+<target name="jmc-target-2020-03" sequenceNumber="47">
     <locations>
         <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
             <unit id="com.sun.mail.jakarta.mail" version="1.6.3"/>
@@ -49,15 +50,15 @@
             <repository location="http://localhost:8080/site"/>
         </location>
         <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-            <unit id="org.eclipse.equinox.executable.feature.group" version="3.8.500.v20190907-0428"/>
-            <unit id="org.eclipse.pde.feature.group" version="3.14.100.v20190916-1045"/>
-            <unit id="org.eclipse.platform.sdk" version="4.13.0.I20190916-1045"/>
-            <repository location="http://download.eclipse.org/releases/2019-09/"/>
+            <unit id="org.eclipse.equinox.executable.feature.group" version="3.8.700.v20200207-2156"/>
+            <unit id="org.eclipse.pde.feature.group" version="3.14.300.v20200305-0155"/>
+            <unit id="org.eclipse.platform.sdk" version="4.15.0.I20200305-0155"/>
+            <repository location="http://download.eclipse.org/releases/2020-03/"/>
         </location>
         <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-            <unit id="org.eclipse.babel.nls_eclipse_ja.feature.group" version="4.12.0.v20190713060001"/>
-            <unit id="org.eclipse.babel.nls_eclipse_zh.feature.group" version="4.12.0.v20190713060001"/>
-            <repository location="https://archive.eclipse.org/technology/babel/update-site/R0.17.0/2019-06/"/>
+            <unit id="org.eclipse.babel.nls_eclipse_ja.feature.group" version="4.14.0.v20200113020001"/>
+            <unit id="org.eclipse.babel.nls_eclipse_zh.feature.group" version="4.14.0.v20200113020001"/>
+            <repository location="https://archive.eclipse.org/technology/babel/update-site/R0.17.1/2019-12/"/>
         </location>
     </locations>
     <targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>

--- a/releng/platform-definitions/platform-definition-2020-03/pom.xml
+++ b/releng/platform-definitions/platform-definition-2020-03/pom.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-   Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+   Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+   Copyright (c) 2020, Datadog, Inc. All rights reserved.
 
    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
@@ -38,7 +39,7 @@
 		<artifactId>platform-definitions</artifactId>
 		<version>8.0.0-SNAPSHOT</version>
 	</parent>
-	<artifactId>platform-definition-2019-09</artifactId>
+	<artifactId>platform-definition-2020-03</artifactId>
 	<packaging>eclipse-target-definition</packaging>
 
 	<properties>

--- a/releng/platform-definitions/pom.xml
+++ b/releng/platform-definitions/pom.xml
@@ -48,7 +48,7 @@
 	<modules>
 		<!-- Photon will be deprecated eventually - don't use it! -->
 		<module>platform-definition-photon</module>
-		<module>platform-definition-2019-09</module>
 		<module>platform-definition-2019-12</module>
+		<module>platform-definition-2020-03</module>
 	</modules>
 </project>


### PR DESCRIPTION
Using 2020-03 as default. Removing 2019-09.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JMC-6744](https://bugs.openjdk.java.net/browse/JMC-6744): Add 2020-03 platform


### Reviewers
 * Jie Kang ([jkang](@jiekang) - Author)
 * Henrik Dafgård ([hdafgard](@Gunde) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jmc pull/69/head:pull/69`
`$ git checkout pull/69`
