### PR TITLE
6767: Empty filter regex should not be compiled

### DIFF
--- a/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/item/ItemFilters.java
+++ b/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/item/ItemFilters.java
@@ -431,6 +431,9 @@ public class ItemFilters {
 
 		@Override
 		protected IPredicate<IItem> getPredicate(IMemberAccessor<? extends String, IItem> accessor, String regexp) {
+			if (regexp.isEmpty()) {
+				return PredicateToolkit.truePredicate();
+			}
 			return PredicateToolkit.matches(accessor, regexp);
 		}
 	}
@@ -442,6 +445,9 @@ public class ItemFilters {
 
 		@Override
 		protected IPredicate<IItem> getPredicate(IMemberAccessor<? extends String, IItem> accessor, String regexp) {
+			if (regexp.isEmpty()) {
+				return PredicateToolkit.truePredicate();
+			}
 			return PredicateToolkit.not(PredicateToolkit.matches(accessor, regexp));
 		}
 	}

--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/latency/JavaBlockingRule.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/latency/JavaBlockingRule.java
@@ -89,13 +89,13 @@ public class JavaBlockingRule implements IRule {
 	private static final String RESULT_ID = "JavaBlocking"; //$NON-NLS-1$
 
 	private Result getResult(IItemCollection items, IPreferenceValueProvider valueProvider) {
-		String threadExcludeRegexp = valueProvider.getPreferenceValue(EXCLUDED_THREADS_REGEXP);
-		items = items.apply(ItemFilters.not(ItemFilters.matches(JdkAttributes.EVENT_THREAD_NAME, threadExcludeRegexp)));
-
 		EventAvailability eventAvailability = RulesToolkit.getEventAvailability(items, JdkTypeIDs.MONITOR_ENTER);
 		if (eventAvailability != EventAvailability.AVAILABLE) {
 			return RulesToolkit.getEventAvailabilityResult(this, items, eventAvailability, JdkTypeIDs.MONITOR_ENTER);
 		}
+
+		String threadExcludeRegexp = valueProvider.getPreferenceValue(EXCLUDED_THREADS_REGEXP);
+		items = items.apply(ItemFilters.notMatches(JdkAttributes.EVENT_THREAD_NAME, threadExcludeRegexp));
 
 		IQuantity startTime = RulesToolkit.getEarliestStartTime(items);
 		IQuantity endTime = RulesToolkit.getLatestEndTime(items);

--- a/core/tests/org.openjdk.jmc.flightrecorder.rules.jdk.test/src/test/resources/baseline/JfrRuleBaseline.xml
+++ b/core/tests/org.openjdk.jmc.flightrecorder.rules.jdk.test/src/test/resources/baseline/JfrRuleBaseline.xml
@@ -3868,7 +3868,7 @@
         <rule>
             <id>JavaBlocking</id>
             <severity>Information</severity>
-            <score>62.05152332723372</score>
+            <score>62.051706560483375</score>
             <shortDescription>Threads in the application were blocked on locks for a total of 1 min 26 s.</shortDescription>
             <longDescription>Threads in the application were blocked on locks for a total of 1 min 26 s. The most blocking monitor class was 'Logger', which was blocked 1,612 times for a total of 1 min 23 s.&lt;p&gt;The following regular expression was used to exclude threads from this rule: '(.*weblogic\.socket\.Muxer.*)'</longDescription>
         </rule>


### PR DESCRIPTION
This PR allows JMC to short-circuit regex-based IItemFilters that use the empty string to just use a TruePredicate instead.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JMC-6767](https://bugs.openjdk.java.net/browse/JMC-6767): Empty filter regex should not be compiled


### Reviewers
 * Marcus Hirt ([hirt](@thegreystone) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jmc pull/72/head:pull/72`
`$ git checkout pull/72`
