### PR TITLE
6778: Removing dependency on OPS4j maven repo and javax.mail:dsn

### DIFF
--- a/application/org.openjdk.jmc.feature.core/feature.xml
+++ b/application/org.openjdk.jmc.feature.core/feature.xml
@@ -174,11 +174,4 @@
          version="0.0.0"
          unpack="false"/>
 
-   <plugin
-         id="javax.mail.dsn"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
 </feature>

--- a/core/tests/org.openjdk.jmc.flightrecorder.rules.jdk.test/src/test/java/org/openjdk/jmc/flightrecorder/test/rules/jdk/TestRulesWithJfr.java
+++ b/core/tests/org.openjdk.jmc.flightrecorder.rules.jdk.test/src/test/java/org/openjdk/jmc/flightrecorder/test/rules/jdk/TestRulesWithJfr.java
@@ -33,7 +33,6 @@
 package org.openjdk.jmc.flightrecorder.test.rules.jdk;
 
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;

--- a/license/THIRDPARTYREADME.txt
+++ b/license/THIRDPARTYREADME.txt
@@ -1186,7 +1186,7 @@ library.  If this is what you want to do, use the GNU Library General
 Public License instead of this License.
 
 
-%% The following notice is provided with respect to Javamail 1.6.3,
+%% The following notice is provided with respect to Javamail 1.6.5,
 which may be included with this product.
 
 Copyright (c) 2016, 2018 Oracle and/or its affiliates. All rights reserved.

--- a/releng/platform-definitions/platform-definition-2019-12/platform-definition-2019-12.target
+++ b/releng/platform-definitions/platform-definition-2019-12/platform-definition-2019-12.target
@@ -36,9 +36,8 @@
 <target name="jmc-target-2019-12" sequenceNumber="47">
     <locations>
         <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-            <unit id="com.sun.mail.jakarta.mail" version="1.6.3"/>
+            <unit id="com.sun.mail.jakarta.mail" version="1.6.5"/>
             <unit id="com.sun.activation.jakarta.activation" version="1.2.1"/>
-            <unit id="javax.mail.dsn" version="1.4.0"/>
             <unit id="org.owasp.encoder" version="1.2.2"/>
             <unit id="org.lz4.lz4-java" version="1.7.1"/>
             <unit id="org.twitter4j.core" version="4.0.7"/>

--- a/releng/platform-definitions/platform-definition-2020-03/platform-definition-2020-03.target
+++ b/releng/platform-definitions/platform-definition-2020-03/platform-definition-2020-03.target
@@ -36,9 +36,8 @@
 <target name="jmc-target-2020-03" sequenceNumber="47">
     <locations>
         <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-            <unit id="com.sun.mail.jakarta.mail" version="1.6.3"/>
+            <unit id="com.sun.mail.jakarta.mail" version="1.6.5"/>
             <unit id="com.sun.activation.jakarta.activation" version="1.2.1"/>
-            <unit id="javax.mail.dsn" version="1.4.0"/>
             <unit id="org.owasp.encoder" version="1.2.2"/>
             <unit id="org.lz4.lz4-java" version="1.7.1"/>
             <unit id="org.twitter4j.core" version="4.0.7"/>

--- a/releng/platform-definitions/platform-definition-photon/platform-definition-photon.target
+++ b/releng/platform-definitions/platform-definition-photon/platform-definition-photon.target
@@ -35,9 +35,8 @@
 <target name="jmc-target-photon" sequenceNumber="47">
     <locations>
         <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-            <unit id="com.sun.mail.jakarta.mail" version="1.6.3"/>
+            <unit id="com.sun.mail.jakarta.mail" version="1.6.5"/>
             <unit id="com.sun.activation.jakarta.activation" version="1.2.1"/>
-            <unit id="javax.mail.dsn" version="1.4.0"/>
             <unit id="org.owasp.encoder" version="1.2.2"/>
             <unit id="org.lz4.lz4-java" version="1.7.1"/>
             <unit id="org.twitter4j.core" version="4.0.7"/>

--- a/releng/third-party/pom.xml
+++ b/releng/third-party/pom.xml
@@ -40,6 +40,7 @@
 
 	<properties>
 		<spotless.config.path>${basedir}/../../configuration/ide/eclipse/formatting/formatting.xml</spotless.config.path>
+		<jakarta.mail.version>1.6.5</jakarta.mail.version>
 	</properties>
 
 	<build>
@@ -61,7 +62,7 @@
 									<id>org.twitter4j:twitter4j-core:4.0.7</id>
 								</artifact>
 								<artifact>
-									<id>com.sun.mail:jakarta.mail:1.6.3</id>
+									<id>com.sun.mail:jakarta.mail:${jakarta.mail.version}</id>
 									<override>true</override>
 									<instructions>
 										<Import-Package>*;resolution:=optional</Import-Package>
@@ -70,9 +71,6 @@
 								</artifact>
 								<artifact>
 									<id>com.sun.activation:jakarta.activation:1.2.1</id>
-								</artifact>
-								<artifact>
-									<id>javax.mail:dsn:1.4</id>
 								</artifact>
 								<artifact>
 									<id>org.owasp.encoder:encoder:1.2.2</id>
@@ -157,10 +155,4 @@
 			</plugin>
 		</plugins>
 	</build>
-	<repositories>
-		<repository>
-			<id>OPS4j</id>
-			<url>http://repository.ops4j.org/maven2/</url>
-		</repository>
-	</repositories>
 </project>


### PR DESCRIPTION
Also upgrading jakarta.mail.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JMC-6778](https://bugs.openjdk.java.net/browse/JMC-6778): OPS4J Maven Repo no longer available


### Reviewers
 * Jie Kang ([jkang](@jiekang) - Author)
 * Henrik Dafgård ([hdafgard](@Gunde) - **Reviewer**)
 * Guru Hb ([ghb](@guruhb) - **Reviewer**)

### Contributors
 * Jason Zaugg `<jzaugg@gmail.com>`

### Download
`$ git fetch https://git.openjdk.java.net/jmc pull/73/head:pull/73`
`$ git checkout pull/73`
