### PR TITLE
Add isHidden() method to IMCMethod interface

### DIFF
--- a/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/IMCMethod.java
+++ b/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/IMCMethod.java
@@ -92,4 +92,12 @@ public interface IMCMethod {
 	 *         {@code null} if the information is not available
 	 */
 	Boolean isNative();
+	
+	/**
+	 * Whether this method is hidden.
+	 *
+	 * @return {@code Boolean.TRUE} if the method is hidden, {@code Boolean.FALSE} if not, or
+	 *         {@code null} if the information is not available
+	 */
+	Boolean isHidden();
 }

--- a/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/util/MCMethod.java
+++ b/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/util/MCMethod.java
@@ -98,6 +98,11 @@ public class MCMethod implements IMCMethod {
 	public final Boolean isNative() {
 		return m_isNative;
 	}
+	
+	@Override
+	public final Boolean isHidden() {
+		return null;
+	}
 
 	@Override
 	public int hashCode() {

--- a/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/internal/parser/v1/StructTypes.java
+++ b/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/internal/parser/v1/StructTypes.java
@@ -606,6 +606,11 @@ class StructTypes {
 		public Boolean isNative() {
 			return null;
 		}
+		
+		@Override
+		public Boolean isHidden() {
+			return (Boolean) hidden;
+		}
 
 		@Override
 		public int hashCode() {

--- a/core/tests/org.openjdk.jmc.flightrecorder.test/src/test/java/org/openjdk/jmc/flightrecorder/test/util/MockStacktraceGenerator.java
+++ b/core/tests/org.openjdk.jmc.flightrecorder.test/src/test/java/org/openjdk/jmc/flightrecorder/test/util/MockStacktraceGenerator.java
@@ -153,6 +153,11 @@ public class MockStacktraceGenerator {
 		public Boolean isNative() {
 			return isNative;
 		}
+		
+		@Override
+		public Boolean isHidden() {
+			return null;
+		}
 
 	}
 


### PR DESCRIPTION
Simply add a method to allow access to the already parsed flag determining whether or not a method is marked as hidden or not.