### PR TITLE
6784: Getting rid of compiler warnings in the agent

### DIFF
--- a/agent/.classpath
+++ b/agent/.classpath
@@ -6,7 +6,11 @@
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="src" path="src/main/resources"/>
+	<classpathentry excluding="**" kind="src" output="target/classes" path="src/main/resources">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="src" output="target/test-classes" path="src/test/java">
 		<attributes>
 			<attribute name="test" value="true"/>

--- a/agent/.settings/org.eclipse.jdt.core.prefs
+++ b/agent/.settings/org.eclipse.jdt.core.prefs
@@ -1,11 +1,13 @@
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.7
 org.eclipse.jdt.core.compiler.compliance=1.7
+org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
 org.eclipse.jdt.core.compiler.problem.forbiddenReference=ignore
 org.eclipse.jdt.core.compiler.problem.invalidJavadocTags=disabled
 org.eclipse.jdt.core.compiler.problem.missingJavadocTagDescription=no_tag
 org.eclipse.jdt.core.compiler.problem.missingOverrideAnnotation=ignore
 org.eclipse.jdt.core.compiler.problem.nonExternalizedStringLiteral=ignore
+org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=ignore
 org.eclipse.jdt.core.compiler.problem.unusedWarningToken=ignore
 org.eclipse.jdt.core.compiler.release=disabled
 org.eclipse.jdt.core.compiler.source=1.7

--- a/agent/src/main/java/org/openjdk/jmc/agent/util/expression/IllegalSyntaxException.java
+++ b/agent/src/main/java/org/openjdk/jmc/agent/util/expression/IllegalSyntaxException.java
@@ -33,6 +33,8 @@
 package org.openjdk.jmc.agent.util.expression;
 
 public class IllegalSyntaxException extends Exception {
+	private static final long serialVersionUID = 1L;
+
 	public IllegalSyntaxException() {
 		super();
 	}

--- a/agent/src/test/java/org/openjdk/jmc/agent/test/InstrumentMe.java
+++ b/agent/src/test/java/org/openjdk/jmc/agent/test/InstrumentMe.java
@@ -53,6 +53,7 @@ public class InstrumentMe {
 	}
 	
 	public class MyInnerClass extends InstrumentMe{
+		@SuppressWarnings("unused")
 		private final String innerClassField = "org.openjdk.jmc.agent.test.InstrumentMe.MyInnerClass.innerClassField";
 
 		public void instrumentationPoint() {


### PR DESCRIPTION
What the title says.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JMC-6784](https://bugs.openjdk.java.net/browse/JMC-6784): Cleanup agent compiler warnings


### Reviewers
 * Henrik Dafgård ([hdafgard](@Gunde) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jmc pull/74/head:pull/74`
`$ git checkout pull/74`
