### PR TITLE
6785: Compiler warning cleanup

### DIFF
--- a/application/org.openjdk.jmc.alert/src/main/java/org/openjdk/jmc/alert/AlertPlugin.java
+++ b/application/org.openjdk.jmc.alert/src/main/java/org/openjdk/jmc/alert/AlertPlugin.java
@@ -43,6 +43,7 @@ import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
+import org.eclipse.ui.PlatformUI;
 import org.openjdk.jmc.rjmx.IConnectionHandle;
 import org.openjdk.jmc.rjmx.triggers.TriggerEvent;
 import org.openjdk.jmc.rjmx.triggers.TriggerRule;
@@ -120,7 +121,7 @@ public class AlertPlugin extends MCAbstractUIPlugin {
 			final String title = Messages.AlertPlugin_TRIGGER_ALERT_TEXT;
 			final int style = SWT.BALLOON | SWT.ICON_WARNING;
 
-			DisplayToolkit.safeAsyncExec(getDefault().getWorkbench().getDisplay(), new Runnable() {
+			DisplayToolkit.safeAsyncExec(PlatformUI.getWorkbench().getDisplay(), new Runnable() {
 				@Override
 				public void run() {
 					UIPlugin.getDefault().getTrayManager().showTooltip(title, message, style);
@@ -179,10 +180,10 @@ public class AlertPlugin extends MCAbstractUIPlugin {
 
 	public void showDialog(boolean alwaysShow) {
 		if (getPopup() || alwaysShow || hasDialog()) {
-			DisplayToolkit.safeAsyncExec(getDefault().getWorkbench().getDisplay(), new Runnable() {
+			DisplayToolkit.safeAsyncExec(PlatformUI.getWorkbench().getDisplay(), new Runnable() {
 				@Override
 				public void run() {
-					Display display = getDefault().getWorkbench().getDisplay();
+					Display display = PlatformUI.getWorkbench().getDisplay();
 					Shell shell = display.getActiveShell();
 					if (shell != null && !shell.isDisposed()) {
 						if (!hasDialog()) {
@@ -212,7 +213,7 @@ public class AlertPlugin extends MCAbstractUIPlugin {
 	}
 
 	public static AlertDialog createDialog(Shell shell) {
-		Display display = getDefault().getWorkbench().getDisplay();
+		Display display = PlatformUI.getWorkbench().getDisplay();
 		if (display != null && !display.isDisposed() && display.getActiveShell() != null
 				&& !display.getActiveShell().isDisposed()) {
 			return new AlertDialog(display.getActiveShell());

--- a/application/org.openjdk.jmc.browser/build.properties
+++ b/application/org.openjdk.jmc.browser/build.properties
@@ -41,3 +41,4 @@ bin.includes = META-INF/,\
                contexts.xml,\
                appicons/
 pde.match.rule.bundle=compatible
+javacDefaultEncoding.. = UTF-8

--- a/application/org.openjdk.jmc.console.jconsole/src/main/java/org/openjdk/jmc/console/jconsole/Activator.java
+++ b/application/org.openjdk.jmc.console.jconsole/src/main/java/org/openjdk/jmc/console/jconsole/Activator.java
@@ -36,11 +36,9 @@ import java.io.File;
 import java.util.logging.Logger;
 
 import org.eclipse.jface.preference.IPreferenceStore;
-import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.ui.plugin.AbstractUIPlugin;
-import org.osgi.framework.BundleContext;
-
 import org.openjdk.jmc.console.jconsole.preferences.PreferenceConstants;
+import org.osgi.framework.BundleContext;
 
 /**
  * The activator class controls the plug-in life cycle
@@ -78,17 +76,6 @@ public class Activator extends AbstractUIPlugin {
 	 */
 	public static Activator getDefault() {
 		return plugin;
-	}
-
-	/**
-	 * Returns an image descriptor for the image file at the given plug-in relative path
-	 *
-	 * @param path
-	 *            the path
-	 * @return the image descriptor
-	 */
-	public static ImageDescriptor getImageDescriptor(String path) {
-		return imageDescriptorFromPlugin(PLUGIN_ID, path);
 	}
 
 	/**

--- a/application/org.openjdk.jmc.console.ui.notification/src/main/java/org/openjdk/jmc/console/ui/notification/action/TriggerActionStartTimeBoundRecording.java
+++ b/application/org.openjdk.jmc.console.ui.notification/src/main/java/org/openjdk/jmc/console/ui/notification/action/TriggerActionStartTimeBoundRecording.java
@@ -41,11 +41,9 @@ import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.osgi.util.NLS;
-
 import org.openjdk.jmc.alert.AlertObject;
 import org.openjdk.jmc.alert.AlertPlugin;
 import org.openjdk.jmc.alert.NotificationUIToolkit;
-import org.openjdk.jmc.common.io.IOToolkit;
 import org.openjdk.jmc.common.unit.IQuantity;
 import org.openjdk.jmc.common.unit.QuantityConversionException;
 import org.openjdk.jmc.common.unit.UnitLookup;

--- a/application/org.openjdk.jmc.console.ui.notification/src/main/java/org/openjdk/jmc/console/ui/notification/action/WriteAndOpenRecordingJob.java
+++ b/application/org.openjdk.jmc.console.ui.notification/src/main/java/org/openjdk/jmc/console/ui/notification/action/WriteAndOpenRecordingJob.java
@@ -42,11 +42,9 @@ import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.osgi.util.NLS;
-
 import org.openjdk.jmc.alert.AlertObject;
 import org.openjdk.jmc.alert.AlertPlugin;
 import org.openjdk.jmc.alert.NotificationUIToolkit;
-import org.openjdk.jmc.common.io.IOToolkit;
 import org.openjdk.jmc.common.unit.IQuantity;
 import org.openjdk.jmc.console.ui.notification.NotificationPlugin;
 import org.openjdk.jmc.rjmx.RJMXPlugin;

--- a/application/org.openjdk.jmc.console.ui.notification/src/main/java/org/openjdk/jmc/console/ui/notification/tab/TriggerToolkit.java
+++ b/application/org.openjdk.jmc.console.ui.notification/src/main/java/org/openjdk/jmc/console/ui/notification/tab/TriggerToolkit.java
@@ -43,19 +43,17 @@ import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.jface.viewers.TreeViewer;
 import org.eclipse.osgi.util.NLS;
-import org.osgi.framework.Bundle;
-import org.w3c.dom.Document;
-import org.w3c.dom.Element;
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
-
-import org.openjdk.jmc.common.io.IOToolkit;
 import org.openjdk.jmc.common.util.XmlToolkit;
 import org.openjdk.jmc.console.ui.notification.NotificationPlugin;
 import org.openjdk.jmc.rjmx.RJMXPlugin;
 import org.openjdk.jmc.rjmx.triggers.TriggerRule;
 import org.openjdk.jmc.rjmx.triggers.internal.NotificationRegistry;
 import org.openjdk.jmc.ui.common.util.StatusFactory;
+import org.osgi.framework.Bundle;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
 
 /**
  * Toolkit for triggers

--- a/application/org.openjdk.jmc.console.ui/src/main/java/org/openjdk/jmc/console/ui/editor/internal/ConsoleFormPage.java
+++ b/application/org.openjdk.jmc.console.ui/src/main/java/org/openjdk/jmc/console/ui/editor/internal/ConsoleFormPage.java
@@ -42,6 +42,7 @@ import org.eclipse.jface.action.IToolBarManager;
 import org.eclipse.jface.dialogs.IMessageProvider;
 import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.jface.resource.JFaceResources;
+import org.eclipse.jface.resource.ResourceLocator;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Display;
@@ -52,15 +53,13 @@ import org.eclipse.ui.forms.IManagedForm;
 import org.eclipse.ui.forms.IMessageManager;
 import org.eclipse.ui.forms.editor.FormPage;
 import org.eclipse.ui.forms.widgets.Form;
-import org.eclipse.ui.plugin.AbstractUIPlugin;
-import org.osgi.service.prefs.Preferences;
-
 import org.openjdk.jmc.console.ui.editor.IConsolePageContainer;
 import org.openjdk.jmc.console.ui.editor.IConsolePageStateHandler;
 import org.openjdk.jmc.rjmx.IConnectionHandle;
 import org.openjdk.jmc.rjmx.RJMXPlugin;
 import org.openjdk.jmc.ui.common.util.Environment;
 import org.openjdk.jmc.ui.misc.MementoToolkit;
+import org.osgi.service.prefs.Preferences;
 
 /**
  * Extension point class that console tabs can subclass. The ConsoleTab uses the FormPage .
@@ -174,7 +173,7 @@ public class ConsoleFormPage extends FormPage implements IConsolePageContainer {
 		String iconName = config.getAttribute(ATTRIBUTE_ICON);
 		if (iconName != null) {
 			String pluginId = config.getDeclaringExtension().getContributor().getName();
-			ImageDescriptor iconDesc = AbstractUIPlugin.imageDescriptorFromPlugin(pluginId, iconName);
+			ImageDescriptor iconDesc = ResourceLocator.imageDescriptorFromBundle(pluginId, iconName).orElse(null);
 			icon = (Image) JFaceResources.getResources().get(iconDesc);
 		}
 	}

--- a/application/org.openjdk.jmc.console.ui/src/main/java/org/openjdk/jmc/console/ui/misc/StartConsole.java
+++ b/application/org.openjdk.jmc.console.ui/src/main/java/org/openjdk/jmc/console/ui/misc/StartConsole.java
@@ -37,11 +37,10 @@ import java.io.PrintStream;
 import org.eclipse.ui.IEditorInput;
 import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.PartInitException;
-
+import org.eclipse.ui.PlatformUI;
 import org.openjdk.jmc.commands.Statement;
 import org.openjdk.jmc.console.ui.editor.internal.ConsoleEditorInput;
 import org.openjdk.jmc.rjmx.util.internal.RJMXStartCommand;
-import org.openjdk.jmc.ui.UIPlugin;
 
 /**
  * Command for starting up the JMX Console on a RJMX-descriptor.
@@ -49,7 +48,7 @@ import org.openjdk.jmc.ui.UIPlugin;
 public class StartConsole extends RJMXStartCommand {
 	@Override
 	public boolean execute(Statement statement, PrintStream out) {
-		IWorkbenchWindow window = UIPlugin.getDefault().getWorkbench().getActiveWorkbenchWindow();
+		IWorkbenchWindow window = PlatformUI.getWorkbench().getActiveWorkbenchWindow();
 		if (window != null) {
 			IEditorInput input = new ConsoleEditorInput(createConnectionDescriptor(statement, out));
 			try {

--- a/application/org.openjdk.jmc.flightrecorder.controlpanel.ui/src/main/java/org/openjdk/jmc/flightrecorder/controlpanel/ui/actions/DumpAnyRecordingAction.java
+++ b/application/org.openjdk.jmc.flightrecorder.controlpanel.ui/src/main/java/org/openjdk/jmc/flightrecorder/controlpanel/ui/actions/DumpAnyRecordingAction.java
@@ -34,8 +34,6 @@ package org.openjdk.jmc.flightrecorder.controlpanel.ui.actions;
 
 import org.eclipse.jface.wizard.IWizard;
 import org.eclipse.osgi.util.NLS;
-
-import org.openjdk.jmc.common.io.IOToolkit;
 import org.openjdk.jmc.flightrecorder.controlpanel.ui.ControlPanel;
 import org.openjdk.jmc.flightrecorder.controlpanel.ui.FlightRecorderProvider;
 import org.openjdk.jmc.flightrecorder.controlpanel.ui.ImageConstants;

--- a/application/org.openjdk.jmc.flightrecorder.controlpanel.ui/src/main/java/org/openjdk/jmc/flightrecorder/controlpanel/ui/actions/StartRecordingAction.java
+++ b/application/org.openjdk.jmc.flightrecorder.controlpanel.ui/src/main/java/org/openjdk/jmc/flightrecorder/controlpanel/ui/actions/StartRecordingAction.java
@@ -33,8 +33,6 @@
 package org.openjdk.jmc.flightrecorder.controlpanel.ui.actions;
 
 import org.eclipse.jface.wizard.IWizard;
-
-import org.openjdk.jmc.common.io.IOToolkit;
 import org.openjdk.jmc.flightrecorder.controlpanel.ui.ControlPanel;
 import org.openjdk.jmc.flightrecorder.controlpanel.ui.FlightRecorderProvider;
 import org.openjdk.jmc.flightrecorder.controlpanel.ui.ImageConstants;

--- a/application/org.openjdk.jmc.flightrecorder.controlpanel.ui/src/main/java/org/openjdk/jmc/flightrecorder/controlpanel/ui/jobs/UpdateRecordingJob.java
+++ b/application/org.openjdk.jmc.flightrecorder.controlpanel.ui/src/main/java/org/openjdk/jmc/flightrecorder/controlpanel/ui/jobs/UpdateRecordingJob.java
@@ -38,7 +38,6 @@ import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.osgi.util.NLS;
-import org.openjdk.jmc.common.io.IOToolkit;
 import org.openjdk.jmc.common.unit.IConstrainedMap;
 import org.openjdk.jmc.flightrecorder.configuration.events.EventOptionID;
 import org.openjdk.jmc.flightrecorder.controlpanel.ui.ControlPanel;

--- a/application/org.openjdk.jmc.flightrecorder.controlpanel.ui/src/main/java/org/openjdk/jmc/flightrecorder/controlpanel/ui/model/PrivateStorageDelegate.java
+++ b/application/org.openjdk.jmc.flightrecorder.controlpanel.ui/src/main/java/org/openjdk/jmc/flightrecorder/controlpanel/ui/model/PrivateStorageDelegate.java
@@ -43,7 +43,6 @@ import java.io.Writer;
 import java.nio.charset.Charset;
 import java.nio.charset.IllegalCharsetNameException;
 
-import org.openjdk.jmc.common.io.IOToolkit;
 import org.openjdk.jmc.flightrecorder.configuration.events.IEventConfiguration;
 import org.openjdk.jmc.flightrecorder.configuration.spi.IConfigurationStorageDelegate;
 import org.openjdk.jmc.flightrecorder.controlpanel.ui.messages.internal.Messages;

--- a/application/org.openjdk.jmc.flightrecorder.ext.jfx/src/main/java/org/openjdk/jmc/flightrecorder/ext/jfx/JfxPage.java
+++ b/application/org.openjdk.jmc.flightrecorder.ext.jfx/src/main/java/org/openjdk/jmc/flightrecorder/ext/jfx/JfxPage.java
@@ -38,6 +38,7 @@ import java.util.List;
 import java.util.stream.Stream;
 
 import org.eclipse.jface.resource.ImageDescriptor;
+import org.eclipse.jface.resource.ResourceLocator;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.SashForm;
 import org.eclipse.swt.graphics.Image;
@@ -45,8 +46,6 @@ import org.eclipse.swt.widgets.Composite;
 import org.eclipse.ui.forms.widgets.Form;
 import org.eclipse.ui.forms.widgets.FormToolkit;
 import org.eclipse.ui.forms.widgets.Section;
-import org.eclipse.ui.plugin.AbstractUIPlugin;
-
 import org.openjdk.jmc.common.IState;
 import org.openjdk.jmc.common.IWritableState;
 import org.openjdk.jmc.common.item.Aggregators;
@@ -99,8 +98,8 @@ public class JfxPage extends AbstractDataPage {
 
 		@Override
 		public ImageDescriptor getImageDescriptor(IState state) {
-			return AbstractUIPlugin.imageDescriptorFromPlugin("org.openjdk.jmc.flightrecorder.ext.jfx", //$NON-NLS-1$
-					"icons/pulse.png"); //$NON-NLS-1$
+			return ResourceLocator.imageDescriptorFromBundle("org.openjdk.jmc.flightrecorder.ext.jfx", //$NON-NLS-1$
+					"icons/pulse.png").orElse(null); //$NON-NLS-1$
 		}
 
 		@Override

--- a/application/org.openjdk.jmc.flightrecorder.flameview/src/main/java/org/openjdk/jmc/flightrecorder/flameview/views/FlameGraphView.java
+++ b/application/org.openjdk.jmc.flightrecorder.flameview/src/main/java/org/openjdk/jmc/flightrecorder/flameview/views/FlameGraphView.java
@@ -33,8 +33,6 @@
  */
 package org.openjdk.jmc.flightrecorder.flameview.views;
 
-import static org.openjdk.jmc.flightrecorder.stacktrace.Messages.STACKTRACE_UNCLASSIFIABLE_FRAME;
-import static org.openjdk.jmc.flightrecorder.stacktrace.Messages.STACKTRACE_UNCLASSIFIABLE_FRAME_DESC;
 import static org.openjdk.jmc.flightrecorder.flameview.Messages.FLAMEVIEW_FLAME_GRAPH;
 import static org.openjdk.jmc.flightrecorder.flameview.Messages.FLAMEVIEW_ICICLE_GRAPH;
 import static org.openjdk.jmc.flightrecorder.flameview.Messages.FLAMEVIEW_JPEG_IMAGE;
@@ -44,11 +42,13 @@ import static org.openjdk.jmc.flightrecorder.flameview.Messages.FLAMEVIEW_SAVE_A
 import static org.openjdk.jmc.flightrecorder.flameview.Messages.FLAMEVIEW_SAVE_FLAME_GRAPH_AS;
 import static org.openjdk.jmc.flightrecorder.flameview.Messages.FLAMEVIEW_SELECT_HTML_TABLE_COUNT;
 import static org.openjdk.jmc.flightrecorder.flameview.Messages.FLAMEVIEW_SELECT_HTML_TABLE_EVENT_TYPE;
+import static org.openjdk.jmc.flightrecorder.flameview.Messages.FLAMEVIEW_SELECT_HTML_TOOLTIP_DESCRIPTION;
 import static org.openjdk.jmc.flightrecorder.flameview.Messages.FLAMEVIEW_SELECT_HTML_TOOLTIP_PACKAGE;
 import static org.openjdk.jmc.flightrecorder.flameview.Messages.FLAMEVIEW_SELECT_HTML_TOOLTIP_SAMPLES;
-import static org.openjdk.jmc.flightrecorder.flameview.Messages.FLAMEVIEW_SELECT_HTML_TOOLTIP_DESCRIPTION;
 import static org.openjdk.jmc.flightrecorder.flameview.MessagesUtils.getFlameviewMessage;
 import static org.openjdk.jmc.flightrecorder.flameview.MessagesUtils.getStacktraceMessage;
+import static org.openjdk.jmc.flightrecorder.stacktrace.Messages.STACKTRACE_UNCLASSIFIABLE_FRAME;
+import static org.openjdk.jmc.flightrecorder.stacktrace.Messages.STACKTRACE_UNCLASSIFIABLE_FRAME_DESC;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -71,6 +71,7 @@ import org.eclipse.jface.action.IMenuManager;
 import org.eclipse.jface.action.IToolBarManager;
 import org.eclipse.jface.action.Separator;
 import org.eclipse.jface.resource.ImageDescriptor;
+import org.eclipse.jface.resource.ResourceLocator;
 import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.swt.SWT;
@@ -82,8 +83,8 @@ import org.eclipse.swt.custom.SashForm;
 import org.eclipse.swt.events.MenuDetectEvent;
 import org.eclipse.swt.events.MenuDetectListener;
 import org.eclipse.swt.graphics.Image;
-import org.eclipse.swt.graphics.ImageLoader;
 import org.eclipse.swt.graphics.ImageData;
+import org.eclipse.swt.graphics.ImageLoader;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.FileDialog;
 import org.eclipse.ui.IMemento;
@@ -94,15 +95,14 @@ import org.eclipse.ui.IWorkbenchPart;
 import org.eclipse.ui.PartInitException;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.part.ViewPart;
-import org.eclipse.ui.plugin.AbstractUIPlugin;
 import org.openjdk.jmc.common.item.IItemCollection;
 import org.openjdk.jmc.common.util.StringToolkit;
 import org.openjdk.jmc.flightrecorder.flameview.FlameviewImages;
 import org.openjdk.jmc.flightrecorder.flameview.tree.TraceNode;
 import org.openjdk.jmc.flightrecorder.flameview.tree.TraceTreeUtils;
 import org.openjdk.jmc.flightrecorder.stacktrace.FrameSeparator;
-import org.openjdk.jmc.flightrecorder.stacktrace.StacktraceModel;
 import org.openjdk.jmc.flightrecorder.stacktrace.FrameSeparator.FrameCategorization;
+import org.openjdk.jmc.flightrecorder.stacktrace.StacktraceModel;
 import org.openjdk.jmc.flightrecorder.ui.FlightRecorderUI;
 import org.openjdk.jmc.flightrecorder.ui.common.ImageConstants;
 import org.openjdk.jmc.flightrecorder.ui.messages.internal.Messages;
@@ -529,7 +529,7 @@ public class FlameGraphView extends ViewPart implements ISelectionListener {
 	}
 
 	private static ImageDescriptor flameviewImageDescriptor(String iconName) {
-		return AbstractUIPlugin.imageDescriptorFromPlugin(PLUGIN_ID, DIR_ICONS + iconName); //$NON-NLS-1$
+		return ResourceLocator.imageDescriptorFromBundle(PLUGIN_ID, DIR_ICONS + iconName).orElse(null); //$NON-NLS-1$
 	}
 
 	private static String getIconBase64(String iconName) {

--- a/application/org.openjdk.jmc.flightrecorder.metadata/src/main/java/org/openjdk/jmc/flightrecorder/metadata/MetadataPage.java
+++ b/application/org.openjdk.jmc.flightrecorder.metadata/src/main/java/org/openjdk/jmc/flightrecorder/metadata/MetadataPage.java
@@ -39,6 +39,7 @@ import java.util.stream.Stream;
 import org.eclipse.jface.layout.GridDataFactory;
 import org.eclipse.jface.layout.GridLayoutFactory;
 import org.eclipse.jface.resource.ImageDescriptor;
+import org.eclipse.jface.resource.ResourceLocator;
 import org.eclipse.jface.viewers.ColumnViewerToolTipSupport;
 import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.jface.viewers.TreePath;
@@ -50,8 +51,6 @@ import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Text;
 import org.eclipse.ui.forms.widgets.Form;
 import org.eclipse.ui.forms.widgets.FormToolkit;
-import org.eclipse.ui.plugin.AbstractUIPlugin;
-
 import org.openjdk.jmc.common.IState;
 import org.openjdk.jmc.common.IWritableState;
 import org.openjdk.jmc.common.item.IItemIterable;
@@ -234,7 +233,7 @@ public class MetadataPage extends AbstractDataPage {
 
 		@Override
 		public ImageDescriptor getImageDescriptor(IState state) {
-			return AbstractUIPlugin.imageDescriptorFromPlugin(PLUGIN_ID, ICON);
+			return ResourceLocator.imageDescriptorFromBundle(PLUGIN_ID, ICON).orElse(null);
 		}
 
 		@Override

--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/FlightRecorderUI.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/FlightRecorderUI.java
@@ -42,8 +42,7 @@ import org.eclipse.ui.IEditorReference;
 import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.IWorkbenchWindow;
-import org.osgi.framework.BundleContext;
-
+import org.eclipse.ui.PlatformUI;
 import org.openjdk.jmc.common.unit.IQuantity;
 import org.openjdk.jmc.common.unit.QuantityConversionException;
 import org.openjdk.jmc.common.unit.UnitLookup;
@@ -52,6 +51,7 @@ import org.openjdk.jmc.flightrecorder.ui.messages.internal.Messages;
 import org.openjdk.jmc.flightrecorder.ui.preferences.PreferenceKeys;
 import org.openjdk.jmc.ui.MCAbstractUIPlugin;
 import org.openjdk.jmc.ui.misc.DisplayToolkit;
+import org.osgi.framework.BundleContext;
 
 /**
  * The activator class controls the life cycle for the Flight Recording plug-in.
@@ -202,7 +202,7 @@ public final class FlightRecorderUI extends MCAbstractUIPlugin {
 
 	public PageManager getPageManager() {
 		if (pageManager == null) {
-			IWorkbench workbench = getWorkbench();
+			IWorkbench workbench = PlatformUI.getWorkbench();
 			Runnable callback = () -> DisplayToolkit.safeAsyncExec(() -> refreshJfrEditors(workbench));
 			pageManager = new PageManager(getPreferences().get(PAGE_MANAGER_ID, null), callback);
 		}

--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/JfrPropertySheet.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/JfrPropertySheet.java
@@ -550,6 +550,7 @@ public class JfrPropertySheet extends Page implements IPropertySheetPage {
 			return Stream.empty();
 		} else {
 			IItemIterable single = iterables.next();
+			@SuppressWarnings("deprecation")
 			List<IAttribute<?>> attributes = single.getType().getAttributes();
 			if (iterables.hasNext()) {
 				attributes = new ArrayList<>(attributes); // modifiable copy

--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/common/ChartToolTipProvider.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/common/ChartToolTipProvider.java
@@ -90,6 +90,7 @@ public class ChartToolTipProvider implements IChartInfoVisitor {
 		return imageMap;
 	}
 
+	@SuppressWarnings("deprecation")
 	protected Stream<IAttribute<?>> getAttributeStream(IType<IItem> type) {
 		return type.getAttributes().stream();
 	}

--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/common/DataPageToolkit.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/common/DataPageToolkit.java
@@ -655,6 +655,7 @@ public class DataPageToolkit {
 
 	public static void createChartTooltip(ChartCanvas chart, Set<IAttribute<?>> excludedAttributes) {
 		createChartTooltip(chart, () -> new ChartToolTipProvider() {
+			@SuppressWarnings("deprecation")
 			@Override
 			protected Stream<IAttribute<?>> getAttributeStream(IType<IItem> type) {
 				return type.getAttributes().stream().filter(a -> !excludedAttributes.contains(a));
@@ -880,6 +881,7 @@ public class DataPageToolkit {
 	}
 
 	// FIXME: Move to some AttributeToolkit?
+	@SuppressWarnings("deprecation")
 	private static Stream<IAttribute<?>> getAttributes(IItemCollection items) {
 		return ItemCollectionToolkit.stream(items).filter(IItemIterable::hasItems)
 				.flatMap(is -> is.getType().getAttributes().stream());
@@ -1070,7 +1072,7 @@ public class DataPageToolkit {
 				}
 
 				private ImageData resizeImage(ImageData imageData, int width, int height) {
-					Image original = ImageDescriptor.createFromImageData(imageData).createImage();
+					Image original = ImageDescriptor.createFromImageDataProvider((zoom) -> imageData).createImage();
 					Image scaled = new Image(Display.getDefault(), width, height);
 					GC gc = new GC(scaled);
 					gc.setAntialias(SWT.ON);

--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/common/ItemList.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/common/ItemList.java
@@ -65,9 +65,9 @@ import org.openjdk.jmc.ui.accessibility.FocusTracker;
 import org.openjdk.jmc.ui.column.ColumnBuilder;
 import org.openjdk.jmc.ui.column.ColumnManager;
 import org.openjdk.jmc.ui.column.ColumnManager.ColumnComparator;
-import org.openjdk.jmc.ui.handlers.MCContextMenuManager;
 import org.openjdk.jmc.ui.column.IColumn;
 import org.openjdk.jmc.ui.column.TableSettings;
+import org.openjdk.jmc.ui.handlers.MCContextMenuManager;
 
 public class ItemList {
 
@@ -76,6 +76,7 @@ public class ItemList {
 		private final List<IColumn> columns = new ArrayList<>();
 
 		public void addColumn(IAttribute<?> a) {
+			@SuppressWarnings("deprecation")
 			IMemberAccessor<?, IItem> accessor = ItemToolkit.accessor(a);
 			// FIXME: Calculate column id, e.g. using getColumnId.
 			// Otherwise there will be problem if adding multiple attributes with the same id.

--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/common/LabeledPageFactory.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/common/LabeledPageFactory.java
@@ -76,7 +76,8 @@ public abstract class LabeledPageFactory implements IDataPageFactory {
 		if (iconStr != null) {
 			byte[] pngData = Base64.getDecoder().decode(iconStr);
 			try {
-				return ImageDescriptor.createFromImageData(new ImageData(new ByteArrayInputStream(pngData)));
+				return ImageDescriptor
+						.createFromImageDataProvider((zoom) -> new ImageData(new ByteArrayInputStream(pngData)));
 			} catch (Exception e) {
 				FlightRecorderUI.getDefault().getLogger().log(Level.WARNING,
 						"Could not load icon for page: " + getName(state), e); //$NON-NLS-1$
@@ -96,7 +97,7 @@ public abstract class LabeledPageFactory implements IDataPageFactory {
 			try {
 				ImageLoader loader = new ImageLoader();
 				ByteArrayOutputStream out = new ByteArrayOutputStream();
-				loader.data = new ImageData[] {image.getImageData()};
+				loader.data = new ImageData[] {image.getImageData(100)};
 				loader.save(out, SWT.IMAGE_PNG);
 				String iconStr = Base64.getEncoder().encodeToString(out.toByteArray());
 				to.putString(LabeledPageFactory.ATTRIBUTE_ICON, iconStr);

--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/overview/ResultReportUi.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/overview/ResultReportUi.java
@@ -225,7 +225,7 @@ public class ResultReportUi {
 			}
 			ImageLoader loader = new ImageLoader();
 			ByteArrayOutputStream out = new ByteArrayOutputStream();
-			loader.data = new ImageData[] {image.getImageData()};
+			loader.data = new ImageData[] {image.getImageData(100)};
 			loader.save(out, SWT.IMAGE_PNG);
 			return Base64.getEncoder().encodeToString(out.toByteArray());
 		}

--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/EventBrowserPage.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/EventBrowserPage.java
@@ -284,6 +284,7 @@ public class EventBrowserPage extends AbstractDataPage {
 			}
 		}
 
+		@SuppressWarnings("deprecation")
 		private void rebuildItemList() {
 			mergeListSettings();
 

--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/itemhandler/AttributeComponentConfiguration.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/itemhandler/AttributeComponentConfiguration.java
@@ -77,6 +77,7 @@ class AttributeComponentConfiguration {
 		populateAttributeMaps(isSuitableForLineCharts(items, allTypes));
 	}
 
+	@SuppressWarnings("deprecation")
 	private void forEachType(IItemCollection items) {
 		if (items != null) {
 			ItemCollectionToolkit.stream(items).map(IItemIterable::getType).forEach(type -> {
@@ -90,6 +91,7 @@ class AttributeComponentConfiguration {
 		}
 	}
 
+	@SuppressWarnings("deprecation")
 	private void populateAttributeMaps(boolean allowLineCharts) {
 		for (Entry<String, IAttribute<?>> a : allAttributes.entrySet()) {
 			if (!commonAttributes.containsKey(a.getKey()) && !uncommonAttributes.containsKey(a.getKey())

--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/itemhandler/ItemListAndChart.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/itemhandler/ItemListAndChart.java
@@ -146,6 +146,7 @@ class ItemListAndChart {
 			String combinedId = entry.getKey();
 			IAttribute<?> a = entry.getValue();
 			ContentType<?> contentType = a.getContentType();
+			@SuppressWarnings("deprecation")
 			IMemberAccessor<?, IItem> accessor = ItemToolkit.accessor(a);
 			itemListBuilder.addColumn(combinedId, a.getName(), a.getDescription(),
 					contentType instanceof LinearKindOfQuantity, accessor);

--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/views/stacktrace/StacktraceView.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/views/stacktrace/StacktraceView.java
@@ -283,6 +283,8 @@ public class StacktraceView extends ViewPart implements ISelectionListener {
 			}
 		}
 
+		// See JMC-6787
+		@SuppressWarnings("deprecation")
 		@Override
 		public void run() {
 			StacktraceFrame frame = (StacktraceFrame) getStructuredSelection().getFirstElement();
@@ -334,6 +336,8 @@ public class StacktraceView extends ViewPart implements ISelectionListener {
 		@Override
 		public void run() {
 			Branch branch = ((StacktraceFrame) getStructuredSelection().getFirstElement()).getBranch();
+			// See JMC-6787
+			@SuppressWarnings("deprecation")
 			Branch selectedSibling = branch.selectSibling(offset);
 			provider.refresh();
 			provider.setSelection(new StructuredSelection(selectedSibling.getFirstFrame()));
@@ -435,7 +439,9 @@ public class StacktraceView extends ViewPart implements ISelectionListener {
 			viewer.setContentProvider(createTreeContentProvider());
 		}
 	}
-
+	
+	// See JMC-6787
+	@SuppressWarnings("deprecation")
 	private void rebuildViewer() {
 		boolean hasFocus = viewer.getControl().isFocusControl();
 		ISelection oldSelection = viewer.getSelection();
@@ -823,6 +829,8 @@ public class StacktraceView extends ViewPart implements ISelectionListener {
 		return isFirstInBranchWithSiblings(frame) && !isInOpenFork(frame);
 	}
 
+	// See JMC-6787
+	@SuppressWarnings("deprecation")
 	private static boolean isInOpenFork(StacktraceFrame frame) {
 		return frame.getBranch().getParentFork().getSelectedBranch() == null;
 	}
@@ -841,6 +849,8 @@ public class StacktraceView extends ViewPart implements ISelectionListener {
 	 * this argument.
 	 */
 	private static void addSelectedBranches(Fork fork, SimpleArray<StacktraceFrame> input, boolean backwards) {
+		// See JMC-6787
+		@SuppressWarnings("deprecation")
 		Branch selectedBranch = fork.getSelectedBranch();
 		if (selectedBranch == null) {
 			Stream.of(fork.getFirstFrames()).forEach(input::add);
@@ -858,6 +868,8 @@ public class StacktraceView extends ViewPart implements ISelectionListener {
 		}
 	}
 
+	// See JMC-6787
+	@SuppressWarnings("deprecation")
 	private static Branch getLastSelectedBranch(Fork fromFork) {
 		Branch lastSelectedBranch = null;
 		Branch branch = fromFork.getSelectedBranch();

--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/views/stacktrace/StacktraceView.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/views/stacktrace/StacktraceView.java
@@ -439,7 +439,7 @@ public class StacktraceView extends ViewPart implements ISelectionListener {
 			viewer.setContentProvider(createTreeContentProvider());
 		}
 	}
-	
+
 	// See JMC-6787
 	@SuppressWarnings("deprecation")
 	private void rebuildViewer() {

--- a/application/org.openjdk.jmc.ide.launch/src/main/java/org/openjdk/jmc/ide/launch/JfrLaunchDelegateHelper.java
+++ b/application/org.openjdk.jmc.ide.launch/src/main/java/org/openjdk/jmc/ide/launch/JfrLaunchDelegateHelper.java
@@ -48,8 +48,6 @@ import org.eclipse.debug.core.IDebugEventSetListener;
 import org.eclipse.debug.core.ILaunchConfiguration;
 import org.eclipse.osgi.util.NLS;
 import org.eclipse.swt.widgets.Display;
-
-import org.openjdk.jmc.common.io.IOToolkit;
 import org.openjdk.jmc.common.unit.IQuantity;
 import org.openjdk.jmc.common.unit.QuantityConversionException;
 import org.openjdk.jmc.common.unit.UnitLookup;

--- a/application/org.openjdk.jmc.ide.launch/src/main/java/org/openjdk/jmc/ide/launch/LaunchPlugin.java
+++ b/application/org.openjdk.jmc.ide.launch/src/main/java/org/openjdk/jmc/ide/launch/LaunchPlugin.java
@@ -35,6 +35,7 @@ package org.openjdk.jmc.ide.launch;
 import org.eclipse.jface.resource.ImageRegistry;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.ui.IWorkbenchWindow;
+import org.eclipse.ui.PlatformUI;
 import org.osgi.framework.BundleContext;
 
 import org.openjdk.jmc.ui.MCAbstractUIPlugin;
@@ -86,7 +87,7 @@ public class LaunchPlugin extends MCAbstractUIPlugin {
 	}
 
 	static Shell getActiveWorkbenchShell() {
-		IWorkbenchWindow window = LaunchPlugin.getDefault().getWorkbench().getActiveWorkbenchWindow();
+		IWorkbenchWindow window = PlatformUI.getWorkbench().getActiveWorkbenchWindow();
 
 		if (window != null) {
 			return window.getShell();

--- a/application/org.openjdk.jmc.joverflow/src/main/java/org/openjdk/jmc/joverflow/util/FileUtils.java
+++ b/application/org.openjdk.jmc.joverflow/src/main/java/org/openjdk/jmc/joverflow/util/FileUtils.java
@@ -44,8 +44,6 @@ import java.io.PrintStream;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.openjdk.jmc.common.io.IOToolkit;
-
 /**
  * Simple file-related utilities.
  */

--- a/application/org.openjdk.jmc.rcp.application/src/main/java/org/openjdk/jmc/rcp/application/Application.java
+++ b/application/org.openjdk.jmc.rcp.application/src/main/java/org/openjdk/jmc/rcp/application/Application.java
@@ -74,6 +74,6 @@ public class Application implements IApplication {
 
 	@Override
 	public void stop() {
-		ApplicationPlugin.getDefault().getWorkbench().close();
+		PlatformUI.getWorkbench().close();
 	}
 }

--- a/application/org.openjdk.jmc.rcp.application/src/main/java/org/openjdk/jmc/rcp/application/ApplicationPlugin.java
+++ b/application/org.openjdk.jmc.rcp.application/src/main/java/org/openjdk/jmc/rcp/application/ApplicationPlugin.java
@@ -39,6 +39,7 @@ import java.util.logging.Logger;
 
 import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.jface.resource.ImageRegistry;
+import org.eclipse.jface.resource.ResourceLocator;
 import org.eclipse.ui.plugin.AbstractUIPlugin;
 import org.openjdk.jmc.common.io.IOToolkit;
 import org.openjdk.jmc.rcp.application.p2.AddRepositoriesJob;
@@ -143,6 +144,6 @@ public class ApplicationPlugin extends AbstractUIPlugin {
 	 * @return the image descriptor
 	 */
 	public static ImageDescriptor getImageDescriptor(String path) {
-		return imageDescriptorFromPlugin(PLUGIN_ID, path);
+		return ResourceLocator.imageDescriptorFromBundle(PLUGIN_ID, path).orElse(null);
 	}
 }

--- a/application/org.openjdk.jmc.rcp.application/src/main/java/org/openjdk/jmc/rcp/application/commands/CloseEditor.java
+++ b/application/org.openjdk.jmc.rcp.application/src/main/java/org/openjdk/jmc/rcp/application/commands/CloseEditor.java
@@ -37,10 +37,9 @@ import java.io.PrintStream;
 import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.IWorkbenchWindow;
-
+import org.eclipse.ui.PlatformUI;
 import org.openjdk.jmc.commands.IExecute;
 import org.openjdk.jmc.commands.Statement;
-import org.openjdk.jmc.ui.UIPlugin;
 
 /**
  * This class should move to core
@@ -49,7 +48,7 @@ public final class CloseEditor implements IExecute {
 
 	@Override
 	public boolean execute(Statement statement, PrintStream out) {
-		IWorkbenchWindow ww = UIPlugin.getDefault().getWorkbench().getActiveWorkbenchWindow();
+		IWorkbenchWindow ww = PlatformUI.getWorkbench().getActiveWorkbenchWindow();
 		if (ww != null) {
 			IWorkbenchPage wp = ww.getActivePage();
 			if (wp != null) {

--- a/application/org.openjdk.jmc.rcp.application/src/main/java/org/openjdk/jmc/rcp/application/scripting/ShellViewCoommand.java
+++ b/application/org.openjdk.jmc.rcp.application/src/main/java/org/openjdk/jmc/rcp/application/scripting/ShellViewCoommand.java
@@ -39,7 +39,7 @@ import org.eclipse.ui.IViewPart;
 import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.PartInitException;
-
+import org.eclipse.ui.PlatformUI;
 import org.openjdk.jmc.ui.ActivitiesToolkit;
 import org.openjdk.jmc.ui.UIPlugin;
 
@@ -54,7 +54,7 @@ public class ShellViewCoommand extends Action {
 
 	@Override
 	public void run() {
-		IWorkbenchWindow w = UIPlugin.getDefault().getWorkbench().getActiveWorkbenchWindow();
+		IWorkbenchWindow w = PlatformUI.getWorkbench().getActiveWorkbenchWindow();
 		if (w != null) {
 			IWorkbenchPage page = w.getActivePage();
 			if (page != null) {

--- a/application/org.openjdk.jmc.rjmx.ui/src/main/java/org/openjdk/jmc/rjmx/ui/internal/RemoveAction.java
+++ b/application/org.openjdk.jmc.rjmx.ui/src/main/java/org/openjdk/jmc/rjmx/ui/internal/RemoveAction.java
@@ -34,17 +34,16 @@ package org.openjdk.jmc.rjmx.ui.internal;
 
 import org.eclipse.jface.action.Action;
 import org.eclipse.jface.resource.ImageDescriptor;
+import org.eclipse.jface.resource.ResourceLocator;
 import org.eclipse.ui.forms.SectionPart;
-import org.eclipse.ui.plugin.AbstractUIPlugin;
-
 import org.openjdk.jmc.ui.misc.MCSectionPart;
 
 /**
  * Action for removing a {@link SectionPart} in a {@link SectionPartManager}
  */
 public class RemoveAction extends Action {
-	private final static ImageDescriptor ICON = AbstractUIPlugin.imageDescriptorFromPlugin("org.eclipse.ui", //$NON-NLS-1$
-			"icons/full/elcl16/close_view.gif"); //$NON-NLS-1$
+	private final static ImageDescriptor ICON = ResourceLocator.imageDescriptorFromBundle("org.eclipse.ui", //$NON-NLS-1$
+			"icons/full/elcl16/close_view.gif").orElse(null); //$NON-NLS-1$
 	final private SectionPartManager m_sectionPartmanager;
 	final private MCSectionPart m_part;
 

--- a/application/org.openjdk.jmc.rjmx/src/main/java/org/openjdk/jmc/rjmx/persistence/internal/PersistenceFile.java
+++ b/application/org.openjdk.jmc.rjmx/src/main/java/org/openjdk/jmc/rjmx/persistence/internal/PersistenceFile.java
@@ -41,7 +41,6 @@ import java.io.RandomAccessFile;
 import java.util.Comparator;
 import java.util.Locale;
 
-import org.openjdk.jmc.common.io.IOToolkit;
 import org.openjdk.jmc.rjmx.subscription.MRI;
 import org.openjdk.jmc.ui.common.xydata.DefaultTimestampedData;
 import org.openjdk.jmc.ui.common.xydata.ITimestampedData;

--- a/application/org.openjdk.jmc.rjmx/src/main/java/org/openjdk/jmc/rjmx/subscription/internal/FileMRIMetadata.java
+++ b/application/org.openjdk.jmc.rjmx/src/main/java/org/openjdk/jmc/rjmx/subscription/internal/FileMRIMetadata.java
@@ -39,16 +39,14 @@ import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import org.w3c.dom.Document;
-import org.w3c.dom.Element;
-import org.w3c.dom.NodeList;
-
-import org.openjdk.jmc.common.io.IOToolkit;
 import org.openjdk.jmc.common.util.XmlToolkit;
 import org.openjdk.jmc.rjmx.subscription.IMRIMetadataProvider;
 import org.openjdk.jmc.rjmx.subscription.MRI;
 import org.openjdk.jmc.rjmx.subscription.MRI.Type;
 import org.openjdk.jmc.rjmx.subscription.MRIMetadataToolkit;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
 
 /**
  * This class is used to read the default metadata from the mrimetadata.xml file.

--- a/application/org.openjdk.jmc.ui.common/src/main/java/org/openjdk/jmc/ui/common/util/MCVersion.java
+++ b/application/org.openjdk.jmc.ui.common/src/main/java/org/openjdk/jmc/ui/common/util/MCVersion.java
@@ -38,8 +38,6 @@ import java.util.Properties;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import org.openjdk.jmc.common.io.IOToolkit;
-
 /**
  * Provides Mission Control version information.
  */

--- a/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/ActivitiesToolkit.java
+++ b/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/ActivitiesToolkit.java
@@ -35,6 +35,7 @@ package org.openjdk.jmc.ui;
 import java.util.HashSet;
 import java.util.Set;
 
+import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.activities.IWorkbenchActivitySupport;
 
 /**
@@ -49,7 +50,7 @@ public final class ActivitiesToolkit {
 	}
 
 	public static IWorkbenchActivitySupport getActivitySupport() {
-		return UIPlugin.getDefault().getWorkbench().getActivitySupport();
+		return PlatformUI.getWorkbench().getActivitySupport();
 	}
 
 	public static boolean enableActivity(String id) {

--- a/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/CoreImages.java
+++ b/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/CoreImages.java
@@ -35,7 +35,7 @@ package org.openjdk.jmc.ui;
 import java.util.MissingResourceException;
 
 import org.eclipse.jface.resource.ImageDescriptor;
-import org.eclipse.ui.plugin.AbstractUIPlugin;
+import org.eclipse.jface.resource.ResourceLocator;
 
 /**
  * Storage for common ImageDescriptors.
@@ -177,7 +177,7 @@ public class CoreImages {
 	}
 
 	private static ImageDescriptor createDescriptor(String relPath) {
-		ImageDescriptor desc = AbstractUIPlugin.imageDescriptorFromPlugin(UIPlugin.PLUGIN_ID, relPath);
+		ImageDescriptor desc = ResourceLocator.imageDescriptorFromBundle(UIPlugin.PLUGIN_ID, relPath).orElse(null);
 		if (desc == null) {
 			// FIXME: Throwing an exception has the development time advantage of being very intrusive. For release time, logging might be better.
 			throw new MissingResourceException("Missing image '" + relPath + '\'', ImageDescriptor.class.getName(), //$NON-NLS-1$

--- a/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/formpage/commands/internal/ContextLookup.java
+++ b/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/formpage/commands/internal/ContextLookup.java
@@ -38,10 +38,9 @@ import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.IWorkbenchPart;
 import org.eclipse.ui.IWorkbenchWindow;
+import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.forms.editor.FormEditor;
 import org.eclipse.ui.forms.editor.IFormPage;
-
-import org.openjdk.jmc.ui.UIPlugin;
 
 public class ContextLookup {
 	public static Object getContext(PrintStream out) {
@@ -53,7 +52,7 @@ public class ContextLookup {
 	}
 
 	final static IEditorPart getActiveMainEditor() {
-		IWorkbenchWindow ww = UIPlugin.getDefault().getWorkbench().getActiveWorkbenchWindow();
+		IWorkbenchWindow ww = PlatformUI.getWorkbench().getActiveWorkbenchWindow();
 		if (ww != null) {
 			IWorkbenchPage wp = ww.getActivePage();
 			if (wp == null) {

--- a/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/misc/ImageDescriptorAdapterFactory.java
+++ b/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/misc/ImageDescriptorAdapterFactory.java
@@ -34,8 +34,7 @@ package org.openjdk.jmc.ui.misc;
 
 import org.eclipse.core.runtime.IAdapterFactory;
 import org.eclipse.jface.resource.ImageDescriptor;
-import org.eclipse.ui.plugin.AbstractUIPlugin;
-
+import org.eclipse.jface.resource.ResourceLocator;
 import org.openjdk.jmc.ui.common.resource.IImageResource;
 import org.openjdk.jmc.ui.common.resource.Resource;
 import org.openjdk.jmc.ui.common.util.AdapterUtil;
@@ -50,8 +49,8 @@ public class ImageDescriptorAdapterFactory implements IAdapterFactory {
 			if (imageResource != null) {
 				Resource r = imageResource.getImageResource();
 				if (r != null) {
-					return adapterType
-							.cast(AbstractUIPlugin.imageDescriptorFromPlugin(r.getPluginId(), r.getResourcePath()));
+					return adapterType.cast(ResourceLocator
+							.imageDescriptorFromBundle(r.getPluginId(), r.getResourcePath()).orElse(null));
 				}
 			}
 			IGraphical g = AdapterUtil.getAdapter(adaptableObject, IGraphical.class);

--- a/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/misc/OverlayImageDescriptor.java
+++ b/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/misc/OverlayImageDescriptor.java
@@ -54,7 +54,7 @@ public class OverlayImageDescriptor extends CompositeImageDescriptor {
 
 	@Override
 	protected void drawCompositeImage(int width, int height) {
-		ImageData id = base.getImageData();
+		ImageData id = base.getImageData(100);
 		if (reduceAlpha) {
 			// Just using global alpha messes up normal alpha
 			for (int x = 0; x < id.width; x++) {
@@ -63,17 +63,18 @@ public class OverlayImageDescriptor extends CompositeImageDescriptor {
 				}
 			}
 		}
-		drawImage(id, 0, 0);
+		// Trick to get the auto scaling to work
+		drawImage(zoom -> zoom == 100 ? id : null, 0, 0);
 		for (ImageDescriptor overlay : overlays) {
 			if (overlay != null) {
-				drawImage(overlay.getImageData(), 0, 0);
+				drawImage((zoom) -> overlay.getImageData(zoom), 0, 0);
 			}
 		}
 	}
 
 	@Override
 	protected Point getSize() {
-		ImageData baseData = base.getImageData();
+		ImageData baseData = base.getImageData(100);
 		return new Point(baseData.width, baseData.height);
 	}
 

--- a/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/misc/SWTColorToolkit.java
+++ b/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/misc/SWTColorToolkit.java
@@ -124,7 +124,7 @@ public class SWTColorToolkit {
 		gc.setForeground(getColor(BORDER_COLOR));
 		gc.drawRectangle(1, 1, size - 3, size - 3);
 		gc.dispose();
-		ImageDescriptor id = ImageDescriptor.createFromImageData(i.getImageData());
+		ImageDescriptor id = ImageDescriptor.createFromImageDataProvider((zoom) -> i.getImageData(zoom));
 		i.dispose();
 		return id;
 	}

--- a/application/tests/org.openjdk.jmc.rjmx.test/src/test/java/org/openjdk/jmc/rjmx/test/PackageExampleTest.java
+++ b/application/tests/org.openjdk.jmc.rjmx.test/src/test/java/org/openjdk/jmc/rjmx/test/PackageExampleTest.java
@@ -35,7 +35,6 @@ package org.openjdk.jmc.rjmx.test;
 import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
-import org.openjdk.jmc.common.io.IOToolkit;
 import org.openjdk.jmc.rjmx.ConnectionDescriptorBuilder;
 import org.openjdk.jmc.rjmx.ConnectionException;
 import org.openjdk.jmc.rjmx.IConnectionDescriptor;

--- a/application/tests/org.openjdk.jmc.ui.common.test/src/test/java/org/openjdk/jmc/ui/common/jvm/JVMCommandLineToolkitTest.java
+++ b/application/tests/org.openjdk.jmc.ui.common.test/src/test/java/org/openjdk/jmc/ui/common/jvm/JVMCommandLineToolkitTest.java
@@ -36,8 +36,6 @@ import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
 
-import org.openjdk.jmc.ui.common.jvm.JVMCommandLineToolkit;
-
 public class JVMCommandLineToolkitTest {
 
 	// Tests for getMainClassOrJar

--- a/application/tests/org.openjdk.jmc.ui.common.test/src/test/java/org/openjdk/jmc/ui/common/labelingrules/NameConverterTest.java
+++ b/application/tests/org.openjdk.jmc.ui.common.test/src/test/java/org/openjdk/jmc/ui/common/labelingrules/NameConverterTest.java
@@ -39,9 +39,6 @@ import static org.junit.Assert.assertTrue;
 import java.text.MessageFormat;
 
 import org.junit.Test;
-
-import org.openjdk.jmc.ui.common.labelingrules.NameConverter;
-import org.openjdk.jmc.ui.common.labelingrules.NamingRule;
 import org.openjdk.jmc.ui.common.util.Environment;
 
 @SuppressWarnings("nls")

--- a/application/tests/org.openjdk.jmc.ui.common.test/src/test/java/org/openjdk/jmc/ui/common/security/SecureStoreTest.java
+++ b/application/tests/org.openjdk.jmc.ui.common.test/src/test/java/org/openjdk/jmc/ui/common/security/SecureStoreTest.java
@@ -45,11 +45,8 @@ import java.util.HashSet;
 import org.junit.Assume;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.osgi.service.prefs.Preferences;
-
-import org.openjdk.jmc.ui.common.security.SecureStore;
-import org.openjdk.jmc.ui.common.security.SecurityException;
 import org.openjdk.jmc.ui.common.util.Environment;
+import org.osgi.service.prefs.Preferences;
 
 @SuppressWarnings("nls")
 public class SecureStoreTest {

--- a/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/item/ItemToolkit.java
+++ b/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/item/ItemToolkit.java
@@ -39,7 +39,7 @@ import java.util.Iterator;
  * Toolkit methods for performing operations on items.
  */
 public class ItemToolkit {
-
+	
 	/**
 	 * @deprecated This method returns a member accessor that is not thread safe. Instead of
 	 *             creating an accessor that could be used for multiple item types, items should be

--- a/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/item/ItemToolkit.java
+++ b/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/item/ItemToolkit.java
@@ -39,7 +39,7 @@ import java.util.Iterator;
  * Toolkit methods for performing operations on items.
  */
 public class ItemToolkit {
-	
+
 	/**
 	 * @deprecated This method returns a member accessor that is not thread safe. Instead of
 	 *             creating an accessor that could be used for multiple item types, items should be

--- a/core/org.openjdk.jmc.flightrecorder.rules/src/main/java/org/openjdk/jmc/flightrecorder/rules/util/SlidingWindowToolkit.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules/src/main/java/org/openjdk/jmc/flightrecorder/rules/util/SlidingWindowToolkit.java
@@ -49,7 +49,6 @@ import org.openjdk.jmc.common.unit.IRange;
 import org.openjdk.jmc.common.unit.QuantityRange;
 import org.openjdk.jmc.common.util.Pair;
 import org.openjdk.jmc.flightrecorder.JfrAttributes;
-import org.openjdk.jmc.flightrecorder.jdk.JdkAggregators;
 import org.openjdk.jmc.flightrecorder.rules.Result;
 
 /**

--- a/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/internal/EventAppearance.java
+++ b/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/internal/EventAppearance.java
@@ -42,8 +42,6 @@ import java.util.Map.Entry;
 import java.util.Properties;
 import java.util.regex.Pattern;
 
-import org.openjdk.jmc.common.io.IOToolkit;
-
 /**
  * Contain algorithmic conversion and overrides for the display name of event path segments. Also,
  * algorithmic generation and overrides for the color of event types. For these purposes, a case

--- a/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/internal/parser/LoaderContext.java
+++ b/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/internal/parser/LoaderContext.java
@@ -94,6 +94,7 @@ public class LoaderContext {
 		return sinkFactory;
 	}
 
+	@SuppressWarnings("deprecation")
 	public EventArray[] buildEventArrays() throws CouldNotLoadRecordingException {
 		sinkFactory.flush();
 		Iterator<EventTypeEntry> eventTypes = repositoryBuilder.getEventTypes();

--- a/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/stacktrace/StacktraceModel.java
+++ b/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/stacktrace/StacktraceModel.java
@@ -90,7 +90,7 @@ import org.openjdk.jmc.flightrecorder.JfrAttributes;
  * queried for more information.
  */
 public class StacktraceModel {
-
+	@SuppressWarnings("deprecation")
 	private final IMemberAccessor<IMCStackTrace, IItem> accessor = ItemToolkit.accessor(JfrAttributes.EVENT_STACKTRACE);
 	private final boolean threadRootAtTop;
 	private final FrameSeparator frameSeparator;
@@ -142,6 +142,7 @@ public class StacktraceModel {
 	 * The first call may take some time due to calculations, so it may be useful to call this in a
 	 * background thread if used in a UI.
 	 */
+	@SuppressWarnings("deprecation")
 	public Fork getRootFork() {
 		if (rootFork == null) {
 			rootFork = new Fork(ItemToolkit.asIterable(items));

--- a/core/org.openjdk.jmc.jdp/.classpath
+++ b/core/org.openjdk.jmc.jdp/.classpath
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="src" output="target/classes" path="src/main/java"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+	<classpathentry kind="src" output="target/classes" path="src/main/java"/>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/core/tests/pom.xml
+++ b/core/tests/pom.xml
@@ -39,7 +39,6 @@
 		<version>8.0.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>missioncontrol.core.tests</artifactId>
-	<version>8.0.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<modules>
 		<module>org.openjdk.jmc.common.test</module>


### PR DESCRIPTION
Cleaning up various compiler warnings. I've opened issues for some internal deprecated JMC APIs that we will need to discuss a bit further.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JMC-6785](https://bugs.openjdk.java.net/browse/JMC-6785): Compiler warning cleanup


### Reviewers
 * Henrik Dafgård ([hdafgard](@Gunde) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jmc pull/75/head:pull/75`
`$ git checkout pull/75`
