### PR TITLE
6801: Improve stackdepth setting rule

### DIFF
--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/general/StackDepthSettingRule.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/general/StackDepthSettingRule.java
@@ -83,7 +83,8 @@ public class StackDepthSettingRule implements IRule {
 		long truncatedTraces = 0L;
 		long totalTraces = 0L;
 		for (IItemIterable itemIterable : items.apply(stackTracesFilter)) {
-			IMemberAccessor<IMCStackTrace, IItem> stacktraceAccessor = JfrAttributes.EVENT_STACKTRACE.getAccessor(itemIterable.getType());
+			IMemberAccessor<IMCStackTrace, IItem> stacktraceAccessor = JfrAttributes.EVENT_STACKTRACE
+					.getAccessor(itemIterable.getType());
 			for (IItem item : itemIterable) {
 				String typeIdentifier = itemIterable.getType().getName();
 				IMCStackTrace stacktrace = stacktraceAccessor.getMember(item);
@@ -92,7 +93,8 @@ public class StackDepthSettingRule implements IRule {
 				tracesByType.put(typeIdentifier, tracesForType + 1);
 				if (stacktrace != null && stacktrace.getTruncationState().isTruncated()) {
 					truncatedTraces++;
-					Long truncatedTracesForType = truncatedTracesByType.containsKey(typeIdentifier) ? truncatedTracesByType.get(typeIdentifier) : 0L;
+					Long truncatedTracesForType = truncatedTracesByType.containsKey(typeIdentifier)
+							? truncatedTracesByType.get(typeIdentifier) : 0L;
 					truncatedTracesByType.put(typeIdentifier, truncatedTracesForType + 1);
 				}
 			}
@@ -108,7 +110,8 @@ public class StackDepthSettingRule implements IRule {
 			for (String type : typesWithTruncatedTraces) {
 				listBuilder.append("<li>"); //$NON-NLS-1$
 				Long value = truncatedTracesByType.get(type);
-				IQuantity percentTruncated = UnitLookup.PERCENT_UNITY.quantity((double) value / (double) tracesByType.get(type));
+				IQuantity percentTruncated = UnitLookup.PERCENT_UNITY
+						.quantity((double) value / (double) tracesByType.get(type));
 				listBuilder.append(
 						MessageFormat.format(Messages.getString(Messages.StackdepthSettingRule_TYPE_LIST_TEMPLATE),
 								Encode.forHtml(type), percentTruncated.displayUsing(IDisplayable.AUTO)));

--- a/core/tests/org.openjdk.jmc.flightrecorder.rules.jdk.test/src/test/resources/baseline/JfrRuleBaseline.xml
+++ b/core/tests/org.openjdk.jmc.flightrecorder.rules.jdk.test/src/test/resources/baseline/JfrRuleBaseline.xml
@@ -1,4427 +1,4427 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <reportcollection>
-    <report>
-        <file>allocation_10s_before.jfr</file>
-        <rule>
-            <id>Allocations.class</id>
-            <severity>Information</severity>
-            <score>66.39548837411446</score>
-            <shortDescription>The most allocated type is likely 'java.lang.Integer', most commonly allocated by: &lt;ul&gt;&lt;li&gt;Integer.valueOf(int) (100 %)&lt;/li&gt;&lt;li&gt;Allocator.go()&lt;/li&gt;&lt;li&gt;Allocator.main(String[])&lt;/li&gt;&lt;/ul&gt;</shortDescription>
-            <longDescription>The most allocated type is likely 'java.lang.Integer', most commonly allocated by: &lt;ul&gt;&lt;li&gt;Integer.valueOf(int) (100 %)&lt;/li&gt;&lt;li&gt;Allocator.go()&lt;/li&gt;&lt;li&gt;Allocator.main(String[])&lt;/li&gt;&lt;/ul&gt;&lt;p&gt;Frequently allocated types are good places to start when trying to reduce garbage collections. Look at where the most common types are being allocated to see if many instances are created along the same call path. Try to reduce the number of instances created by invoking the most commonly taken paths less.</longDescription>
-        </rule>
-        <rule>
-            <id>Allocations.thread</id>
-            <severity>Information</severity>
-            <score>66.40149861711905</score>
-            <shortDescription>The most allocations were likely done by thread 'main' at: &lt;ul&gt;&lt;li&gt;Integer.valueOf(int) (100 %)&lt;/li&gt;&lt;li&gt;Allocator.go()&lt;/li&gt;&lt;li&gt;Allocator.main(String[])&lt;/li&gt;&lt;/ul&gt;</shortDescription>
-            <longDescription>The most allocations were likely done by thread 'main' at: &lt;ul&gt;&lt;li&gt;Integer.valueOf(int) (100 %)&lt;/li&gt;&lt;li&gt;Allocator.go()&lt;/li&gt;&lt;li&gt;Allocator.main(String[])&lt;/li&gt;&lt;/ul&gt;&lt;p&gt;Many allocations performed by the same thread might indicate a problem in a multi-threaded program. Look at the stack traces for the thread with the highest allocation rate. See if the allocation rate can be brought down, or balanced among the active threads.</longDescription>
-        </rule>
-        <rule>
-            <id>ApplicationHalts</id>
-            <severity>OK</severity>
-            <score>0.9591288888888891</score>
-            <shortDescription>Application efficiency was not highly affected by halts.</shortDescription>
-            <longDescription>Application efficiency was not highly affected by halts.&lt;p&gt;The highest ratio of application halts to execution time was 0.192 % for 1 min at 4/26/18 12:10:29 PM. 28.068 % of the halts were for reasons other than GC.&lt;p&gt;The halts ratio for the entire recording was 1.162 %. 28.068 % of the total halts were for reasons other than GC.&lt;/p&gt;</longDescription>
-        </rule>
-        <rule>
-            <id>BufferLost</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>No Flight Recorder buffers were lost during the recording.</shortDescription>
-            <longDescription>No Flight Recorder buffers were lost during the recording.</longDescription>
-        </rule>
-        <rule>
-            <id>BytecodeVerification</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>The application ran with bytecode verification enabled.</shortDescription>
-            <longDescription>The application ran with bytecode verification enabled.</longDescription>
-        </rule>
-        <rule>
-            <id>ClassLeak</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'Class Load', 'Class Unload'.</shortDescription>
-            <longDescription>The Class Leak rule requires that the following event types are enabled: 'Class Load', 'Class Unload'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>ClassLoading</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'Class Load'.</shortDescription>
-            <longDescription>The Class Loading Pressure rule requires that the following event types are enabled: 'Class Load'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>CodeCache</id>
-            <severity>OK</severity>
-            <score>21.736190753325</score>
-            <shortDescription>No problems with the code cache were detected in the recording.</shortDescription>
-            <longDescription>No problems with the code cache were detected in the recording.</longDescription>
-        </rule>
-        <rule>
-            <id>CompareCpu</id>
-            <severity>OK</severity>
-            <score>0.05434774741663761</score>
-            <shortDescription>An average CPU load of 1 % was caused by other processes for 1.027 s at 4/26/18 12:10:33 PM.</shortDescription>
-            <longDescription>An average CPU load of 1 % was caused by other processes for 1.027 s at 4/26/18 12:10:33 PM.</longDescription>
-        </rule>
-        <rule>
-            <id>CompressedOops</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>The settings for Compressed Oops were OK.</shortDescription>
-            <longDescription>The settings for Compressed Oops were OK.</longDescription>
-        </rule>
-        <rule>
-            <id>ContextSwitch</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires events to be available from the following event types: 'Thread Context Switch Rate'.</shortDescription>
-            <longDescription>The Context Switches rule requires events to be available from the following event types: 'Thread Context Switch Rate'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>DMSIncident</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>The DMS Incidents rule requires the following event types: 'http://www.oracle.com/dms/dfw/dms/dfw/DFW_Incident/DFW_Incident_state'.</shortDescription>
-            <longDescription>The DMS Incidents rule requires the following event types: 'http://www.oracle.com/dms/dfw/dms/dfw/DFW_Incident/DFW_Incident_state'.&lt;p&gt;They are either not available in this version of Java, or must be enabled in a third-party component. If you are using an older Java version, then you can consider upgrading.</longDescription>
-        </rule>
-        <rule>
-            <id>DebugNonSafepoints</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>DebugNonSafepoints was implicitly enabled in the JVM version used to create this recording.</shortDescription>
-            <longDescription>DebugNonSafepoints was implicitly enabled in the JVM version used to create this recording.</longDescription>
-        </rule>
-        <rule>
-            <id>DiscouragedVmOptions</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>No problems were found with the VM options.</shortDescription>
-            <longDescription>No problems were found with the VM options.</longDescription>
-        </rule>
-        <rule>
-            <id>DumpReason</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>This recording was not dumped for an exceptional reason.</shortDescription>
-            <longDescription>This recording was not dumped for an exceptional reason.</longDescription>
-        </rule>
-        <rule>
-            <id>DuplicateFlags</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>There were no duplicate JVM flags on the command line.</shortDescription>
-            <longDescription>There were no duplicate JVM flags on the command line.</longDescription>
-        </rule>
-        <rule>
-            <id>Errors</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires events to be available from the following event types: 'Java Error'.</shortDescription>
-            <longDescription>The Thrown Errors rule requires events to be available from the following event types: 'Java Error'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>Exceptions</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>The program generated 0 exceptions per second for 1.017 s at 4/26/18 12:10:30 PM.</shortDescription>
-            <longDescription>The program generated 0 exceptions per second for 1.017 s at 4/26/18 12:10:30 PM.</longDescription>
-        </rule>
-        <rule>
-            <id>Fatal Errors</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>The Fatal Errors rule requires the following event types: 'jdk.Shutdown'.</shortDescription>
-            <longDescription>The Fatal Errors rule requires the following event types: 'jdk.Shutdown'.&lt;p&gt;They are either not available in this version of Java, or must be enabled in a third-party component. If you are using an older Java version, then you can consider upgrading.</longDescription>
-        </rule>
-        <rule>
-            <id>FewSampledThreads</id>
-            <severity>Information</severity>
-            <score>29.510744962334375</score>
-            <shortDescription>There are fewer sampled threads than the total number of hardware threads (cores).</shortDescription>
-            <longDescription>There are fewer sampled threads than the total number of hardware threads (cores).&lt;p&gt;1 threads with at least 4 method samples were found, but the machine has 32 hardware threads (cores). The application might benefit from a higher level of parallelism. This could also be caused by threads doing something else than running Java code, for example running native code or spending time in the JVM internals.&lt;p&gt;This recording is only 9.903 s long, consider creating a recording longer than 20 s for improved rule accuracy.</longDescription>
-        </rule>
-        <rule>
-            <id>FileRead</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>There are no file read events in this recording.</shortDescription>
-            <longDescription>There are no file read events in this recording.</longDescription>
-        </rule>
-        <rule>
-            <id>FileWrite</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires events to be available from the following event types: 'File Write'.</shortDescription>
-            <longDescription>The File Write Peak Duration rule requires events to be available from the following event types: 'File Write'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>FlightRecordingSupport</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>The JVM version used for this recording has full Flight Recorder support.</shortDescription>
-            <longDescription>The JVM version used for this recording has full Flight Recorder support.</longDescription>
-        </rule>
-        <rule>
-            <id>FullGc</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>No Stop-the-World, Full GC events detected.</shortDescription>
-            <longDescription>No Stop-the-World, Full GC events detected.</longDescription>
-        </rule>
-        <rule>
-            <id>GcFreedRatio</id>
-            <severity>Information</severity>
-            <score>34.4635049904725</score>
-            <shortDescription>The ratio between memory freed by garbage collections per second and liveset is 65. This may be excessive.</shortDescription>
-            <longDescription>242 MiB per second was freed by garbage collections for 10 s at 4/26/18 12:10:29 PM. This is 65.013 times the average liveset which was 3.72 MiB. This may be excessive.&lt;p&gt;If the garbage collector can free a lot of memory, it may be because the application allocates a lot of short lived objects. Investigate the allocation stack traces to see which code paths cause the most allocations, and see if they can be reduced.&lt;p&gt;This recording is only 9.903 s long, consider creating a recording longer than 20 s for improved rule accuracy.</longDescription>
-        </rule>
-        <rule>
-            <id>GcLocker</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>No GCs were affected by the GC Locker.</shortDescription>
-            <longDescription>No GCs were affected by the GC Locker.</longDescription>
-        </rule>
-        <rule>
-            <id>GcOptions</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>No problems were found with the GC configuration.</shortDescription>
-            <longDescription>No problems were found with the GC configuration.</longDescription>
-        </rule>
-        <rule>
-            <id>GcPauseRatio</id>
-            <severity>OK</severity>
-            <score>0.6899182222222222</score>
-            <shortDescription>Application efficiency was not highly affected by GC pauses.</shortDescription>
-            <longDescription>Application efficiency was not highly affected by GC pauses.&lt;p&gt;The highest ratio between garbage collection pauses and execution time was 0.138 % for 1 min at 4/26/18 12:10:29 PM. The garbage collection pause ratio of the entire recording was 0.836 %.</longDescription>
-        </rule>
-        <rule>
-            <id>GcStall</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>No indications that the garbage collector could not keep up with the workload were detected.</shortDescription>
-            <longDescription>No indications that the garbage collector could not keep up with the workload were detected.</longDescription>
-        </rule>
-        <rule>
-            <id>HeapContent</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'Object Count'.</shortDescription>
-            <longDescription>The Heap Content rule requires that the following event types are enabled: 'Object Count'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>HeapInspectionGc</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>The JVM did not perform any heap inspection GCs.</shortDescription>
-            <longDescription>The JVM did not perform any heap inspection GCs. This is good since they usually take a lot of time.</longDescription>
-        </rule>
-        <rule>
-            <id>HighGc</id>
-            <severity>OK</severity>
-            <score>2.5016205991264973</score>
-            <shortDescription>The JVM was paused for 100 % of the 11.003 ms at 4/26/18 12:10:36 PM.</shortDescription>
-            <longDescription>The JVM was paused for 100 % of the 11.003 ms at 4/26/18 12:10:36 PM. The time spent performing garbage collection may be reduced by increasing the heap size or by trying to reduce allocation.</longDescription>
-        </rule>
-        <rule>
-            <id>HighJvmCpu</id>
-            <severity>OK</severity>
-            <score>1.3537208124606583</score>
-            <shortDescription>The JVM does not seem to cause a lot of CPU load.</shortDescription>
-            <longDescription>The JVM does not seem to cause a lot of CPU load.</longDescription>
-        </rule>
-        <rule>
-            <id>IncreasingLiveSet</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>No memory leaks were detected.</shortDescription>
-            <longDescription>No memory leaks were detected.</longDescription>
-        </rule>
-        <rule>
-            <id>IncreasingMetaSpaceLiveSet</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>The class data does not seem to increase during the recording.</shortDescription>
-            <longDescription>The class data does not seem to increase during the recording.</longDescription>
-        </rule>
-        <rule>
-            <id>JavaBlocking</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires events to be available from the following event types: 'Java Monitor Blocked'.</shortDescription>
-            <longDescription>The Java Blocking rule requires events to be available from the following event types: 'Java Monitor Blocked'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>LongGcPause</id>
-            <severity>OK</severity>
-            <score>0.3348866229800136</score>
-            <shortDescription>The longest GC pause was 11.003 ms.</shortDescription>
-            <longDescription>The longest GC pause was 11.003 ms.</longDescription>
-        </rule>
-        <rule>
-            <id>LowOnPhysicalMemory</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>The system did not run low on physical memory during this recording.</shortDescription>
-            <longDescription>The system did not run low on physical memory during this recording.</longDescription>
-        </rule>
-        <rule>
-            <id>ManagementAgent</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'Initial System Property'.</shortDescription>
-            <longDescription>The Discouraged Management Agent Settings rule requires that the following event types are enabled: 'Initial System Property'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>ManyRunningProcesses</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'System Process'.</shortDescription>
-            <longDescription>The Competing Processes rule requires that the following event types are enabled: 'System Process'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>MetaspaceOom</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>The metaspace was not exhausted during this recording.</shortDescription>
-            <longDescription>The metaspace was not exhausted during this recording.</longDescription>
-        </rule>
-        <rule>
-            <id>MethodProfiling</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>No methods where optimization would be particularly efficient could be detected.</shortDescription>
-            <longDescription>No methods where optimization would be particularly efficient could be detected.</longDescription>
-        </rule>
-        <rule>
-            <id>Options</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>No undocumented, deprecated or non-recommended option flags were detected.</shortDescription>
-            <longDescription>No undocumented, deprecated or non-recommended option flags were detected.</longDescription>
-        </rule>
-        <rule>
-            <id>OverAggressiveRecordingSetting</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'Initial System Property'.</shortDescription>
-            <longDescription>The Discouraged Recording Settings rule requires that the following event types are enabled: 'Initial System Property'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>PasswordsInArguments</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>The recording does not seem to contain passwords in the application arguments.</shortDescription>
-            <longDescription>The recording does not seem to contain passwords in the application arguments.</longDescription>
-        </rule>
-        <rule>
-            <id>PasswordsInEnvironment</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'Initial Environment Variable'.</shortDescription>
-            <longDescription>The Passwords in Environment Variables rule requires that the following event types are enabled: 'Initial Environment Variable'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>PasswordsInSystemProperties</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'Initial System Property'.</shortDescription>
-            <longDescription>The Passwords in System Properties rule requires that the following event types are enabled: 'Initial System Property'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>PrimitiveToObjectConversion</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires events to be available from the following event types: 'Allocation in new TLAB', 'Allocation outside TLAB'.</shortDescription>
-            <longDescription>The Primitive To Object Conversion rule requires events to be available from the following event types: 'Allocation in new TLAB', 'Allocation outside TLAB'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>SocketRead</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires events to be available from the following event types: 'Socket Read'.</shortDescription>
-            <longDescription>The Socket Read Peak Duration rule requires events to be available from the following event types: 'Socket Read'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>SocketWrite</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires events to be available from the following event types: 'Socket Write'.</shortDescription>
-            <longDescription>The Socket Write Peak Duration rule requires events to be available from the following event types: 'Socket Write'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>StackdepthSetting</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>No stack traces were truncated in this recording.</shortDescription>
-            <longDescription>No stack traces were truncated in this recording.</longDescription>
-        </rule>
-        <rule>
-            <id>StringDeduplication</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>Found no allocation events for the internal arrays in strings. Either the frame filter preference is incorrectly defined, or the stackTrace attribute is not enabled for the allocation events.</shortDescription>
-            <longDescription>Found no allocation events for the internal arrays in strings. Either the frame filter preference is incorrectly defined, or the stackTrace attribute is not enabled for the allocation events.</longDescription>
-        </rule>
-        <rule>
-            <id>SystemGc</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>No garbage collections were caused by System.gc().</shortDescription>
-            <longDescription>No garbage collections were caused by System.gc().</longDescription>
-        </rule>
-        <rule>
-            <id>TlabAllocationRatio</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>No object allocations outside of TLABs detected.</shortDescription>
-            <longDescription>No object allocations outside of TLABs detected.</longDescription>
-        </rule>
-        <rule>
-            <id>VMOperations</id>
-            <severity>OK</severity>
-            <score>0.75795475</score>
-            <shortDescription>No excessively long VM operations were found in this recording (the longest was 30.318 ms).</shortDescription>
-            <longDescription>No excessively long VM operations were found in this recording (the longest was 30.318 ms).</longDescription>
-        </rule>
-        <rule>
-            <id>biasedLockingRevocation</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>The Biased Locking Revocation rule requires the following event types: 'jdk.BiasedLockClassRevocation'.</shortDescription>
-            <longDescription>The Biased Locking Revocation rule requires the following event types: 'jdk.BiasedLockClassRevocation'.&lt;p&gt;They are either not available in this version of Java, or must be enabled in a third-party component. If you are using an older Java version, then you can consider upgrading.</longDescription>
-        </rule>
-        <rule>
-            <id>biasedLockingRevocationPause</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>No revocation of biased locks found.</shortDescription>
-            <longDescription>No revocation of biased locks found.</longDescription>
-        </rule>
-    </report>
-    <report>
-        <file>allocation_10s_fixed.jfr</file>
-        <rule>
-            <id>Allocations.class</id>
-            <severity>OK</severity>
-            <score>0.06321740358971492</score>
-            <shortDescription>The most allocated type is likely 'java.util.HashMap$ValueIterator', most commonly allocated by: &lt;ul&gt;&lt;li&gt;HashMap$Values.iterator() (100 %)&lt;/li&gt;&lt;li&gt;Allocator.go()&lt;/li&gt;&lt;li&gt;Allocator.main(String[])&lt;/li&gt;&lt;/ul&gt;</shortDescription>
-            <longDescription>The most allocated type is likely 'java.util.HashMap$ValueIterator', most commonly allocated by: &lt;ul&gt;&lt;li&gt;HashMap$Values.iterator() (100 %)&lt;/li&gt;&lt;li&gt;Allocator.go()&lt;/li&gt;&lt;li&gt;Allocator.main(String[])&lt;/li&gt;&lt;/ul&gt;&lt;p&gt;Frequently allocated types are good places to start when trying to reduce garbage collections. Look at where the most common types are being allocated to see if many instances are created along the same call path. Try to reduce the number of instances created by invoking the most commonly taken paths less.</longDescription>
-        </rule>
-        <rule>
-            <id>Allocations.thread</id>
-            <severity>OK</severity>
-            <score>0.06321740358971492</score>
-            <shortDescription>The most allocations were likely done by thread 'main' at: &lt;ul&gt;&lt;li&gt;HashMap$Values.iterator() (100 %)&lt;/li&gt;&lt;li&gt;Allocator.go()&lt;/li&gt;&lt;li&gt;Allocator.main(String[])&lt;/li&gt;&lt;/ul&gt;</shortDescription>
-            <longDescription>The most allocations were likely done by thread 'main' at: &lt;ul&gt;&lt;li&gt;HashMap$Values.iterator() (100 %)&lt;/li&gt;&lt;li&gt;Allocator.go()&lt;/li&gt;&lt;li&gt;Allocator.main(String[])&lt;/li&gt;&lt;/ul&gt;&lt;p&gt;Many allocations performed by the same thread might indicate a problem in a multi-threaded program. Look at the stack traces for the thread with the highest allocation rate. See if the allocation rate can be brought down, or balanced among the active threads.</longDescription>
-        </rule>
-        <rule>
-            <id>ApplicationHalts</id>
-            <severity>OK</severity>
-            <score>0.15440711111111113</score>
-            <shortDescription>Application efficiency was not highly affected by halts.</shortDescription>
-            <longDescription>Application efficiency was not highly affected by halts.&lt;p&gt;The highest ratio of application halts to execution time was 0.031 % for 1 min at 4/26/18 12:12:46 PM. 100 % of the halts were for reasons other than GC.&lt;p&gt;The halts ratio for the entire recording was 0.187 %. 100 % of the total halts were for reasons other than GC.&lt;/p&gt;</longDescription>
-        </rule>
-        <rule>
-            <id>BufferLost</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>No Flight Recorder buffers were lost during the recording.</shortDescription>
-            <longDescription>No Flight Recorder buffers were lost during the recording.</longDescription>
-        </rule>
-        <rule>
-            <id>BytecodeVerification</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>The application ran with bytecode verification enabled.</shortDescription>
-            <longDescription>The application ran with bytecode verification enabled.</longDescription>
-        </rule>
-        <rule>
-            <id>ClassLeak</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'Class Load', 'Class Unload'.</shortDescription>
-            <longDescription>The Class Leak rule requires that the following event types are enabled: 'Class Load', 'Class Unload'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>ClassLoading</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'Class Load'.</shortDescription>
-            <longDescription>The Class Loading Pressure rule requires that the following event types are enabled: 'Class Load'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>CodeCache</id>
-            <severity>OK</severity>
-            <score>21.808180522170357</score>
-            <shortDescription>No problems with the code cache were detected in the recording.</shortDescription>
-            <longDescription>No problems with the code cache were detected in the recording.</longDescription>
-        </rule>
-        <rule>
-            <id>CompareCpu</id>
-            <severity>OK</severity>
-            <score>0.9473864515664224</score>
-            <shortDescription>An average CPU load of 7 % was caused by other processes for 1.212 s at 4/26/18 12:12:47 PM.</shortDescription>
-            <longDescription>An average CPU load of 7 % was caused by other processes for 1.212 s at 4/26/18 12:12:47 PM.</longDescription>
-        </rule>
-        <rule>
-            <id>CompressedOops</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>The settings for Compressed Oops were OK.</shortDescription>
-            <longDescription>The settings for Compressed Oops were OK.</longDescription>
-        </rule>
-        <rule>
-            <id>ContextSwitch</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires events to be available from the following event types: 'Thread Context Switch Rate'.</shortDescription>
-            <longDescription>The Context Switches rule requires events to be available from the following event types: 'Thread Context Switch Rate'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>DMSIncident</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>The DMS Incidents rule requires the following event types: 'http://www.oracle.com/dms/dfw/dms/dfw/DFW_Incident/DFW_Incident_state'.</shortDescription>
-            <longDescription>The DMS Incidents rule requires the following event types: 'http://www.oracle.com/dms/dfw/dms/dfw/DFW_Incident/DFW_Incident_state'.&lt;p&gt;They are either not available in this version of Java, or must be enabled in a third-party component. If you are using an older Java version, then you can consider upgrading.</longDescription>
-        </rule>
-        <rule>
-            <id>DebugNonSafepoints</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>DebugNonSafepoints was implicitly enabled in the JVM version used to create this recording.</shortDescription>
-            <longDescription>DebugNonSafepoints was implicitly enabled in the JVM version used to create this recording.</longDescription>
-        </rule>
-        <rule>
-            <id>DiscouragedVmOptions</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>No problems were found with the VM options.</shortDescription>
-            <longDescription>No problems were found with the VM options.</longDescription>
-        </rule>
-        <rule>
-            <id>DumpReason</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>This recording was not dumped for an exceptional reason.</shortDescription>
-            <longDescription>This recording was not dumped for an exceptional reason.</longDescription>
-        </rule>
-        <rule>
-            <id>DuplicateFlags</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>There were no duplicate JVM flags on the command line.</shortDescription>
-            <longDescription>There were no duplicate JVM flags on the command line.</longDescription>
-        </rule>
-        <rule>
-            <id>Errors</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires events to be available from the following event types: 'Java Error'.</shortDescription>
-            <longDescription>The Thrown Errors rule requires events to be available from the following event types: 'Java Error'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>Exceptions</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>The program generated 0 exceptions per second for 1.210 s at 4/26/18 12:12:47 PM.</shortDescription>
-            <longDescription>The program generated 0 exceptions per second for 1.210 s at 4/26/18 12:12:47 PM.</longDescription>
-        </rule>
-        <rule>
-            <id>Fatal Errors</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>The Fatal Errors rule requires the following event types: 'jdk.Shutdown'.</shortDescription>
-            <longDescription>The Fatal Errors rule requires the following event types: 'jdk.Shutdown'.&lt;p&gt;They are either not available in this version of Java, or must be enabled in a third-party component. If you are using an older Java version, then you can consider upgrading.</longDescription>
-        </rule>
-        <rule>
-            <id>FewSampledThreads</id>
-            <severity>Information</severity>
-            <score>29.510744962334375</score>
-            <shortDescription>There are fewer sampled threads than the total number of hardware threads (cores).</shortDescription>
-            <longDescription>There are fewer sampled threads than the total number of hardware threads (cores).&lt;p&gt;1 threads with at least 4 method samples were found, but the machine has 32 hardware threads (cores). The application might benefit from a higher level of parallelism. This could also be caused by threads doing something else than running Java code, for example running native code or spending time in the JVM internals.&lt;p&gt;This recording is only 9.921 s long, consider creating a recording longer than 20 s for improved rule accuracy.</longDescription>
-        </rule>
-        <rule>
-            <id>FileRead</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>There are no file read events in this recording.</shortDescription>
-            <longDescription>There are no file read events in this recording.</longDescription>
-        </rule>
-        <rule>
-            <id>FileWrite</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires events to be available from the following event types: 'File Write'.</shortDescription>
-            <longDescription>The File Write Peak Duration rule requires events to be available from the following event types: 'File Write'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>FlightRecordingSupport</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>The JVM version used for this recording has full Flight Recorder support.</shortDescription>
-            <longDescription>The JVM version used for this recording has full Flight Recorder support.</longDescription>
-        </rule>
-        <rule>
-            <id>FullGc</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires events to be available from the following event types: 'Garbage Collection'.</shortDescription>
-            <longDescription>The G1/CMS Full Collection rule requires events to be available from the following event types: 'Garbage Collection'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>GcFreedRatio</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>Only 0 heap summary events were found, this rule requires at least 10 events to be able to calculate a relevant result. This likely means that only a few garbage collections occurred during the recording. Having few garbage collections is generally a good sign.</shortDescription>
-            <longDescription>Only 0 heap summary events were found, this rule requires at least 10 events to be able to calculate a relevant result. This likely means that only a few garbage collections occurred during the recording. Having few garbage collections is generally a good sign.</longDescription>
-        </rule>
-        <rule>
-            <id>GcLocker</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>No GCs were affected by the GC Locker.</shortDescription>
-            <longDescription>No GCs were affected by the GC Locker.</longDescription>
-        </rule>
-        <rule>
-            <id>GcOptions</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>No problems were found with the GC configuration.</shortDescription>
-            <longDescription>No problems were found with the GC configuration.</longDescription>
-        </rule>
-        <rule>
-            <id>GcPauseRatio</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>Application efficiency was not highly affected by GC pauses.</shortDescription>
-            <longDescription>Application efficiency was not highly affected by GC pauses.&lt;p&gt;The highest ratio between garbage collection pauses and execution time was 0 % for 1 min at 4/26/18 12:12:46 PM. The garbage collection pause ratio of the entire recording was 0 %.</longDescription>
-        </rule>
-        <rule>
-            <id>GcStall</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>No indications that the garbage collector could not keep up with the workload were detected.</shortDescription>
-            <longDescription>No indications that the garbage collector could not keep up with the workload were detected.</longDescription>
-        </rule>
-        <rule>
-            <id>HeapContent</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'Object Count'.</shortDescription>
-            <longDescription>The Heap Content rule requires that the following event types are enabled: 'Object Count'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>HeapInspectionGc</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires events to be available from the following event types: 'Garbage Collection'.</shortDescription>
-            <longDescription>The GCs Caused by Heap Inspection rule requires events to be available from the following event types: 'Garbage Collection'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>HighGc</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>The runtime did not spend much time performing garbage collections.</shortDescription>
-            <longDescription>The runtime did not spend much time performing garbage collections.</longDescription>
-        </rule>
-        <rule>
-            <id>HighJvmCpu</id>
-            <severity>OK</severity>
-            <score>1.193150385433165</score>
-            <shortDescription>The JVM does not seem to cause a lot of CPU load.</shortDescription>
-            <longDescription>The JVM does not seem to cause a lot of CPU load.</longDescription>
-        </rule>
-        <rule>
-            <id>IncreasingLiveSet</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>Too few events to calculate the result.</shortDescription>
-            <longDescription>Too few events to calculate the result.</longDescription>
-        </rule>
-        <rule>
-            <id>IncreasingMetaSpaceLiveSet</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>The class data does not seem to increase during the recording.</shortDescription>
-            <longDescription>The class data does not seem to increase during the recording.</longDescription>
-        </rule>
-        <rule>
-            <id>JavaBlocking</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires events to be available from the following event types: 'Java Monitor Blocked'.</shortDescription>
-            <longDescription>The Java Blocking rule requires events to be available from the following event types: 'Java Monitor Blocked'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>LongGcPause</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>The application did not cause any long GC pause times.</shortDescription>
-            <longDescription>The application did not cause any long GC pause times.</longDescription>
-        </rule>
-        <rule>
-            <id>LowOnPhysicalMemory</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>The system did not run low on physical memory during this recording.</shortDescription>
-            <longDescription>The system did not run low on physical memory during this recording.</longDescription>
-        </rule>
-        <rule>
-            <id>ManagementAgent</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'Initial System Property'.</shortDescription>
-            <longDescription>The Discouraged Management Agent Settings rule requires that the following event types are enabled: 'Initial System Property'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>ManyRunningProcesses</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'System Process'.</shortDescription>
-            <longDescription>The Competing Processes rule requires that the following event types are enabled: 'System Process'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>MetaspaceOom</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>The metaspace was not exhausted during this recording.</shortDescription>
-            <longDescription>The metaspace was not exhausted during this recording.</longDescription>
-        </rule>
-        <rule>
-            <id>MethodProfiling</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>No methods where optimization would be particularly efficient could be detected.</shortDescription>
-            <longDescription>No methods where optimization would be particularly efficient could be detected.</longDescription>
-        </rule>
-        <rule>
-            <id>Options</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>No undocumented, deprecated or non-recommended option flags were detected.</shortDescription>
-            <longDescription>No undocumented, deprecated or non-recommended option flags were detected.</longDescription>
-        </rule>
-        <rule>
-            <id>OverAggressiveRecordingSetting</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'Initial System Property'.</shortDescription>
-            <longDescription>The Discouraged Recording Settings rule requires that the following event types are enabled: 'Initial System Property'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>PasswordsInArguments</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>The recording does not seem to contain passwords in the application arguments.</shortDescription>
-            <longDescription>The recording does not seem to contain passwords in the application arguments.</longDescription>
-        </rule>
-        <rule>
-            <id>PasswordsInEnvironment</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'Initial Environment Variable'.</shortDescription>
-            <longDescription>The Passwords in Environment Variables rule requires that the following event types are enabled: 'Initial Environment Variable'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>PasswordsInSystemProperties</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'Initial System Property'.</shortDescription>
-            <longDescription>The Passwords in System Properties rule requires that the following event types are enabled: 'Initial System Property'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>PrimitiveToObjectConversion</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires events to be available from the following event types: 'Allocation in new TLAB', 'Allocation outside TLAB'.</shortDescription>
-            <longDescription>The Primitive To Object Conversion rule requires events to be available from the following event types: 'Allocation in new TLAB', 'Allocation outside TLAB'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>SocketRead</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires events to be available from the following event types: 'Socket Read'.</shortDescription>
-            <longDescription>The Socket Read Peak Duration rule requires events to be available from the following event types: 'Socket Read'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>SocketWrite</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires events to be available from the following event types: 'Socket Write'.</shortDescription>
-            <longDescription>The Socket Write Peak Duration rule requires events to be available from the following event types: 'Socket Write'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>StackdepthSetting</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>No stack traces were truncated in this recording.</shortDescription>
-            <longDescription>No stack traces were truncated in this recording.</longDescription>
-        </rule>
-        <rule>
-            <id>StringDeduplication</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires events to be available from the following event types: 'Heap Summary'.</shortDescription>
-            <longDescription>The String Deduplication rule requires events to be available from the following event types: 'Heap Summary'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>SystemGc</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires events to be available from the following event types: 'Garbage Collection'.</shortDescription>
-            <longDescription>The GCs Caused by System.gc() rule requires events to be available from the following event types: 'Garbage Collection'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>TlabAllocationRatio</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>No object allocations outside of TLABs detected.</shortDescription>
-            <longDescription>No object allocations outside of TLABs detected.</longDescription>
-        </rule>
-        <rule>
-            <id>VMOperations</id>
-            <severity>OK</severity>
-            <score>0.44893575</score>
-            <shortDescription>No excessively long VM operations were found in this recording (the longest was 17.957 ms).</shortDescription>
-            <longDescription>No excessively long VM operations were found in this recording (the longest was 17.957 ms).</longDescription>
-        </rule>
-        <rule>
-            <id>biasedLockingRevocation</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>The Biased Locking Revocation rule requires the following event types: 'jdk.BiasedLockClassRevocation'.</shortDescription>
-            <longDescription>The Biased Locking Revocation rule requires the following event types: 'jdk.BiasedLockClassRevocation'.&lt;p&gt;They are either not available in this version of Java, or must be enabled in a third-party component. If you are using an older Java version, then you can consider upgrading.</longDescription>
-        </rule>
-        <rule>
-            <id>biasedLockingRevocationPause</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>No revocation of biased locks found.</shortDescription>
-            <longDescription>No revocation of biased locks found.</longDescription>
-        </rule>
-    </report>
-    <report>
-        <file>crash_jdk9.jfr</file>
-        <rule>
-            <id>Allocations.class</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'Allocation in new TLAB', 'Allocation outside TLAB'.</shortDescription>
-            <longDescription>The Allocated Classes rule requires that the following event types are enabled: 'Allocation in new TLAB', 'Allocation outside TLAB'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>Allocations.thread</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'Allocation in new TLAB', 'Allocation outside TLAB'.</shortDescription>
-            <longDescription>The Threads Allocating rule requires that the following event types are enabled: 'Allocation in new TLAB', 'Allocation outside TLAB'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>ApplicationHalts</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>Application efficiency was not highly affected by halts.</shortDescription>
-            <longDescription>Application efficiency was not highly affected by halts.&lt;p&gt;The highest ratio of application halts to execution time was 0 % for 1 min at 4/24/18 10:16:27 AM. 0 % of the halts were for reasons other than GC.&lt;p&gt;The halts ratio for the entire recording was 0 %. 0 % of the total halts were for reasons other than GC.&lt;/p&gt;</longDescription>
-        </rule>
-        <rule>
-            <id>BufferLost</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>No Flight Recorder buffers were lost during the recording.</shortDescription>
-            <longDescription>No Flight Recorder buffers were lost during the recording.</longDescription>
-        </rule>
-        <rule>
-            <id>BytecodeVerification</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>The application ran with bytecode verification enabled.</shortDescription>
-            <longDescription>The application ran with bytecode verification enabled.</longDescription>
-        </rule>
-        <rule>
-            <id>ClassLeak</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'Class Load', 'Class Unload'.</shortDescription>
-            <longDescription>The Class Leak rule requires that the following event types are enabled: 'Class Load', 'Class Unload'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>ClassLoading</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'Class Load'.</shortDescription>
-            <longDescription>The Class Loading Pressure rule requires that the following event types are enabled: 'Class Load'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>CodeCache</id>
-            <severity>OK</severity>
-            <score>21.686110914128236</score>
-            <shortDescription>No problems with the code cache were detected in the recording.</shortDescription>
-            <longDescription>No problems with the code cache were detected in the recording.</longDescription>
-        </rule>
-        <rule>
-            <id>CompareCpu</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires events to be available from the following event types: 'CPU Load'.</shortDescription>
-            <longDescription>The Competing CPU Ratio Usage rule requires events to be available from the following event types: 'CPU Load'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>CompressedOops</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>The settings for Compressed Oops were OK.</shortDescription>
-            <longDescription>The settings for Compressed Oops were OK.</longDescription>
-        </rule>
-        <rule>
-            <id>ContextSwitch</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires events to be available from the following event types: 'Thread Context Switch Rate'.</shortDescription>
-            <longDescription>The Context Switches rule requires events to be available from the following event types: 'Thread Context Switch Rate'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>DMSIncident</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>The DMS Incidents rule requires the following event types: 'http://www.oracle.com/dms/dfw/dms/dfw/DFW_Incident/DFW_Incident_state'.</shortDescription>
-            <longDescription>The DMS Incidents rule requires the following event types: 'http://www.oracle.com/dms/dfw/dms/dfw/DFW_Incident/DFW_Incident_state'.&lt;p&gt;They are either not available in this version of Java, or must be enabled in a third-party component. If you are using an older Java version, then you can consider upgrading.</longDescription>
-        </rule>
-        <rule>
-            <id>DebugNonSafepoints</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>DebugNonSafepoints was implicitly enabled in the JVM version used to create this recording.</shortDescription>
-            <longDescription>DebugNonSafepoints was implicitly enabled in the JVM version used to create this recording.</longDescription>
-        </rule>
-        <rule>
-            <id>DiscouragedVmOptions</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>No problems were found with the VM options.</shortDescription>
-            <longDescription>No problems were found with the VM options.</longDescription>
-        </rule>
-        <rule>
-            <id>DumpReason</id>
-            <severity>Warning</severity>
-            <score>100.0</score>
-            <shortDescription>This recording was dumped for an exceptional reason.</shortDescription>
-            <longDescription>Recording was dumped due to a JVM crash. Some events are likely missing from the end of the recording.</longDescription>
-        </rule>
-        <rule>
-            <id>DuplicateFlags</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>There were no duplicate JVM flags on the command line.</shortDescription>
-            <longDescription>There were no duplicate JVM flags on the command line.</longDescription>
-        </rule>
-        <rule>
-            <id>Errors</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires events to be available from the following event types: 'Java Error'.</shortDescription>
-            <longDescription>The Thrown Errors rule requires events to be available from the following event types: 'Java Error'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>Exceptions</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires events to be available from the following event types: 'Exception Statistics'.</shortDescription>
-            <longDescription>The Thrown Exceptions rule requires events to be available from the following event types: 'Exception Statistics'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>Fatal Errors</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>The Fatal Errors rule requires the following event types: 'jdk.Shutdown'.</shortDescription>
-            <longDescription>The Fatal Errors rule requires the following event types: 'jdk.Shutdown'.&lt;p&gt;They are either not available in this version of Java, or must be enabled in a third-party component. If you are using an older Java version, then you can consider upgrading.</longDescription>
-        </rule>
-        <rule>
-            <id>FewSampledThreads</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires events to be available from the following event types: 'CPU Information', 'Method Profiling Sample', 'Recording Setting'.</shortDescription>
-            <longDescription>The Parallel Threads rule requires events to be available from the following event types: 'CPU Information', 'Method Profiling Sample', 'Recording Setting'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>FileRead</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>There are no file read events in this recording.</shortDescription>
-            <longDescription>There are no file read events in this recording.</longDescription>
-        </rule>
-        <rule>
-            <id>FileWrite</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires events to be available from the following event types: 'File Write'.</shortDescription>
-            <longDescription>The File Write Peak Duration rule requires events to be available from the following event types: 'File Write'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>FlightRecordingSupport</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>The JVM version used for this recording has full Flight Recorder support.</shortDescription>
-            <longDescription>The JVM version used for this recording has full Flight Recorder support.</longDescription>
-        </rule>
-        <rule>
-            <id>FullGc</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires events to be available from the following event types: 'Garbage Collection'.</shortDescription>
-            <longDescription>The G1/CMS Full Collection rule requires events to be available from the following event types: 'Garbage Collection'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>GcFreedRatio</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>Only 0 heap summary events were found, this rule requires at least 10 events to be able to calculate a relevant result. This likely means that only a few garbage collections occurred during the recording. Having few garbage collections is generally a good sign.</shortDescription>
-            <longDescription>Only 0 heap summary events were found, this rule requires at least 10 events to be able to calculate a relevant result. This likely means that only a few garbage collections occurred during the recording. Having few garbage collections is generally a good sign.</longDescription>
-        </rule>
-        <rule>
-            <id>GcLocker</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>No GCs were affected by the GC Locker.</shortDescription>
-            <longDescription>No GCs were affected by the GC Locker.</longDescription>
-        </rule>
-        <rule>
-            <id>GcOptions</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>No problems were found with the GC configuration.</shortDescription>
-            <longDescription>No problems were found with the GC configuration.</longDescription>
-        </rule>
-        <rule>
-            <id>GcPauseRatio</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>Application efficiency was not highly affected by GC pauses.</shortDescription>
-            <longDescription>Application efficiency was not highly affected by GC pauses.&lt;p&gt;The highest ratio between garbage collection pauses and execution time was 0 % for 1 min at 4/24/18 10:16:27 AM. The garbage collection pause ratio of the entire recording was 0 %.</longDescription>
-        </rule>
-        <rule>
-            <id>GcStall</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>No indications that the garbage collector could not keep up with the workload were detected.</shortDescription>
-            <longDescription>No indications that the garbage collector could not keep up with the workload were detected.</longDescription>
-        </rule>
-        <rule>
-            <id>HeapContent</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'Object Count'.</shortDescription>
-            <longDescription>The Heap Content rule requires that the following event types are enabled: 'Object Count'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>HeapInspectionGc</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires events to be available from the following event types: 'Garbage Collection'.</shortDescription>
-            <longDescription>The GCs Caused by Heap Inspection rule requires events to be available from the following event types: 'Garbage Collection'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>HighGc</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>The runtime did not spend much time performing garbage collections.</shortDescription>
-            <longDescription>The runtime did not spend much time performing garbage collections.</longDescription>
-        </rule>
-        <rule>
-            <id>HighJvmCpu</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires events to be available from the following event types: 'CPU Load'.</shortDescription>
-            <longDescription>The High JVM CPU Load rule requires events to be available from the following event types: 'CPU Load'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>IncreasingLiveSet</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>Too few events to calculate the result.</shortDescription>
-            <longDescription>Too few events to calculate the result.</longDescription>
-        </rule>
-        <rule>
-            <id>IncreasingMetaSpaceLiveSet</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>The class data does not seem to increase during the recording.</shortDescription>
-            <longDescription>The class data does not seem to increase during the recording.</longDescription>
-        </rule>
-        <rule>
-            <id>JavaBlocking</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires events to be available from the following event types: 'Java Monitor Blocked'.</shortDescription>
-            <longDescription>The Java Blocking rule requires events to be available from the following event types: 'Java Monitor Blocked'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>LongGcPause</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>The application did not cause any long GC pause times.</shortDescription>
-            <longDescription>The application did not cause any long GC pause times.</longDescription>
-        </rule>
-        <rule>
-            <id>LowOnPhysicalMemory</id>
-            <severity>Information</severity>
-            <score>51.06889156143796</score>
-            <shortDescription>The maximum amount of used memory was 88.9 % of the physical memory available.</shortDescription>
-            <longDescription>The maximum amount of memory used was 28.4 GiB. This is 88.9 % of the 31.9 GiB of physical memory available. Having little free memory may lead to swapping, which is very expensive. To avoid this, either decrease the memory usage or increase the amount of available memory.</longDescription>
-        </rule>
-        <rule>
-            <id>ManagementAgent</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'Initial System Property'.</shortDescription>
-            <longDescription>The Discouraged Management Agent Settings rule requires that the following event types are enabled: 'Initial System Property'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>ManyRunningProcesses</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'System Process'.</shortDescription>
-            <longDescription>The Competing Processes rule requires that the following event types are enabled: 'System Process'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>MetaspaceOom</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>The metaspace was not exhausted during this recording.</shortDescription>
-            <longDescription>The metaspace was not exhausted during this recording.</longDescription>
-        </rule>
-        <rule>
-            <id>MethodProfiling</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires events to be available from the following event types: 'Method Profiling Sample', 'Recording Setting'.</shortDescription>
-            <longDescription>The Method Profiling rule requires events to be available from the following event types: 'Method Profiling Sample', 'Recording Setting'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>Options</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>No undocumented, deprecated or non-recommended option flags were detected.</shortDescription>
-            <longDescription>No undocumented, deprecated or non-recommended option flags were detected.</longDescription>
-        </rule>
-        <rule>
-            <id>OverAggressiveRecordingSetting</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'Initial System Property'.</shortDescription>
-            <longDescription>The Discouraged Recording Settings rule requires that the following event types are enabled: 'Initial System Property'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>PasswordsInArguments</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>The recording does not seem to contain passwords in the application arguments.</shortDescription>
-            <longDescription>The recording does not seem to contain passwords in the application arguments.</longDescription>
-        </rule>
-        <rule>
-            <id>PasswordsInEnvironment</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'Initial Environment Variable'.</shortDescription>
-            <longDescription>The Passwords in Environment Variables rule requires that the following event types are enabled: 'Initial Environment Variable'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>PasswordsInSystemProperties</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'Initial System Property'.</shortDescription>
-            <longDescription>The Passwords in System Properties rule requires that the following event types are enabled: 'Initial System Property'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>PrimitiveToObjectConversion</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'Allocation in new TLAB', 'Allocation outside TLAB'.</shortDescription>
-            <longDescription>The Primitive To Object Conversion rule requires that the following event types are enabled: 'Allocation in new TLAB', 'Allocation outside TLAB'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>SocketRead</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires events to be available from the following event types: 'Socket Read'.</shortDescription>
-            <longDescription>The Socket Read Peak Duration rule requires events to be available from the following event types: 'Socket Read'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>SocketWrite</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires events to be available from the following event types: 'Socket Write'.</shortDescription>
-            <longDescription>The Socket Write Peak Duration rule requires events to be available from the following event types: 'Socket Write'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>StackdepthSetting</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>No stack traces were truncated in this recording.</shortDescription>
-            <longDescription>No stack traces were truncated in this recording.</longDescription>
-        </rule>
-        <rule>
-            <id>StringDeduplication</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires events to be available from the following event types: 'Heap Summary'.</shortDescription>
-            <longDescription>The String Deduplication rule requires events to be available from the following event types: 'Heap Summary'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>SystemGc</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires events to be available from the following event types: 'Garbage Collection'.</shortDescription>
-            <longDescription>The GCs Caused by System.gc() rule requires events to be available from the following event types: 'Garbage Collection'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>TlabAllocationRatio</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'Allocation in new TLAB', 'Allocation outside TLAB'.</shortDescription>
-            <longDescription>The TLAB Allocation Ratio rule requires that the following event types are enabled: 'Allocation in new TLAB', 'Allocation outside TLAB'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>VMOperations</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>No excessively long VM operations were found in this recording (the longest was 0 s).</shortDescription>
-            <longDescription>No excessively long VM operations were found in this recording (the longest was 0 s).</longDescription>
-        </rule>
-        <rule>
-            <id>biasedLockingRevocation</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>The Biased Locking Revocation rule requires the following event types: 'jdk.BiasedLockClassRevocation'.</shortDescription>
-            <longDescription>The Biased Locking Revocation rule requires the following event types: 'jdk.BiasedLockClassRevocation'.&lt;p&gt;They are either not available in this version of Java, or must be enabled in a third-party component. If you are using an older Java version, then you can consider upgrading.</longDescription>
-        </rule>
-        <rule>
-            <id>biasedLockingRevocationPause</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>No revocation of biased locks found.</shortDescription>
-            <longDescription>No revocation of biased locks found.</longDescription>
-        </rule>
-    </report>
-    <report>
-        <file>flight_recording_hidden.jfr</file>
-        <rule>
-            <id>Allocations.class</id>
-            <severity>OK</severity>
-            <score>0.09287686767432358</score>
-            <shortDescription>The most allocated type is likely 'byte[]', most commonly allocated by: &lt;ul&gt;&lt;li&gt;ByteArrayOutputStream.&amp;lt;init&amp;gt;(int) (50 %)&lt;/li&gt;&lt;li&gt;ByteArrayOutputStream.&amp;lt;init&amp;gt;()&lt;/li&gt;&lt;li&gt;JdpPacketWriter.&amp;lt;init&amp;gt;()&lt;/li&gt;&lt;li&gt;JdpJmxPacket.getPacketData()&lt;/li&gt;&lt;li&gt;JdpBroadcaster.sendPacket(JdpPacket)&lt;/li&gt;&lt;li&gt;JdpController$JDPControllerRunner.run()&lt;/li&gt;&lt;/ul&gt;</shortDescription>
-            <longDescription>The most allocated type is likely 'byte[]', most commonly allocated by: &lt;ul&gt;&lt;li&gt;ByteArrayOutputStream.&amp;lt;init&amp;gt;(int) (50 %)&lt;/li&gt;&lt;li&gt;ByteArrayOutputStream.&amp;lt;init&amp;gt;()&lt;/li&gt;&lt;li&gt;JdpPacketWriter.&amp;lt;init&amp;gt;()&lt;/li&gt;&lt;li&gt;JdpJmxPacket.getPacketData()&lt;/li&gt;&lt;li&gt;JdpBroadcaster.sendPacket(JdpPacket)&lt;/li&gt;&lt;li&gt;JdpController$JDPControllerRunner.run()&lt;/li&gt;&lt;/ul&gt;&lt;p&gt;Frequently allocated types are good places to start when trying to reduce garbage collections. Look at where the most common types are being allocated to see if many instances are created along the same call path. Try to reduce the number of instances created by invoking the most commonly taken paths less.</longDescription>
-        </rule>
-        <rule>
-            <id>Allocations.thread</id>
-            <severity>OK</severity>
-            <score>0.1274345677812541</score>
-            <shortDescription>The most allocations were likely done by thread 'AWT-EventQueue-0' at: &lt;ul&gt;&lt;li&gt;EventQueue.dispatchEvent(AWTEvent) (60 %)&lt;/li&gt;&lt;li&gt;EventDispatchThread.pumpOneEventForFilters(int)&lt;/li&gt;&lt;li&gt;EventDispatchThread.pumpEventsForFilter(int, Conditional, EventFilter)&lt;/li&gt;&lt;li&gt;EventDispatchThread.pumpEventsForHierarchy(int, Conditional, Component)&lt;/li&gt;&lt;li&gt;EventDispatchThread.pumpEvents(int, Conditional)&lt;/li&gt;&lt;li&gt;EventDispatchThread.pumpEvents(Conditional)&lt;/li&gt;&lt;/ul&gt;</shortDescription>
-            <longDescription>The most allocations were likely done by thread 'AWT-EventQueue-0' at: &lt;ul&gt;&lt;li&gt;EventQueue.dispatchEvent(AWTEvent) (60 %)&lt;/li&gt;&lt;li&gt;EventDispatchThread.pumpOneEventForFilters(int)&lt;/li&gt;&lt;li&gt;EventDispatchThread.pumpEventsForFilter(int, Conditional, EventFilter)&lt;/li&gt;&lt;li&gt;EventDispatchThread.pumpEventsForHierarchy(int, Conditional, Component)&lt;/li&gt;&lt;li&gt;EventDispatchThread.pumpEvents(int, Conditional)&lt;/li&gt;&lt;li&gt;EventDispatchThread.pumpEvents(Conditional)&lt;/li&gt;&lt;/ul&gt;&lt;p&gt;Many allocations performed by the same thread might indicate a problem in a multi-threaded program. Look at the stack traces for the thread with the highest allocation rate. See if the allocation rate can be brought down, or balanced among the active threads.</longDescription>
-        </rule>
-        <rule>
-            <id>ApplicationHalts</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires events to be available from the following event types: 'GC Phase Pause', 'VM Operation'.</shortDescription>
-            <longDescription>The Application Halts rule requires events to be available from the following event types: 'GC Phase Pause', 'VM Operation'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>BufferLost</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>No Flight Recorder buffers were lost during the recording.</shortDescription>
-            <longDescription>No Flight Recorder buffers were lost during the recording.</longDescription>
-        </rule>
-        <rule>
-            <id>BytecodeVerification</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>The application ran with bytecode verification enabled.</shortDescription>
-            <longDescription>The application ran with bytecode verification enabled.</longDescription>
-        </rule>
-        <rule>
-            <id>ClassLeak</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'Class Load', 'Class Unload'.</shortDescription>
-            <longDescription>The Class Leak rule requires that the following event types are enabled: 'Class Load', 'Class Unload'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>ClassLoading</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'Class Load'.</shortDescription>
-            <longDescription>The Class Loading Pressure rule requires that the following event types are enabled: 'Class Load'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>CodeCache</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires events to be available from the following event types: 'Code Cache Configuration', 'Code Cache Full', 'Code Cache Statistics', 'JVM Information'.</shortDescription>
-            <longDescription>The Code Cache rule requires events to be available from the following event types: 'Code Cache Configuration', 'Code Cache Full', 'Code Cache Statistics', 'JVM Information'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>CompareCpu</id>
-            <severity>Warning</severity>
-            <score>77.36067322482806</score>
-            <shortDescription>An average CPU load of 60 % was caused by other processes for 8.047 s at 4/25/18 11:38:36 AM.</shortDescription>
-            <longDescription>An average CPU load of 60 % was caused by other processes for 8.047 s at 4/25/18 11:38:36 AM.&lt;p&gt;The application performance can be affected when the machine is under heavy load and there are other processes that use CPU or other resources on the same computer. To profile representatively or get higher throughput, shut down other resource intensive processes running on the machine.</longDescription>
-        </rule>
-        <rule>
-            <id>CompressedOops</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires events to be available from the following event types: 'Boolean Flag', 'JVM Information', 'Unsigned Long Flag'.</shortDescription>
-            <longDescription>The Compressed Oops rule requires events to be available from the following event types: 'Boolean Flag', 'JVM Information', 'Unsigned Long Flag'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>ContextSwitch</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>The program did not context switch excessively during the recording.</shortDescription>
-            <longDescription>The program did not context switch excessively during the recording.</longDescription>
-        </rule>
-        <rule>
-            <id>DMSIncident</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>The DMS Incidents rule requires the following event types: 'http://www.oracle.com/dms/dfw/dms/dfw/DFW_Incident/DFW_Incident_state'.</shortDescription>
-            <longDescription>The DMS Incidents rule requires the following event types: 'http://www.oracle.com/dms/dfw/dms/dfw/DFW_Incident/DFW_Incident_state'.&lt;p&gt;They are either not available in this version of Java, or must be enabled in a third-party component. If you are using an older Java version, then you can consider upgrading.</longDescription>
-        </rule>
-        <rule>
-            <id>DebugNonSafepoints</id>
-            <severity>Information</severity>
-            <score>50.0</score>
-            <shortDescription>DebugNonSafepoints was not enabled.</shortDescription>
-            <longDescription>DebugNonSafepoints was not enabled.&lt;p&gt;If DebugNonSafepoints is not enabled, the method profiling data will be less accurate as threads that are not at safepoints will not be correctly sampled. Use the following JVM flags to enable this: '-XX:+UnlockDiagnosticVMOptions -XX:+DebugNonSafepoints'. There is a slight performance overhead when enabling these flags. For more information see &lt;a href="http://openjdk.java.net/groups/hotspot/docs/RuntimeOverview.html#Thread%20Management|outline"&gt;HotSpot Runtime Overview/Thread Management&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>DiscouragedVmOptions</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'Boolean Flag'.</shortDescription>
-            <longDescription>The Discouraged VM Options rule requires that the following event types are enabled: 'Boolean Flag'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>DumpReason</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>This recording was not dumped for an exceptional reason.</shortDescription>
-            <longDescription>This recording was not dumped for an exceptional reason.</longDescription>
-        </rule>
-        <rule>
-            <id>DuplicateFlags</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>There were no duplicate JVM flags on the command line.</shortDescription>
-            <longDescription>There were no duplicate JVM flags on the command line.</longDescription>
-        </rule>
-        <rule>
-            <id>Errors</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires events to be available from the following event types: 'Java Error'.</shortDescription>
-            <longDescription>The Thrown Errors rule requires events to be available from the following event types: 'Java Error'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>Exceptions</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>The program generated 0 exceptions per second for 1.000 s at 4/25/18 11:38:36 AM.</shortDescription>
-            <longDescription>The program generated 0 exceptions per second for 1.000 s at 4/25/18 11:38:36 AM.</longDescription>
-        </rule>
-        <rule>
-            <id>Fatal Errors</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>The Fatal Errors rule requires the following event types: 'jdk.Shutdown'.</shortDescription>
-            <longDescription>The Fatal Errors rule requires the following event types: 'jdk.Shutdown'.&lt;p&gt;They are either not available in this version of Java, or must be enabled in a third-party component. If you are using an older Java version, then you can consider upgrading.</longDescription>
-        </rule>
-        <rule>
-            <id>FewSampledThreads</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires events to be available from the following event types: 'CPU Information', 'Method Profiling Sample', 'Recording Setting'.</shortDescription>
-            <longDescription>The Parallel Threads rule requires events to be available from the following event types: 'CPU Information', 'Method Profiling Sample', 'Recording Setting'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>FileRead</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'File Read'.</shortDescription>
-            <longDescription>The File Read Peak Duration rule requires that the following event types are enabled: 'File Read'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>FileWrite</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'File Write'.</shortDescription>
-            <longDescription>The File Write Peak Duration rule requires that the following event types are enabled: 'File Write'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>FlightRecordingSupport</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>The JVM version used for this recording has full Flight Recorder support.</shortDescription>
-            <longDescription>The JVM version used for this recording has full Flight Recorder support.</longDescription>
-        </rule>
-        <rule>
-            <id>FullGc</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule is only valid for CMS and G1 Garbage Collectors, neither of which were detected for this JVM.</shortDescription>
-            <longDescription>This rule is only valid for CMS and G1 Garbage Collectors, neither of which were detected for this JVM.</longDescription>
-        </rule>
-        <rule>
-            <id>GcFreedRatio</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'Heap Summary'.</shortDescription>
-            <longDescription>The GC Freed Ratio rule requires that the following event types are enabled: 'Heap Summary'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>GcLocker</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'Garbage Collection'.</shortDescription>
-            <longDescription>The GCs Caused by GC Locker rule requires that the following event types are enabled: 'Garbage Collection'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>GcOptions</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>No problems were found with the GC configuration.</shortDescription>
-            <longDescription>No problems were found with the GC configuration.</longDescription>
-        </rule>
-        <rule>
-            <id>GcPauseRatio</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'GC Phase Pause'.</shortDescription>
-            <longDescription>The GC Pauses rule requires that the following event types are enabled: 'GC Phase Pause'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>GcStall</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'Garbage Collection'.</shortDescription>
-            <longDescription>The GC Stall rule requires that the following event types are enabled: 'Garbage Collection'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>HeapContent</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'Object Count'.</shortDescription>
-            <longDescription>The Heap Content rule requires that the following event types are enabled: 'Object Count'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>HeapInspectionGc</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'Garbage Collection'.</shortDescription>
-            <longDescription>The GCs Caused by Heap Inspection rule requires that the following event types are enabled: 'Garbage Collection'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>HighGc</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'GC Phase Pause'.</shortDescription>
-            <longDescription>The GC Pressure rule requires that the following event types are enabled: 'GC Phase Pause'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>HighJvmCpu</id>
-            <severity>OK</severity>
-            <score>0.8641130870553131</score>
-            <shortDescription>The JVM does not seem to cause a lot of CPU load.</shortDescription>
-            <longDescription>The JVM does not seem to cause a lot of CPU load.</longDescription>
-        </rule>
-        <rule>
-            <id>IncreasingLiveSet</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'Heap Summary'.</shortDescription>
-            <longDescription>The Heap Live Set Trend rule requires that the following event types are enabled: 'Heap Summary'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>IncreasingMetaSpaceLiveSet</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'Metaspace Summary'.</shortDescription>
-            <longDescription>The Metaspace Live Set Trend rule requires that the following event types are enabled: 'Metaspace Summary'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>JavaBlocking</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires events to be available from the following event types: 'Java Monitor Blocked'.</shortDescription>
-            <longDescription>The Java Blocking rule requires events to be available from the following event types: 'Java Monitor Blocked'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>LongGcPause</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>The application did not cause any long GC pause times.</shortDescription>
-            <longDescription>The application did not cause any long GC pause times.</longDescription>
-        </rule>
-        <rule>
-            <id>LowOnPhysicalMemory</id>
-            <severity>Warning</severity>
-            <score>85.24971081406179</score>
-            <shortDescription>The maximum amount of used memory was 99.8 % of the physical memory available.</shortDescription>
-            <longDescription>The maximum amount of memory used was 16 GiB. This is 99.8 % of the 16 GiB of physical memory available. Having little free memory may lead to swapping, which is very expensive. To avoid this, either decrease the memory usage or increase the amount of available memory.</longDescription>
-        </rule>
-        <rule>
-            <id>ManagementAgent</id>
-            <severity>Warning</severity>
-            <score>100.0</score>
-            <shortDescription>Insecure management agent settings: Both password authentication and SSL were disabled.</shortDescription>
-            <longDescription>The runtime management agent settings were insecure. Both password authentication and SSL were disabled. A remote user who knows (or guesses) the port number and host name will be able to monitor and control the Java application and platform. This is highly discouraged for production systems.&lt;p&gt;See the &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/guides/management/agent.html"&gt;Java Monitoring and Management Guide&lt;/a&gt; for more information about how to configure the management agent.</longDescription>
-        </rule>
-        <rule>
-            <id>ManyRunningProcesses</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'System Process'.</shortDescription>
-            <longDescription>The Competing Processes rule requires that the following event types are enabled: 'System Process'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>MetaspaceOom</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'Metaspace Out of Memory'.</shortDescription>
-            <longDescription>The Metaspace Out of Memory rule requires that the following event types are enabled: 'Metaspace Out of Memory'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>MethodProfiling</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires events to be available from the following event types: 'Method Profiling Sample', 'Recording Setting'.</shortDescription>
-            <longDescription>The Method Profiling rule requires events to be available from the following event types: 'Method Profiling Sample', 'Recording Setting'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>Options</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>No undocumented, deprecated or non-recommended option flags were detected.</shortDescription>
-            <longDescription>No undocumented, deprecated or non-recommended option flags were detected.</longDescription>
-        </rule>
-        <rule>
-            <id>OverAggressiveRecordingSetting</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>No problems were found with the recording settings.</shortDescription>
-            <longDescription>No problems were found with the recording settings.</longDescription>
-        </rule>
-        <rule>
-            <id>PasswordsInArguments</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>The recording does not seem to contain passwords in the application arguments.</shortDescription>
-            <longDescription>The recording does not seem to contain passwords in the application arguments.</longDescription>
-        </rule>
-        <rule>
-            <id>PasswordsInEnvironment</id>
-            <severity>Warning</severity>
-            <score>100.0</score>
-            <shortDescription>The environment variables in the recording may contain passwords.</shortDescription>
-            <longDescription>The following suspicious environment variables were found in this recording: &lt;ul&gt;&lt;li&gt;P4PASSWD&lt;/li&gt;&lt;/ul&gt;&lt;p&gt;They may contain passwords. If you wish to keep having passwords in your environment variables, but want to be able to share recordings without also sharing the passwords, please disable the 'Initial Environment Variable' event.</longDescription>
-        </rule>
-        <rule>
-            <id>PasswordsInSystemProperties</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>The recording does not seem to contain passwords in the system properties.</shortDescription>
-            <longDescription>The recording does not seem to contain passwords in the system properties.</longDescription>
-        </rule>
-        <rule>
-            <id>PrimitiveToObjectConversion</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires events to be available from the following event types: 'Allocation in new TLAB', 'Allocation outside TLAB'.</shortDescription>
-            <longDescription>The Primitive To Object Conversion rule requires events to be available from the following event types: 'Allocation in new TLAB', 'Allocation outside TLAB'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>SocketRead</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'Socket Read'.</shortDescription>
-            <longDescription>The Socket Read Peak Duration rule requires that the following event types are enabled: 'Socket Read'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>SocketWrite</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'Socket Write'.</shortDescription>
-            <longDescription>The Socket Write Peak Duration rule requires that the following event types are enabled: 'Socket Write'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>StackdepthSetting</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>No stack traces were truncated in this recording.</shortDescription>
-            <longDescription>No stack traces were truncated in this recording.</longDescription>
-        </rule>
-        <rule>
-            <id>StringDeduplication</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'Heap Summary'.</shortDescription>
-            <longDescription>The String Deduplication rule requires that the following event types are enabled: 'Heap Summary'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>SystemGc</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'Garbage Collection'.</shortDescription>
-            <longDescription>The GCs Caused by System.gc() rule requires that the following event types are enabled: 'Garbage Collection'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>TlabAllocationRatio</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>No object allocations outside of TLABs detected.</shortDescription>
-            <longDescription>No object allocations outside of TLABs detected.</longDescription>
-        </rule>
-        <rule>
-            <id>VMOperations</id>
-            <severity>OK</severity>
-            <score>1.6971702250000003</score>
-            <shortDescription>No excessively long VM operations were found in this recording (the longest was 67.887 ms).</shortDescription>
-            <longDescription>No excessively long VM operations were found in this recording (the longest was 67.887 ms).</longDescription>
-        </rule>
-        <rule>
-            <id>biasedLockingRevocation</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>The Biased Locking Revocation rule requires the following event types: 'jdk.BiasedLockClassRevocation'.</shortDescription>
-            <longDescription>The Biased Locking Revocation rule requires the following event types: 'jdk.BiasedLockClassRevocation'.&lt;p&gt;They are either not available in this version of Java, or must be enabled in a third-party component. If you are using an older Java version, then you can consider upgrading.</longDescription>
-        </rule>
-        <rule>
-            <id>biasedLockingRevocationPause</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>No revocation of biased locks found.</shortDescription>
-            <longDescription>No revocation of biased locks found.</longDescription>
-        </rule>
-    </report>
-    <report>
-        <file>full_gc_cms.jfr</file>
-        <rule>
-            <id>Allocations.class</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'Allocation in new TLAB', 'Allocation outside TLAB'.</shortDescription>
-            <longDescription>The Allocated Classes rule requires that the following event types are enabled: 'Allocation in new TLAB', 'Allocation outside TLAB'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>Allocations.thread</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'Allocation in new TLAB', 'Allocation outside TLAB'.</shortDescription>
-            <longDescription>The Threads Allocating rule requires that the following event types are enabled: 'Allocation in new TLAB', 'Allocation outside TLAB'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>ApplicationHalts</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'GC Phase Pause', 'VM Operation'.</shortDescription>
-            <longDescription>The Application Halts rule requires that the following event types are enabled: 'GC Phase Pause', 'VM Operation'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>BufferLost</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>No Flight Recorder buffers were lost during the recording.</shortDescription>
-            <longDescription>No Flight Recorder buffers were lost during the recording.</longDescription>
-        </rule>
-        <rule>
-            <id>BytecodeVerification</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'JVM Information'.</shortDescription>
-            <longDescription>The Bytecode Verification rule requires that the following event types are enabled: 'JVM Information'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>ClassLeak</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'Class Load', 'Class Unload'.</shortDescription>
-            <longDescription>The Class Leak rule requires that the following event types are enabled: 'Class Load', 'Class Unload'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>ClassLoading</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'Class Load'.</shortDescription>
-            <longDescription>The Class Loading Pressure rule requires that the following event types are enabled: 'Class Load'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>CodeCache</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'Code Cache Configuration', 'Code Cache Full', 'Code Cache Statistics', 'JVM Information'.</shortDescription>
-            <longDescription>The Code Cache rule requires that the following event types are enabled: 'Code Cache Configuration', 'Code Cache Full', 'Code Cache Statistics', 'JVM Information'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>CompareCpu</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'CPU Load'.</shortDescription>
-            <longDescription>The Competing CPU Ratio Usage rule requires that the following event types are enabled: 'CPU Load'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>CompressedOops</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'Boolean Flag', 'JVM Information', 'Unsigned Long Flag'.</shortDescription>
-            <longDescription>The Compressed Oops rule requires that the following event types are enabled: 'Boolean Flag', 'JVM Information', 'Unsigned Long Flag'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>ContextSwitch</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'Thread Context Switch Rate'.</shortDescription>
-            <longDescription>The Context Switches rule requires that the following event types are enabled: 'Thread Context Switch Rate'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>DMSIncident</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>The DMS Incidents rule requires the following event types: 'http://www.oracle.com/dms/dfw/dms/dfw/DFW_Incident/DFW_Incident_state'.</shortDescription>
-            <longDescription>The DMS Incidents rule requires the following event types: 'http://www.oracle.com/dms/dfw/dms/dfw/DFW_Incident/DFW_Incident_state'.&lt;p&gt;They are either not available in this version of Java, or must be enabled in a third-party component. If you are using an older Java version, then you can consider upgrading.</longDescription>
-        </rule>
-        <rule>
-            <id>DebugNonSafepoints</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>The Java version could not be determined.</shortDescription>
-            <longDescription>The Java version could not be determined.</longDescription>
-        </rule>
-        <rule>
-            <id>DiscouragedVmOptions</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'Boolean Flag'.</shortDescription>
-            <longDescription>The Discouraged VM Options rule requires that the following event types are enabled: 'Boolean Flag'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>DumpReason</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>This recording was not dumped for an exceptional reason.</shortDescription>
-            <longDescription>This recording was not dumped for an exceptional reason.</longDescription>
-        </rule>
-        <rule>
-            <id>DuplicateFlags</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'JVM Information'.</shortDescription>
-            <longDescription>The Duplicated Flags rule requires that the following event types are enabled: 'JVM Information'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>Errors</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'Java Error'.</shortDescription>
-            <longDescription>The Thrown Errors rule requires that the following event types are enabled: 'Java Error'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>Exceptions</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'Exception Statistics'.</shortDescription>
-            <longDescription>The Thrown Exceptions rule requires that the following event types are enabled: 'Exception Statistics'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>Fatal Errors</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'VM Shutdown'.</shortDescription>
-            <longDescription>The Fatal Errors rule requires that the following event types are enabled: 'VM Shutdown'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>FewSampledThreads</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires events to be available from the following event types: 'CPU Information', 'Method Profiling Sample', 'Recording Setting'.</shortDescription>
-            <longDescription>The Parallel Threads rule requires events to be available from the following event types: 'CPU Information', 'Method Profiling Sample', 'Recording Setting'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>FileRead</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'File Read'.</shortDescription>
-            <longDescription>The File Read Peak Duration rule requires that the following event types are enabled: 'File Read'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>FileWrite</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'File Write'.</shortDescription>
-            <longDescription>The File Write Peak Duration rule requires that the following event types are enabled: 'File Write'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>FlightRecordingSupport</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'JVM Information'.</shortDescription>
-            <longDescription>The Flight Recording Support rule requires that the following event types are enabled: 'JVM Information'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>FullGc</id>
-            <severity>Warning</severity>
-            <score>100.0</score>
-            <shortDescription>Full GC detected.</shortDescription>
-            <longDescription>At least one Full, Stop-The-World Garbage Collection occurred during this recording. For the CMS and G1 collectors, Full GC events are a strong negative performance indicator. Tunable GC parameters can be used to allow the collector to operate in concurrent mode, avoiding Stop-The-World pauses and increasing GC and application performance.</longDescription>
-        </rule>
-        <rule>
-            <id>GcFreedRatio</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'Heap Summary'.</shortDescription>
-            <longDescription>The GC Freed Ratio rule requires that the following event types are enabled: 'Heap Summary'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>GcLocker</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>No GCs were affected by the GC Locker.</shortDescription>
-            <longDescription>No GCs were affected by the GC Locker.</longDescription>
-        </rule>
-        <rule>
-            <id>GcOptions</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'CPU Information'.</shortDescription>
-            <longDescription>The GC Setup rule requires that the following event types are enabled: 'CPU Information'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>GcPauseRatio</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'GC Phase Pause'.</shortDescription>
-            <longDescription>The GC Pauses rule requires that the following event types are enabled: 'GC Phase Pause'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>GcStall</id>
-            <severity>Warning</severity>
-            <score>100.0</score>
-            <shortDescription>The CMS garbage collector was used, but the JVM had to revert to do a Serial Old Collection.</shortDescription>
-            <longDescription>The application used the Concurrent Mark Sweep garbage collector, but the JVM had to revert to a Serial Old Collection, which takes more time. This is because the Concurrent Collector could not keep up with the object allocations that happened during the collection. You can decrease the risk of this by lowering the value of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/guides/vm/gctuning/cms.html"&gt;-XX:CMSInitiatingOccupancyFraction&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>HeapContent</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'Object Count'.</shortDescription>
-            <longDescription>The Heap Content rule requires that the following event types are enabled: 'Object Count'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>HeapInspectionGc</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>The JVM did not perform any heap inspection GCs.</shortDescription>
-            <longDescription>The JVM did not perform any heap inspection GCs. This is good since they usually take a lot of time.</longDescription>
-        </rule>
-        <rule>
-            <id>HighGc</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'GC Phase Pause'.</shortDescription>
-            <longDescription>The GC Pressure rule requires that the following event types are enabled: 'GC Phase Pause'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>HighJvmCpu</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'CPU Load'.</shortDescription>
-            <longDescription>The High JVM CPU Load rule requires that the following event types are enabled: 'CPU Load'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>IncreasingLiveSet</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'Heap Summary'.</shortDescription>
-            <longDescription>The Heap Live Set Trend rule requires that the following event types are enabled: 'Heap Summary'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>IncreasingMetaSpaceLiveSet</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'Metaspace Summary'.</shortDescription>
-            <longDescription>The Metaspace Live Set Trend rule requires that the following event types are enabled: 'Metaspace Summary'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>JavaBlocking</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'Java Monitor Blocked'.</shortDescription>
-            <longDescription>The Java Blocking rule requires that the following event types are enabled: 'Java Monitor Blocked'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>LongGcPause</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>The application did not cause any long GC pause times.</shortDescription>
-            <longDescription>The application did not cause any long GC pause times.</longDescription>
-        </rule>
-        <rule>
-            <id>LowOnPhysicalMemory</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'Physical Memory'.</shortDescription>
-            <longDescription>The Free Physical Memory rule requires that the following event types are enabled: 'Physical Memory'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>ManagementAgent</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'Initial System Property'.</shortDescription>
-            <longDescription>The Discouraged Management Agent Settings rule requires that the following event types are enabled: 'Initial System Property'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>ManyRunningProcesses</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'System Process'.</shortDescription>
-            <longDescription>The Competing Processes rule requires that the following event types are enabled: 'System Process'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>MetaspaceOom</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'Metaspace Out of Memory'.</shortDescription>
-            <longDescription>The Metaspace Out of Memory rule requires that the following event types are enabled: 'Metaspace Out of Memory'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>MethodProfiling</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires events to be available from the following event types: 'Method Profiling Sample', 'Recording Setting'.</shortDescription>
-            <longDescription>The Method Profiling rule requires events to be available from the following event types: 'Method Profiling Sample', 'Recording Setting'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>Options</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>No events with JVM arguments were recorded.</shortDescription>
-            <longDescription>No events with JVM arguments were recorded.</longDescription>
-        </rule>
-        <rule>
-            <id>OverAggressiveRecordingSetting</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'Initial System Property'.</shortDescription>
-            <longDescription>The Discouraged Recording Settings rule requires that the following event types are enabled: 'Initial System Property'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>PasswordsInArguments</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'JVM Information'.</shortDescription>
-            <longDescription>The Passwords in Java Arguments rule requires that the following event types are enabled: 'JVM Information'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>PasswordsInEnvironment</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'Initial Environment Variable'.</shortDescription>
-            <longDescription>The Passwords in Environment Variables rule requires that the following event types are enabled: 'Initial Environment Variable'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>PasswordsInSystemProperties</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'Initial System Property'.</shortDescription>
-            <longDescription>The Passwords in System Properties rule requires that the following event types are enabled: 'Initial System Property'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>PrimitiveToObjectConversion</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'Allocation in new TLAB', 'Allocation outside TLAB'.</shortDescription>
-            <longDescription>The Primitive To Object Conversion rule requires that the following event types are enabled: 'Allocation in new TLAB', 'Allocation outside TLAB'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>SocketRead</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'Socket Read'.</shortDescription>
-            <longDescription>The Socket Read Peak Duration rule requires that the following event types are enabled: 'Socket Read'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>SocketWrite</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'Socket Write'.</shortDescription>
-            <longDescription>The Socket Write Peak Duration rule requires that the following event types are enabled: 'Socket Write'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>StackdepthSetting</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>No stack traces were truncated in this recording.</shortDescription>
-            <longDescription>No stack traces were truncated in this recording.</longDescription>
-        </rule>
-        <rule>
-            <id>StringDeduplication</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>The Java version could not be determined.</shortDescription>
-            <longDescription>The Java version could not be determined.</longDescription>
-        </rule>
-        <rule>
-            <id>SystemGc</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>No garbage collections were caused by System.gc().</shortDescription>
-            <longDescription>No garbage collections were caused by System.gc().</longDescription>
-        </rule>
-        <rule>
-            <id>TlabAllocationRatio</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'Allocation in new TLAB', 'Allocation outside TLAB'.</shortDescription>
-            <longDescription>The TLAB Allocation Ratio rule requires that the following event types are enabled: 'Allocation in new TLAB', 'Allocation outside TLAB'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>VMOperations</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'VM Operation'.</shortDescription>
-            <longDescription>The VMOperation Peak Duration rule requires that the following event types are enabled: 'VM Operation'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>biasedLockingRevocation</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'Biased Lock Class Revocation'.</shortDescription>
-            <longDescription>The Biased Locking Revocation rule requires that the following event types are enabled: 'Biased Lock Class Revocation'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>biasedLockingRevocationPause</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'VM Operation'.</shortDescription>
-            <longDescription>The Biased Locking Revocation Pauses rule requires that the following event types are enabled: 'VM Operation'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-    </report>
-    <report>
-        <file>full_gc_g1.jfr</file>
-        <rule>
-            <id>Allocations.class</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'Allocation in new TLAB', 'Allocation outside TLAB'.</shortDescription>
-            <longDescription>The Allocated Classes rule requires that the following event types are enabled: 'Allocation in new TLAB', 'Allocation outside TLAB'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>Allocations.thread</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'Allocation in new TLAB', 'Allocation outside TLAB'.</shortDescription>
-            <longDescription>The Threads Allocating rule requires that the following event types are enabled: 'Allocation in new TLAB', 'Allocation outside TLAB'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>ApplicationHalts</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'GC Phase Pause', 'VM Operation'.</shortDescription>
-            <longDescription>The Application Halts rule requires that the following event types are enabled: 'GC Phase Pause', 'VM Operation'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>BufferLost</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>No Flight Recorder buffers were lost during the recording.</shortDescription>
-            <longDescription>No Flight Recorder buffers were lost during the recording.</longDescription>
-        </rule>
-        <rule>
-            <id>BytecodeVerification</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'JVM Information'.</shortDescription>
-            <longDescription>The Bytecode Verification rule requires that the following event types are enabled: 'JVM Information'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>ClassLeak</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'Class Load', 'Class Unload'.</shortDescription>
-            <longDescription>The Class Leak rule requires that the following event types are enabled: 'Class Load', 'Class Unload'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>ClassLoading</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'Class Load'.</shortDescription>
-            <longDescription>The Class Loading Pressure rule requires that the following event types are enabled: 'Class Load'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>CodeCache</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'Code Cache Configuration', 'Code Cache Full', 'Code Cache Statistics', 'JVM Information'.</shortDescription>
-            <longDescription>The Code Cache rule requires that the following event types are enabled: 'Code Cache Configuration', 'Code Cache Full', 'Code Cache Statistics', 'JVM Information'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>CompareCpu</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'CPU Load'.</shortDescription>
-            <longDescription>The Competing CPU Ratio Usage rule requires that the following event types are enabled: 'CPU Load'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>CompressedOops</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'Boolean Flag', 'JVM Information', 'Unsigned Long Flag'.</shortDescription>
-            <longDescription>The Compressed Oops rule requires that the following event types are enabled: 'Boolean Flag', 'JVM Information', 'Unsigned Long Flag'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>ContextSwitch</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'Thread Context Switch Rate'.</shortDescription>
-            <longDescription>The Context Switches rule requires that the following event types are enabled: 'Thread Context Switch Rate'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>DMSIncident</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>The DMS Incidents rule requires the following event types: 'http://www.oracle.com/dms/dfw/dms/dfw/DFW_Incident/DFW_Incident_state'.</shortDescription>
-            <longDescription>The DMS Incidents rule requires the following event types: 'http://www.oracle.com/dms/dfw/dms/dfw/DFW_Incident/DFW_Incident_state'.&lt;p&gt;They are either not available in this version of Java, or must be enabled in a third-party component. If you are using an older Java version, then you can consider upgrading.</longDescription>
-        </rule>
-        <rule>
-            <id>DebugNonSafepoints</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>The Java version could not be determined.</shortDescription>
-            <longDescription>The Java version could not be determined.</longDescription>
-        </rule>
-        <rule>
-            <id>DiscouragedVmOptions</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'Boolean Flag'.</shortDescription>
-            <longDescription>The Discouraged VM Options rule requires that the following event types are enabled: 'Boolean Flag'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>DumpReason</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>This recording was not dumped for an exceptional reason.</shortDescription>
-            <longDescription>This recording was not dumped for an exceptional reason.</longDescription>
-        </rule>
-        <rule>
-            <id>DuplicateFlags</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'JVM Information'.</shortDescription>
-            <longDescription>The Duplicated Flags rule requires that the following event types are enabled: 'JVM Information'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>Errors</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'Java Error'.</shortDescription>
-            <longDescription>The Thrown Errors rule requires that the following event types are enabled: 'Java Error'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>Exceptions</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'Exception Statistics'.</shortDescription>
-            <longDescription>The Thrown Exceptions rule requires that the following event types are enabled: 'Exception Statistics'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>Fatal Errors</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'VM Shutdown'.</shortDescription>
-            <longDescription>The Fatal Errors rule requires that the following event types are enabled: 'VM Shutdown'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>FewSampledThreads</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires events to be available from the following event types: 'CPU Information', 'Method Profiling Sample', 'Recording Setting'.</shortDescription>
-            <longDescription>The Parallel Threads rule requires events to be available from the following event types: 'CPU Information', 'Method Profiling Sample', 'Recording Setting'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>FileRead</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'File Read'.</shortDescription>
-            <longDescription>The File Read Peak Duration rule requires that the following event types are enabled: 'File Read'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>FileWrite</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'File Write'.</shortDescription>
-            <longDescription>The File Write Peak Duration rule requires that the following event types are enabled: 'File Write'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>FlightRecordingSupport</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'JVM Information'.</shortDescription>
-            <longDescription>The Flight Recording Support rule requires that the following event types are enabled: 'JVM Information'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>FullGc</id>
-            <severity>Warning</severity>
-            <score>100.0</score>
-            <shortDescription>Full GC detected.</shortDescription>
-            <longDescription>At least one Full, Stop-The-World Garbage Collection occurred during this recording. For the CMS and G1 collectors, Full GC events are a strong negative performance indicator. Tunable GC parameters can be used to allow the collector to operate in concurrent mode, avoiding Stop-The-World pauses and increasing GC and application performance.</longDescription>
-        </rule>
-        <rule>
-            <id>GcFreedRatio</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'Heap Summary'.</shortDescription>
-            <longDescription>The GC Freed Ratio rule requires that the following event types are enabled: 'Heap Summary'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>GcLocker</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>No GCs were affected by the GC Locker.</shortDescription>
-            <longDescription>No GCs were affected by the GC Locker.</longDescription>
-        </rule>
-        <rule>
-            <id>GcOptions</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'CPU Information'.</shortDescription>
-            <longDescription>The GC Setup rule requires that the following event types are enabled: 'CPU Information'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>GcPauseRatio</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'GC Phase Pause'.</shortDescription>
-            <longDescription>The GC Pauses rule requires that the following event types are enabled: 'GC Phase Pause'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>GcStall</id>
-            <severity>Warning</severity>
-            <score>100.0</score>
-            <shortDescription>There occurred Concurrent Mode failures during certain garbage collections.</shortDescription>
-            <longDescription>Concurrent Mode failures means that the Garbage Collector hasn't been able to keep up with the Java Program. Try lowering the value of &lt;a href="http://www.oracle.com/technetwork/articles/java/vmoptions-jsp-140102.html"&gt;-XX:InitiatingHeapOccupancyPercent&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>HeapContent</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'Object Count'.</shortDescription>
-            <longDescription>The Heap Content rule requires that the following event types are enabled: 'Object Count'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>HeapInspectionGc</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>The JVM did not perform any heap inspection GCs.</shortDescription>
-            <longDescription>The JVM did not perform any heap inspection GCs. This is good since they usually take a lot of time.</longDescription>
-        </rule>
-        <rule>
-            <id>HighGc</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'GC Phase Pause'.</shortDescription>
-            <longDescription>The GC Pressure rule requires that the following event types are enabled: 'GC Phase Pause'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>HighJvmCpu</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'CPU Load'.</shortDescription>
-            <longDescription>The High JVM CPU Load rule requires that the following event types are enabled: 'CPU Load'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>IncreasingLiveSet</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'Heap Summary'.</shortDescription>
-            <longDescription>The Heap Live Set Trend rule requires that the following event types are enabled: 'Heap Summary'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>IncreasingMetaSpaceLiveSet</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'Metaspace Summary'.</shortDescription>
-            <longDescription>The Metaspace Live Set Trend rule requires that the following event types are enabled: 'Metaspace Summary'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>JavaBlocking</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'Java Monitor Blocked'.</shortDescription>
-            <longDescription>The Java Blocking rule requires that the following event types are enabled: 'Java Monitor Blocked'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>LongGcPause</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>The application did not cause any long GC pause times.</shortDescription>
-            <longDescription>The application did not cause any long GC pause times.</longDescription>
-        </rule>
-        <rule>
-            <id>LowOnPhysicalMemory</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'Physical Memory'.</shortDescription>
-            <longDescription>The Free Physical Memory rule requires that the following event types are enabled: 'Physical Memory'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>ManagementAgent</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'Initial System Property'.</shortDescription>
-            <longDescription>The Discouraged Management Agent Settings rule requires that the following event types are enabled: 'Initial System Property'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>ManyRunningProcesses</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'System Process'.</shortDescription>
-            <longDescription>The Competing Processes rule requires that the following event types are enabled: 'System Process'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>MetaspaceOom</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'Metaspace Out of Memory'.</shortDescription>
-            <longDescription>The Metaspace Out of Memory rule requires that the following event types are enabled: 'Metaspace Out of Memory'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>MethodProfiling</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires events to be available from the following event types: 'Method Profiling Sample', 'Recording Setting'.</shortDescription>
-            <longDescription>The Method Profiling rule requires events to be available from the following event types: 'Method Profiling Sample', 'Recording Setting'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>Options</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>No events with JVM arguments were recorded.</shortDescription>
-            <longDescription>No events with JVM arguments were recorded.</longDescription>
-        </rule>
-        <rule>
-            <id>OverAggressiveRecordingSetting</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'Initial System Property'.</shortDescription>
-            <longDescription>The Discouraged Recording Settings rule requires that the following event types are enabled: 'Initial System Property'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>PasswordsInArguments</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'JVM Information'.</shortDescription>
-            <longDescription>The Passwords in Java Arguments rule requires that the following event types are enabled: 'JVM Information'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>PasswordsInEnvironment</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'Initial Environment Variable'.</shortDescription>
-            <longDescription>The Passwords in Environment Variables rule requires that the following event types are enabled: 'Initial Environment Variable'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>PasswordsInSystemProperties</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'Initial System Property'.</shortDescription>
-            <longDescription>The Passwords in System Properties rule requires that the following event types are enabled: 'Initial System Property'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>PrimitiveToObjectConversion</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'Allocation in new TLAB', 'Allocation outside TLAB'.</shortDescription>
-            <longDescription>The Primitive To Object Conversion rule requires that the following event types are enabled: 'Allocation in new TLAB', 'Allocation outside TLAB'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>SocketRead</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'Socket Read'.</shortDescription>
-            <longDescription>The Socket Read Peak Duration rule requires that the following event types are enabled: 'Socket Read'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>SocketWrite</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'Socket Write'.</shortDescription>
-            <longDescription>The Socket Write Peak Duration rule requires that the following event types are enabled: 'Socket Write'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>StackdepthSetting</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>No stack traces were truncated in this recording.</shortDescription>
-            <longDescription>No stack traces were truncated in this recording.</longDescription>
-        </rule>
-        <rule>
-            <id>StringDeduplication</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>The Java version could not be determined.</shortDescription>
-            <longDescription>The Java version could not be determined.</longDescription>
-        </rule>
-        <rule>
-            <id>SystemGc</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>No garbage collections were caused by System.gc().</shortDescription>
-            <longDescription>No garbage collections were caused by System.gc().</longDescription>
-        </rule>
-        <rule>
-            <id>TlabAllocationRatio</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'Allocation in new TLAB', 'Allocation outside TLAB'.</shortDescription>
-            <longDescription>The TLAB Allocation Ratio rule requires that the following event types are enabled: 'Allocation in new TLAB', 'Allocation outside TLAB'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>VMOperations</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'VM Operation'.</shortDescription>
-            <longDescription>The VMOperation Peak Duration rule requires that the following event types are enabled: 'VM Operation'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>biasedLockingRevocation</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'Biased Lock Class Revocation'.</shortDescription>
-            <longDescription>The Biased Locking Revocation rule requires that the following event types are enabled: 'Biased Lock Class Revocation'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>biasedLockingRevocationPause</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'VM Operation'.</shortDescription>
-            <longDescription>The Biased Locking Revocation Pauses rule requires that the following event types are enabled: 'VM Operation'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-    </report>
-    <report>
-        <file>parallel-gc_cpu.jfr</file>
-        <rule>
-            <id>Allocations.class</id>
-            <severity>OK</severity>
-            <score>0.02670579099297634</score>
-            <shortDescription>The most allocated type is likely 'java.util.ArrayList', most commonly allocated by: &lt;ul&gt;&lt;li&gt;JFRImpl.getRecordings() (100 %)&lt;/li&gt;&lt;li&gt;MetaProducer.onNewChunk()&lt;/li&gt;&lt;li&gt;JFRImpl.onNewChunk()&lt;/li&gt;&lt;/ul&gt;</shortDescription>
-            <longDescription>The most allocated type is likely 'java.util.ArrayList', most commonly allocated by: &lt;ul&gt;&lt;li&gt;JFRImpl.getRecordings() (100 %)&lt;/li&gt;&lt;li&gt;MetaProducer.onNewChunk()&lt;/li&gt;&lt;li&gt;JFRImpl.onNewChunk()&lt;/li&gt;&lt;/ul&gt;&lt;p&gt;Frequently allocated types are good places to start when trying to reduce garbage collections. Look at where the most common types are being allocated to see if many instances are created along the same call path. Try to reduce the number of instances created by invoking the most commonly taken paths less.</longDescription>
-        </rule>
-        <rule>
-            <id>Allocations.thread</id>
-            <severity>OK</severity>
-            <score>0.07261458520440227</score>
-            <shortDescription>The most allocations were likely done by thread 'RMI TCP Connection(1)-127.0.0.1' at: &lt;ul&gt;&lt;li&gt;ObjectInputStream$BlockDataInputStream.&amp;lt;init&amp;gt;(ObjectInputStream, InputStream) (50 %)&lt;/li&gt;&lt;li&gt;ObjectInputStream.&amp;lt;init&amp;gt;(InputStream)&lt;/li&gt;&lt;li&gt;MarshalInputStream.&amp;lt;init&amp;gt;(InputStream)&lt;/li&gt;&lt;li&gt;ConnectionInputStream.&amp;lt;init&amp;gt;(InputStream)&lt;/li&gt;&lt;li&gt;StreamRemoteCall.getInputStream()&lt;/li&gt;&lt;li&gt;Transport.serviceCall(RemoteCall)&lt;/li&gt;&lt;/ul&gt;</shortDescription>
-            <longDescription>The most allocations were likely done by thread 'RMI TCP Connection(1)-127.0.0.1' at: &lt;ul&gt;&lt;li&gt;ObjectInputStream$BlockDataInputStream.&amp;lt;init&amp;gt;(ObjectInputStream, InputStream) (50 %)&lt;/li&gt;&lt;li&gt;ObjectInputStream.&amp;lt;init&amp;gt;(InputStream)&lt;/li&gt;&lt;li&gt;MarshalInputStream.&amp;lt;init&amp;gt;(InputStream)&lt;/li&gt;&lt;li&gt;ConnectionInputStream.&amp;lt;init&amp;gt;(InputStream)&lt;/li&gt;&lt;li&gt;StreamRemoteCall.getInputStream()&lt;/li&gt;&lt;li&gt;Transport.serviceCall(RemoteCall)&lt;/li&gt;&lt;/ul&gt;&lt;p&gt;Many allocations performed by the same thread might indicate a problem in a multi-threaded program. Look at the stack traces for the thread with the highest allocation rate. See if the allocation rate can be brought down, or balanced among the active threads.</longDescription>
-        </rule>
-        <rule>
-            <id>ApplicationHalts</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>Application efficiency was not highly affected by halts.</shortDescription>
-            <longDescription>Application efficiency was not highly affected by halts.&lt;p&gt;The highest ratio of application halts to execution time was 0 % for 1 min at 4/4/14 11:17:05 AM. 0 % of the halts were for reasons other than GC.&lt;p&gt;The halts ratio for the entire recording was 0 %. 0 % of the total halts were for reasons other than GC.&lt;/p&gt;&lt;p&gt;Enabling the following event types would improve the accuracy of this rule: jdk.SafepointBegin</longDescription>
-        </rule>
-        <rule>
-            <id>BufferLost</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>No Flight Recorder buffers were lost during the recording.</shortDescription>
-            <longDescription>No Flight Recorder buffers were lost during the recording.</longDescription>
-        </rule>
-        <rule>
-            <id>BytecodeVerification</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>The application ran with bytecode verification enabled.</shortDescription>
-            <longDescription>The application ran with bytecode verification enabled.</longDescription>
-        </rule>
-        <rule>
-            <id>ClassLeak</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'Class Load', 'Class Unload'.</shortDescription>
-            <longDescription>The Class Leak rule requires that the following event types are enabled: 'Class Load', 'Class Unload'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>ClassLoading</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'Class Load'.</shortDescription>
-            <longDescription>The Class Loading Pressure rule requires that the following event types are enabled: 'Class Load'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>CodeCache</id>
-            <severity>OK</severity>
-            <score>2.07672119140625</score>
-            <shortDescription>No problems with the code cache were detected in the recording.</shortDescription>
-            <longDescription>No problems with the code cache were detected in the recording.</longDescription>
-        </rule>
-        <rule>
-            <id>CompareCpu</id>
-            <severity>OK</severity>
-            <score>9.313225746154785E-7</score>
-            <shortDescription>An average CPU load of 0 % was caused by other processes for 1.011 s at 4/4/14 11:17:07 AM.</shortDescription>
-            <longDescription>An average CPU load of 0 % was caused by other processes for 1.011 s at 4/4/14 11:17:07 AM.</longDescription>
-        </rule>
-        <rule>
-            <id>CompressedOops</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>The settings for Compressed Oops were OK.</shortDescription>
-            <longDescription>The settings for Compressed Oops were OK.</longDescription>
-        </rule>
-        <rule>
-            <id>ContextSwitch</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires events to be available from the following event types: 'Thread Context Switch Rate'.</shortDescription>
-            <longDescription>The Context Switches rule requires events to be available from the following event types: 'Thread Context Switch Rate'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>DMSIncident</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>The DMS Incidents rule requires the following event types: 'http://www.oracle.com/dms/dfw/dms/dfw/DFW_Incident/DFW_Incident_state'.</shortDescription>
-            <longDescription>The DMS Incidents rule requires the following event types: 'http://www.oracle.com/dms/dfw/dms/dfw/DFW_Incident/DFW_Incident_state'.&lt;p&gt;They are either not available in this version of Java, or must be enabled in a third-party component. If you are using an older Java version, then you can consider upgrading.</longDescription>
-        </rule>
-        <rule>
-            <id>DebugNonSafepoints</id>
-            <severity>Information</severity>
-            <score>50.0</score>
-            <shortDescription>DebugNonSafepoints was not enabled.</shortDescription>
-            <longDescription>DebugNonSafepoints was not enabled.&lt;p&gt;If DebugNonSafepoints is not enabled, the method profiling data will be less accurate as threads that are not at safepoints will not be correctly sampled. Use the following JVM flags to enable this: '-XX:+UnlockDiagnosticVMOptions -XX:+DebugNonSafepoints'. There is a slight performance overhead when enabling these flags. For more information see &lt;a href="http://openjdk.java.net/groups/hotspot/docs/RuntimeOverview.html#Thread%20Management|outline"&gt;HotSpot Runtime Overview/Thread Management&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>DiscouragedVmOptions</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>No problems were found with the VM options.</shortDescription>
-            <longDescription>No problems were found with the VM options.</longDescription>
-        </rule>
-        <rule>
-            <id>DumpReason</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>This recording was not dumped for an exceptional reason.</shortDescription>
-            <longDescription>This recording was not dumped for an exceptional reason.</longDescription>
-        </rule>
-        <rule>
-            <id>DuplicateFlags</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>There were no duplicate JVM flags on the command line.</shortDescription>
-            <longDescription>There were no duplicate JVM flags on the command line.</longDescription>
-        </rule>
-        <rule>
-            <id>Errors</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires events to be available from the following event types: 'Java Error'.</shortDescription>
-            <longDescription>The Thrown Errors rule requires events to be available from the following event types: 'Java Error'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>Exceptions</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>The program generated 0 exceptions per second for 999.487 ms at 4/4/14 11:17:06 AM.</shortDescription>
-            <longDescription>The program generated 0 exceptions per second for 999.487 ms at 4/4/14 11:17:06 AM.</longDescription>
-        </rule>
-        <rule>
-            <id>Fatal Errors</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>The Fatal Errors rule requires the following event types: 'jdk.Shutdown'.</shortDescription>
-            <longDescription>The Fatal Errors rule requires the following event types: 'jdk.Shutdown'.&lt;p&gt;They are either not available in this version of Java, or must be enabled in a third-party component. If you are using an older Java version, then you can consider upgrading.</longDescription>
-        </rule>
-        <rule>
-            <id>FewSampledThreads</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>There were no problems with the amount of sampled threads.</shortDescription>
-            <longDescription>There were no problems with the amount of sampled threads.&lt;p&gt;There are more sampled threads than the amount of hardware threads. This indicates that the application has enough parallelism for the available hardware.&lt;p&gt;This recording is only 5.171 s long, consider creating a recording longer than 20 s for improved rule accuracy.</longDescription>
-        </rule>
-        <rule>
-            <id>FileRead</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>There are no file read events in this recording.</shortDescription>
-            <longDescription>There are no file read events in this recording.</longDescription>
-        </rule>
-        <rule>
-            <id>FileWrite</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires events to be available from the following event types: 'File Write'.</shortDescription>
-            <longDescription>The File Write Peak Duration rule requires events to be available from the following event types: 'File Write'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>FlightRecordingSupport</id>
-            <severity>Warning</severity>
-            <score>80.0</score>
-            <shortDescription>The recording is from an early access build.</shortDescription>
-            <longDescription>This recording is from an early access build of the JRE (Java HotSpot(TM) Client VM (25.20-b08) for linux-x86 JRE (1.8.0_20-ea-b08), built on Apr  1 2014 19:40:24 by &amp;#34;java_re&amp;#34; with gcc 4.3.0 20080428 (Red Hat 4.3.0-8)). The automated analysis is not supported, and you may see errors when attempting to analyze the recording.</longDescription>
-        </rule>
-        <rule>
-            <id>FullGc</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires events to be available from the following event types: 'Garbage Collection'.</shortDescription>
-            <longDescription>The G1/CMS Full Collection rule requires events to be available from the following event types: 'Garbage Collection'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>GcFreedRatio</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>Only 0 heap summary events were found, this rule requires at least 10 events to be able to calculate a relevant result. This likely means that only a few garbage collections occurred during the recording. Having few garbage collections is generally a good sign.</shortDescription>
-            <longDescription>Only 0 heap summary events were found, this rule requires at least 10 events to be able to calculate a relevant result. This likely means that only a few garbage collections occurred during the recording. Having few garbage collections is generally a good sign.</longDescription>
-        </rule>
-        <rule>
-            <id>GcLocker</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>No GCs were affected by the GC Locker.</shortDescription>
-            <longDescription>No GCs were affected by the GC Locker.</longDescription>
-        </rule>
-        <rule>
-            <id>GcOptions</id>
-            <severity>Information</severity>
-            <score>50.0</score>
-            <shortDescription>The runtime used 2 GC threads on a machine with 1 CPU cores.</shortDescription>
-            <longDescription>The runtime used 2 GC threads on a machine with 1 CPU cores. It's suboptimal to use more GC threads than available cores. Removing the '-XX:ParallelGCThreads' flag will allow the JVM to set the number of GC threads automatically.</longDescription>
-        </rule>
-        <rule>
-            <id>GcPauseRatio</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>Application efficiency was not highly affected by GC pauses.</shortDescription>
-            <longDescription>Application efficiency was not highly affected by GC pauses.&lt;p&gt;The highest ratio between garbage collection pauses and execution time was 0 % for 1 min at 4/4/14 11:17:05 AM. The garbage collection pause ratio of the entire recording was 0 %.</longDescription>
-        </rule>
-        <rule>
-            <id>GcStall</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>No indications that the garbage collector could not keep up with the workload were detected.</shortDescription>
-            <longDescription>No indications that the garbage collector could not keep up with the workload were detected.</longDescription>
-        </rule>
-        <rule>
-            <id>HeapContent</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'Object Count'.</shortDescription>
-            <longDescription>The Heap Content rule requires that the following event types are enabled: 'Object Count'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>HeapInspectionGc</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires events to be available from the following event types: 'Garbage Collection'.</shortDescription>
-            <longDescription>The GCs Caused by Heap Inspection rule requires events to be available from the following event types: 'Garbage Collection'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>HighGc</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>The runtime did not spend much time performing garbage collections.</shortDescription>
-            <longDescription>The runtime did not spend much time performing garbage collections.</longDescription>
-        </rule>
-        <rule>
-            <id>HighJvmCpu</id>
-            <severity>Information</severity>
-            <score>27.969203755893627</score>
-            <shortDescription>This recording contains few profiling samples even though the CPU load is high.</shortDescription>
-            <longDescription>This recording contains few profiling samples even though the CPU load is high. The profiling data is thus likely not relevant. This might be because the application is running a lot JNI code or that the JVM is spending a lot of time in GC, class loading, JIT compilation etc.</longDescription>
-        </rule>
-        <rule>
-            <id>IncreasingLiveSet</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>Too few events to calculate the result.</shortDescription>
-            <longDescription>Too few events to calculate the result.</longDescription>
-        </rule>
-        <rule>
-            <id>IncreasingMetaSpaceLiveSet</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>The class data does not seem to increase during the recording.</shortDescription>
-            <longDescription>The class data does not seem to increase during the recording.</longDescription>
-        </rule>
-        <rule>
-            <id>JavaBlocking</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires events to be available from the following event types: 'Java Monitor Blocked'.</shortDescription>
-            <longDescription>The Java Blocking rule requires events to be available from the following event types: 'Java Monitor Blocked'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>LongGcPause</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>The application did not cause any long GC pause times.</shortDescription>
-            <longDescription>The application did not cause any long GC pause times.</longDescription>
-        </rule>
-        <rule>
-            <id>LowOnPhysicalMemory</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>The system did not run low on physical memory during this recording.</shortDescription>
-            <longDescription>The system did not run low on physical memory during this recording.</longDescription>
-        </rule>
-        <rule>
-            <id>ManagementAgent</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>No problems were found with the management agent settings.</shortDescription>
-            <longDescription>No problems were found with the management agent settings.</longDescription>
-        </rule>
-        <rule>
-            <id>ManyRunningProcesses</id>
-            <severity>OK</severity>
-            <score>23.21768417223916</score>
-            <shortDescription>137 processes were running while this Flight Recording was made.</shortDescription>
-            <longDescription>At 4/4/14 11:17:10 AM, a total of 137 other processes were running on the host machine that this Flight Recording was made on.</longDescription>
-        </rule>
-        <rule>
-            <id>MetaspaceOom</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'Metaspace Out of Memory'.</shortDescription>
-            <longDescription>The Metaspace Out of Memory rule requires that the following event types are enabled: 'Metaspace Out of Memory'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>MethodProfiling</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>No methods where optimization would be particularly efficient could be detected.</shortDescription>
-            <longDescription>No methods where optimization would be particularly efficient could be detected.</longDescription>
-        </rule>
-        <rule>
-            <id>Options</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>No undocumented, deprecated or non-recommended option flags were detected.</shortDescription>
-            <longDescription>No undocumented, deprecated or non-recommended option flags were detected.</longDescription>
-        </rule>
-        <rule>
-            <id>OverAggressiveRecordingSetting</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>No problems were found with the recording settings.</shortDescription>
-            <longDescription>No problems were found with the recording settings.</longDescription>
-        </rule>
-        <rule>
-            <id>PasswordsInArguments</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>The recording does not seem to contain passwords in the application arguments.</shortDescription>
-            <longDescription>The recording does not seem to contain passwords in the application arguments.</longDescription>
-        </rule>
-        <rule>
-            <id>PasswordsInEnvironment</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>The recording does not seem to contain passwords in the environment variables.</shortDescription>
-            <longDescription>The recording does not seem to contain passwords in the environment variables.</longDescription>
-        </rule>
-        <rule>
-            <id>PasswordsInSystemProperties</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>The recording does not seem to contain passwords in the system properties.</shortDescription>
-            <longDescription>The recording does not seem to contain passwords in the system properties.</longDescription>
-        </rule>
-        <rule>
-            <id>PrimitiveToObjectConversion</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires events to be available from the following event types: 'Allocation in new TLAB', 'Allocation outside TLAB'.</shortDescription>
-            <longDescription>The Primitive To Object Conversion rule requires events to be available from the following event types: 'Allocation in new TLAB', 'Allocation outside TLAB'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>SocketRead</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>There are no socket read events in this recording.</shortDescription>
-            <longDescription>There are no socket read events in this recording.&lt;p&gt;Note that there are some socket read patterns with high duration reads that we consider to be normal and are therefore excluded. Such patterns include JMX RMI communication and MQ series.</longDescription>
-        </rule>
-        <rule>
-            <id>SocketWrite</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>There are no socket write events in this recording.</shortDescription>
-            <longDescription>There are no socket write events in this recording.&lt;p&gt;Note that there are some socket write patterns with high duration writes that we consider to be normal and are therefore excluded. Such patterns include JMX RMI communication.</longDescription>
-        </rule>
-        <rule>
-            <id>StackdepthSetting</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>No stack traces were truncated in this recording.</shortDescription>
-            <longDescription>No stack traces were truncated in this recording.</longDescription>
-        </rule>
-        <rule>
-            <id>StringDeduplication</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires events to be available from the following event types: 'Heap Summary'.</shortDescription>
-            <longDescription>The String Deduplication rule requires events to be available from the following event types: 'Heap Summary'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>SystemGc</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires events to be available from the following event types: 'Garbage Collection'.</shortDescription>
-            <longDescription>The GCs Caused by System.gc() rule requires events to be available from the following event types: 'Garbage Collection'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>TlabAllocationRatio</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>No object allocations outside of TLABs detected.</shortDescription>
-            <longDescription>No object allocations outside of TLABs detected.</longDescription>
-        </rule>
-        <rule>
-            <id>VMOperations</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>No excessively long VM operations were found in this recording (the longest was 0 s).</shortDescription>
-            <longDescription>No excessively long VM operations were found in this recording (the longest was 0 s).</longDescription>
-        </rule>
-        <rule>
-            <id>biasedLockingRevocation</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>The Biased Locking Revocation rule requires the following event types: 'jdk.BiasedLockClassRevocation'.</shortDescription>
-            <longDescription>The Biased Locking Revocation rule requires the following event types: 'jdk.BiasedLockClassRevocation'.&lt;p&gt;They are either not available in this version of Java, or must be enabled in a third-party component. If you are using an older Java version, then you can consider upgrading.</longDescription>
-        </rule>
-        <rule>
-            <id>biasedLockingRevocationPause</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>No revocation of biased locks found.</shortDescription>
-            <longDescription>No revocation of biased locks found.</longDescription>
-        </rule>
-    </report>
-    <report>
-        <file>parallel-on-singlecpu.jfr</file>
-        <rule>
-            <id>Allocations.class</id>
-            <severity>OK</severity>
-            <score>0.031334794765092246</score>
-            <shortDescription>The most allocated type is likely 'java.lang.Object[]', most commonly allocated by: &lt;ul&gt;&lt;li&gt;AbstractCollection.toArray() (100 %)&lt;/li&gt;&lt;li&gt;ArrayList.&amp;lt;init&amp;gt;(Collection)&lt;/li&gt;&lt;li&gt;JFRImpl.getRecordings()&lt;/li&gt;&lt;li&gt;MetaProducer.onNewChunk()&lt;/li&gt;&lt;li&gt;JFRImpl.onNewChunk()&lt;/li&gt;&lt;/ul&gt;</shortDescription>
-            <longDescription>The most allocated type is likely 'java.lang.Object[]', most commonly allocated by: &lt;ul&gt;&lt;li&gt;AbstractCollection.toArray() (100 %)&lt;/li&gt;&lt;li&gt;ArrayList.&amp;lt;init&amp;gt;(Collection)&lt;/li&gt;&lt;li&gt;JFRImpl.getRecordings()&lt;/li&gt;&lt;li&gt;MetaProducer.onNewChunk()&lt;/li&gt;&lt;li&gt;JFRImpl.onNewChunk()&lt;/li&gt;&lt;/ul&gt;&lt;p&gt;Frequently allocated types are good places to start when trying to reduce garbage collections. Look at where the most common types are being allocated to see if many instances are created along the same call path. Try to reduce the number of instances created by invoking the most commonly taken paths less.</longDescription>
-        </rule>
-        <rule>
-            <id>Allocations.thread</id>
-            <severity>OK</severity>
-            <score>0.031334794765092246</score>
-            <shortDescription>The most allocations were likely done by thread 'RMI TCP Connection(1)-127.0.0.1' at: &lt;ul&gt;&lt;li&gt;Throwable.fillInStackTrace(int) (100 %)&lt;/li&gt;&lt;li&gt;Throwable.fillInStackTrace()&lt;/li&gt;&lt;li&gt;Throwable.&amp;lt;init&amp;gt;(String)&lt;/li&gt;&lt;li&gt;Exception.&amp;lt;init&amp;gt;(String)&lt;/li&gt;&lt;li&gt;ReflectiveOperationException.&amp;lt;init&amp;gt;(String)&lt;/li&gt;&lt;li&gt;NoSuchFieldException.&amp;lt;init&amp;gt;(String)&lt;/li&gt;&lt;/ul&gt;</shortDescription>
-            <longDescription>The most allocations were likely done by thread 'RMI TCP Connection(1)-127.0.0.1' at: &lt;ul&gt;&lt;li&gt;Throwable.fillInStackTrace(int) (100 %)&lt;/li&gt;&lt;li&gt;Throwable.fillInStackTrace()&lt;/li&gt;&lt;li&gt;Throwable.&amp;lt;init&amp;gt;(String)&lt;/li&gt;&lt;li&gt;Exception.&amp;lt;init&amp;gt;(String)&lt;/li&gt;&lt;li&gt;ReflectiveOperationException.&amp;lt;init&amp;gt;(String)&lt;/li&gt;&lt;li&gt;NoSuchFieldException.&amp;lt;init&amp;gt;(String)&lt;/li&gt;&lt;/ul&gt;&lt;p&gt;Many allocations performed by the same thread might indicate a problem in a multi-threaded program. Look at the stack traces for the thread with the highest allocation rate. See if the allocation rate can be brought down, or balanced among the active threads.</longDescription>
-        </rule>
-        <rule>
-            <id>ApplicationHalts</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>Application efficiency was not highly affected by halts.</shortDescription>
-            <longDescription>Application efficiency was not highly affected by halts.&lt;p&gt;The highest ratio of application halts to execution time was 0 % for 1 min at 4/4/14 8:54:33 AM. 0 % of the halts were for reasons other than GC.&lt;p&gt;The halts ratio for the entire recording was 0 %. 0 % of the total halts were for reasons other than GC.&lt;/p&gt;&lt;p&gt;Enabling the following event types would improve the accuracy of this rule: jdk.SafepointBegin</longDescription>
-        </rule>
-        <rule>
-            <id>BufferLost</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>No Flight Recorder buffers were lost during the recording.</shortDescription>
-            <longDescription>No Flight Recorder buffers were lost during the recording.</longDescription>
-        </rule>
-        <rule>
-            <id>BytecodeVerification</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>The application ran with bytecode verification enabled.</shortDescription>
-            <longDescription>The application ran with bytecode verification enabled.</longDescription>
-        </rule>
-        <rule>
-            <id>ClassLeak</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'Class Load', 'Class Unload'.</shortDescription>
-            <longDescription>The Class Leak rule requires that the following event types are enabled: 'Class Load', 'Class Unload'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>ClassLoading</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'Class Load'.</shortDescription>
-            <longDescription>The Class Loading Pressure rule requires that the following event types are enabled: 'Class Load'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>CodeCache</id>
-            <severity>OK</severity>
-            <score>2.0233154296875</score>
-            <shortDescription>No problems with the code cache were detected in the recording.</shortDescription>
-            <longDescription>No problems with the code cache were detected in the recording.</longDescription>
-        </rule>
-        <rule>
-            <id>CompareCpu</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>An average CPU load of 0 % was caused by other processes for 1.010 s at 4/4/14 8:54:36 AM.</shortDescription>
-            <longDescription>An average CPU load of 0 % was caused by other processes for 1.010 s at 4/4/14 8:54:36 AM.</longDescription>
-        </rule>
-        <rule>
-            <id>CompressedOops</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>The settings for Compressed Oops were OK.</shortDescription>
-            <longDescription>The settings for Compressed Oops were OK.</longDescription>
-        </rule>
-        <rule>
-            <id>ContextSwitch</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>The program did not context switch excessively during the recording.</shortDescription>
-            <longDescription>The program did not context switch excessively during the recording.</longDescription>
-        </rule>
-        <rule>
-            <id>DMSIncident</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>The DMS Incidents rule requires the following event types: 'http://www.oracle.com/dms/dfw/dms/dfw/DFW_Incident/DFW_Incident_state'.</shortDescription>
-            <longDescription>The DMS Incidents rule requires the following event types: 'http://www.oracle.com/dms/dfw/dms/dfw/DFW_Incident/DFW_Incident_state'.&lt;p&gt;They are either not available in this version of Java, or must be enabled in a third-party component. If you are using an older Java version, then you can consider upgrading.</longDescription>
-        </rule>
-        <rule>
-            <id>DebugNonSafepoints</id>
-            <severity>Information</severity>
-            <score>50.0</score>
-            <shortDescription>DebugNonSafepoints was not enabled.</shortDescription>
-            <longDescription>DebugNonSafepoints was not enabled.&lt;p&gt;If DebugNonSafepoints is not enabled, the method profiling data will be less accurate as threads that are not at safepoints will not be correctly sampled. Use the following JVM flags to enable this: '-XX:+UnlockDiagnosticVMOptions -XX:+DebugNonSafepoints'. There is a slight performance overhead when enabling these flags. For more information see &lt;a href="http://openjdk.java.net/groups/hotspot/docs/RuntimeOverview.html#Thread%20Management|outline"&gt;HotSpot Runtime Overview/Thread Management&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>DiscouragedVmOptions</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>No problems were found with the VM options.</shortDescription>
-            <longDescription>No problems were found with the VM options.</longDescription>
-        </rule>
-        <rule>
-            <id>DumpReason</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>This recording was not dumped for an exceptional reason.</shortDescription>
-            <longDescription>This recording was not dumped for an exceptional reason.</longDescription>
-        </rule>
-        <rule>
-            <id>DuplicateFlags</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>There were no duplicate JVM flags on the command line.</shortDescription>
-            <longDescription>There were no duplicate JVM flags on the command line.</longDescription>
-        </rule>
-        <rule>
-            <id>Errors</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires events to be available from the following event types: 'Java Error'.</shortDescription>
-            <longDescription>The Thrown Errors rule requires events to be available from the following event types: 'Java Error'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>Exceptions</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>The program generated 0 exceptions per second for 1.009 s at 4/4/14 8:54:34 AM.</shortDescription>
-            <longDescription>The program generated 0 exceptions per second for 1.009 s at 4/4/14 8:54:34 AM.</longDescription>
-        </rule>
-        <rule>
-            <id>Fatal Errors</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>The Fatal Errors rule requires the following event types: 'jdk.Shutdown'.</shortDescription>
-            <longDescription>The Fatal Errors rule requires the following event types: 'jdk.Shutdown'.&lt;p&gt;They are either not available in this version of Java, or must be enabled in a third-party component. If you are using an older Java version, then you can consider upgrading.</longDescription>
-        </rule>
-        <rule>
-            <id>FewSampledThreads</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>There were no problems with the amount of sampled threads.</shortDescription>
-            <longDescription>There were no problems with the amount of sampled threads.&lt;p&gt;There are more sampled threads than the amount of hardware threads. This indicates that the application has enough parallelism for the available hardware.&lt;p&gt;This recording is only 5.136 s long, consider creating a recording longer than 20 s for improved rule accuracy.</longDescription>
-        </rule>
-        <rule>
-            <id>FileRead</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>There are no file read events in this recording.</shortDescription>
-            <longDescription>There are no file read events in this recording.</longDescription>
-        </rule>
-        <rule>
-            <id>FileWrite</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires events to be available from the following event types: 'File Write'.</shortDescription>
-            <longDescription>The File Write Peak Duration rule requires events to be available from the following event types: 'File Write'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>FlightRecordingSupport</id>
-            <severity>Warning</severity>
-            <score>80.0</score>
-            <shortDescription>The recording is from an early access build.</shortDescription>
-            <longDescription>This recording is from an early access build of the JRE (Java HotSpot(TM) Client VM (25.20-b08) for linux-x86 JRE (1.8.0_20-ea-b08), built on Apr  1 2014 19:40:24 by &amp;#34;java_re&amp;#34; with gcc 4.3.0 20080428 (Red Hat 4.3.0-8)). The automated analysis is not supported, and you may see errors when attempting to analyze the recording.</longDescription>
-        </rule>
-        <rule>
-            <id>FullGc</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule is only valid for CMS and G1 Garbage Collectors, neither of which were detected for this JVM.</shortDescription>
-            <longDescription>This rule is only valid for CMS and G1 Garbage Collectors, neither of which were detected for this JVM.</longDescription>
-        </rule>
-        <rule>
-            <id>GcFreedRatio</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>Only 0 heap summary events were found, this rule requires at least 10 events to be able to calculate a relevant result. This likely means that only a few garbage collections occurred during the recording. Having few garbage collections is generally a good sign.</shortDescription>
-            <longDescription>Only 0 heap summary events were found, this rule requires at least 10 events to be able to calculate a relevant result. This likely means that only a few garbage collections occurred during the recording. Having few garbage collections is generally a good sign.</longDescription>
-        </rule>
-        <rule>
-            <id>GcLocker</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>No GCs were affected by the GC Locker.</shortDescription>
-            <longDescription>No GCs were affected by the GC Locker.</longDescription>
-        </rule>
-        <rule>
-            <id>GcOptions</id>
-            <severity>Information</severity>
-            <score>50.0</score>
-            <shortDescription>The runtime used a parallel GC on a single-core machine.</shortDescription>
-            <longDescription>The runtime used a parallel GC on a single-core machine. This is not optimal. Use the &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/guides/vm/gctuning/collectors.html"&gt;Serial Collector&lt;/a&gt; instead, which is optimized for single-core machines.</longDescription>
-        </rule>
-        <rule>
-            <id>GcPauseRatio</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>Application efficiency was not highly affected by GC pauses.</shortDescription>
-            <longDescription>Application efficiency was not highly affected by GC pauses.&lt;p&gt;The highest ratio between garbage collection pauses and execution time was 0 % for 1 min at 4/4/14 8:54:33 AM. The garbage collection pause ratio of the entire recording was 0 %.</longDescription>
-        </rule>
-        <rule>
-            <id>GcStall</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>No indications that the garbage collector could not keep up with the workload were detected.</shortDescription>
-            <longDescription>No indications that the garbage collector could not keep up with the workload were detected.</longDescription>
-        </rule>
-        <rule>
-            <id>HeapContent</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'Object Count'.</shortDescription>
-            <longDescription>The Heap Content rule requires that the following event types are enabled: 'Object Count'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>HeapInspectionGc</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires events to be available from the following event types: 'Garbage Collection'.</shortDescription>
-            <longDescription>The GCs Caused by Heap Inspection rule requires events to be available from the following event types: 'Garbage Collection'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>HighGc</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>The runtime did not spend much time performing garbage collections.</shortDescription>
-            <longDescription>The runtime did not spend much time performing garbage collections.</longDescription>
-        </rule>
-        <rule>
-            <id>HighJvmCpu</id>
-            <severity>Information</severity>
-            <score>35.27744043201552</score>
-            <shortDescription>This recording contains few profiling samples even though the CPU load is high.</shortDescription>
-            <longDescription>This recording contains few profiling samples even though the CPU load is high. The profiling data is thus likely not relevant. This might be because the application is running a lot JNI code or that the JVM is spending a lot of time in GC, class loading, JIT compilation etc.</longDescription>
-        </rule>
-        <rule>
-            <id>IncreasingLiveSet</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>Too few events to calculate the result.</shortDescription>
-            <longDescription>Too few events to calculate the result.</longDescription>
-        </rule>
-        <rule>
-            <id>IncreasingMetaSpaceLiveSet</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>The class data does not seem to increase during the recording.</shortDescription>
-            <longDescription>The class data does not seem to increase during the recording.</longDescription>
-        </rule>
-        <rule>
-            <id>JavaBlocking</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires events to be available from the following event types: 'Java Monitor Blocked'.</shortDescription>
-            <longDescription>The Java Blocking rule requires events to be available from the following event types: 'Java Monitor Blocked'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>LongGcPause</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>The application did not cause any long GC pause times.</shortDescription>
-            <longDescription>The application did not cause any long GC pause times.</longDescription>
-        </rule>
-        <rule>
-            <id>LowOnPhysicalMemory</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>The system did not run low on physical memory during this recording.</shortDescription>
-            <longDescription>The system did not run low on physical memory during this recording.</longDescription>
-        </rule>
-        <rule>
-            <id>ManagementAgent</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>No problems were found with the management agent settings.</shortDescription>
-            <longDescription>No problems were found with the management agent settings.</longDescription>
-        </rule>
-        <rule>
-            <id>ManyRunningProcesses</id>
-            <severity>OK</severity>
-            <score>23.21768417223916</score>
-            <shortDescription>137 processes were running while this Flight Recording was made.</shortDescription>
-            <longDescription>At 4/4/14 8:54:38 AM, a total of 137 other processes were running on the host machine that this Flight Recording was made on.</longDescription>
-        </rule>
-        <rule>
-            <id>MetaspaceOom</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'Metaspace Out of Memory'.</shortDescription>
-            <longDescription>The Metaspace Out of Memory rule requires that the following event types are enabled: 'Metaspace Out of Memory'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>MethodProfiling</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>No methods where optimization would be particularly efficient could be detected.</shortDescription>
-            <longDescription>No methods where optimization would be particularly efficient could be detected.</longDescription>
-        </rule>
-        <rule>
-            <id>Options</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>No undocumented, deprecated or non-recommended option flags were detected.</shortDescription>
-            <longDescription>No undocumented, deprecated or non-recommended option flags were detected.</longDescription>
-        </rule>
-        <rule>
-            <id>OverAggressiveRecordingSetting</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>No problems were found with the recording settings.</shortDescription>
-            <longDescription>No problems were found with the recording settings.</longDescription>
-        </rule>
-        <rule>
-            <id>PasswordsInArguments</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>The recording does not seem to contain passwords in the application arguments.</shortDescription>
-            <longDescription>The recording does not seem to contain passwords in the application arguments.</longDescription>
-        </rule>
-        <rule>
-            <id>PasswordsInEnvironment</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>The recording does not seem to contain passwords in the environment variables.</shortDescription>
-            <longDescription>The recording does not seem to contain passwords in the environment variables.</longDescription>
-        </rule>
-        <rule>
-            <id>PasswordsInSystemProperties</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>The recording does not seem to contain passwords in the system properties.</shortDescription>
-            <longDescription>The recording does not seem to contain passwords in the system properties.</longDescription>
-        </rule>
-        <rule>
-            <id>PrimitiveToObjectConversion</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires events to be available from the following event types: 'Allocation in new TLAB', 'Allocation outside TLAB'.</shortDescription>
-            <longDescription>The Primitive To Object Conversion rule requires events to be available from the following event types: 'Allocation in new TLAB', 'Allocation outside TLAB'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>SocketRead</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>There are no socket read events in this recording.</shortDescription>
-            <longDescription>There are no socket read events in this recording.&lt;p&gt;Note that there are some socket read patterns with high duration reads that we consider to be normal and are therefore excluded. Such patterns include JMX RMI communication and MQ series.</longDescription>
-        </rule>
-        <rule>
-            <id>SocketWrite</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires events to be available from the following event types: 'Socket Write'.</shortDescription>
-            <longDescription>The Socket Write Peak Duration rule requires events to be available from the following event types: 'Socket Write'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>StackdepthSetting</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>No stack traces were truncated in this recording.</shortDescription>
-            <longDescription>No stack traces were truncated in this recording.</longDescription>
-        </rule>
-        <rule>
-            <id>StringDeduplication</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires events to be available from the following event types: 'Heap Summary'.</shortDescription>
-            <longDescription>The String Deduplication rule requires events to be available from the following event types: 'Heap Summary'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>SystemGc</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires events to be available from the following event types: 'Garbage Collection'.</shortDescription>
-            <longDescription>The GCs Caused by System.gc() rule requires events to be available from the following event types: 'Garbage Collection'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>TlabAllocationRatio</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>No object allocations outside of TLABs detected.</shortDescription>
-            <longDescription>No object allocations outside of TLABs detected.</longDescription>
-        </rule>
-        <rule>
-            <id>VMOperations</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>No excessively long VM operations were found in this recording (the longest was 0 s).</shortDescription>
-            <longDescription>No excessively long VM operations were found in this recording (the longest was 0 s).</longDescription>
-        </rule>
-        <rule>
-            <id>biasedLockingRevocation</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>The Biased Locking Revocation rule requires the following event types: 'jdk.BiasedLockClassRevocation'.</shortDescription>
-            <longDescription>The Biased Locking Revocation rule requires the following event types: 'jdk.BiasedLockClassRevocation'.&lt;p&gt;They are either not available in this version of Java, or must be enabled in a third-party component. If you are using an older Java version, then you can consider upgrading.</longDescription>
-        </rule>
-        <rule>
-            <id>biasedLockingRevocationPause</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>No revocation of biased locks found.</shortDescription>
-            <longDescription>No revocation of biased locks found.</longDescription>
-        </rule>
-    </report>
-    <report>
-        <file>stringdedup_enabled_jdk9.jfr</file>
-        <rule>
-            <id>Allocations.class</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'Allocation in new TLAB', 'Allocation outside TLAB'.</shortDescription>
-            <longDescription>The Allocated Classes rule requires that the following event types are enabled: 'Allocation in new TLAB', 'Allocation outside TLAB'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>Allocations.thread</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'Allocation in new TLAB', 'Allocation outside TLAB'.</shortDescription>
-            <longDescription>The Threads Allocating rule requires that the following event types are enabled: 'Allocation in new TLAB', 'Allocation outside TLAB'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>ApplicationHalts</id>
-            <severity>OK</severity>
-            <score>0.4097173333333334</score>
-            <shortDescription>Application efficiency was not highly affected by halts.</shortDescription>
-            <longDescription>Application efficiency was not highly affected by halts.&lt;p&gt;The highest ratio of application halts to execution time was 0.082 % for 1 min at 4/24/18 10:08:52 AM. 51.552 % of the halts were for reasons other than GC.&lt;p&gt;The halts ratio for the entire recording was 1.003 %. 51.552 % of the total halts were for reasons other than GC.&lt;/p&gt;</longDescription>
-        </rule>
-        <rule>
-            <id>BufferLost</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>No Flight Recorder buffers were lost during the recording.</shortDescription>
-            <longDescription>No Flight Recorder buffers were lost during the recording.</longDescription>
-        </rule>
-        <rule>
-            <id>BytecodeVerification</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>The application ran with bytecode verification enabled.</shortDescription>
-            <longDescription>The application ran with bytecode verification enabled.</longDescription>
-        </rule>
-        <rule>
-            <id>ClassLeak</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'Class Load', 'Class Unload'.</shortDescription>
-            <longDescription>The Class Leak rule requires that the following event types are enabled: 'Class Load', 'Class Unload'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>ClassLoading</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'Class Load'.</shortDescription>
-            <longDescription>The Class Loading Pressure rule requires that the following event types are enabled: 'Class Load'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>CodeCache</id>
-            <severity>OK</severity>
-            <score>21.734625758350106</score>
-            <shortDescription>No problems with the code cache were detected in the recording.</shortDescription>
-            <longDescription>No problems with the code cache were detected in the recording.</longDescription>
-        </rule>
-        <rule>
-            <id>CompareCpu</id>
-            <severity>OK</severity>
-            <score>3.3944677554909966</score>
-            <shortDescription>An average CPU load of 15 % was caused by other processes for 1.060 s at 4/24/18 10:08:54 AM.</shortDescription>
-            <longDescription>An average CPU load of 15 % was caused by other processes for 1.060 s at 4/24/18 10:08:54 AM.</longDescription>
-        </rule>
-        <rule>
-            <id>CompressedOops</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>The settings for Compressed Oops were OK.</shortDescription>
-            <longDescription>The settings for Compressed Oops were OK.</longDescription>
-        </rule>
-        <rule>
-            <id>ContextSwitch</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires events to be available from the following event types: 'Thread Context Switch Rate'.</shortDescription>
-            <longDescription>The Context Switches rule requires events to be available from the following event types: 'Thread Context Switch Rate'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>DMSIncident</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>The DMS Incidents rule requires the following event types: 'http://www.oracle.com/dms/dfw/dms/dfw/DFW_Incident/DFW_Incident_state'.</shortDescription>
-            <longDescription>The DMS Incidents rule requires the following event types: 'http://www.oracle.com/dms/dfw/dms/dfw/DFW_Incident/DFW_Incident_state'.&lt;p&gt;They are either not available in this version of Java, or must be enabled in a third-party component. If you are using an older Java version, then you can consider upgrading.</longDescription>
-        </rule>
-        <rule>
-            <id>DebugNonSafepoints</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>DebugNonSafepoints was implicitly enabled in the JVM version used to create this recording.</shortDescription>
-            <longDescription>DebugNonSafepoints was implicitly enabled in the JVM version used to create this recording.</longDescription>
-        </rule>
-        <rule>
-            <id>DiscouragedVmOptions</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>No problems were found with the VM options.</shortDescription>
-            <longDescription>No problems were found with the VM options.</longDescription>
-        </rule>
-        <rule>
-            <id>DumpReason</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>This recording was not dumped for an exceptional reason.</shortDescription>
-            <longDescription>This recording was not dumped for an exceptional reason.</longDescription>
-        </rule>
-        <rule>
-            <id>DuplicateFlags</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>There were no duplicate JVM flags on the command line.</shortDescription>
-            <longDescription>There were no duplicate JVM flags on the command line.</longDescription>
-        </rule>
-        <rule>
-            <id>Errors</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires events to be available from the following event types: 'Java Error'.</shortDescription>
-            <longDescription>The Thrown Errors rule requires events to be available from the following event types: 'Java Error'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>Exceptions</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>The program generated 0 exceptions per second for 1.054 s at 4/24/18 10:08:53 AM.</shortDescription>
-            <longDescription>The program generated 0 exceptions per second for 1.054 s at 4/24/18 10:08:53 AM.</longDescription>
-        </rule>
-        <rule>
-            <id>Fatal Errors</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>The Fatal Errors rule requires the following event types: 'jdk.Shutdown'.</shortDescription>
-            <longDescription>The Fatal Errors rule requires the following event types: 'jdk.Shutdown'.&lt;p&gt;They are either not available in this version of Java, or must be enabled in a third-party component. If you are using an older Java version, then you can consider upgrading.</longDescription>
-        </rule>
-        <rule>
-            <id>FewSampledThreads</id>
-            <severity>Information</severity>
-            <score>29.510744962334375</score>
-            <shortDescription>There are fewer sampled threads than the total number of hardware threads (cores).</shortDescription>
-            <longDescription>There are fewer sampled threads than the total number of hardware threads (cores).&lt;p&gt;1 threads with at least 4 method samples were found, but the machine has 32 hardware threads (cores). The application might benefit from a higher level of parallelism. This could also be caused by threads doing something else than running Java code, for example running native code or spending time in the JVM internals.&lt;p&gt;This recording is only 4.902 s long, consider creating a recording longer than 20 s for improved rule accuracy.</longDescription>
-        </rule>
-        <rule>
-            <id>FileRead</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>There are no file read events in this recording.</shortDescription>
-            <longDescription>There are no file read events in this recording.</longDescription>
-        </rule>
-        <rule>
-            <id>FileWrite</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires events to be available from the following event types: 'File Write'.</shortDescription>
-            <longDescription>The File Write Peak Duration rule requires events to be available from the following event types: 'File Write'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>FlightRecordingSupport</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>The JVM version used for this recording has full Flight Recorder support.</shortDescription>
-            <longDescription>The JVM version used for this recording has full Flight Recorder support.</longDescription>
-        </rule>
-        <rule>
-            <id>FullGc</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>No Stop-the-World, Full GC events detected.</shortDescription>
-            <longDescription>No Stop-the-World, Full GC events detected.</longDescription>
-        </rule>
-        <rule>
-            <id>GcFreedRatio</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>Only 6 heap summary events were found, this rule requires at least 10 events to be able to calculate a relevant result. This likely means that only a few garbage collections occurred during the recording. Having few garbage collections is generally a good sign.</shortDescription>
-            <longDescription>Only 6 heap summary events were found, this rule requires at least 10 events to be able to calculate a relevant result. This likely means that only a few garbage collections occurred during the recording. Having few garbage collections is generally a good sign.</longDescription>
-        </rule>
-        <rule>
-            <id>GcLocker</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>No GCs were affected by the GC Locker.</shortDescription>
-            <longDescription>No GCs were affected by the GC Locker.</longDescription>
-        </rule>
-        <rule>
-            <id>GcOptions</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>No problems were found with the GC configuration.</shortDescription>
-            <longDescription>No problems were found with the GC configuration.</longDescription>
-        </rule>
-        <rule>
-            <id>GcPauseRatio</id>
-            <severity>OK</severity>
-            <score>0.1985013333333333</score>
-            <shortDescription>Application efficiency was not highly affected by GC pauses.</shortDescription>
-            <longDescription>Application efficiency was not highly affected by GC pauses.&lt;p&gt;The highest ratio between garbage collection pauses and execution time was 0.04 % for 1 min at 4/24/18 10:08:52 AM. The garbage collection pause ratio of the entire recording was 0.486 %.</longDescription>
-        </rule>
-        <rule>
-            <id>GcStall</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>No indications that the garbage collector could not keep up with the workload were detected.</shortDescription>
-            <longDescription>No indications that the garbage collector could not keep up with the workload were detected.</longDescription>
-        </rule>
-        <rule>
-            <id>HeapContent</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'Object Count'.</shortDescription>
-            <longDescription>The Heap Content rule requires that the following event types are enabled: 'Object Count'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>HeapInspectionGc</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>The JVM did not perform any heap inspection GCs.</shortDescription>
-            <longDescription>The JVM did not perform any heap inspection GCs. This is good since they usually take a lot of time.</longDescription>
-        </rule>
-        <rule>
-            <id>HighGc</id>
-            <severity>OK</severity>
-            <score>2.054924803137792</score>
-            <shortDescription>The JVM was paused for 100 % of the 9.017 ms at 4/24/18 10:08:53 AM.</shortDescription>
-            <longDescription>The JVM was paused for 100 % of the 9.017 ms at 4/24/18 10:08:53 AM. The time spent performing garbage collection may be reduced by increasing the heap size or by trying to reduce allocation.&lt;p&gt;To improve rule accuracy and/or get more details for further investigation, it is recommended to enable the following event types: 'Allocation in new TLAB', 'Allocation outside TLAB'.</longDescription>
-        </rule>
-        <rule>
-            <id>HighJvmCpu</id>
-            <severity>OK</severity>
-            <score>1.4885947328122275</score>
-            <shortDescription>The JVM does not seem to cause a lot of CPU load.</shortDescription>
-            <longDescription>The JVM does not seem to cause a lot of CPU load.</longDescription>
-        </rule>
-        <rule>
-            <id>IncreasingLiveSet</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>Too few events to calculate the result.</shortDescription>
-            <longDescription>Too few events to calculate the result.</longDescription>
-        </rule>
-        <rule>
-            <id>IncreasingMetaSpaceLiveSet</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>The class data does not seem to increase during the recording.</shortDescription>
-            <longDescription>The class data does not seem to increase during the recording.</longDescription>
-        </rule>
-        <rule>
-            <id>JavaBlocking</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires events to be available from the following event types: 'Java Monitor Blocked'.</shortDescription>
-            <longDescription>The Java Blocking rule requires events to be available from the following event types: 'Java Monitor Blocked'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>LongGcPause</id>
-            <severity>OK</severity>
-            <score>0.27457770686965866</score>
-            <shortDescription>The longest GC pause was 9.017 ms.</shortDescription>
-            <longDescription>The longest GC pause was 9.017 ms.</longDescription>
-        </rule>
-        <rule>
-            <id>LowOnPhysicalMemory</id>
-            <severity>Information</severity>
-            <score>64.30361523113581</score>
-            <shortDescription>The maximum amount of used memory was 91.8 % of the physical memory available.</shortDescription>
-            <longDescription>The maximum amount of memory used was 29.3 GiB. This is 91.8 % of the 31.9 GiB of physical memory available. Having little free memory may lead to swapping, which is very expensive. To avoid this, either decrease the memory usage or increase the amount of available memory.</longDescription>
-        </rule>
-        <rule>
-            <id>ManagementAgent</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'Initial System Property'.</shortDescription>
-            <longDescription>The Discouraged Management Agent Settings rule requires that the following event types are enabled: 'Initial System Property'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>ManyRunningProcesses</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'System Process'.</shortDescription>
-            <longDescription>The Competing Processes rule requires that the following event types are enabled: 'System Process'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>MetaspaceOom</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>The metaspace was not exhausted during this recording.</shortDescription>
-            <longDescription>The metaspace was not exhausted during this recording.</longDescription>
-        </rule>
-        <rule>
-            <id>MethodProfiling</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>No methods where optimization would be particularly efficient could be detected.</shortDescription>
-            <longDescription>No methods where optimization would be particularly efficient could be detected.</longDescription>
-        </rule>
-        <rule>
-            <id>Options</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>No undocumented, deprecated or non-recommended option flags were detected.</shortDescription>
-            <longDescription>No undocumented, deprecated or non-recommended option flags were detected.</longDescription>
-        </rule>
-        <rule>
-            <id>OverAggressiveRecordingSetting</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'Initial System Property'.</shortDescription>
-            <longDescription>The Discouraged Recording Settings rule requires that the following event types are enabled: 'Initial System Property'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>PasswordsInArguments</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>The recording does not seem to contain passwords in the application arguments.</shortDescription>
-            <longDescription>The recording does not seem to contain passwords in the application arguments.</longDescription>
-        </rule>
-        <rule>
-            <id>PasswordsInEnvironment</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'Initial Environment Variable'.</shortDescription>
-            <longDescription>The Passwords in Environment Variables rule requires that the following event types are enabled: 'Initial Environment Variable'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>PasswordsInSystemProperties</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'Initial System Property'.</shortDescription>
-            <longDescription>The Passwords in System Properties rule requires that the following event types are enabled: 'Initial System Property'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>PrimitiveToObjectConversion</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'Allocation in new TLAB', 'Allocation outside TLAB'.</shortDescription>
-            <longDescription>The Primitive To Object Conversion rule requires that the following event types are enabled: 'Allocation in new TLAB', 'Allocation outside TLAB'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>SocketRead</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires events to be available from the following event types: 'Socket Read'.</shortDescription>
-            <longDescription>The Socket Read Peak Duration rule requires events to be available from the following event types: 'Socket Read'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>SocketWrite</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires events to be available from the following event types: 'Socket Write'.</shortDescription>
-            <longDescription>The Socket Write Peak Duration rule requires events to be available from the following event types: 'Socket Write'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>StackdepthSetting</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>No stack traces were truncated in this recording.</shortDescription>
-            <longDescription>No stack traces were truncated in this recording.</longDescription>
-        </rule>
-        <rule>
-            <id>StringDeduplication</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>String deduplication is already enabled.</shortDescription>
-            <longDescription>String deduplication is already enabled.</longDescription>
-        </rule>
-        <rule>
-            <id>SystemGc</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>No garbage collections were caused by System.gc().</shortDescription>
-            <longDescription>No garbage collections were caused by System.gc().</longDescription>
-        </rule>
-        <rule>
-            <id>TlabAllocationRatio</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'Allocation in new TLAB', 'Allocation outside TLAB'.</shortDescription>
-            <longDescription>The TLAB Allocation Ratio rule requires that the following event types are enabled: 'Allocation in new TLAB', 'Allocation outside TLAB'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>VMOperations</id>
-            <severity>OK</severity>
-            <score>0.6336485833333333</score>
-            <shortDescription>No excessively long VM operations were found in this recording (the longest was 25.346 ms).</shortDescription>
-            <longDescription>No excessively long VM operations were found in this recording (the longest was 25.346 ms).</longDescription>
-        </rule>
-        <rule>
-            <id>biasedLockingRevocation</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>The Biased Locking Revocation rule requires the following event types: 'jdk.BiasedLockClassRevocation'.</shortDescription>
-            <longDescription>The Biased Locking Revocation rule requires the following event types: 'jdk.BiasedLockClassRevocation'.&lt;p&gt;They are either not available in this version of Java, or must be enabled in a third-party component. If you are using an older Java version, then you can consider upgrading.</longDescription>
-        </rule>
-        <rule>
-            <id>biasedLockingRevocationPause</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>No revocation of biased locks found.</shortDescription>
-            <longDescription>No revocation of biased locks found.</longDescription>
-        </rule>
-    </report>
-    <report>
-        <file>wldf.jfr</file>
-        <rule>
-            <id>Allocations.class</id>
-            <severity>Information</severity>
-            <score>46.750432285649964</score>
-            <shortDescription>The most allocated type is likely 'char[]', most commonly allocated by: &lt;ul&gt;&lt;li&gt;Arrays.copyOfRange(char[], int, int) (44.9 %)&lt;/li&gt;&lt;/ul&gt;</shortDescription>
-            <longDescription>The most allocated type is likely 'char[]', most commonly allocated by: &lt;ul&gt;&lt;li&gt;Arrays.copyOfRange(char[], int, int) (44.9 %)&lt;/li&gt;&lt;/ul&gt;&lt;p&gt;Frequently allocated types are good places to start when trying to reduce garbage collections. Look at where the most common types are being allocated to see if many instances are created along the same call path. Try to reduce the number of instances created by invoking the most commonly taken paths less.</longDescription>
-        </rule>
-        <rule>
-            <id>Allocations.thread</id>
-            <severity>OK</severity>
-            <score>24.595150095883856</score>
-            <shortDescription>The most allocations were likely done by thread '[ACTIVE] ExecuteThread: &amp;#39;5&amp;#39; for queue: &amp;#39;weblogic.kernel.Default (self-tuning)&amp;#39;' at: &lt;ul&gt;&lt;li&gt;Arrays.copyOfRange(char[], int, int) (53.3 %)&lt;/li&gt;&lt;/ul&gt;</shortDescription>
-            <longDescription>The most allocations were likely done by thread '[ACTIVE] ExecuteThread: &amp;#39;5&amp;#39; for queue: &amp;#39;weblogic.kernel.Default (self-tuning)&amp;#39;' at: &lt;ul&gt;&lt;li&gt;Arrays.copyOfRange(char[], int, int) (53.3 %)&lt;/li&gt;&lt;/ul&gt;&lt;p&gt;Many allocations performed by the same thread might indicate a problem in a multi-threaded program. Look at the stack traces for the thread with the highest allocation rate. See if the allocation rate can be brought down, or balanced among the active threads.</longDescription>
-        </rule>
-        <rule>
-            <id>ApplicationHalts</id>
-            <severity>OK</severity>
-            <score>11.086075208333334</score>
-            <shortDescription>Application efficiency was not highly affected by halts.</shortDescription>
-            <longDescription>Application efficiency was not highly affected by halts.&lt;p&gt;The highest ratio of application halts to execution time was 2.217 % for 1 min at 9/24/15 10:08:56 AM. 0.027 % of the halts were for reasons other than GC.&lt;p&gt;The halts ratio for the entire recording was 1.882 %. 0.021 % of the total halts were for reasons other than GC.&lt;/p&gt;&lt;p&gt;Enabling the following event types would improve the accuracy of this rule: jdk.SafepointBegin</longDescription>
-        </rule>
-        <rule>
-            <id>BufferLost</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>No Flight Recorder buffers were lost during the recording.</shortDescription>
-            <longDescription>No Flight Recorder buffers were lost during the recording.</longDescription>
-        </rule>
-        <rule>
-            <id>BytecodeVerification</id>
-            <severity>OK</severity>
-            <score>1.0</score>
-            <shortDescription>The application ran WebLogic Server with bytecode verification disabled.</shortDescription>
-            <longDescription>The application ran WebLogic Server with bytecode verification disabled. While not generally recommended, it is considered OK for WLS.</longDescription>
-        </rule>
-        <rule>
-            <id>ClassLeak</id>
-            <severity>Information</severity>
-            <score>74.99995410111316</score>
-            <shortDescription>The difference between the number of times a class has been loaded and the number it has been unloaded, has exceeded the user specified limit. Most loaded: java.lang.Object (258)</shortDescription>
-            <longDescription>Some classes have been loaded multiple times, and the difference between the number of times a class have been loaded and the number of times it has been unloaded has exceeded the user specified limit. This in itself need not be a problem, but check to see if you expect these classes to be loaded multiple times to make sure that you do not have a class loader leak.&lt;p&gt;Top 5 loaded classes:&lt;/p&gt;&lt;p&gt;&lt;ul&gt;&lt;li&gt;java.lang.Object (258)&lt;/li&gt;&lt;li&gt;java.lang.String (95)&lt;/li&gt;&lt;li&gt;java.lang.Class (81)&lt;/li&gt;&lt;li&gt;java.lang.Integer (52)&lt;/li&gt;&lt;li&gt;oracle.jrockit.jfr.VMJFR (46)&lt;/li&gt;&lt;/ul&gt;&lt;/p&gt;</longDescription>
-        </rule>
-        <rule>
-            <id>ClassLoading</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>No significant time was spent loading new classes during this recording.</shortDescription>
-            <longDescription>No significant time was spent loading new classes during this recording.</longDescription>
-        </rule>
-        <rule>
-            <id>CodeCache</id>
-            <severity>OK</severity>
-            <score>16.62089029947917</score>
-            <shortDescription>No problems with the code cache were detected in the recording.</shortDescription>
-            <longDescription>No problems with the code cache were detected in the recording.</longDescription>
-        </rule>
-        <rule>
-            <id>CompareCpu</id>
-            <severity>Warning</severity>
-            <score>87.07809686085879</score>
-            <shortDescription>An average CPU load of 54 % was caused by other processes for 4.938 s at 9/24/15 10:08:17 AM.</shortDescription>
-            <longDescription>An average CPU load of 54 % was caused by other processes for 4.938 s at 9/24/15 10:08:17 AM.&lt;p&gt;The application performance can be affected when the machine is under heavy load and there are other processes that use CPU or other resources on the same computer. To profile representatively or get higher throughput, shut down other resource intensive processes running on the machine.</longDescription>
-        </rule>
-        <rule>
-            <id>CompressedOops</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>The settings for Compressed Oops were OK.</shortDescription>
-            <longDescription>The settings for Compressed Oops were OK.</longDescription>
-        </rule>
-        <rule>
-            <id>ContextSwitch</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>The program did not context switch excessively during the recording.</shortDescription>
-            <longDescription>The program did not context switch excessively during the recording.</longDescription>
-        </rule>
-        <rule>
-            <id>DMSIncident</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>The DMS Incidents rule requires the following event types: 'http://www.oracle.com/dms/dfw/dms/dfw/DFW_Incident/DFW_Incident_state'.</shortDescription>
-            <longDescription>The DMS Incidents rule requires the following event types: 'http://www.oracle.com/dms/dfw/dms/dfw/DFW_Incident/DFW_Incident_state'.&lt;p&gt;They are either not available in this version of Java, or must be enabled in a third-party component. If you are using an older Java version, then you can consider upgrading.</longDescription>
-        </rule>
-        <rule>
-            <id>DebugNonSafepoints</id>
-            <severity>Information</severity>
-            <score>50.0</score>
-            <shortDescription>DebugNonSafepoints was not enabled.</shortDescription>
-            <longDescription>DebugNonSafepoints was not enabled.&lt;p&gt;If DebugNonSafepoints is not enabled, the method profiling data will be less accurate as threads that are not at safepoints will not be correctly sampled. Use the following JVM flags to enable this: '-XX:+UnlockDiagnosticVMOptions -XX:+DebugNonSafepoints'. There is a slight performance overhead when enabling these flags. For more information see &lt;a href="http://openjdk.java.net/groups/hotspot/docs/RuntimeOverview.html#Thread%20Management|outline"&gt;HotSpot Runtime Overview/Thread Management&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>DiscouragedVmOptions</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>No problems were found with the VM options.</shortDescription>
-            <longDescription>No problems were found with the VM options.</longDescription>
-        </rule>
-        <rule>
-            <id>DumpReason</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>This recording was not dumped for an exceptional reason.</shortDescription>
-            <longDescription>This recording was not dumped for an exceptional reason.</longDescription>
-        </rule>
-        <rule>
-            <id>DuplicateFlags</id>
-            <severity>Information</severity>
-            <score>50.0</score>
-            <shortDescription>There were 2 JVM duplicated flags.</shortDescription>
-            <longDescription>There were 2 JVM duplicated flags. Duplicated JVM flags may be caused by multiple layers of scripts used when launching the application. Having duplicate flags is dangerous as changing one of the flags in one of the scripts may not have the intended effect. This can be especially dangerous for security related system properties. Try to find all the places where the flag is defined and keep only one. The following flags were duplicated: &lt;ul&gt;&lt;li&gt;-Djava.endorsed.dirs=c:\java\JDK18~1.0_6\jre\lib\endorsed;C:\tmp\WLS-JFR\oracle_common\modules\endorsed, -Djava.endorsed.dirs=c:\java\JDK18~1.0_6\jre\lib\endorsed;C:\tmp\WLS-JFR\oracle_common\modules\endorsed&lt;/li&gt;&lt;li&gt;-Xverify:none, -Xverify:none&lt;/li&gt;&lt;/ul&gt;</longDescription>
-        </rule>
-        <rule>
-            <id>Errors</id>
-            <severity>OK</severity>
-            <score>14.166666666666668</score>
-            <shortDescription>The program generated an average of 17 errors per minute during 9/24/2015 10:08:14 AM – 10:09:14 AM.</shortDescription>
-            <longDescription>The program generated an average of 17 errors per minute during 9/24/2015 10:08:14 AM – 10:09:14 AM. 17 errors were thrown in total.&lt;p&gt;The most common error was 'java.lang.NoSuchMethodError', which was thrown 13 times.&lt;p&gt;Investigate the thrown errors to see if they can be avoided. Errors indicate that something went wrong with the code execution and should never be used for flow control. The following regular expression was used to exclude 381 errors from this rule: '(com.sun.el.parser.ELParser\$LookaheadSuccess)'.</longDescription>
-        </rule>
-        <rule>
-            <id>Exceptions</id>
-            <severity>OK</severity>
-            <score>2.573808918421875</score>
-            <shortDescription>The program generated 515 exceptions per second for 28.060 s at 9/24/15 10:08:58 AM.</shortDescription>
-            <longDescription>The program generated 515 exceptions per second for 28.060 s at 9/24/15 10:08:58 AM.</longDescription>
-        </rule>
-        <rule>
-            <id>Fatal Errors</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>The Fatal Errors rule requires the following event types: 'jdk.Shutdown'.</shortDescription>
-            <longDescription>The Fatal Errors rule requires the following event types: 'jdk.Shutdown'.&lt;p&gt;They are either not available in this version of Java, or must be enabled in a third-party component. If you are using an older Java version, then you can consider upgrading.</longDescription>
-        </rule>
-        <rule>
-            <id>FewSampledThreads</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>There were no problems with the amount of sampled threads.</shortDescription>
-            <longDescription>There were no problems with the amount of sampled threads.&lt;p&gt;There are more sampled threads than the amount of hardware threads. This indicates that the application has enough parallelism for the available hardware.</longDescription>
-        </rule>
-        <rule>
-            <id>FileRead</id>
-            <severity>OK</severity>
-            <score>0.2033639625</score>
-            <shortDescription>No long file read pauses were found in this recording (the longest was 16.269 ms).</shortDescription>
-            <longDescription>No long file read pauses were found in this recording (the longest was 16.269 ms).</longDescription>
-        </rule>
-        <rule>
-            <id>FileWrite</id>
-            <severity>OK</severity>
-            <score>2.1551020875</score>
-            <shortDescription>No long file write pauses were found in this recording (the longest was 172.408 ms).</shortDescription>
-            <longDescription>No long file write pauses were found in this recording (the longest was 172.408 ms).</longDescription>
-        </rule>
-        <rule>
-            <id>FlightRecordingSupport</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>The JVM version used for this recording has full Flight Recorder support.</shortDescription>
-            <longDescription>The JVM version used for this recording has full Flight Recorder support.</longDescription>
-        </rule>
-        <rule>
-            <id>FullGc</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule is only valid for CMS and G1 Garbage Collectors, neither of which were detected for this JVM.</shortDescription>
-            <longDescription>This rule is only valid for CMS and G1 Garbage Collectors, neither of which were detected for this JVM.</longDescription>
-        </rule>
-        <rule>
-            <id>GcFreedRatio</id>
-            <severity>OK</severity>
-            <score>1.4318707405222828</score>
-            <shortDescription>The ratio between memory freed by garbage collections per second and liveset is 0.5. This is likely a reasonable amount.</shortDescription>
-            <longDescription>61.4 MiB per second was freed by garbage collections for 10 s at 9/24/15 10:09:18 AM. This is 0.474 times the average liveset which was 130 MiB. This is likely a reasonable amount.</longDescription>
-        </rule>
-        <rule>
-            <id>GcLocker</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>No GCs were affected by the GC Locker.</shortDescription>
-            <longDescription>No GCs were affected by the GC Locker.</longDescription>
-        </rule>
-        <rule>
-            <id>GcOptions</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>No problems were found with the GC configuration.</shortDescription>
-            <longDescription>No problems were found with the GC configuration.</longDescription>
-        </rule>
-        <rule>
-            <id>GcPauseRatio</id>
-            <severity>OK</severity>
-            <score>11.083072308333335</score>
-            <shortDescription>Application efficiency was not highly affected by GC pauses.</shortDescription>
-            <longDescription>Application efficiency was not highly affected by GC pauses.&lt;p&gt;The highest ratio between garbage collection pauses and execution time was 2.217 % for 1 min at 9/24/15 10:08:56 AM. The garbage collection pause ratio of the entire recording was 1.882 %.</longDescription>
-        </rule>
-        <rule>
-            <id>GcStall</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>No indications that the garbage collector could not keep up with the workload were detected.</shortDescription>
-            <longDescription>No indications that the garbage collector could not keep up with the workload were detected.</longDescription>
-        </rule>
-        <rule>
-            <id>HeapContent</id>
-            <severity>Warning</severity>
-            <score>91.23973830878204</score>
-            <shortDescription>Most of the heap was used by only a few classes.</shortDescription>
-            <longDescription>Most of the heap was used by only a few classes. If the heap usage needs to be reduced, then this would be a good place to start.</longDescription>
-        </rule>
-        <rule>
-            <id>HeapInspectionGc</id>
-            <severity>Information</severity>
-            <score>59.77379177936154</score>
-            <shortDescription>The JVM performed 4 heap inspection garbage collections.</shortDescription>
-            <longDescription>The JVM performed 4 heap inspection garbage collections. Performing heap inspection garbage collections may be a problem since they usually take a lot of time.&lt;p&gt;Some of these inspections were caused by the 'Object Count' JFR event. It triggers a full garbage collection at the beginning and end of every recording where that event is enabled. If recordings are only made on demand or not too often, then these garbage collections are usually not a problem since the resulting pauses are not part of the normal application behavior. If recordings are collected often, for example by automatic scripts, or if the application is sensitive to pauses, then it might become an issue. In that case you can consider disabling the 'Object Count' event.</longDescription>
-        </rule>
-        <rule>
-            <id>HighGc</id>
-            <severity>Information</severity>
-            <score>72.91379413109293</score>
-            <shortDescription>The JVM was paused for 100 % of the 567.258 ms at 9/24/15 10:07:58 AM.</shortDescription>
-            <longDescription>The JVM was paused for 100 % of the 567.258 ms at 9/24/15 10:07:58 AM. The time spent performing garbage collection may be reduced by increasing the heap size or by trying to reduce allocation.</longDescription>
-        </rule>
-        <rule>
-            <id>HighJvmCpu</id>
-            <severity>OK</severity>
-            <score>13.536580012735357</score>
-            <shortDescription>The JVM does not seem to cause a lot of CPU load.</shortDescription>
-            <longDescription>The JVM does not seem to cause a lot of CPU load.</longDescription>
-        </rule>
-        <rule>
-            <id>IncreasingLiveSet</id>
-            <severity>Information</severity>
-            <score>58.89187525739308</score>
-            <shortDescription>The live set on the heap seems to increase with a speed of about 638 KiB per second during the recording.</shortDescription>
-            <longDescription>The live set on the heap seems to increase with a speed of about 638 KiB per second during the recording.&lt;p&gt;This may be due to a memory leak in the application or it may be an artifact of a short recording if the JVM has recently been started. The recording began 3.249 s after the JVM was started. More information can be gathered by using the Old Object Sample event, if available.</longDescription>
-        </rule>
-        <rule>
-            <id>IncreasingMetaSpaceLiveSet</id>
-            <severity>Information</severity>
-            <score>56.00212873123657</score>
-            <shortDescription>The class data seems to increase constantly in the metaspace during the recording.</shortDescription>
-            <longDescription>The class data seems to increase constantly in the metaspace during the recording. This behavior may indicate a memory leak in the metaspace, this could be due to the application not unloading classes as needed.</longDescription>
-        </rule>
-        <rule>
-            <id>JavaBlocking</id>
-            <severity>Information</severity>
-            <score>62.051706560483375</score>
-            <shortDescription>Threads in the application were blocked on locks for a total of 1 min 26 s.</shortDescription>
-            <longDescription>Threads in the application were blocked on locks for a total of 1 min 26 s. The most blocking monitor class was 'Logger', which was blocked 1,612 times for a total of 1 min 23 s.&lt;p&gt;The following regular expression was used to exclude threads from this rule: '(.*weblogic\.socket\.Muxer.*)'</longDescription>
-        </rule>
-        <rule>
-            <id>LongGcPause</id>
-            <severity>OK</severity>
-            <score>15.646056210732606</score>
-            <shortDescription>The longest GC pause was 576.207 ms.</shortDescription>
-            <longDescription>The longest GC pause was 576.207 ms.</longDescription>
-        </rule>
-        <rule>
-            <id>LowOnPhysicalMemory</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>The system did not run low on physical memory during this recording.</shortDescription>
-            <longDescription>The system did not run low on physical memory during this recording.</longDescription>
-        </rule>
-        <rule>
-            <id>ManagementAgent</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>No problems were found with the management agent settings.</shortDescription>
-            <longDescription>No problems were found with the management agent settings.</longDescription>
-        </rule>
-        <rule>
-            <id>ManyRunningProcesses</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'System Process'.</shortDescription>
-            <longDescription>The Competing Processes rule requires that the following event types are enabled: 'System Process'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>MetaspaceOom</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>The metaspace was not exhausted during this recording.</shortDescription>
-            <longDescription>The metaspace was not exhausted during this recording.</longDescription>
-        </rule>
-        <rule>
-            <id>MethodProfiling</id>
-            <severity>OK</severity>
-            <score>0.8005001984324781</score>
-            <shortDescription>No methods where optimization would be particularly efficient could be detected.</shortDescription>
-            <longDescription>No methods where optimization would be particularly efficient could be detected.</longDescription>
-        </rule>
-        <rule>
-            <id>Options</id>
-            <severity>Information</severity>
-            <score>74.0</score>
-            <shortDescription>Deprecated option flags were detected.</shortDescription>
-            <longDescription>The following option flags are or will be deprecated. Deprecated option flags should be avoided. In some cases they enable legacy code and in other cases they are ignored completely. They will usually be removed in a later Java release.&lt;ul&gt;&lt;li&gt;-XX:PermSize=128m: Ignored in Java 8 and removed in Java 9. PermGen was removed in JDK 8, since Java users should not need to know up front how much memory to reserve for class metadata etc. Just like in the JRockit and J9 JVMs, native memory is now used for class metadata, and it will dynamically grow as needed. The equivalent of java.lang.OutOfMemoryError: PermGen will be much harder to provoke. To influence when to start attempting to reclaim metaspace memory, check out the &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;MaxMetaspaceSize flag&lt;/a&gt;.&lt;/li&gt;&lt;li&gt;-XX:MaxPermSize=256m: Ignored in Java 8 and removed in Java 9. PermGen was removed in JDK 8, since Java users should not need to know up front how much memory to reserve for class metadata etc. Just like in the JRockit and J9 JVMs, native memory is now used for class metadata, and it will dynamically grow as needed. The equivalent of java.lang.OutOfMemoryError: PermGen will be much harder to provoke. To influence when to start attempting to reclaim metaspace memory, check out the &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;MaxMetaspaceSize flag&lt;/a&gt;.&lt;/li&gt;&lt;/ul&gt;</longDescription>
-        </rule>
-        <rule>
-            <id>OverAggressiveRecordingSetting</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>No problems were found with the recording settings.</shortDescription>
-            <longDescription>No problems were found with the recording settings.</longDescription>
-        </rule>
-        <rule>
-            <id>PasswordsInArguments</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>The recording does not seem to contain passwords in the application arguments.</shortDescription>
-            <longDescription>The recording does not seem to contain passwords in the application arguments.</longDescription>
-        </rule>
-        <rule>
-            <id>PasswordsInEnvironment</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires that the following event types are enabled: 'Initial Environment Variable'.</shortDescription>
-            <longDescription>The Passwords in Environment Variables rule requires that the following event types are enabled: 'Initial Environment Variable'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>PasswordsInSystemProperties</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>The recording does not seem to contain passwords in the system properties.</shortDescription>
-            <longDescription>The recording does not seem to contain passwords in the system properties.</longDescription>
-        </rule>
-        <rule>
-            <id>PrimitiveToObjectConversion</id>
-            <severity>OK</severity>
-            <score>0.11127751568911523</score>
-            <shortDescription>0 % of the total allocation (1.88 MiB) is caused by conversion from primitive types to object types. The most common object type that primitives are converted into is 'java.lang.Integer'.</shortDescription>
-            <longDescription>0 % of the total allocation (1.88 MiB) is caused by conversion from primitive types to object types.&lt;p&gt;The most common object type that primitives are converted into is 'java.lang.Integer', which causes 1.11 MiB to be allocated. The most common call site is 'weblogic.socket.NIOSocketMuxer$NIOOutputStream.initPool():887'.&lt;p&gt;Conversion from primitives to the corresponding object types can either be done explicitly, or be caused by autoboxing. If a considerable amount of the total allocation is caused by such conversions, consider changing the application source code to avoid this behavior. Look at the allocation stack traces to see which parts of the code to change. This rule finds the calls to the valueOf method for any of the eight object types that have primitive counterparts.</longDescription>
-        </rule>
-        <rule>
-            <id>SocketRead</id>
-            <severity>OK</severity>
-            <score>9.634721636363636</score>
-            <shortDescription>No long socket read pauses were found in this recording (the longest was 105.982 ms).</shortDescription>
-            <longDescription>No long socket read pauses were found in this recording (the longest was 105.982 ms).&lt;p&gt;Note that there are some socket read patterns with high duration reads that we consider to be normal and are therefore excluded. Such patterns include JMX RMI communication and MQ series.</longDescription>
-        </rule>
-        <rule>
-            <id>SocketWrite</id>
-            <severity>Information</severity>
-            <score>28.486599569171002</score>
-            <shortDescription>There are long socket write pauses in this recording (the longest is 349.745 ms).</shortDescription>
-            <longDescription>The longest recorded socket write took 349.745 ms to write 81 B to the host at 10.161.190.213. Note that there are some socket write patterns with high duration writes that we consider to be normal and are therefore excluded. Such patterns include JMX RMI communication.</longDescription>
-        </rule>
-        <rule>
-            <id>StackdepthSetting</id>
-            <severity>Warning</severity>
-            <score>99.99654514135385</score>
-            <shortDescription>Some stack traces were truncated in this recording.</shortDescription>
-            <longDescription>Some stack traces were truncated in this recording.&lt;p&gt;The Flight Recorder is configured with a maximum captured stack depth of 64. This is the default depth. 35.7 % of all traces were larger than this option, and were therefore truncated. If more detailed traces are required, increase the '-XX:FlightRecorderOptions=stackdepth=&amp;lt;value&amp;gt;' value.&lt;p&gt;Events of the following types have truncated stack traces:&lt;ul&gt;&lt;li&gt;Allocation in new TLAB (42.4 % truncated traces)&lt;/li&gt;&lt;li&gt;Class Load (42.8 % truncated traces)&lt;/li&gt;&lt;li&gt;Allocation outside TLAB (60.7 % truncated traces)&lt;/li&gt;&lt;li&gt;EJB Pool Manager Pre Invoke (47.1 % truncated traces)&lt;/li&gt;&lt;li&gt;EJB Business Method Invoke (47.1 % truncated traces)&lt;/li&gt;&lt;li&gt;EJB Business Method Post Invoke Cleanup (47.1 % truncated traces)&lt;/li&gt;&lt;li&gt;EJB Pool Manager Post Invoke (47.1 % truncated traces)&lt;/li&gt;&lt;li&gt;EJB Business Method Post Invoke (44.4 % truncated traces)&lt;/li&gt;&lt;li&gt;EJB Business Method Pre Invoke (44.4 % truncated traces)&lt;/li&gt;&lt;li&gt;Servlet Execute (26.2 % truncated traces)&lt;/li&gt;&lt;li&gt;Servlet Request Dispatch (45 % truncated traces)&lt;/li&gt;&lt;li&gt;Method Profiling Sample (24.3 % truncated traces)&lt;/li&gt;&lt;li&gt;JTA Transaction Start (80 % truncated traces)&lt;/li&gt;&lt;li&gt;JDBC Transaction Start (100 % truncated traces)&lt;/li&gt;&lt;li&gt;JDBC Statement Creation (54.4 % truncated traces)&lt;/li&gt;&lt;li&gt;JDBC Connection Prepare (54.4 % truncated traces)&lt;/li&gt;&lt;li&gt;JDBC Statement Execute (54.4 % truncated traces)&lt;/li&gt;&lt;li&gt;JDBC Statement Execute Begin (54.4 % truncated traces)&lt;/li&gt;&lt;li&gt;JDBC Connection Close (73 % truncated traces)&lt;/li&gt;&lt;li&gt;JTA Transaction End (51.5 % truncated traces)&lt;/li&gt;&lt;li&gt;JTA Transaction Commit (51 % truncated traces)&lt;/li&gt;&lt;li&gt;JDBC Connection Release (65 % truncated traces)&lt;/li&gt;&lt;li&gt;JDBC Transaction Commit (65 % truncated traces)&lt;/li&gt;&lt;li&gt;JDBC Transaction End (65.6 % truncated traces)&lt;/li&gt;&lt;li&gt;Socket Read (41.6 % truncated traces)&lt;/li&gt;&lt;li&gt;File Write (32.6 % truncated traces)&lt;/li&gt;&lt;li&gt;Java Error (29.1 % truncated traces)&lt;/li&gt;&lt;li&gt;Webservices JAXRPC Client Request (45.4 % truncated traces)&lt;/li&gt;&lt;li&gt;Webservices JAXRPC Client Response (100 % truncated traces)&lt;/li&gt;&lt;li&gt;Java Monitor Blocked (1.09 % truncated traces)&lt;/li&gt;&lt;li&gt;EJB PoolManager Create (32.7 % truncated traces)&lt;/li&gt;&lt;li&gt;Allocation Requiring GC (31.6 % truncated traces)&lt;/li&gt;&lt;li&gt;JDBC Transaction Is Same RM (6.59 % truncated traces)&lt;/li&gt;&lt;li&gt;Servlet Response Write Headers (0.753 % truncated traces)&lt;/li&gt;&lt;li&gt;Socket Write (20.6 % truncated traces)&lt;/li&gt;&lt;li&gt;Java Monitor Wait (0.134 % truncated traces)&lt;/li&gt;&lt;li&gt;File Read (100 % truncated traces)&lt;/li&gt;&lt;li&gt;Java Thread Sleep (33.3 % truncated traces)&lt;/li&gt;&lt;li&gt;Java Thread Park (0.223 % truncated traces)&lt;/li&gt;&lt;/ul&gt;</longDescription>
-        </rule>
-        <rule>
-            <id>StringDeduplication</id>
-            <severity>OK</severity>
-            <score>11.944505390960535</score>
-            <shortDescription>Approximately 17 % of the live set consists of the internal array type of strings ('char[]' for this JDK version).
+<report>
+<file>allocation_10s_before.jfr</file>
+<rule>
+<id>Allocations.class</id>
+<severity>Information</severity>
+<score>66.39548837411446</score>
+<shortDescription>The most allocated type is likely 'java.lang.Integer', most commonly allocated by: &lt;ul&gt;&lt;li&gt;Integer.valueOf(int) (100 %)&lt;/li&gt;&lt;li&gt;Allocator.go()&lt;/li&gt;&lt;li&gt;Allocator.main(String[])&lt;/li&gt;&lt;/ul&gt;</shortDescription>
+<longDescription>The most allocated type is likely 'java.lang.Integer', most commonly allocated by: &lt;ul&gt;&lt;li&gt;Integer.valueOf(int) (100 %)&lt;/li&gt;&lt;li&gt;Allocator.go()&lt;/li&gt;&lt;li&gt;Allocator.main(String[])&lt;/li&gt;&lt;/ul&gt;&lt;p&gt;Frequently allocated types are good places to start when trying to reduce garbage collections. Look at where the most common types are being allocated to see if many instances are created along the same call path. Try to reduce the number of instances created by invoking the most commonly taken paths less.</longDescription>
+</rule>
+<rule>
+<id>Allocations.thread</id>
+<severity>Information</severity>
+<score>66.40149861711905</score>
+<shortDescription>The most allocations were likely done by thread 'main' at: &lt;ul&gt;&lt;li&gt;Integer.valueOf(int) (100 %)&lt;/li&gt;&lt;li&gt;Allocator.go()&lt;/li&gt;&lt;li&gt;Allocator.main(String[])&lt;/li&gt;&lt;/ul&gt;</shortDescription>
+<longDescription>The most allocations were likely done by thread 'main' at: &lt;ul&gt;&lt;li&gt;Integer.valueOf(int) (100 %)&lt;/li&gt;&lt;li&gt;Allocator.go()&lt;/li&gt;&lt;li&gt;Allocator.main(String[])&lt;/li&gt;&lt;/ul&gt;&lt;p&gt;Many allocations performed by the same thread might indicate a problem in a multi-threaded program. Look at the stack traces for the thread with the highest allocation rate. See if the allocation rate can be brought down, or balanced among the active threads.</longDescription>
+</rule>
+<rule>
+<id>ApplicationHalts</id>
+<severity>OK</severity>
+<score>0.9591288888888891</score>
+<shortDescription>Application efficiency was not highly affected by halts.</shortDescription>
+<longDescription>Application efficiency was not highly affected by halts.&lt;p&gt;The highest ratio of application halts to execution time was 0.192 % for 1 min at 4/26/18 12:10:29 PM. 28.068 % of the halts were for reasons other than GC.&lt;p&gt;The halts ratio for the entire recording was 1.162 %. 28.068 % of the total halts were for reasons other than GC.&lt;/p&gt;</longDescription>
+</rule>
+<rule>
+<id>BufferLost</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>No Flight Recorder buffers were lost during the recording.</shortDescription>
+<longDescription>No Flight Recorder buffers were lost during the recording.</longDescription>
+</rule>
+<rule>
+<id>BytecodeVerification</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>The application ran with bytecode verification enabled.</shortDescription>
+<longDescription>The application ran with bytecode verification enabled.</longDescription>
+</rule>
+<rule>
+<id>ClassLeak</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'Class Load', 'Class Unload'.</shortDescription>
+<longDescription>The Class Leak rule requires that the following event types are enabled: 'Class Load', 'Class Unload'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>ClassLoading</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'Class Load'.</shortDescription>
+<longDescription>The Class Loading Pressure rule requires that the following event types are enabled: 'Class Load'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>CodeCache</id>
+<severity>OK</severity>
+<score>21.736190753325</score>
+<shortDescription>No problems with the code cache were detected in the recording.</shortDescription>
+<longDescription>No problems with the code cache were detected in the recording.</longDescription>
+</rule>
+<rule>
+<id>CompareCpu</id>
+<severity>OK</severity>
+<score>0.05434774741663761</score>
+<shortDescription>An average CPU load of 1 % was caused by other processes for 1.027 s at 4/26/18 12:10:33 PM.</shortDescription>
+<longDescription>An average CPU load of 1 % was caused by other processes for 1.027 s at 4/26/18 12:10:33 PM.</longDescription>
+</rule>
+<rule>
+<id>CompressedOops</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>The settings for Compressed Oops were OK.</shortDescription>
+<longDescription>The settings for Compressed Oops were OK.</longDescription>
+</rule>
+<rule>
+<id>ContextSwitch</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires events to be available from the following event types: 'Thread Context Switch Rate'.</shortDescription>
+<longDescription>The Context Switches rule requires events to be available from the following event types: 'Thread Context Switch Rate'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>DMSIncident</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>The DMS Incidents rule requires the following event types: 'http://www.oracle.com/dms/dfw/dms/dfw/DFW_Incident/DFW_Incident_state'.</shortDescription>
+<longDescription>The DMS Incidents rule requires the following event types: 'http://www.oracle.com/dms/dfw/dms/dfw/DFW_Incident/DFW_Incident_state'.&lt;p&gt;They are either not available in this version of Java, or must be enabled in a third-party component. If you are using an older Java version, then you can consider upgrading.</longDescription>
+</rule>
+<rule>
+<id>DebugNonSafepoints</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>DebugNonSafepoints was implicitly enabled in the JVM version used to create this recording.</shortDescription>
+<longDescription>DebugNonSafepoints was implicitly enabled in the JVM version used to create this recording.</longDescription>
+</rule>
+<rule>
+<id>DiscouragedVmOptions</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>No problems were found with the VM options.</shortDescription>
+<longDescription>No problems were found with the VM options.</longDescription>
+</rule>
+<rule>
+<id>DumpReason</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>This recording was not dumped for an exceptional reason.</shortDescription>
+<longDescription>This recording was not dumped for an exceptional reason.</longDescription>
+</rule>
+<rule>
+<id>DuplicateFlags</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>There were no duplicate JVM flags on the command line.</shortDescription>
+<longDescription>There were no duplicate JVM flags on the command line.</longDescription>
+</rule>
+<rule>
+<id>Errors</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires events to be available from the following event types: 'Java Error'.</shortDescription>
+<longDescription>The Thrown Errors rule requires events to be available from the following event types: 'Java Error'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>Exceptions</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>The program generated 0 exceptions per second for 1.017 s at 4/26/18 12:10:30 PM.</shortDescription>
+<longDescription>The program generated 0 exceptions per second for 1.017 s at 4/26/18 12:10:30 PM.</longDescription>
+</rule>
+<rule>
+<id>Fatal Errors</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>The Fatal Errors rule requires the following event types: 'jdk.Shutdown'.</shortDescription>
+<longDescription>The Fatal Errors rule requires the following event types: 'jdk.Shutdown'.&lt;p&gt;They are either not available in this version of Java, or must be enabled in a third-party component. If you are using an older Java version, then you can consider upgrading.</longDescription>
+</rule>
+<rule>
+<id>FewSampledThreads</id>
+<severity>Information</severity>
+<score>29.510744962334375</score>
+<shortDescription>There are fewer sampled threads than the total number of hardware threads (cores).</shortDescription>
+<longDescription>There are fewer sampled threads than the total number of hardware threads (cores).&lt;p&gt;1 threads with at least 4 method samples were found, but the machine has 32 hardware threads (cores). The application might benefit from a higher level of parallelism. This could also be caused by threads doing something else than running Java code, for example running native code or spending time in the JVM internals.&lt;p&gt;This recording is only 9.903 s long, consider creating a recording longer than 20 s for improved rule accuracy.</longDescription>
+</rule>
+<rule>
+<id>FileRead</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>There are no file read events in this recording.</shortDescription>
+<longDescription>There are no file read events in this recording.</longDescription>
+</rule>
+<rule>
+<id>FileWrite</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires events to be available from the following event types: 'File Write'.</shortDescription>
+<longDescription>The File Write Peak Duration rule requires events to be available from the following event types: 'File Write'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>FlightRecordingSupport</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>The JVM version used for this recording has full Flight Recorder support.</shortDescription>
+<longDescription>The JVM version used for this recording has full Flight Recorder support.</longDescription>
+</rule>
+<rule>
+<id>FullGc</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>No Stop-the-World, Full GC events detected.</shortDescription>
+<longDescription>No Stop-the-World, Full GC events detected.</longDescription>
+</rule>
+<rule>
+<id>GcFreedRatio</id>
+<severity>Information</severity>
+<score>34.4635049904725</score>
+<shortDescription>The ratio between memory freed by garbage collections per second and liveset is 65. This may be excessive.</shortDescription>
+<longDescription>242 MiB per second was freed by garbage collections for 10 s at 4/26/18 12:10:29 PM. This is 65.013 times the average liveset which was 3.72 MiB. This may be excessive.&lt;p&gt;If the garbage collector can free a lot of memory, it may be because the application allocates a lot of short lived objects. Investigate the allocation stack traces to see which code paths cause the most allocations, and see if they can be reduced.&lt;p&gt;This recording is only 9.903 s long, consider creating a recording longer than 20 s for improved rule accuracy.</longDescription>
+</rule>
+<rule>
+<id>GcLocker</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>No GCs were affected by the GC Locker.</shortDescription>
+<longDescription>No GCs were affected by the GC Locker.</longDescription>
+</rule>
+<rule>
+<id>GcOptions</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>No problems were found with the GC configuration.</shortDescription>
+<longDescription>No problems were found with the GC configuration.</longDescription>
+</rule>
+<rule>
+<id>GcPauseRatio</id>
+<severity>OK</severity>
+<score>0.6899182222222222</score>
+<shortDescription>Application efficiency was not highly affected by GC pauses.</shortDescription>
+<longDescription>Application efficiency was not highly affected by GC pauses.&lt;p&gt;The highest ratio between garbage collection pauses and execution time was 0.138 % for 1 min at 4/26/18 12:10:29 PM. The garbage collection pause ratio of the entire recording was 0.836 %.</longDescription>
+</rule>
+<rule>
+<id>GcStall</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>No indications that the garbage collector could not keep up with the workload were detected.</shortDescription>
+<longDescription>No indications that the garbage collector could not keep up with the workload were detected.</longDescription>
+</rule>
+<rule>
+<id>HeapContent</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'Object Count'.</shortDescription>
+<longDescription>The Heap Content rule requires that the following event types are enabled: 'Object Count'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>HeapInspectionGc</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>The JVM did not perform any heap inspection GCs.</shortDescription>
+<longDescription>The JVM did not perform any heap inspection GCs. This is good since they usually take a lot of time.</longDescription>
+</rule>
+<rule>
+<id>HighGc</id>
+<severity>OK</severity>
+<score>2.5016205991264973</score>
+<shortDescription>The JVM was paused for 100 % of the 11.003 ms at 4/26/18 12:10:36 PM.</shortDescription>
+<longDescription>The JVM was paused for 100 % of the 11.003 ms at 4/26/18 12:10:36 PM. The time spent performing garbage collection may be reduced by increasing the heap size or by trying to reduce allocation.</longDescription>
+</rule>
+<rule>
+<id>HighJvmCpu</id>
+<severity>OK</severity>
+<score>1.3537208124606583</score>
+<shortDescription>The JVM does not seem to cause a lot of CPU load.</shortDescription>
+<longDescription>The JVM does not seem to cause a lot of CPU load.</longDescription>
+</rule>
+<rule>
+<id>IncreasingLiveSet</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>No memory leaks were detected.</shortDescription>
+<longDescription>No memory leaks were detected.</longDescription>
+</rule>
+<rule>
+<id>IncreasingMetaSpaceLiveSet</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>The class data does not seem to increase during the recording.</shortDescription>
+<longDescription>The class data does not seem to increase during the recording.</longDescription>
+</rule>
+<rule>
+<id>JavaBlocking</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires events to be available from the following event types: 'Java Monitor Blocked'.</shortDescription>
+<longDescription>The Java Blocking rule requires events to be available from the following event types: 'Java Monitor Blocked'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>LongGcPause</id>
+<severity>OK</severity>
+<score>0.3348866229800136</score>
+<shortDescription>The longest GC pause was 11.003 ms.</shortDescription>
+<longDescription>The longest GC pause was 11.003 ms.</longDescription>
+</rule>
+<rule>
+<id>LowOnPhysicalMemory</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>The system did not run low on physical memory during this recording.</shortDescription>
+<longDescription>The system did not run low on physical memory during this recording.</longDescription>
+</rule>
+<rule>
+<id>ManagementAgent</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'Initial System Property'.</shortDescription>
+<longDescription>The Discouraged Management Agent Settings rule requires that the following event types are enabled: 'Initial System Property'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>ManyRunningProcesses</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'System Process'.</shortDescription>
+<longDescription>The Competing Processes rule requires that the following event types are enabled: 'System Process'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>MetaspaceOom</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>The metaspace was not exhausted during this recording.</shortDescription>
+<longDescription>The metaspace was not exhausted during this recording.</longDescription>
+</rule>
+<rule>
+<id>MethodProfiling</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>No methods where optimization would be particularly efficient could be detected.</shortDescription>
+<longDescription>No methods where optimization would be particularly efficient could be detected.</longDescription>
+</rule>
+<rule>
+<id>Options</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>No undocumented, deprecated or non-recommended option flags were detected.</shortDescription>
+<longDescription>No undocumented, deprecated or non-recommended option flags were detected.</longDescription>
+</rule>
+<rule>
+<id>OverAggressiveRecordingSetting</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'Initial System Property'.</shortDescription>
+<longDescription>The Discouraged Recording Settings rule requires that the following event types are enabled: 'Initial System Property'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>PasswordsInArguments</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>The recording does not seem to contain passwords in the application arguments.</shortDescription>
+<longDescription>The recording does not seem to contain passwords in the application arguments.</longDescription>
+</rule>
+<rule>
+<id>PasswordsInEnvironment</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'Initial Environment Variable'.</shortDescription>
+<longDescription>The Passwords in Environment Variables rule requires that the following event types are enabled: 'Initial Environment Variable'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>PasswordsInSystemProperties</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'Initial System Property'.</shortDescription>
+<longDescription>The Passwords in System Properties rule requires that the following event types are enabled: 'Initial System Property'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>PrimitiveToObjectConversion</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires events to be available from the following event types: 'Allocation in new TLAB', 'Allocation outside TLAB'.</shortDescription>
+<longDescription>The Primitive To Object Conversion rule requires events to be available from the following event types: 'Allocation in new TLAB', 'Allocation outside TLAB'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>SocketRead</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires events to be available from the following event types: 'Socket Read'.</shortDescription>
+<longDescription>The Socket Read Peak Duration rule requires events to be available from the following event types: 'Socket Read'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>SocketWrite</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires events to be available from the following event types: 'Socket Write'.</shortDescription>
+<longDescription>The Socket Write Peak Duration rule requires events to be available from the following event types: 'Socket Write'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>StackdepthSetting</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>No stack traces were truncated in this recording.</shortDescription>
+<longDescription>No stack traces were truncated in this recording.</longDescription>
+</rule>
+<rule>
+<id>StringDeduplication</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>Found no allocation events for the internal arrays in strings. Either the frame filter preference is incorrectly defined, or the stackTrace attribute is not enabled for the allocation events.</shortDescription>
+<longDescription>Found no allocation events for the internal arrays in strings. Either the frame filter preference is incorrectly defined, or the stackTrace attribute is not enabled for the allocation events.</longDescription>
+</rule>
+<rule>
+<id>SystemGc</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>No garbage collections were caused by System.gc().</shortDescription>
+<longDescription>No garbage collections were caused by System.gc().</longDescription>
+</rule>
+<rule>
+<id>TlabAllocationRatio</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>No object allocations outside of TLABs detected.</shortDescription>
+<longDescription>No object allocations outside of TLABs detected.</longDescription>
+</rule>
+<rule>
+<id>VMOperations</id>
+<severity>OK</severity>
+<score>0.75795475</score>
+<shortDescription>No excessively long VM operations were found in this recording (the longest was 30.318 ms).</shortDescription>
+<longDescription>No excessively long VM operations were found in this recording (the longest was 30.318 ms).</longDescription>
+</rule>
+<rule>
+<id>biasedLockingRevocation</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>The Biased Locking Revocation rule requires the following event types: 'jdk.BiasedLockClassRevocation'.</shortDescription>
+<longDescription>The Biased Locking Revocation rule requires the following event types: 'jdk.BiasedLockClassRevocation'.&lt;p&gt;They are either not available in this version of Java, or must be enabled in a third-party component. If you are using an older Java version, then you can consider upgrading.</longDescription>
+</rule>
+<rule>
+<id>biasedLockingRevocationPause</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>No revocation of biased locks found.</shortDescription>
+<longDescription>No revocation of biased locks found.</longDescription>
+</rule>
+</report>
+<report>
+<file>allocation_10s_fixed.jfr</file>
+<rule>
+<id>Allocations.class</id>
+<severity>OK</severity>
+<score>0.06321740358971492</score>
+<shortDescription>The most allocated type is likely 'java.util.HashMap$ValueIterator', most commonly allocated by: &lt;ul&gt;&lt;li&gt;HashMap$Values.iterator() (100 %)&lt;/li&gt;&lt;li&gt;Allocator.go()&lt;/li&gt;&lt;li&gt;Allocator.main(String[])&lt;/li&gt;&lt;/ul&gt;</shortDescription>
+<longDescription>The most allocated type is likely 'java.util.HashMap$ValueIterator', most commonly allocated by: &lt;ul&gt;&lt;li&gt;HashMap$Values.iterator() (100 %)&lt;/li&gt;&lt;li&gt;Allocator.go()&lt;/li&gt;&lt;li&gt;Allocator.main(String[])&lt;/li&gt;&lt;/ul&gt;&lt;p&gt;Frequently allocated types are good places to start when trying to reduce garbage collections. Look at where the most common types are being allocated to see if many instances are created along the same call path. Try to reduce the number of instances created by invoking the most commonly taken paths less.</longDescription>
+</rule>
+<rule>
+<id>Allocations.thread</id>
+<severity>OK</severity>
+<score>0.06321740358971492</score>
+<shortDescription>The most allocations were likely done by thread 'main' at: &lt;ul&gt;&lt;li&gt;HashMap$Values.iterator() (100 %)&lt;/li&gt;&lt;li&gt;Allocator.go()&lt;/li&gt;&lt;li&gt;Allocator.main(String[])&lt;/li&gt;&lt;/ul&gt;</shortDescription>
+<longDescription>The most allocations were likely done by thread 'main' at: &lt;ul&gt;&lt;li&gt;HashMap$Values.iterator() (100 %)&lt;/li&gt;&lt;li&gt;Allocator.go()&lt;/li&gt;&lt;li&gt;Allocator.main(String[])&lt;/li&gt;&lt;/ul&gt;&lt;p&gt;Many allocations performed by the same thread might indicate a problem in a multi-threaded program. Look at the stack traces for the thread with the highest allocation rate. See if the allocation rate can be brought down, or balanced among the active threads.</longDescription>
+</rule>
+<rule>
+<id>ApplicationHalts</id>
+<severity>OK</severity>
+<score>0.15440711111111113</score>
+<shortDescription>Application efficiency was not highly affected by halts.</shortDescription>
+<longDescription>Application efficiency was not highly affected by halts.&lt;p&gt;The highest ratio of application halts to execution time was 0.031 % for 1 min at 4/26/18 12:12:46 PM. 100 % of the halts were for reasons other than GC.&lt;p&gt;The halts ratio for the entire recording was 0.187 %. 100 % of the total halts were for reasons other than GC.&lt;/p&gt;</longDescription>
+</rule>
+<rule>
+<id>BufferLost</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>No Flight Recorder buffers were lost during the recording.</shortDescription>
+<longDescription>No Flight Recorder buffers were lost during the recording.</longDescription>
+</rule>
+<rule>
+<id>BytecodeVerification</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>The application ran with bytecode verification enabled.</shortDescription>
+<longDescription>The application ran with bytecode verification enabled.</longDescription>
+</rule>
+<rule>
+<id>ClassLeak</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'Class Load', 'Class Unload'.</shortDescription>
+<longDescription>The Class Leak rule requires that the following event types are enabled: 'Class Load', 'Class Unload'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>ClassLoading</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'Class Load'.</shortDescription>
+<longDescription>The Class Loading Pressure rule requires that the following event types are enabled: 'Class Load'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>CodeCache</id>
+<severity>OK</severity>
+<score>21.808180522170357</score>
+<shortDescription>No problems with the code cache were detected in the recording.</shortDescription>
+<longDescription>No problems with the code cache were detected in the recording.</longDescription>
+</rule>
+<rule>
+<id>CompareCpu</id>
+<severity>OK</severity>
+<score>0.9473864515664224</score>
+<shortDescription>An average CPU load of 7 % was caused by other processes for 1.212 s at 4/26/18 12:12:47 PM.</shortDescription>
+<longDescription>An average CPU load of 7 % was caused by other processes for 1.212 s at 4/26/18 12:12:47 PM.</longDescription>
+</rule>
+<rule>
+<id>CompressedOops</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>The settings for Compressed Oops were OK.</shortDescription>
+<longDescription>The settings for Compressed Oops were OK.</longDescription>
+</rule>
+<rule>
+<id>ContextSwitch</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires events to be available from the following event types: 'Thread Context Switch Rate'.</shortDescription>
+<longDescription>The Context Switches rule requires events to be available from the following event types: 'Thread Context Switch Rate'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>DMSIncident</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>The DMS Incidents rule requires the following event types: 'http://www.oracle.com/dms/dfw/dms/dfw/DFW_Incident/DFW_Incident_state'.</shortDescription>
+<longDescription>The DMS Incidents rule requires the following event types: 'http://www.oracle.com/dms/dfw/dms/dfw/DFW_Incident/DFW_Incident_state'.&lt;p&gt;They are either not available in this version of Java, or must be enabled in a third-party component. If you are using an older Java version, then you can consider upgrading.</longDescription>
+</rule>
+<rule>
+<id>DebugNonSafepoints</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>DebugNonSafepoints was implicitly enabled in the JVM version used to create this recording.</shortDescription>
+<longDescription>DebugNonSafepoints was implicitly enabled in the JVM version used to create this recording.</longDescription>
+</rule>
+<rule>
+<id>DiscouragedVmOptions</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>No problems were found with the VM options.</shortDescription>
+<longDescription>No problems were found with the VM options.</longDescription>
+</rule>
+<rule>
+<id>DumpReason</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>This recording was not dumped for an exceptional reason.</shortDescription>
+<longDescription>This recording was not dumped for an exceptional reason.</longDescription>
+</rule>
+<rule>
+<id>DuplicateFlags</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>There were no duplicate JVM flags on the command line.</shortDescription>
+<longDescription>There were no duplicate JVM flags on the command line.</longDescription>
+</rule>
+<rule>
+<id>Errors</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires events to be available from the following event types: 'Java Error'.</shortDescription>
+<longDescription>The Thrown Errors rule requires events to be available from the following event types: 'Java Error'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>Exceptions</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>The program generated 0 exceptions per second for 1.210 s at 4/26/18 12:12:47 PM.</shortDescription>
+<longDescription>The program generated 0 exceptions per second for 1.210 s at 4/26/18 12:12:47 PM.</longDescription>
+</rule>
+<rule>
+<id>Fatal Errors</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>The Fatal Errors rule requires the following event types: 'jdk.Shutdown'.</shortDescription>
+<longDescription>The Fatal Errors rule requires the following event types: 'jdk.Shutdown'.&lt;p&gt;They are either not available in this version of Java, or must be enabled in a third-party component. If you are using an older Java version, then you can consider upgrading.</longDescription>
+</rule>
+<rule>
+<id>FewSampledThreads</id>
+<severity>Information</severity>
+<score>29.510744962334375</score>
+<shortDescription>There are fewer sampled threads than the total number of hardware threads (cores).</shortDescription>
+<longDescription>There are fewer sampled threads than the total number of hardware threads (cores).&lt;p&gt;1 threads with at least 4 method samples were found, but the machine has 32 hardware threads (cores). The application might benefit from a higher level of parallelism. This could also be caused by threads doing something else than running Java code, for example running native code or spending time in the JVM internals.&lt;p&gt;This recording is only 9.921 s long, consider creating a recording longer than 20 s for improved rule accuracy.</longDescription>
+</rule>
+<rule>
+<id>FileRead</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>There are no file read events in this recording.</shortDescription>
+<longDescription>There are no file read events in this recording.</longDescription>
+</rule>
+<rule>
+<id>FileWrite</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires events to be available from the following event types: 'File Write'.</shortDescription>
+<longDescription>The File Write Peak Duration rule requires events to be available from the following event types: 'File Write'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>FlightRecordingSupport</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>The JVM version used for this recording has full Flight Recorder support.</shortDescription>
+<longDescription>The JVM version used for this recording has full Flight Recorder support.</longDescription>
+</rule>
+<rule>
+<id>FullGc</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires events to be available from the following event types: 'Garbage Collection'.</shortDescription>
+<longDescription>The G1/CMS Full Collection rule requires events to be available from the following event types: 'Garbage Collection'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>GcFreedRatio</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>Only 0 heap summary events were found, this rule requires at least 10 events to be able to calculate a relevant result. This likely means that only a few garbage collections occurred during the recording. Having few garbage collections is generally a good sign.</shortDescription>
+<longDescription>Only 0 heap summary events were found, this rule requires at least 10 events to be able to calculate a relevant result. This likely means that only a few garbage collections occurred during the recording. Having few garbage collections is generally a good sign.</longDescription>
+</rule>
+<rule>
+<id>GcLocker</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>No GCs were affected by the GC Locker.</shortDescription>
+<longDescription>No GCs were affected by the GC Locker.</longDescription>
+</rule>
+<rule>
+<id>GcOptions</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>No problems were found with the GC configuration.</shortDescription>
+<longDescription>No problems were found with the GC configuration.</longDescription>
+</rule>
+<rule>
+<id>GcPauseRatio</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>Application efficiency was not highly affected by GC pauses.</shortDescription>
+<longDescription>Application efficiency was not highly affected by GC pauses.&lt;p&gt;The highest ratio between garbage collection pauses and execution time was 0 % for 1 min at 4/26/18 12:12:46 PM. The garbage collection pause ratio of the entire recording was 0 %.</longDescription>
+</rule>
+<rule>
+<id>GcStall</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>No indications that the garbage collector could not keep up with the workload were detected.</shortDescription>
+<longDescription>No indications that the garbage collector could not keep up with the workload were detected.</longDescription>
+</rule>
+<rule>
+<id>HeapContent</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'Object Count'.</shortDescription>
+<longDescription>The Heap Content rule requires that the following event types are enabled: 'Object Count'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>HeapInspectionGc</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires events to be available from the following event types: 'Garbage Collection'.</shortDescription>
+<longDescription>The GCs Caused by Heap Inspection rule requires events to be available from the following event types: 'Garbage Collection'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>HighGc</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>The runtime did not spend much time performing garbage collections.</shortDescription>
+<longDescription>The runtime did not spend much time performing garbage collections.</longDescription>
+</rule>
+<rule>
+<id>HighJvmCpu</id>
+<severity>OK</severity>
+<score>1.193150385433165</score>
+<shortDescription>The JVM does not seem to cause a lot of CPU load.</shortDescription>
+<longDescription>The JVM does not seem to cause a lot of CPU load.</longDescription>
+</rule>
+<rule>
+<id>IncreasingLiveSet</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>Too few events to calculate the result.</shortDescription>
+<longDescription>Too few events to calculate the result.</longDescription>
+</rule>
+<rule>
+<id>IncreasingMetaSpaceLiveSet</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>The class data does not seem to increase during the recording.</shortDescription>
+<longDescription>The class data does not seem to increase during the recording.</longDescription>
+</rule>
+<rule>
+<id>JavaBlocking</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires events to be available from the following event types: 'Java Monitor Blocked'.</shortDescription>
+<longDescription>The Java Blocking rule requires events to be available from the following event types: 'Java Monitor Blocked'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>LongGcPause</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>The application did not cause any long GC pause times.</shortDescription>
+<longDescription>The application did not cause any long GC pause times.</longDescription>
+</rule>
+<rule>
+<id>LowOnPhysicalMemory</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>The system did not run low on physical memory during this recording.</shortDescription>
+<longDescription>The system did not run low on physical memory during this recording.</longDescription>
+</rule>
+<rule>
+<id>ManagementAgent</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'Initial System Property'.</shortDescription>
+<longDescription>The Discouraged Management Agent Settings rule requires that the following event types are enabled: 'Initial System Property'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>ManyRunningProcesses</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'System Process'.</shortDescription>
+<longDescription>The Competing Processes rule requires that the following event types are enabled: 'System Process'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>MetaspaceOom</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>The metaspace was not exhausted during this recording.</shortDescription>
+<longDescription>The metaspace was not exhausted during this recording.</longDescription>
+</rule>
+<rule>
+<id>MethodProfiling</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>No methods where optimization would be particularly efficient could be detected.</shortDescription>
+<longDescription>No methods where optimization would be particularly efficient could be detected.</longDescription>
+</rule>
+<rule>
+<id>Options</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>No undocumented, deprecated or non-recommended option flags were detected.</shortDescription>
+<longDescription>No undocumented, deprecated or non-recommended option flags were detected.</longDescription>
+</rule>
+<rule>
+<id>OverAggressiveRecordingSetting</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'Initial System Property'.</shortDescription>
+<longDescription>The Discouraged Recording Settings rule requires that the following event types are enabled: 'Initial System Property'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>PasswordsInArguments</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>The recording does not seem to contain passwords in the application arguments.</shortDescription>
+<longDescription>The recording does not seem to contain passwords in the application arguments.</longDescription>
+</rule>
+<rule>
+<id>PasswordsInEnvironment</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'Initial Environment Variable'.</shortDescription>
+<longDescription>The Passwords in Environment Variables rule requires that the following event types are enabled: 'Initial Environment Variable'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>PasswordsInSystemProperties</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'Initial System Property'.</shortDescription>
+<longDescription>The Passwords in System Properties rule requires that the following event types are enabled: 'Initial System Property'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>PrimitiveToObjectConversion</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires events to be available from the following event types: 'Allocation in new TLAB', 'Allocation outside TLAB'.</shortDescription>
+<longDescription>The Primitive To Object Conversion rule requires events to be available from the following event types: 'Allocation in new TLAB', 'Allocation outside TLAB'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>SocketRead</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires events to be available from the following event types: 'Socket Read'.</shortDescription>
+<longDescription>The Socket Read Peak Duration rule requires events to be available from the following event types: 'Socket Read'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>SocketWrite</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires events to be available from the following event types: 'Socket Write'.</shortDescription>
+<longDescription>The Socket Write Peak Duration rule requires events to be available from the following event types: 'Socket Write'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>StackdepthSetting</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>No stack traces were truncated in this recording.</shortDescription>
+<longDescription>No stack traces were truncated in this recording.</longDescription>
+</rule>
+<rule>
+<id>StringDeduplication</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires events to be available from the following event types: 'Heap Summary'.</shortDescription>
+<longDescription>The String Deduplication rule requires events to be available from the following event types: 'Heap Summary'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>SystemGc</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires events to be available from the following event types: 'Garbage Collection'.</shortDescription>
+<longDescription>The GCs Caused by System.gc() rule requires events to be available from the following event types: 'Garbage Collection'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>TlabAllocationRatio</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>No object allocations outside of TLABs detected.</shortDescription>
+<longDescription>No object allocations outside of TLABs detected.</longDescription>
+</rule>
+<rule>
+<id>VMOperations</id>
+<severity>OK</severity>
+<score>0.44893575</score>
+<shortDescription>No excessively long VM operations were found in this recording (the longest was 17.957 ms).</shortDescription>
+<longDescription>No excessively long VM operations were found in this recording (the longest was 17.957 ms).</longDescription>
+</rule>
+<rule>
+<id>biasedLockingRevocation</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>The Biased Locking Revocation rule requires the following event types: 'jdk.BiasedLockClassRevocation'.</shortDescription>
+<longDescription>The Biased Locking Revocation rule requires the following event types: 'jdk.BiasedLockClassRevocation'.&lt;p&gt;They are either not available in this version of Java, or must be enabled in a third-party component. If you are using an older Java version, then you can consider upgrading.</longDescription>
+</rule>
+<rule>
+<id>biasedLockingRevocationPause</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>No revocation of biased locks found.</shortDescription>
+<longDescription>No revocation of biased locks found.</longDescription>
+</rule>
+</report>
+<report>
+<file>crash_jdk9.jfr</file>
+<rule>
+<id>Allocations.class</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'Allocation in new TLAB', 'Allocation outside TLAB'.</shortDescription>
+<longDescription>The Allocated Classes rule requires that the following event types are enabled: 'Allocation in new TLAB', 'Allocation outside TLAB'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>Allocations.thread</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'Allocation in new TLAB', 'Allocation outside TLAB'.</shortDescription>
+<longDescription>The Threads Allocating rule requires that the following event types are enabled: 'Allocation in new TLAB', 'Allocation outside TLAB'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>ApplicationHalts</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>Application efficiency was not highly affected by halts.</shortDescription>
+<longDescription>Application efficiency was not highly affected by halts.&lt;p&gt;The highest ratio of application halts to execution time was 0 % for 1 min at 4/24/18 10:16:27 AM. 0 % of the halts were for reasons other than GC.&lt;p&gt;The halts ratio for the entire recording was 0 %. 0 % of the total halts were for reasons other than GC.&lt;/p&gt;</longDescription>
+</rule>
+<rule>
+<id>BufferLost</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>No Flight Recorder buffers were lost during the recording.</shortDescription>
+<longDescription>No Flight Recorder buffers were lost during the recording.</longDescription>
+</rule>
+<rule>
+<id>BytecodeVerification</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>The application ran with bytecode verification enabled.</shortDescription>
+<longDescription>The application ran with bytecode verification enabled.</longDescription>
+</rule>
+<rule>
+<id>ClassLeak</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'Class Load', 'Class Unload'.</shortDescription>
+<longDescription>The Class Leak rule requires that the following event types are enabled: 'Class Load', 'Class Unload'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>ClassLoading</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'Class Load'.</shortDescription>
+<longDescription>The Class Loading Pressure rule requires that the following event types are enabled: 'Class Load'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>CodeCache</id>
+<severity>OK</severity>
+<score>21.686110914128236</score>
+<shortDescription>No problems with the code cache were detected in the recording.</shortDescription>
+<longDescription>No problems with the code cache were detected in the recording.</longDescription>
+</rule>
+<rule>
+<id>CompareCpu</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires events to be available from the following event types: 'CPU Load'.</shortDescription>
+<longDescription>The Competing CPU Ratio Usage rule requires events to be available from the following event types: 'CPU Load'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>CompressedOops</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>The settings for Compressed Oops were OK.</shortDescription>
+<longDescription>The settings for Compressed Oops were OK.</longDescription>
+</rule>
+<rule>
+<id>ContextSwitch</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires events to be available from the following event types: 'Thread Context Switch Rate'.</shortDescription>
+<longDescription>The Context Switches rule requires events to be available from the following event types: 'Thread Context Switch Rate'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>DMSIncident</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>The DMS Incidents rule requires the following event types: 'http://www.oracle.com/dms/dfw/dms/dfw/DFW_Incident/DFW_Incident_state'.</shortDescription>
+<longDescription>The DMS Incidents rule requires the following event types: 'http://www.oracle.com/dms/dfw/dms/dfw/DFW_Incident/DFW_Incident_state'.&lt;p&gt;They are either not available in this version of Java, or must be enabled in a third-party component. If you are using an older Java version, then you can consider upgrading.</longDescription>
+</rule>
+<rule>
+<id>DebugNonSafepoints</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>DebugNonSafepoints was implicitly enabled in the JVM version used to create this recording.</shortDescription>
+<longDescription>DebugNonSafepoints was implicitly enabled in the JVM version used to create this recording.</longDescription>
+</rule>
+<rule>
+<id>DiscouragedVmOptions</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>No problems were found with the VM options.</shortDescription>
+<longDescription>No problems were found with the VM options.</longDescription>
+</rule>
+<rule>
+<id>DumpReason</id>
+<severity>Warning</severity>
+<score>100.0</score>
+<shortDescription>This recording was dumped for an exceptional reason.</shortDescription>
+<longDescription>Recording was dumped due to a JVM crash. Some events are likely missing from the end of the recording.</longDescription>
+</rule>
+<rule>
+<id>DuplicateFlags</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>There were no duplicate JVM flags on the command line.</shortDescription>
+<longDescription>There were no duplicate JVM flags on the command line.</longDescription>
+</rule>
+<rule>
+<id>Errors</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires events to be available from the following event types: 'Java Error'.</shortDescription>
+<longDescription>The Thrown Errors rule requires events to be available from the following event types: 'Java Error'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>Exceptions</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires events to be available from the following event types: 'Exception Statistics'.</shortDescription>
+<longDescription>The Thrown Exceptions rule requires events to be available from the following event types: 'Exception Statistics'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>Fatal Errors</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>The Fatal Errors rule requires the following event types: 'jdk.Shutdown'.</shortDescription>
+<longDescription>The Fatal Errors rule requires the following event types: 'jdk.Shutdown'.&lt;p&gt;They are either not available in this version of Java, or must be enabled in a third-party component. If you are using an older Java version, then you can consider upgrading.</longDescription>
+</rule>
+<rule>
+<id>FewSampledThreads</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires events to be available from the following event types: 'CPU Information', 'Method Profiling Sample', 'Recording Setting'.</shortDescription>
+<longDescription>The Parallel Threads rule requires events to be available from the following event types: 'CPU Information', 'Method Profiling Sample', 'Recording Setting'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>FileRead</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>There are no file read events in this recording.</shortDescription>
+<longDescription>There are no file read events in this recording.</longDescription>
+</rule>
+<rule>
+<id>FileWrite</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires events to be available from the following event types: 'File Write'.</shortDescription>
+<longDescription>The File Write Peak Duration rule requires events to be available from the following event types: 'File Write'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>FlightRecordingSupport</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>The JVM version used for this recording has full Flight Recorder support.</shortDescription>
+<longDescription>The JVM version used for this recording has full Flight Recorder support.</longDescription>
+</rule>
+<rule>
+<id>FullGc</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires events to be available from the following event types: 'Garbage Collection'.</shortDescription>
+<longDescription>The G1/CMS Full Collection rule requires events to be available from the following event types: 'Garbage Collection'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>GcFreedRatio</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>Only 0 heap summary events were found, this rule requires at least 10 events to be able to calculate a relevant result. This likely means that only a few garbage collections occurred during the recording. Having few garbage collections is generally a good sign.</shortDescription>
+<longDescription>Only 0 heap summary events were found, this rule requires at least 10 events to be able to calculate a relevant result. This likely means that only a few garbage collections occurred during the recording. Having few garbage collections is generally a good sign.</longDescription>
+</rule>
+<rule>
+<id>GcLocker</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>No GCs were affected by the GC Locker.</shortDescription>
+<longDescription>No GCs were affected by the GC Locker.</longDescription>
+</rule>
+<rule>
+<id>GcOptions</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>No problems were found with the GC configuration.</shortDescription>
+<longDescription>No problems were found with the GC configuration.</longDescription>
+</rule>
+<rule>
+<id>GcPauseRatio</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>Application efficiency was not highly affected by GC pauses.</shortDescription>
+<longDescription>Application efficiency was not highly affected by GC pauses.&lt;p&gt;The highest ratio between garbage collection pauses and execution time was 0 % for 1 min at 4/24/18 10:16:27 AM. The garbage collection pause ratio of the entire recording was 0 %.</longDescription>
+</rule>
+<rule>
+<id>GcStall</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>No indications that the garbage collector could not keep up with the workload were detected.</shortDescription>
+<longDescription>No indications that the garbage collector could not keep up with the workload were detected.</longDescription>
+</rule>
+<rule>
+<id>HeapContent</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'Object Count'.</shortDescription>
+<longDescription>The Heap Content rule requires that the following event types are enabled: 'Object Count'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>HeapInspectionGc</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires events to be available from the following event types: 'Garbage Collection'.</shortDescription>
+<longDescription>The GCs Caused by Heap Inspection rule requires events to be available from the following event types: 'Garbage Collection'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>HighGc</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>The runtime did not spend much time performing garbage collections.</shortDescription>
+<longDescription>The runtime did not spend much time performing garbage collections.</longDescription>
+</rule>
+<rule>
+<id>HighJvmCpu</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires events to be available from the following event types: 'CPU Load'.</shortDescription>
+<longDescription>The High JVM CPU Load rule requires events to be available from the following event types: 'CPU Load'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>IncreasingLiveSet</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>Too few events to calculate the result.</shortDescription>
+<longDescription>Too few events to calculate the result.</longDescription>
+</rule>
+<rule>
+<id>IncreasingMetaSpaceLiveSet</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>The class data does not seem to increase during the recording.</shortDescription>
+<longDescription>The class data does not seem to increase during the recording.</longDescription>
+</rule>
+<rule>
+<id>JavaBlocking</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires events to be available from the following event types: 'Java Monitor Blocked'.</shortDescription>
+<longDescription>The Java Blocking rule requires events to be available from the following event types: 'Java Monitor Blocked'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>LongGcPause</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>The application did not cause any long GC pause times.</shortDescription>
+<longDescription>The application did not cause any long GC pause times.</longDescription>
+</rule>
+<rule>
+<id>LowOnPhysicalMemory</id>
+<severity>Information</severity>
+<score>51.06889156143796</score>
+<shortDescription>The maximum amount of used memory was 88.9 % of the physical memory available.</shortDescription>
+<longDescription>The maximum amount of memory used was 28.4 GiB. This is 88.9 % of the 31.9 GiB of physical memory available. Having little free memory may lead to swapping, which is very expensive. To avoid this, either decrease the memory usage or increase the amount of available memory.</longDescription>
+</rule>
+<rule>
+<id>ManagementAgent</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'Initial System Property'.</shortDescription>
+<longDescription>The Discouraged Management Agent Settings rule requires that the following event types are enabled: 'Initial System Property'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>ManyRunningProcesses</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'System Process'.</shortDescription>
+<longDescription>The Competing Processes rule requires that the following event types are enabled: 'System Process'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>MetaspaceOom</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>The metaspace was not exhausted during this recording.</shortDescription>
+<longDescription>The metaspace was not exhausted during this recording.</longDescription>
+</rule>
+<rule>
+<id>MethodProfiling</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires events to be available from the following event types: 'Method Profiling Sample', 'Recording Setting'.</shortDescription>
+<longDescription>The Method Profiling rule requires events to be available from the following event types: 'Method Profiling Sample', 'Recording Setting'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>Options</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>No undocumented, deprecated or non-recommended option flags were detected.</shortDescription>
+<longDescription>No undocumented, deprecated or non-recommended option flags were detected.</longDescription>
+</rule>
+<rule>
+<id>OverAggressiveRecordingSetting</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'Initial System Property'.</shortDescription>
+<longDescription>The Discouraged Recording Settings rule requires that the following event types are enabled: 'Initial System Property'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>PasswordsInArguments</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>The recording does not seem to contain passwords in the application arguments.</shortDescription>
+<longDescription>The recording does not seem to contain passwords in the application arguments.</longDescription>
+</rule>
+<rule>
+<id>PasswordsInEnvironment</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'Initial Environment Variable'.</shortDescription>
+<longDescription>The Passwords in Environment Variables rule requires that the following event types are enabled: 'Initial Environment Variable'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>PasswordsInSystemProperties</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'Initial System Property'.</shortDescription>
+<longDescription>The Passwords in System Properties rule requires that the following event types are enabled: 'Initial System Property'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>PrimitiveToObjectConversion</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'Allocation in new TLAB', 'Allocation outside TLAB'.</shortDescription>
+<longDescription>The Primitive To Object Conversion rule requires that the following event types are enabled: 'Allocation in new TLAB', 'Allocation outside TLAB'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>SocketRead</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires events to be available from the following event types: 'Socket Read'.</shortDescription>
+<longDescription>The Socket Read Peak Duration rule requires events to be available from the following event types: 'Socket Read'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>SocketWrite</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires events to be available from the following event types: 'Socket Write'.</shortDescription>
+<longDescription>The Socket Write Peak Duration rule requires events to be available from the following event types: 'Socket Write'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>StackdepthSetting</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>No stack traces were truncated in this recording.</shortDescription>
+<longDescription>No stack traces were truncated in this recording.</longDescription>
+</rule>
+<rule>
+<id>StringDeduplication</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires events to be available from the following event types: 'Heap Summary'.</shortDescription>
+<longDescription>The String Deduplication rule requires events to be available from the following event types: 'Heap Summary'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>SystemGc</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires events to be available from the following event types: 'Garbage Collection'.</shortDescription>
+<longDescription>The GCs Caused by System.gc() rule requires events to be available from the following event types: 'Garbage Collection'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>TlabAllocationRatio</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'Allocation in new TLAB', 'Allocation outside TLAB'.</shortDescription>
+<longDescription>The TLAB Allocation Ratio rule requires that the following event types are enabled: 'Allocation in new TLAB', 'Allocation outside TLAB'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>VMOperations</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>No excessively long VM operations were found in this recording (the longest was 0 s).</shortDescription>
+<longDescription>No excessively long VM operations were found in this recording (the longest was 0 s).</longDescription>
+</rule>
+<rule>
+<id>biasedLockingRevocation</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>The Biased Locking Revocation rule requires the following event types: 'jdk.BiasedLockClassRevocation'.</shortDescription>
+<longDescription>The Biased Locking Revocation rule requires the following event types: 'jdk.BiasedLockClassRevocation'.&lt;p&gt;They are either not available in this version of Java, or must be enabled in a third-party component. If you are using an older Java version, then you can consider upgrading.</longDescription>
+</rule>
+<rule>
+<id>biasedLockingRevocationPause</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>No revocation of biased locks found.</shortDescription>
+<longDescription>No revocation of biased locks found.</longDescription>
+</rule>
+</report>
+<report>
+<file>flight_recording_hidden.jfr</file>
+<rule>
+<id>Allocations.class</id>
+<severity>OK</severity>
+<score>0.09287686767432358</score>
+<shortDescription>The most allocated type is likely 'byte[]', most commonly allocated by: &lt;ul&gt;&lt;li&gt;ByteArrayOutputStream.&amp;lt;init&amp;gt;(int) (50 %)&lt;/li&gt;&lt;li&gt;ByteArrayOutputStream.&amp;lt;init&amp;gt;()&lt;/li&gt;&lt;li&gt;JdpPacketWriter.&amp;lt;init&amp;gt;()&lt;/li&gt;&lt;li&gt;JdpJmxPacket.getPacketData()&lt;/li&gt;&lt;li&gt;JdpBroadcaster.sendPacket(JdpPacket)&lt;/li&gt;&lt;li&gt;JdpController$JDPControllerRunner.run()&lt;/li&gt;&lt;/ul&gt;</shortDescription>
+<longDescription>The most allocated type is likely 'byte[]', most commonly allocated by: &lt;ul&gt;&lt;li&gt;ByteArrayOutputStream.&amp;lt;init&amp;gt;(int) (50 %)&lt;/li&gt;&lt;li&gt;ByteArrayOutputStream.&amp;lt;init&amp;gt;()&lt;/li&gt;&lt;li&gt;JdpPacketWriter.&amp;lt;init&amp;gt;()&lt;/li&gt;&lt;li&gt;JdpJmxPacket.getPacketData()&lt;/li&gt;&lt;li&gt;JdpBroadcaster.sendPacket(JdpPacket)&lt;/li&gt;&lt;li&gt;JdpController$JDPControllerRunner.run()&lt;/li&gt;&lt;/ul&gt;&lt;p&gt;Frequently allocated types are good places to start when trying to reduce garbage collections. Look at where the most common types are being allocated to see if many instances are created along the same call path. Try to reduce the number of instances created by invoking the most commonly taken paths less.</longDescription>
+</rule>
+<rule>
+<id>Allocations.thread</id>
+<severity>OK</severity>
+<score>0.1274345677812541</score>
+<shortDescription>The most allocations were likely done by thread 'AWT-EventQueue-0' at: &lt;ul&gt;&lt;li&gt;EventQueue.dispatchEvent(AWTEvent) (60 %)&lt;/li&gt;&lt;li&gt;EventDispatchThread.pumpOneEventForFilters(int)&lt;/li&gt;&lt;li&gt;EventDispatchThread.pumpEventsForFilter(int, Conditional, EventFilter)&lt;/li&gt;&lt;li&gt;EventDispatchThread.pumpEventsForHierarchy(int, Conditional, Component)&lt;/li&gt;&lt;li&gt;EventDispatchThread.pumpEvents(int, Conditional)&lt;/li&gt;&lt;li&gt;EventDispatchThread.pumpEvents(Conditional)&lt;/li&gt;&lt;/ul&gt;</shortDescription>
+<longDescription>The most allocations were likely done by thread 'AWT-EventQueue-0' at: &lt;ul&gt;&lt;li&gt;EventQueue.dispatchEvent(AWTEvent) (60 %)&lt;/li&gt;&lt;li&gt;EventDispatchThread.pumpOneEventForFilters(int)&lt;/li&gt;&lt;li&gt;EventDispatchThread.pumpEventsForFilter(int, Conditional, EventFilter)&lt;/li&gt;&lt;li&gt;EventDispatchThread.pumpEventsForHierarchy(int, Conditional, Component)&lt;/li&gt;&lt;li&gt;EventDispatchThread.pumpEvents(int, Conditional)&lt;/li&gt;&lt;li&gt;EventDispatchThread.pumpEvents(Conditional)&lt;/li&gt;&lt;/ul&gt;&lt;p&gt;Many allocations performed by the same thread might indicate a problem in a multi-threaded program. Look at the stack traces for the thread with the highest allocation rate. See if the allocation rate can be brought down, or balanced among the active threads.</longDescription>
+</rule>
+<rule>
+<id>ApplicationHalts</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires events to be available from the following event types: 'GC Phase Pause', 'VM Operation'.</shortDescription>
+<longDescription>The Application Halts rule requires events to be available from the following event types: 'GC Phase Pause', 'VM Operation'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>BufferLost</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>No Flight Recorder buffers were lost during the recording.</shortDescription>
+<longDescription>No Flight Recorder buffers were lost during the recording.</longDescription>
+</rule>
+<rule>
+<id>BytecodeVerification</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>The application ran with bytecode verification enabled.</shortDescription>
+<longDescription>The application ran with bytecode verification enabled.</longDescription>
+</rule>
+<rule>
+<id>ClassLeak</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'Class Load', 'Class Unload'.</shortDescription>
+<longDescription>The Class Leak rule requires that the following event types are enabled: 'Class Load', 'Class Unload'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>ClassLoading</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'Class Load'.</shortDescription>
+<longDescription>The Class Loading Pressure rule requires that the following event types are enabled: 'Class Load'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>CodeCache</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires events to be available from the following event types: 'Code Cache Configuration', 'Code Cache Full', 'Code Cache Statistics', 'JVM Information'.</shortDescription>
+<longDescription>The Code Cache rule requires events to be available from the following event types: 'Code Cache Configuration', 'Code Cache Full', 'Code Cache Statistics', 'JVM Information'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>CompareCpu</id>
+<severity>Warning</severity>
+<score>77.36067322482806</score>
+<shortDescription>An average CPU load of 60 % was caused by other processes for 8.047 s at 4/25/18 11:38:36 AM.</shortDescription>
+<longDescription>An average CPU load of 60 % was caused by other processes for 8.047 s at 4/25/18 11:38:36 AM.&lt;p&gt;The application performance can be affected when the machine is under heavy load and there are other processes that use CPU or other resources on the same computer. To profile representatively or get higher throughput, shut down other resource intensive processes running on the machine.</longDescription>
+</rule>
+<rule>
+<id>CompressedOops</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires events to be available from the following event types: 'Boolean Flag', 'JVM Information', 'Unsigned Long Flag'.</shortDescription>
+<longDescription>The Compressed Oops rule requires events to be available from the following event types: 'Boolean Flag', 'JVM Information', 'Unsigned Long Flag'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>ContextSwitch</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>The program did not context switch excessively during the recording.</shortDescription>
+<longDescription>The program did not context switch excessively during the recording.</longDescription>
+</rule>
+<rule>
+<id>DMSIncident</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>The DMS Incidents rule requires the following event types: 'http://www.oracle.com/dms/dfw/dms/dfw/DFW_Incident/DFW_Incident_state'.</shortDescription>
+<longDescription>The DMS Incidents rule requires the following event types: 'http://www.oracle.com/dms/dfw/dms/dfw/DFW_Incident/DFW_Incident_state'.&lt;p&gt;They are either not available in this version of Java, or must be enabled in a third-party component. If you are using an older Java version, then you can consider upgrading.</longDescription>
+</rule>
+<rule>
+<id>DebugNonSafepoints</id>
+<severity>Information</severity>
+<score>50.0</score>
+<shortDescription>DebugNonSafepoints was not enabled.</shortDescription>
+<longDescription>DebugNonSafepoints was not enabled.&lt;p&gt;If DebugNonSafepoints is not enabled, the method profiling data will be less accurate as threads that are not at safepoints will not be correctly sampled. Use the following JVM flags to enable this: '-XX:+UnlockDiagnosticVMOptions -XX:+DebugNonSafepoints'. There is a slight performance overhead when enabling these flags. For more information see &lt;a href="http://openjdk.java.net/groups/hotspot/docs/RuntimeOverview.html#Thread%20Management|outline"&gt;HotSpot Runtime Overview/Thread Management&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>DiscouragedVmOptions</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'Boolean Flag'.</shortDescription>
+<longDescription>The Discouraged VM Options rule requires that the following event types are enabled: 'Boolean Flag'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>DumpReason</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>This recording was not dumped for an exceptional reason.</shortDescription>
+<longDescription>This recording was not dumped for an exceptional reason.</longDescription>
+</rule>
+<rule>
+<id>DuplicateFlags</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>There were no duplicate JVM flags on the command line.</shortDescription>
+<longDescription>There were no duplicate JVM flags on the command line.</longDescription>
+</rule>
+<rule>
+<id>Errors</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires events to be available from the following event types: 'Java Error'.</shortDescription>
+<longDescription>The Thrown Errors rule requires events to be available from the following event types: 'Java Error'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>Exceptions</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>The program generated 0 exceptions per second for 1.000 s at 4/25/18 11:38:36 AM.</shortDescription>
+<longDescription>The program generated 0 exceptions per second for 1.000 s at 4/25/18 11:38:36 AM.</longDescription>
+</rule>
+<rule>
+<id>Fatal Errors</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>The Fatal Errors rule requires the following event types: 'jdk.Shutdown'.</shortDescription>
+<longDescription>The Fatal Errors rule requires the following event types: 'jdk.Shutdown'.&lt;p&gt;They are either not available in this version of Java, or must be enabled in a third-party component. If you are using an older Java version, then you can consider upgrading.</longDescription>
+</rule>
+<rule>
+<id>FewSampledThreads</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires events to be available from the following event types: 'CPU Information', 'Method Profiling Sample', 'Recording Setting'.</shortDescription>
+<longDescription>The Parallel Threads rule requires events to be available from the following event types: 'CPU Information', 'Method Profiling Sample', 'Recording Setting'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>FileRead</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'File Read'.</shortDescription>
+<longDescription>The File Read Peak Duration rule requires that the following event types are enabled: 'File Read'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>FileWrite</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'File Write'.</shortDescription>
+<longDescription>The File Write Peak Duration rule requires that the following event types are enabled: 'File Write'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>FlightRecordingSupport</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>The JVM version used for this recording has full Flight Recorder support.</shortDescription>
+<longDescription>The JVM version used for this recording has full Flight Recorder support.</longDescription>
+</rule>
+<rule>
+<id>FullGc</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule is only valid for CMS and G1 Garbage Collectors, neither of which were detected for this JVM.</shortDescription>
+<longDescription>This rule is only valid for CMS and G1 Garbage Collectors, neither of which were detected for this JVM.</longDescription>
+</rule>
+<rule>
+<id>GcFreedRatio</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'Heap Summary'.</shortDescription>
+<longDescription>The GC Freed Ratio rule requires that the following event types are enabled: 'Heap Summary'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>GcLocker</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'Garbage Collection'.</shortDescription>
+<longDescription>The GCs Caused by GC Locker rule requires that the following event types are enabled: 'Garbage Collection'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>GcOptions</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>No problems were found with the GC configuration.</shortDescription>
+<longDescription>No problems were found with the GC configuration.</longDescription>
+</rule>
+<rule>
+<id>GcPauseRatio</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'GC Phase Pause'.</shortDescription>
+<longDescription>The GC Pauses rule requires that the following event types are enabled: 'GC Phase Pause'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>GcStall</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'Garbage Collection'.</shortDescription>
+<longDescription>The GC Stall rule requires that the following event types are enabled: 'Garbage Collection'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>HeapContent</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'Object Count'.</shortDescription>
+<longDescription>The Heap Content rule requires that the following event types are enabled: 'Object Count'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>HeapInspectionGc</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'Garbage Collection'.</shortDescription>
+<longDescription>The GCs Caused by Heap Inspection rule requires that the following event types are enabled: 'Garbage Collection'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>HighGc</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'GC Phase Pause'.</shortDescription>
+<longDescription>The GC Pressure rule requires that the following event types are enabled: 'GC Phase Pause'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>HighJvmCpu</id>
+<severity>OK</severity>
+<score>0.8641130870553131</score>
+<shortDescription>The JVM does not seem to cause a lot of CPU load.</shortDescription>
+<longDescription>The JVM does not seem to cause a lot of CPU load.</longDescription>
+</rule>
+<rule>
+<id>IncreasingLiveSet</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'Heap Summary'.</shortDescription>
+<longDescription>The Heap Live Set Trend rule requires that the following event types are enabled: 'Heap Summary'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>IncreasingMetaSpaceLiveSet</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'Metaspace Summary'.</shortDescription>
+<longDescription>The Metaspace Live Set Trend rule requires that the following event types are enabled: 'Metaspace Summary'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>JavaBlocking</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires events to be available from the following event types: 'Java Monitor Blocked'.</shortDescription>
+<longDescription>The Java Blocking rule requires events to be available from the following event types: 'Java Monitor Blocked'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>LongGcPause</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>The application did not cause any long GC pause times.</shortDescription>
+<longDescription>The application did not cause any long GC pause times.</longDescription>
+</rule>
+<rule>
+<id>LowOnPhysicalMemory</id>
+<severity>Warning</severity>
+<score>85.24971081406179</score>
+<shortDescription>The maximum amount of used memory was 99.8 % of the physical memory available.</shortDescription>
+<longDescription>The maximum amount of memory used was 16 GiB. This is 99.8 % of the 16 GiB of physical memory available. Having little free memory may lead to swapping, which is very expensive. To avoid this, either decrease the memory usage or increase the amount of available memory.</longDescription>
+</rule>
+<rule>
+<id>ManagementAgent</id>
+<severity>Warning</severity>
+<score>100.0</score>
+<shortDescription>Insecure management agent settings: Both password authentication and SSL were disabled.</shortDescription>
+<longDescription>The runtime management agent settings were insecure. Both password authentication and SSL were disabled. A remote user who knows (or guesses) the port number and host name will be able to monitor and control the Java application and platform. This is highly discouraged for production systems.&lt;p&gt;See the &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/guides/management/agent.html"&gt;Java Monitoring and Management Guide&lt;/a&gt; for more information about how to configure the management agent.</longDescription>
+</rule>
+<rule>
+<id>ManyRunningProcesses</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'System Process'.</shortDescription>
+<longDescription>The Competing Processes rule requires that the following event types are enabled: 'System Process'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>MetaspaceOom</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'Metaspace Out of Memory'.</shortDescription>
+<longDescription>The Metaspace Out of Memory rule requires that the following event types are enabled: 'Metaspace Out of Memory'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>MethodProfiling</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires events to be available from the following event types: 'Method Profiling Sample', 'Recording Setting'.</shortDescription>
+<longDescription>The Method Profiling rule requires events to be available from the following event types: 'Method Profiling Sample', 'Recording Setting'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>Options</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>No undocumented, deprecated or non-recommended option flags were detected.</shortDescription>
+<longDescription>No undocumented, deprecated or non-recommended option flags were detected.</longDescription>
+</rule>
+<rule>
+<id>OverAggressiveRecordingSetting</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>No problems were found with the recording settings.</shortDescription>
+<longDescription>No problems were found with the recording settings.</longDescription>
+</rule>
+<rule>
+<id>PasswordsInArguments</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>The recording does not seem to contain passwords in the application arguments.</shortDescription>
+<longDescription>The recording does not seem to contain passwords in the application arguments.</longDescription>
+</rule>
+<rule>
+<id>PasswordsInEnvironment</id>
+<severity>Warning</severity>
+<score>100.0</score>
+<shortDescription>The environment variables in the recording may contain passwords.</shortDescription>
+<longDescription>The following suspicious environment variables were found in this recording: &lt;ul&gt;&lt;li&gt;P4PASSWD&lt;/li&gt;&lt;/ul&gt;&lt;p&gt;They may contain passwords. If you wish to keep having passwords in your environment variables, but want to be able to share recordings without also sharing the passwords, please disable the 'Initial Environment Variable' event.</longDescription>
+</rule>
+<rule>
+<id>PasswordsInSystemProperties</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>The recording does not seem to contain passwords in the system properties.</shortDescription>
+<longDescription>The recording does not seem to contain passwords in the system properties.</longDescription>
+</rule>
+<rule>
+<id>PrimitiveToObjectConversion</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires events to be available from the following event types: 'Allocation in new TLAB', 'Allocation outside TLAB'.</shortDescription>
+<longDescription>The Primitive To Object Conversion rule requires events to be available from the following event types: 'Allocation in new TLAB', 'Allocation outside TLAB'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>SocketRead</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'Socket Read'.</shortDescription>
+<longDescription>The Socket Read Peak Duration rule requires that the following event types are enabled: 'Socket Read'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>SocketWrite</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'Socket Write'.</shortDescription>
+<longDescription>The Socket Write Peak Duration rule requires that the following event types are enabled: 'Socket Write'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>StackdepthSetting</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>No stack traces were truncated in this recording.</shortDescription>
+<longDescription>No stack traces were truncated in this recording.</longDescription>
+</rule>
+<rule>
+<id>StringDeduplication</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'Heap Summary'.</shortDescription>
+<longDescription>The String Deduplication rule requires that the following event types are enabled: 'Heap Summary'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>SystemGc</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'Garbage Collection'.</shortDescription>
+<longDescription>The GCs Caused by System.gc() rule requires that the following event types are enabled: 'Garbage Collection'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>TlabAllocationRatio</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>No object allocations outside of TLABs detected.</shortDescription>
+<longDescription>No object allocations outside of TLABs detected.</longDescription>
+</rule>
+<rule>
+<id>VMOperations</id>
+<severity>OK</severity>
+<score>1.6971702250000003</score>
+<shortDescription>No excessively long VM operations were found in this recording (the longest was 67.887 ms).</shortDescription>
+<longDescription>No excessively long VM operations were found in this recording (the longest was 67.887 ms).</longDescription>
+</rule>
+<rule>
+<id>biasedLockingRevocation</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>The Biased Locking Revocation rule requires the following event types: 'jdk.BiasedLockClassRevocation'.</shortDescription>
+<longDescription>The Biased Locking Revocation rule requires the following event types: 'jdk.BiasedLockClassRevocation'.&lt;p&gt;They are either not available in this version of Java, or must be enabled in a third-party component. If you are using an older Java version, then you can consider upgrading.</longDescription>
+</rule>
+<rule>
+<id>biasedLockingRevocationPause</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>No revocation of biased locks found.</shortDescription>
+<longDescription>No revocation of biased locks found.</longDescription>
+</rule>
+</report>
+<report>
+<file>full_gc_cms.jfr</file>
+<rule>
+<id>Allocations.class</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'Allocation in new TLAB', 'Allocation outside TLAB'.</shortDescription>
+<longDescription>The Allocated Classes rule requires that the following event types are enabled: 'Allocation in new TLAB', 'Allocation outside TLAB'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>Allocations.thread</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'Allocation in new TLAB', 'Allocation outside TLAB'.</shortDescription>
+<longDescription>The Threads Allocating rule requires that the following event types are enabled: 'Allocation in new TLAB', 'Allocation outside TLAB'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>ApplicationHalts</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'GC Phase Pause', 'VM Operation'.</shortDescription>
+<longDescription>The Application Halts rule requires that the following event types are enabled: 'GC Phase Pause', 'VM Operation'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>BufferLost</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>No Flight Recorder buffers were lost during the recording.</shortDescription>
+<longDescription>No Flight Recorder buffers were lost during the recording.</longDescription>
+</rule>
+<rule>
+<id>BytecodeVerification</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'JVM Information'.</shortDescription>
+<longDescription>The Bytecode Verification rule requires that the following event types are enabled: 'JVM Information'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>ClassLeak</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'Class Load', 'Class Unload'.</shortDescription>
+<longDescription>The Class Leak rule requires that the following event types are enabled: 'Class Load', 'Class Unload'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>ClassLoading</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'Class Load'.</shortDescription>
+<longDescription>The Class Loading Pressure rule requires that the following event types are enabled: 'Class Load'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>CodeCache</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'Code Cache Configuration', 'Code Cache Full', 'Code Cache Statistics', 'JVM Information'.</shortDescription>
+<longDescription>The Code Cache rule requires that the following event types are enabled: 'Code Cache Configuration', 'Code Cache Full', 'Code Cache Statistics', 'JVM Information'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>CompareCpu</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'CPU Load'.</shortDescription>
+<longDescription>The Competing CPU Ratio Usage rule requires that the following event types are enabled: 'CPU Load'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>CompressedOops</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'Boolean Flag', 'JVM Information', 'Unsigned Long Flag'.</shortDescription>
+<longDescription>The Compressed Oops rule requires that the following event types are enabled: 'Boolean Flag', 'JVM Information', 'Unsigned Long Flag'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>ContextSwitch</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'Thread Context Switch Rate'.</shortDescription>
+<longDescription>The Context Switches rule requires that the following event types are enabled: 'Thread Context Switch Rate'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>DMSIncident</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>The DMS Incidents rule requires the following event types: 'http://www.oracle.com/dms/dfw/dms/dfw/DFW_Incident/DFW_Incident_state'.</shortDescription>
+<longDescription>The DMS Incidents rule requires the following event types: 'http://www.oracle.com/dms/dfw/dms/dfw/DFW_Incident/DFW_Incident_state'.&lt;p&gt;They are either not available in this version of Java, or must be enabled in a third-party component. If you are using an older Java version, then you can consider upgrading.</longDescription>
+</rule>
+<rule>
+<id>DebugNonSafepoints</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>The Java version could not be determined.</shortDescription>
+<longDescription>The Java version could not be determined.</longDescription>
+</rule>
+<rule>
+<id>DiscouragedVmOptions</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'Boolean Flag'.</shortDescription>
+<longDescription>The Discouraged VM Options rule requires that the following event types are enabled: 'Boolean Flag'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>DumpReason</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>This recording was not dumped for an exceptional reason.</shortDescription>
+<longDescription>This recording was not dumped for an exceptional reason.</longDescription>
+</rule>
+<rule>
+<id>DuplicateFlags</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'JVM Information'.</shortDescription>
+<longDescription>The Duplicated Flags rule requires that the following event types are enabled: 'JVM Information'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>Errors</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'Java Error'.</shortDescription>
+<longDescription>The Thrown Errors rule requires that the following event types are enabled: 'Java Error'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>Exceptions</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'Exception Statistics'.</shortDescription>
+<longDescription>The Thrown Exceptions rule requires that the following event types are enabled: 'Exception Statistics'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>Fatal Errors</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'VM Shutdown'.</shortDescription>
+<longDescription>The Fatal Errors rule requires that the following event types are enabled: 'VM Shutdown'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>FewSampledThreads</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires events to be available from the following event types: 'CPU Information', 'Method Profiling Sample', 'Recording Setting'.</shortDescription>
+<longDescription>The Parallel Threads rule requires events to be available from the following event types: 'CPU Information', 'Method Profiling Sample', 'Recording Setting'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>FileRead</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'File Read'.</shortDescription>
+<longDescription>The File Read Peak Duration rule requires that the following event types are enabled: 'File Read'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>FileWrite</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'File Write'.</shortDescription>
+<longDescription>The File Write Peak Duration rule requires that the following event types are enabled: 'File Write'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>FlightRecordingSupport</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'JVM Information'.</shortDescription>
+<longDescription>The Flight Recording Support rule requires that the following event types are enabled: 'JVM Information'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>FullGc</id>
+<severity>Warning</severity>
+<score>100.0</score>
+<shortDescription>Full GC detected.</shortDescription>
+<longDescription>At least one Full, Stop-The-World Garbage Collection occurred during this recording. For the CMS and G1 collectors, Full GC events are a strong negative performance indicator. Tunable GC parameters can be used to allow the collector to operate in concurrent mode, avoiding Stop-The-World pauses and increasing GC and application performance.</longDescription>
+</rule>
+<rule>
+<id>GcFreedRatio</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'Heap Summary'.</shortDescription>
+<longDescription>The GC Freed Ratio rule requires that the following event types are enabled: 'Heap Summary'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>GcLocker</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>No GCs were affected by the GC Locker.</shortDescription>
+<longDescription>No GCs were affected by the GC Locker.</longDescription>
+</rule>
+<rule>
+<id>GcOptions</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'CPU Information'.</shortDescription>
+<longDescription>The GC Setup rule requires that the following event types are enabled: 'CPU Information'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>GcPauseRatio</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'GC Phase Pause'.</shortDescription>
+<longDescription>The GC Pauses rule requires that the following event types are enabled: 'GC Phase Pause'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>GcStall</id>
+<severity>Warning</severity>
+<score>100.0</score>
+<shortDescription>The CMS garbage collector was used, but the JVM had to revert to do a Serial Old Collection.</shortDescription>
+<longDescription>The application used the Concurrent Mark Sweep garbage collector, but the JVM had to revert to a Serial Old Collection, which takes more time. This is because the Concurrent Collector could not keep up with the object allocations that happened during the collection. You can decrease the risk of this by lowering the value of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/guides/vm/gctuning/cms.html"&gt;-XX:CMSInitiatingOccupancyFraction&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>HeapContent</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'Object Count'.</shortDescription>
+<longDescription>The Heap Content rule requires that the following event types are enabled: 'Object Count'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>HeapInspectionGc</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>The JVM did not perform any heap inspection GCs.</shortDescription>
+<longDescription>The JVM did not perform any heap inspection GCs. This is good since they usually take a lot of time.</longDescription>
+</rule>
+<rule>
+<id>HighGc</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'GC Phase Pause'.</shortDescription>
+<longDescription>The GC Pressure rule requires that the following event types are enabled: 'GC Phase Pause'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>HighJvmCpu</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'CPU Load'.</shortDescription>
+<longDescription>The High JVM CPU Load rule requires that the following event types are enabled: 'CPU Load'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>IncreasingLiveSet</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'Heap Summary'.</shortDescription>
+<longDescription>The Heap Live Set Trend rule requires that the following event types are enabled: 'Heap Summary'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>IncreasingMetaSpaceLiveSet</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'Metaspace Summary'.</shortDescription>
+<longDescription>The Metaspace Live Set Trend rule requires that the following event types are enabled: 'Metaspace Summary'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>JavaBlocking</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'Java Monitor Blocked'.</shortDescription>
+<longDescription>The Java Blocking rule requires that the following event types are enabled: 'Java Monitor Blocked'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>LongGcPause</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>The application did not cause any long GC pause times.</shortDescription>
+<longDescription>The application did not cause any long GC pause times.</longDescription>
+</rule>
+<rule>
+<id>LowOnPhysicalMemory</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'Physical Memory'.</shortDescription>
+<longDescription>The Free Physical Memory rule requires that the following event types are enabled: 'Physical Memory'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>ManagementAgent</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'Initial System Property'.</shortDescription>
+<longDescription>The Discouraged Management Agent Settings rule requires that the following event types are enabled: 'Initial System Property'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>ManyRunningProcesses</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'System Process'.</shortDescription>
+<longDescription>The Competing Processes rule requires that the following event types are enabled: 'System Process'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>MetaspaceOom</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'Metaspace Out of Memory'.</shortDescription>
+<longDescription>The Metaspace Out of Memory rule requires that the following event types are enabled: 'Metaspace Out of Memory'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>MethodProfiling</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires events to be available from the following event types: 'Method Profiling Sample', 'Recording Setting'.</shortDescription>
+<longDescription>The Method Profiling rule requires events to be available from the following event types: 'Method Profiling Sample', 'Recording Setting'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>Options</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>No events with JVM arguments were recorded.</shortDescription>
+<longDescription>No events with JVM arguments were recorded.</longDescription>
+</rule>
+<rule>
+<id>OverAggressiveRecordingSetting</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'Initial System Property'.</shortDescription>
+<longDescription>The Discouraged Recording Settings rule requires that the following event types are enabled: 'Initial System Property'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>PasswordsInArguments</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'JVM Information'.</shortDescription>
+<longDescription>The Passwords in Java Arguments rule requires that the following event types are enabled: 'JVM Information'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>PasswordsInEnvironment</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'Initial Environment Variable'.</shortDescription>
+<longDescription>The Passwords in Environment Variables rule requires that the following event types are enabled: 'Initial Environment Variable'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>PasswordsInSystemProperties</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'Initial System Property'.</shortDescription>
+<longDescription>The Passwords in System Properties rule requires that the following event types are enabled: 'Initial System Property'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>PrimitiveToObjectConversion</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'Allocation in new TLAB', 'Allocation outside TLAB'.</shortDescription>
+<longDescription>The Primitive To Object Conversion rule requires that the following event types are enabled: 'Allocation in new TLAB', 'Allocation outside TLAB'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>SocketRead</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'Socket Read'.</shortDescription>
+<longDescription>The Socket Read Peak Duration rule requires that the following event types are enabled: 'Socket Read'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>SocketWrite</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'Socket Write'.</shortDescription>
+<longDescription>The Socket Write Peak Duration rule requires that the following event types are enabled: 'Socket Write'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>StackdepthSetting</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>No stack traces were truncated in this recording.</shortDescription>
+<longDescription>No stack traces were truncated in this recording.</longDescription>
+</rule>
+<rule>
+<id>StringDeduplication</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>The Java version could not be determined.</shortDescription>
+<longDescription>The Java version could not be determined.</longDescription>
+</rule>
+<rule>
+<id>SystemGc</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>No garbage collections were caused by System.gc().</shortDescription>
+<longDescription>No garbage collections were caused by System.gc().</longDescription>
+</rule>
+<rule>
+<id>TlabAllocationRatio</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'Allocation in new TLAB', 'Allocation outside TLAB'.</shortDescription>
+<longDescription>The TLAB Allocation Ratio rule requires that the following event types are enabled: 'Allocation in new TLAB', 'Allocation outside TLAB'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>VMOperations</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'VM Operation'.</shortDescription>
+<longDescription>The VMOperation Peak Duration rule requires that the following event types are enabled: 'VM Operation'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>biasedLockingRevocation</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'Biased Lock Class Revocation'.</shortDescription>
+<longDescription>The Biased Locking Revocation rule requires that the following event types are enabled: 'Biased Lock Class Revocation'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>biasedLockingRevocationPause</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'VM Operation'.</shortDescription>
+<longDescription>The Biased Locking Revocation Pauses rule requires that the following event types are enabled: 'VM Operation'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+</report>
+<report>
+<file>full_gc_g1.jfr</file>
+<rule>
+<id>Allocations.class</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'Allocation in new TLAB', 'Allocation outside TLAB'.</shortDescription>
+<longDescription>The Allocated Classes rule requires that the following event types are enabled: 'Allocation in new TLAB', 'Allocation outside TLAB'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>Allocations.thread</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'Allocation in new TLAB', 'Allocation outside TLAB'.</shortDescription>
+<longDescription>The Threads Allocating rule requires that the following event types are enabled: 'Allocation in new TLAB', 'Allocation outside TLAB'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>ApplicationHalts</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'GC Phase Pause', 'VM Operation'.</shortDescription>
+<longDescription>The Application Halts rule requires that the following event types are enabled: 'GC Phase Pause', 'VM Operation'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>BufferLost</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>No Flight Recorder buffers were lost during the recording.</shortDescription>
+<longDescription>No Flight Recorder buffers were lost during the recording.</longDescription>
+</rule>
+<rule>
+<id>BytecodeVerification</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'JVM Information'.</shortDescription>
+<longDescription>The Bytecode Verification rule requires that the following event types are enabled: 'JVM Information'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>ClassLeak</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'Class Load', 'Class Unload'.</shortDescription>
+<longDescription>The Class Leak rule requires that the following event types are enabled: 'Class Load', 'Class Unload'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>ClassLoading</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'Class Load'.</shortDescription>
+<longDescription>The Class Loading Pressure rule requires that the following event types are enabled: 'Class Load'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>CodeCache</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'Code Cache Configuration', 'Code Cache Full', 'Code Cache Statistics', 'JVM Information'.</shortDescription>
+<longDescription>The Code Cache rule requires that the following event types are enabled: 'Code Cache Configuration', 'Code Cache Full', 'Code Cache Statistics', 'JVM Information'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>CompareCpu</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'CPU Load'.</shortDescription>
+<longDescription>The Competing CPU Ratio Usage rule requires that the following event types are enabled: 'CPU Load'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>CompressedOops</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'Boolean Flag', 'JVM Information', 'Unsigned Long Flag'.</shortDescription>
+<longDescription>The Compressed Oops rule requires that the following event types are enabled: 'Boolean Flag', 'JVM Information', 'Unsigned Long Flag'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>ContextSwitch</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'Thread Context Switch Rate'.</shortDescription>
+<longDescription>The Context Switches rule requires that the following event types are enabled: 'Thread Context Switch Rate'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>DMSIncident</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>The DMS Incidents rule requires the following event types: 'http://www.oracle.com/dms/dfw/dms/dfw/DFW_Incident/DFW_Incident_state'.</shortDescription>
+<longDescription>The DMS Incidents rule requires the following event types: 'http://www.oracle.com/dms/dfw/dms/dfw/DFW_Incident/DFW_Incident_state'.&lt;p&gt;They are either not available in this version of Java, or must be enabled in a third-party component. If you are using an older Java version, then you can consider upgrading.</longDescription>
+</rule>
+<rule>
+<id>DebugNonSafepoints</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>The Java version could not be determined.</shortDescription>
+<longDescription>The Java version could not be determined.</longDescription>
+</rule>
+<rule>
+<id>DiscouragedVmOptions</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'Boolean Flag'.</shortDescription>
+<longDescription>The Discouraged VM Options rule requires that the following event types are enabled: 'Boolean Flag'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>DumpReason</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>This recording was not dumped for an exceptional reason.</shortDescription>
+<longDescription>This recording was not dumped for an exceptional reason.</longDescription>
+</rule>
+<rule>
+<id>DuplicateFlags</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'JVM Information'.</shortDescription>
+<longDescription>The Duplicated Flags rule requires that the following event types are enabled: 'JVM Information'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>Errors</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'Java Error'.</shortDescription>
+<longDescription>The Thrown Errors rule requires that the following event types are enabled: 'Java Error'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>Exceptions</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'Exception Statistics'.</shortDescription>
+<longDescription>The Thrown Exceptions rule requires that the following event types are enabled: 'Exception Statistics'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>Fatal Errors</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'VM Shutdown'.</shortDescription>
+<longDescription>The Fatal Errors rule requires that the following event types are enabled: 'VM Shutdown'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>FewSampledThreads</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires events to be available from the following event types: 'CPU Information', 'Method Profiling Sample', 'Recording Setting'.</shortDescription>
+<longDescription>The Parallel Threads rule requires events to be available from the following event types: 'CPU Information', 'Method Profiling Sample', 'Recording Setting'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>FileRead</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'File Read'.</shortDescription>
+<longDescription>The File Read Peak Duration rule requires that the following event types are enabled: 'File Read'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>FileWrite</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'File Write'.</shortDescription>
+<longDescription>The File Write Peak Duration rule requires that the following event types are enabled: 'File Write'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>FlightRecordingSupport</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'JVM Information'.</shortDescription>
+<longDescription>The Flight Recording Support rule requires that the following event types are enabled: 'JVM Information'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>FullGc</id>
+<severity>Warning</severity>
+<score>100.0</score>
+<shortDescription>Full GC detected.</shortDescription>
+<longDescription>At least one Full, Stop-The-World Garbage Collection occurred during this recording. For the CMS and G1 collectors, Full GC events are a strong negative performance indicator. Tunable GC parameters can be used to allow the collector to operate in concurrent mode, avoiding Stop-The-World pauses and increasing GC and application performance.</longDescription>
+</rule>
+<rule>
+<id>GcFreedRatio</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'Heap Summary'.</shortDescription>
+<longDescription>The GC Freed Ratio rule requires that the following event types are enabled: 'Heap Summary'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>GcLocker</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>No GCs were affected by the GC Locker.</shortDescription>
+<longDescription>No GCs were affected by the GC Locker.</longDescription>
+</rule>
+<rule>
+<id>GcOptions</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'CPU Information'.</shortDescription>
+<longDescription>The GC Setup rule requires that the following event types are enabled: 'CPU Information'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>GcPauseRatio</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'GC Phase Pause'.</shortDescription>
+<longDescription>The GC Pauses rule requires that the following event types are enabled: 'GC Phase Pause'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>GcStall</id>
+<severity>Warning</severity>
+<score>100.0</score>
+<shortDescription>There occurred Concurrent Mode failures during certain garbage collections.</shortDescription>
+<longDescription>Concurrent Mode failures means that the Garbage Collector hasn't been able to keep up with the Java Program. Try lowering the value of &lt;a href="http://www.oracle.com/technetwork/articles/java/vmoptions-jsp-140102.html"&gt;-XX:InitiatingHeapOccupancyPercent&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>HeapContent</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'Object Count'.</shortDescription>
+<longDescription>The Heap Content rule requires that the following event types are enabled: 'Object Count'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>HeapInspectionGc</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>The JVM did not perform any heap inspection GCs.</shortDescription>
+<longDescription>The JVM did not perform any heap inspection GCs. This is good since they usually take a lot of time.</longDescription>
+</rule>
+<rule>
+<id>HighGc</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'GC Phase Pause'.</shortDescription>
+<longDescription>The GC Pressure rule requires that the following event types are enabled: 'GC Phase Pause'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>HighJvmCpu</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'CPU Load'.</shortDescription>
+<longDescription>The High JVM CPU Load rule requires that the following event types are enabled: 'CPU Load'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>IncreasingLiveSet</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'Heap Summary'.</shortDescription>
+<longDescription>The Heap Live Set Trend rule requires that the following event types are enabled: 'Heap Summary'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>IncreasingMetaSpaceLiveSet</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'Metaspace Summary'.</shortDescription>
+<longDescription>The Metaspace Live Set Trend rule requires that the following event types are enabled: 'Metaspace Summary'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>JavaBlocking</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'Java Monitor Blocked'.</shortDescription>
+<longDescription>The Java Blocking rule requires that the following event types are enabled: 'Java Monitor Blocked'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>LongGcPause</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>The application did not cause any long GC pause times.</shortDescription>
+<longDescription>The application did not cause any long GC pause times.</longDescription>
+</rule>
+<rule>
+<id>LowOnPhysicalMemory</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'Physical Memory'.</shortDescription>
+<longDescription>The Free Physical Memory rule requires that the following event types are enabled: 'Physical Memory'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>ManagementAgent</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'Initial System Property'.</shortDescription>
+<longDescription>The Discouraged Management Agent Settings rule requires that the following event types are enabled: 'Initial System Property'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>ManyRunningProcesses</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'System Process'.</shortDescription>
+<longDescription>The Competing Processes rule requires that the following event types are enabled: 'System Process'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>MetaspaceOom</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'Metaspace Out of Memory'.</shortDescription>
+<longDescription>The Metaspace Out of Memory rule requires that the following event types are enabled: 'Metaspace Out of Memory'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>MethodProfiling</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires events to be available from the following event types: 'Method Profiling Sample', 'Recording Setting'.</shortDescription>
+<longDescription>The Method Profiling rule requires events to be available from the following event types: 'Method Profiling Sample', 'Recording Setting'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>Options</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>No events with JVM arguments were recorded.</shortDescription>
+<longDescription>No events with JVM arguments were recorded.</longDescription>
+</rule>
+<rule>
+<id>OverAggressiveRecordingSetting</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'Initial System Property'.</shortDescription>
+<longDescription>The Discouraged Recording Settings rule requires that the following event types are enabled: 'Initial System Property'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>PasswordsInArguments</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'JVM Information'.</shortDescription>
+<longDescription>The Passwords in Java Arguments rule requires that the following event types are enabled: 'JVM Information'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>PasswordsInEnvironment</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'Initial Environment Variable'.</shortDescription>
+<longDescription>The Passwords in Environment Variables rule requires that the following event types are enabled: 'Initial Environment Variable'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>PasswordsInSystemProperties</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'Initial System Property'.</shortDescription>
+<longDescription>The Passwords in System Properties rule requires that the following event types are enabled: 'Initial System Property'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>PrimitiveToObjectConversion</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'Allocation in new TLAB', 'Allocation outside TLAB'.</shortDescription>
+<longDescription>The Primitive To Object Conversion rule requires that the following event types are enabled: 'Allocation in new TLAB', 'Allocation outside TLAB'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>SocketRead</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'Socket Read'.</shortDescription>
+<longDescription>The Socket Read Peak Duration rule requires that the following event types are enabled: 'Socket Read'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>SocketWrite</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'Socket Write'.</shortDescription>
+<longDescription>The Socket Write Peak Duration rule requires that the following event types are enabled: 'Socket Write'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>StackdepthSetting</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>No stack traces were truncated in this recording.</shortDescription>
+<longDescription>No stack traces were truncated in this recording.</longDescription>
+</rule>
+<rule>
+<id>StringDeduplication</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>The Java version could not be determined.</shortDescription>
+<longDescription>The Java version could not be determined.</longDescription>
+</rule>
+<rule>
+<id>SystemGc</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>No garbage collections were caused by System.gc().</shortDescription>
+<longDescription>No garbage collections were caused by System.gc().</longDescription>
+</rule>
+<rule>
+<id>TlabAllocationRatio</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'Allocation in new TLAB', 'Allocation outside TLAB'.</shortDescription>
+<longDescription>The TLAB Allocation Ratio rule requires that the following event types are enabled: 'Allocation in new TLAB', 'Allocation outside TLAB'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>VMOperations</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'VM Operation'.</shortDescription>
+<longDescription>The VMOperation Peak Duration rule requires that the following event types are enabled: 'VM Operation'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>biasedLockingRevocation</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'Biased Lock Class Revocation'.</shortDescription>
+<longDescription>The Biased Locking Revocation rule requires that the following event types are enabled: 'Biased Lock Class Revocation'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>biasedLockingRevocationPause</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'VM Operation'.</shortDescription>
+<longDescription>The Biased Locking Revocation Pauses rule requires that the following event types are enabled: 'VM Operation'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+</report>
+<report>
+<file>parallel-gc_cpu.jfr</file>
+<rule>
+<id>Allocations.class</id>
+<severity>OK</severity>
+<score>0.02670579099297634</score>
+<shortDescription>The most allocated type is likely 'java.util.ArrayList', most commonly allocated by: &lt;ul&gt;&lt;li&gt;JFRImpl.getRecordings() (100 %)&lt;/li&gt;&lt;li&gt;MetaProducer.onNewChunk()&lt;/li&gt;&lt;li&gt;JFRImpl.onNewChunk()&lt;/li&gt;&lt;/ul&gt;</shortDescription>
+<longDescription>The most allocated type is likely 'java.util.ArrayList', most commonly allocated by: &lt;ul&gt;&lt;li&gt;JFRImpl.getRecordings() (100 %)&lt;/li&gt;&lt;li&gt;MetaProducer.onNewChunk()&lt;/li&gt;&lt;li&gt;JFRImpl.onNewChunk()&lt;/li&gt;&lt;/ul&gt;&lt;p&gt;Frequently allocated types are good places to start when trying to reduce garbage collections. Look at where the most common types are being allocated to see if many instances are created along the same call path. Try to reduce the number of instances created by invoking the most commonly taken paths less.</longDescription>
+</rule>
+<rule>
+<id>Allocations.thread</id>
+<severity>OK</severity>
+<score>0.07261458520440227</score>
+<shortDescription>The most allocations were likely done by thread 'RMI TCP Connection(1)-127.0.0.1' at: &lt;ul&gt;&lt;li&gt;ObjectInputStream$BlockDataInputStream.&amp;lt;init&amp;gt;(ObjectInputStream, InputStream) (50 %)&lt;/li&gt;&lt;li&gt;ObjectInputStream.&amp;lt;init&amp;gt;(InputStream)&lt;/li&gt;&lt;li&gt;MarshalInputStream.&amp;lt;init&amp;gt;(InputStream)&lt;/li&gt;&lt;li&gt;ConnectionInputStream.&amp;lt;init&amp;gt;(InputStream)&lt;/li&gt;&lt;li&gt;StreamRemoteCall.getInputStream()&lt;/li&gt;&lt;li&gt;Transport.serviceCall(RemoteCall)&lt;/li&gt;&lt;/ul&gt;</shortDescription>
+<longDescription>The most allocations were likely done by thread 'RMI TCP Connection(1)-127.0.0.1' at: &lt;ul&gt;&lt;li&gt;ObjectInputStream$BlockDataInputStream.&amp;lt;init&amp;gt;(ObjectInputStream, InputStream) (50 %)&lt;/li&gt;&lt;li&gt;ObjectInputStream.&amp;lt;init&amp;gt;(InputStream)&lt;/li&gt;&lt;li&gt;MarshalInputStream.&amp;lt;init&amp;gt;(InputStream)&lt;/li&gt;&lt;li&gt;ConnectionInputStream.&amp;lt;init&amp;gt;(InputStream)&lt;/li&gt;&lt;li&gt;StreamRemoteCall.getInputStream()&lt;/li&gt;&lt;li&gt;Transport.serviceCall(RemoteCall)&lt;/li&gt;&lt;/ul&gt;&lt;p&gt;Many allocations performed by the same thread might indicate a problem in a multi-threaded program. Look at the stack traces for the thread with the highest allocation rate. See if the allocation rate can be brought down, or balanced among the active threads.</longDescription>
+</rule>
+<rule>
+<id>ApplicationHalts</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>Application efficiency was not highly affected by halts.</shortDescription>
+<longDescription>Application efficiency was not highly affected by halts.&lt;p&gt;The highest ratio of application halts to execution time was 0 % for 1 min at 4/4/14 11:17:05 AM. 0 % of the halts were for reasons other than GC.&lt;p&gt;The halts ratio for the entire recording was 0 %. 0 % of the total halts were for reasons other than GC.&lt;/p&gt;&lt;p&gt;Enabling the following event types would improve the accuracy of this rule: jdk.SafepointBegin</longDescription>
+</rule>
+<rule>
+<id>BufferLost</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>No Flight Recorder buffers were lost during the recording.</shortDescription>
+<longDescription>No Flight Recorder buffers were lost during the recording.</longDescription>
+</rule>
+<rule>
+<id>BytecodeVerification</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>The application ran with bytecode verification enabled.</shortDescription>
+<longDescription>The application ran with bytecode verification enabled.</longDescription>
+</rule>
+<rule>
+<id>ClassLeak</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'Class Load', 'Class Unload'.</shortDescription>
+<longDescription>The Class Leak rule requires that the following event types are enabled: 'Class Load', 'Class Unload'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>ClassLoading</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'Class Load'.</shortDescription>
+<longDescription>The Class Loading Pressure rule requires that the following event types are enabled: 'Class Load'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>CodeCache</id>
+<severity>OK</severity>
+<score>2.07672119140625</score>
+<shortDescription>No problems with the code cache were detected in the recording.</shortDescription>
+<longDescription>No problems with the code cache were detected in the recording.</longDescription>
+</rule>
+<rule>
+<id>CompareCpu</id>
+<severity>OK</severity>
+<score>9.313225746154785E-7</score>
+<shortDescription>An average CPU load of 0 % was caused by other processes for 1.011 s at 4/4/14 11:17:07 AM.</shortDescription>
+<longDescription>An average CPU load of 0 % was caused by other processes for 1.011 s at 4/4/14 11:17:07 AM.</longDescription>
+</rule>
+<rule>
+<id>CompressedOops</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>The settings for Compressed Oops were OK.</shortDescription>
+<longDescription>The settings for Compressed Oops were OK.</longDescription>
+</rule>
+<rule>
+<id>ContextSwitch</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires events to be available from the following event types: 'Thread Context Switch Rate'.</shortDescription>
+<longDescription>The Context Switches rule requires events to be available from the following event types: 'Thread Context Switch Rate'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>DMSIncident</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>The DMS Incidents rule requires the following event types: 'http://www.oracle.com/dms/dfw/dms/dfw/DFW_Incident/DFW_Incident_state'.</shortDescription>
+<longDescription>The DMS Incidents rule requires the following event types: 'http://www.oracle.com/dms/dfw/dms/dfw/DFW_Incident/DFW_Incident_state'.&lt;p&gt;They are either not available in this version of Java, or must be enabled in a third-party component. If you are using an older Java version, then you can consider upgrading.</longDescription>
+</rule>
+<rule>
+<id>DebugNonSafepoints</id>
+<severity>Information</severity>
+<score>50.0</score>
+<shortDescription>DebugNonSafepoints was not enabled.</shortDescription>
+<longDescription>DebugNonSafepoints was not enabled.&lt;p&gt;If DebugNonSafepoints is not enabled, the method profiling data will be less accurate as threads that are not at safepoints will not be correctly sampled. Use the following JVM flags to enable this: '-XX:+UnlockDiagnosticVMOptions -XX:+DebugNonSafepoints'. There is a slight performance overhead when enabling these flags. For more information see &lt;a href="http://openjdk.java.net/groups/hotspot/docs/RuntimeOverview.html#Thread%20Management|outline"&gt;HotSpot Runtime Overview/Thread Management&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>DiscouragedVmOptions</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>No problems were found with the VM options.</shortDescription>
+<longDescription>No problems were found with the VM options.</longDescription>
+</rule>
+<rule>
+<id>DumpReason</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>This recording was not dumped for an exceptional reason.</shortDescription>
+<longDescription>This recording was not dumped for an exceptional reason.</longDescription>
+</rule>
+<rule>
+<id>DuplicateFlags</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>There were no duplicate JVM flags on the command line.</shortDescription>
+<longDescription>There were no duplicate JVM flags on the command line.</longDescription>
+</rule>
+<rule>
+<id>Errors</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires events to be available from the following event types: 'Java Error'.</shortDescription>
+<longDescription>The Thrown Errors rule requires events to be available from the following event types: 'Java Error'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>Exceptions</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>The program generated 0 exceptions per second for 999.487 ms at 4/4/14 11:17:06 AM.</shortDescription>
+<longDescription>The program generated 0 exceptions per second for 999.487 ms at 4/4/14 11:17:06 AM.</longDescription>
+</rule>
+<rule>
+<id>Fatal Errors</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>The Fatal Errors rule requires the following event types: 'jdk.Shutdown'.</shortDescription>
+<longDescription>The Fatal Errors rule requires the following event types: 'jdk.Shutdown'.&lt;p&gt;They are either not available in this version of Java, or must be enabled in a third-party component. If you are using an older Java version, then you can consider upgrading.</longDescription>
+</rule>
+<rule>
+<id>FewSampledThreads</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>There were no problems with the amount of sampled threads.</shortDescription>
+<longDescription>There were no problems with the amount of sampled threads.&lt;p&gt;There are more sampled threads than the amount of hardware threads. This indicates that the application has enough parallelism for the available hardware.&lt;p&gt;This recording is only 5.171 s long, consider creating a recording longer than 20 s for improved rule accuracy.</longDescription>
+</rule>
+<rule>
+<id>FileRead</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>There are no file read events in this recording.</shortDescription>
+<longDescription>There are no file read events in this recording.</longDescription>
+</rule>
+<rule>
+<id>FileWrite</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires events to be available from the following event types: 'File Write'.</shortDescription>
+<longDescription>The File Write Peak Duration rule requires events to be available from the following event types: 'File Write'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>FlightRecordingSupport</id>
+<severity>Warning</severity>
+<score>80.0</score>
+<shortDescription>The recording is from an early access build.</shortDescription>
+<longDescription>This recording is from an early access build of the JRE (Java HotSpot(TM) Client VM (25.20-b08) for linux-x86 JRE (1.8.0_20-ea-b08), built on Apr  1 2014 19:40:24 by &amp;#34;java_re&amp;#34; with gcc 4.3.0 20080428 (Red Hat 4.3.0-8)). The automated analysis is not supported, and you may see errors when attempting to analyze the recording.</longDescription>
+</rule>
+<rule>
+<id>FullGc</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires events to be available from the following event types: 'Garbage Collection'.</shortDescription>
+<longDescription>The G1/CMS Full Collection rule requires events to be available from the following event types: 'Garbage Collection'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>GcFreedRatio</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>Only 0 heap summary events were found, this rule requires at least 10 events to be able to calculate a relevant result. This likely means that only a few garbage collections occurred during the recording. Having few garbage collections is generally a good sign.</shortDescription>
+<longDescription>Only 0 heap summary events were found, this rule requires at least 10 events to be able to calculate a relevant result. This likely means that only a few garbage collections occurred during the recording. Having few garbage collections is generally a good sign.</longDescription>
+</rule>
+<rule>
+<id>GcLocker</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>No GCs were affected by the GC Locker.</shortDescription>
+<longDescription>No GCs were affected by the GC Locker.</longDescription>
+</rule>
+<rule>
+<id>GcOptions</id>
+<severity>Information</severity>
+<score>50.0</score>
+<shortDescription>The runtime used 2 GC threads on a machine with 1 CPU cores.</shortDescription>
+<longDescription>The runtime used 2 GC threads on a machine with 1 CPU cores. It's suboptimal to use more GC threads than available cores. Removing the '-XX:ParallelGCThreads' flag will allow the JVM to set the number of GC threads automatically.</longDescription>
+</rule>
+<rule>
+<id>GcPauseRatio</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>Application efficiency was not highly affected by GC pauses.</shortDescription>
+<longDescription>Application efficiency was not highly affected by GC pauses.&lt;p&gt;The highest ratio between garbage collection pauses and execution time was 0 % for 1 min at 4/4/14 11:17:05 AM. The garbage collection pause ratio of the entire recording was 0 %.</longDescription>
+</rule>
+<rule>
+<id>GcStall</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>No indications that the garbage collector could not keep up with the workload were detected.</shortDescription>
+<longDescription>No indications that the garbage collector could not keep up with the workload were detected.</longDescription>
+</rule>
+<rule>
+<id>HeapContent</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'Object Count'.</shortDescription>
+<longDescription>The Heap Content rule requires that the following event types are enabled: 'Object Count'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>HeapInspectionGc</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires events to be available from the following event types: 'Garbage Collection'.</shortDescription>
+<longDescription>The GCs Caused by Heap Inspection rule requires events to be available from the following event types: 'Garbage Collection'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>HighGc</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>The runtime did not spend much time performing garbage collections.</shortDescription>
+<longDescription>The runtime did not spend much time performing garbage collections.</longDescription>
+</rule>
+<rule>
+<id>HighJvmCpu</id>
+<severity>Information</severity>
+<score>27.969203755893627</score>
+<shortDescription>This recording contains few profiling samples even though the CPU load is high.</shortDescription>
+<longDescription>This recording contains few profiling samples even though the CPU load is high. The profiling data is thus likely not relevant. This might be because the application is running a lot JNI code or that the JVM is spending a lot of time in GC, class loading, JIT compilation etc.</longDescription>
+</rule>
+<rule>
+<id>IncreasingLiveSet</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>Too few events to calculate the result.</shortDescription>
+<longDescription>Too few events to calculate the result.</longDescription>
+</rule>
+<rule>
+<id>IncreasingMetaSpaceLiveSet</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>The class data does not seem to increase during the recording.</shortDescription>
+<longDescription>The class data does not seem to increase during the recording.</longDescription>
+</rule>
+<rule>
+<id>JavaBlocking</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires events to be available from the following event types: 'Java Monitor Blocked'.</shortDescription>
+<longDescription>The Java Blocking rule requires events to be available from the following event types: 'Java Monitor Blocked'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>LongGcPause</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>The application did not cause any long GC pause times.</shortDescription>
+<longDescription>The application did not cause any long GC pause times.</longDescription>
+</rule>
+<rule>
+<id>LowOnPhysicalMemory</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>The system did not run low on physical memory during this recording.</shortDescription>
+<longDescription>The system did not run low on physical memory during this recording.</longDescription>
+</rule>
+<rule>
+<id>ManagementAgent</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>No problems were found with the management agent settings.</shortDescription>
+<longDescription>No problems were found with the management agent settings.</longDescription>
+</rule>
+<rule>
+<id>ManyRunningProcesses</id>
+<severity>OK</severity>
+<score>23.21768417223916</score>
+<shortDescription>137 processes were running while this Flight Recording was made.</shortDescription>
+<longDescription>At 4/4/14 11:17:10 AM, a total of 137 other processes were running on the host machine that this Flight Recording was made on.</longDescription>
+</rule>
+<rule>
+<id>MetaspaceOom</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'Metaspace Out of Memory'.</shortDescription>
+<longDescription>The Metaspace Out of Memory rule requires that the following event types are enabled: 'Metaspace Out of Memory'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>MethodProfiling</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>No methods where optimization would be particularly efficient could be detected.</shortDescription>
+<longDescription>No methods where optimization would be particularly efficient could be detected.</longDescription>
+</rule>
+<rule>
+<id>Options</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>No undocumented, deprecated or non-recommended option flags were detected.</shortDescription>
+<longDescription>No undocumented, deprecated or non-recommended option flags were detected.</longDescription>
+</rule>
+<rule>
+<id>OverAggressiveRecordingSetting</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>No problems were found with the recording settings.</shortDescription>
+<longDescription>No problems were found with the recording settings.</longDescription>
+</rule>
+<rule>
+<id>PasswordsInArguments</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>The recording does not seem to contain passwords in the application arguments.</shortDescription>
+<longDescription>The recording does not seem to contain passwords in the application arguments.</longDescription>
+</rule>
+<rule>
+<id>PasswordsInEnvironment</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>The recording does not seem to contain passwords in the environment variables.</shortDescription>
+<longDescription>The recording does not seem to contain passwords in the environment variables.</longDescription>
+</rule>
+<rule>
+<id>PasswordsInSystemProperties</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>The recording does not seem to contain passwords in the system properties.</shortDescription>
+<longDescription>The recording does not seem to contain passwords in the system properties.</longDescription>
+</rule>
+<rule>
+<id>PrimitiveToObjectConversion</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires events to be available from the following event types: 'Allocation in new TLAB', 'Allocation outside TLAB'.</shortDescription>
+<longDescription>The Primitive To Object Conversion rule requires events to be available from the following event types: 'Allocation in new TLAB', 'Allocation outside TLAB'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>SocketRead</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>There are no socket read events in this recording.</shortDescription>
+<longDescription>There are no socket read events in this recording.&lt;p&gt;Note that there are some socket read patterns with high duration reads that we consider to be normal and are therefore excluded. Such patterns include JMX RMI communication and MQ series.</longDescription>
+</rule>
+<rule>
+<id>SocketWrite</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>There are no socket write events in this recording.</shortDescription>
+<longDescription>There are no socket write events in this recording.&lt;p&gt;Note that there are some socket write patterns with high duration writes that we consider to be normal and are therefore excluded. Such patterns include JMX RMI communication.</longDescription>
+</rule>
+<rule>
+<id>StackdepthSetting</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>No stack traces were truncated in this recording.</shortDescription>
+<longDescription>No stack traces were truncated in this recording.</longDescription>
+</rule>
+<rule>
+<id>StringDeduplication</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires events to be available from the following event types: 'Heap Summary'.</shortDescription>
+<longDescription>The String Deduplication rule requires events to be available from the following event types: 'Heap Summary'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>SystemGc</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires events to be available from the following event types: 'Garbage Collection'.</shortDescription>
+<longDescription>The GCs Caused by System.gc() rule requires events to be available from the following event types: 'Garbage Collection'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>TlabAllocationRatio</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>No object allocations outside of TLABs detected.</shortDescription>
+<longDescription>No object allocations outside of TLABs detected.</longDescription>
+</rule>
+<rule>
+<id>VMOperations</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>No excessively long VM operations were found in this recording (the longest was 0 s).</shortDescription>
+<longDescription>No excessively long VM operations were found in this recording (the longest was 0 s).</longDescription>
+</rule>
+<rule>
+<id>biasedLockingRevocation</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>The Biased Locking Revocation rule requires the following event types: 'jdk.BiasedLockClassRevocation'.</shortDescription>
+<longDescription>The Biased Locking Revocation rule requires the following event types: 'jdk.BiasedLockClassRevocation'.&lt;p&gt;They are either not available in this version of Java, or must be enabled in a third-party component. If you are using an older Java version, then you can consider upgrading.</longDescription>
+</rule>
+<rule>
+<id>biasedLockingRevocationPause</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>No revocation of biased locks found.</shortDescription>
+<longDescription>No revocation of biased locks found.</longDescription>
+</rule>
+</report>
+<report>
+<file>parallel-on-singlecpu.jfr</file>
+<rule>
+<id>Allocations.class</id>
+<severity>OK</severity>
+<score>0.031334794765092246</score>
+<shortDescription>The most allocated type is likely 'java.lang.Object[]', most commonly allocated by: &lt;ul&gt;&lt;li&gt;AbstractCollection.toArray() (100 %)&lt;/li&gt;&lt;li&gt;ArrayList.&amp;lt;init&amp;gt;(Collection)&lt;/li&gt;&lt;li&gt;JFRImpl.getRecordings()&lt;/li&gt;&lt;li&gt;MetaProducer.onNewChunk()&lt;/li&gt;&lt;li&gt;JFRImpl.onNewChunk()&lt;/li&gt;&lt;/ul&gt;</shortDescription>
+<longDescription>The most allocated type is likely 'java.lang.Object[]', most commonly allocated by: &lt;ul&gt;&lt;li&gt;AbstractCollection.toArray() (100 %)&lt;/li&gt;&lt;li&gt;ArrayList.&amp;lt;init&amp;gt;(Collection)&lt;/li&gt;&lt;li&gt;JFRImpl.getRecordings()&lt;/li&gt;&lt;li&gt;MetaProducer.onNewChunk()&lt;/li&gt;&lt;li&gt;JFRImpl.onNewChunk()&lt;/li&gt;&lt;/ul&gt;&lt;p&gt;Frequently allocated types are good places to start when trying to reduce garbage collections. Look at where the most common types are being allocated to see if many instances are created along the same call path. Try to reduce the number of instances created by invoking the most commonly taken paths less.</longDescription>
+</rule>
+<rule>
+<id>Allocations.thread</id>
+<severity>OK</severity>
+<score>0.031334794765092246</score>
+<shortDescription>The most allocations were likely done by thread 'RMI TCP Connection(1)-127.0.0.1' at: &lt;ul&gt;&lt;li&gt;Throwable.fillInStackTrace(int) (100 %)&lt;/li&gt;&lt;li&gt;Throwable.fillInStackTrace()&lt;/li&gt;&lt;li&gt;Throwable.&amp;lt;init&amp;gt;(String)&lt;/li&gt;&lt;li&gt;Exception.&amp;lt;init&amp;gt;(String)&lt;/li&gt;&lt;li&gt;ReflectiveOperationException.&amp;lt;init&amp;gt;(String)&lt;/li&gt;&lt;li&gt;NoSuchFieldException.&amp;lt;init&amp;gt;(String)&lt;/li&gt;&lt;/ul&gt;</shortDescription>
+<longDescription>The most allocations were likely done by thread 'RMI TCP Connection(1)-127.0.0.1' at: &lt;ul&gt;&lt;li&gt;Throwable.fillInStackTrace(int) (100 %)&lt;/li&gt;&lt;li&gt;Throwable.fillInStackTrace()&lt;/li&gt;&lt;li&gt;Throwable.&amp;lt;init&amp;gt;(String)&lt;/li&gt;&lt;li&gt;Exception.&amp;lt;init&amp;gt;(String)&lt;/li&gt;&lt;li&gt;ReflectiveOperationException.&amp;lt;init&amp;gt;(String)&lt;/li&gt;&lt;li&gt;NoSuchFieldException.&amp;lt;init&amp;gt;(String)&lt;/li&gt;&lt;/ul&gt;&lt;p&gt;Many allocations performed by the same thread might indicate a problem in a multi-threaded program. Look at the stack traces for the thread with the highest allocation rate. See if the allocation rate can be brought down, or balanced among the active threads.</longDescription>
+</rule>
+<rule>
+<id>ApplicationHalts</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>Application efficiency was not highly affected by halts.</shortDescription>
+<longDescription>Application efficiency was not highly affected by halts.&lt;p&gt;The highest ratio of application halts to execution time was 0 % for 1 min at 4/4/14 8:54:33 AM. 0 % of the halts were for reasons other than GC.&lt;p&gt;The halts ratio for the entire recording was 0 %. 0 % of the total halts were for reasons other than GC.&lt;/p&gt;&lt;p&gt;Enabling the following event types would improve the accuracy of this rule: jdk.SafepointBegin</longDescription>
+</rule>
+<rule>
+<id>BufferLost</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>No Flight Recorder buffers were lost during the recording.</shortDescription>
+<longDescription>No Flight Recorder buffers were lost during the recording.</longDescription>
+</rule>
+<rule>
+<id>BytecodeVerification</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>The application ran with bytecode verification enabled.</shortDescription>
+<longDescription>The application ran with bytecode verification enabled.</longDescription>
+</rule>
+<rule>
+<id>ClassLeak</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'Class Load', 'Class Unload'.</shortDescription>
+<longDescription>The Class Leak rule requires that the following event types are enabled: 'Class Load', 'Class Unload'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>ClassLoading</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'Class Load'.</shortDescription>
+<longDescription>The Class Loading Pressure rule requires that the following event types are enabled: 'Class Load'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>CodeCache</id>
+<severity>OK</severity>
+<score>2.0233154296875</score>
+<shortDescription>No problems with the code cache were detected in the recording.</shortDescription>
+<longDescription>No problems with the code cache were detected in the recording.</longDescription>
+</rule>
+<rule>
+<id>CompareCpu</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>An average CPU load of 0 % was caused by other processes for 1.010 s at 4/4/14 8:54:36 AM.</shortDescription>
+<longDescription>An average CPU load of 0 % was caused by other processes for 1.010 s at 4/4/14 8:54:36 AM.</longDescription>
+</rule>
+<rule>
+<id>CompressedOops</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>The settings for Compressed Oops were OK.</shortDescription>
+<longDescription>The settings for Compressed Oops were OK.</longDescription>
+</rule>
+<rule>
+<id>ContextSwitch</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>The program did not context switch excessively during the recording.</shortDescription>
+<longDescription>The program did not context switch excessively during the recording.</longDescription>
+</rule>
+<rule>
+<id>DMSIncident</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>The DMS Incidents rule requires the following event types: 'http://www.oracle.com/dms/dfw/dms/dfw/DFW_Incident/DFW_Incident_state'.</shortDescription>
+<longDescription>The DMS Incidents rule requires the following event types: 'http://www.oracle.com/dms/dfw/dms/dfw/DFW_Incident/DFW_Incident_state'.&lt;p&gt;They are either not available in this version of Java, or must be enabled in a third-party component. If you are using an older Java version, then you can consider upgrading.</longDescription>
+</rule>
+<rule>
+<id>DebugNonSafepoints</id>
+<severity>Information</severity>
+<score>50.0</score>
+<shortDescription>DebugNonSafepoints was not enabled.</shortDescription>
+<longDescription>DebugNonSafepoints was not enabled.&lt;p&gt;If DebugNonSafepoints is not enabled, the method profiling data will be less accurate as threads that are not at safepoints will not be correctly sampled. Use the following JVM flags to enable this: '-XX:+UnlockDiagnosticVMOptions -XX:+DebugNonSafepoints'. There is a slight performance overhead when enabling these flags. For more information see &lt;a href="http://openjdk.java.net/groups/hotspot/docs/RuntimeOverview.html#Thread%20Management|outline"&gt;HotSpot Runtime Overview/Thread Management&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>DiscouragedVmOptions</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>No problems were found with the VM options.</shortDescription>
+<longDescription>No problems were found with the VM options.</longDescription>
+</rule>
+<rule>
+<id>DumpReason</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>This recording was not dumped for an exceptional reason.</shortDescription>
+<longDescription>This recording was not dumped for an exceptional reason.</longDescription>
+</rule>
+<rule>
+<id>DuplicateFlags</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>There were no duplicate JVM flags on the command line.</shortDescription>
+<longDescription>There were no duplicate JVM flags on the command line.</longDescription>
+</rule>
+<rule>
+<id>Errors</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires events to be available from the following event types: 'Java Error'.</shortDescription>
+<longDescription>The Thrown Errors rule requires events to be available from the following event types: 'Java Error'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>Exceptions</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>The program generated 0 exceptions per second for 1.009 s at 4/4/14 8:54:34 AM.</shortDescription>
+<longDescription>The program generated 0 exceptions per second for 1.009 s at 4/4/14 8:54:34 AM.</longDescription>
+</rule>
+<rule>
+<id>Fatal Errors</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>The Fatal Errors rule requires the following event types: 'jdk.Shutdown'.</shortDescription>
+<longDescription>The Fatal Errors rule requires the following event types: 'jdk.Shutdown'.&lt;p&gt;They are either not available in this version of Java, or must be enabled in a third-party component. If you are using an older Java version, then you can consider upgrading.</longDescription>
+</rule>
+<rule>
+<id>FewSampledThreads</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>There were no problems with the amount of sampled threads.</shortDescription>
+<longDescription>There were no problems with the amount of sampled threads.&lt;p&gt;There are more sampled threads than the amount of hardware threads. This indicates that the application has enough parallelism for the available hardware.&lt;p&gt;This recording is only 5.136 s long, consider creating a recording longer than 20 s for improved rule accuracy.</longDescription>
+</rule>
+<rule>
+<id>FileRead</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>There are no file read events in this recording.</shortDescription>
+<longDescription>There are no file read events in this recording.</longDescription>
+</rule>
+<rule>
+<id>FileWrite</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires events to be available from the following event types: 'File Write'.</shortDescription>
+<longDescription>The File Write Peak Duration rule requires events to be available from the following event types: 'File Write'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>FlightRecordingSupport</id>
+<severity>Warning</severity>
+<score>80.0</score>
+<shortDescription>The recording is from an early access build.</shortDescription>
+<longDescription>This recording is from an early access build of the JRE (Java HotSpot(TM) Client VM (25.20-b08) for linux-x86 JRE (1.8.0_20-ea-b08), built on Apr  1 2014 19:40:24 by &amp;#34;java_re&amp;#34; with gcc 4.3.0 20080428 (Red Hat 4.3.0-8)). The automated analysis is not supported, and you may see errors when attempting to analyze the recording.</longDescription>
+</rule>
+<rule>
+<id>FullGc</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule is only valid for CMS and G1 Garbage Collectors, neither of which were detected for this JVM.</shortDescription>
+<longDescription>This rule is only valid for CMS and G1 Garbage Collectors, neither of which were detected for this JVM.</longDescription>
+</rule>
+<rule>
+<id>GcFreedRatio</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>Only 0 heap summary events were found, this rule requires at least 10 events to be able to calculate a relevant result. This likely means that only a few garbage collections occurred during the recording. Having few garbage collections is generally a good sign.</shortDescription>
+<longDescription>Only 0 heap summary events were found, this rule requires at least 10 events to be able to calculate a relevant result. This likely means that only a few garbage collections occurred during the recording. Having few garbage collections is generally a good sign.</longDescription>
+</rule>
+<rule>
+<id>GcLocker</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>No GCs were affected by the GC Locker.</shortDescription>
+<longDescription>No GCs were affected by the GC Locker.</longDescription>
+</rule>
+<rule>
+<id>GcOptions</id>
+<severity>Information</severity>
+<score>50.0</score>
+<shortDescription>The runtime used a parallel GC on a single-core machine.</shortDescription>
+<longDescription>The runtime used a parallel GC on a single-core machine. This is not optimal. Use the &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/guides/vm/gctuning/collectors.html"&gt;Serial Collector&lt;/a&gt; instead, which is optimized for single-core machines.</longDescription>
+</rule>
+<rule>
+<id>GcPauseRatio</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>Application efficiency was not highly affected by GC pauses.</shortDescription>
+<longDescription>Application efficiency was not highly affected by GC pauses.&lt;p&gt;The highest ratio between garbage collection pauses and execution time was 0 % for 1 min at 4/4/14 8:54:33 AM. The garbage collection pause ratio of the entire recording was 0 %.</longDescription>
+</rule>
+<rule>
+<id>GcStall</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>No indications that the garbage collector could not keep up with the workload were detected.</shortDescription>
+<longDescription>No indications that the garbage collector could not keep up with the workload were detected.</longDescription>
+</rule>
+<rule>
+<id>HeapContent</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'Object Count'.</shortDescription>
+<longDescription>The Heap Content rule requires that the following event types are enabled: 'Object Count'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>HeapInspectionGc</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires events to be available from the following event types: 'Garbage Collection'.</shortDescription>
+<longDescription>The GCs Caused by Heap Inspection rule requires events to be available from the following event types: 'Garbage Collection'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>HighGc</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>The runtime did not spend much time performing garbage collections.</shortDescription>
+<longDescription>The runtime did not spend much time performing garbage collections.</longDescription>
+</rule>
+<rule>
+<id>HighJvmCpu</id>
+<severity>Information</severity>
+<score>35.27744043201552</score>
+<shortDescription>This recording contains few profiling samples even though the CPU load is high.</shortDescription>
+<longDescription>This recording contains few profiling samples even though the CPU load is high. The profiling data is thus likely not relevant. This might be because the application is running a lot JNI code or that the JVM is spending a lot of time in GC, class loading, JIT compilation etc.</longDescription>
+</rule>
+<rule>
+<id>IncreasingLiveSet</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>Too few events to calculate the result.</shortDescription>
+<longDescription>Too few events to calculate the result.</longDescription>
+</rule>
+<rule>
+<id>IncreasingMetaSpaceLiveSet</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>The class data does not seem to increase during the recording.</shortDescription>
+<longDescription>The class data does not seem to increase during the recording.</longDescription>
+</rule>
+<rule>
+<id>JavaBlocking</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires events to be available from the following event types: 'Java Monitor Blocked'.</shortDescription>
+<longDescription>The Java Blocking rule requires events to be available from the following event types: 'Java Monitor Blocked'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>LongGcPause</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>The application did not cause any long GC pause times.</shortDescription>
+<longDescription>The application did not cause any long GC pause times.</longDescription>
+</rule>
+<rule>
+<id>LowOnPhysicalMemory</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>The system did not run low on physical memory during this recording.</shortDescription>
+<longDescription>The system did not run low on physical memory during this recording.</longDescription>
+</rule>
+<rule>
+<id>ManagementAgent</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>No problems were found with the management agent settings.</shortDescription>
+<longDescription>No problems were found with the management agent settings.</longDescription>
+</rule>
+<rule>
+<id>ManyRunningProcesses</id>
+<severity>OK</severity>
+<score>23.21768417223916</score>
+<shortDescription>137 processes were running while this Flight Recording was made.</shortDescription>
+<longDescription>At 4/4/14 8:54:38 AM, a total of 137 other processes were running on the host machine that this Flight Recording was made on.</longDescription>
+</rule>
+<rule>
+<id>MetaspaceOom</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'Metaspace Out of Memory'.</shortDescription>
+<longDescription>The Metaspace Out of Memory rule requires that the following event types are enabled: 'Metaspace Out of Memory'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>MethodProfiling</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>No methods where optimization would be particularly efficient could be detected.</shortDescription>
+<longDescription>No methods where optimization would be particularly efficient could be detected.</longDescription>
+</rule>
+<rule>
+<id>Options</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>No undocumented, deprecated or non-recommended option flags were detected.</shortDescription>
+<longDescription>No undocumented, deprecated or non-recommended option flags were detected.</longDescription>
+</rule>
+<rule>
+<id>OverAggressiveRecordingSetting</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>No problems were found with the recording settings.</shortDescription>
+<longDescription>No problems were found with the recording settings.</longDescription>
+</rule>
+<rule>
+<id>PasswordsInArguments</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>The recording does not seem to contain passwords in the application arguments.</shortDescription>
+<longDescription>The recording does not seem to contain passwords in the application arguments.</longDescription>
+</rule>
+<rule>
+<id>PasswordsInEnvironment</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>The recording does not seem to contain passwords in the environment variables.</shortDescription>
+<longDescription>The recording does not seem to contain passwords in the environment variables.</longDescription>
+</rule>
+<rule>
+<id>PasswordsInSystemProperties</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>The recording does not seem to contain passwords in the system properties.</shortDescription>
+<longDescription>The recording does not seem to contain passwords in the system properties.</longDescription>
+</rule>
+<rule>
+<id>PrimitiveToObjectConversion</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires events to be available from the following event types: 'Allocation in new TLAB', 'Allocation outside TLAB'.</shortDescription>
+<longDescription>The Primitive To Object Conversion rule requires events to be available from the following event types: 'Allocation in new TLAB', 'Allocation outside TLAB'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>SocketRead</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>There are no socket read events in this recording.</shortDescription>
+<longDescription>There are no socket read events in this recording.&lt;p&gt;Note that there are some socket read patterns with high duration reads that we consider to be normal and are therefore excluded. Such patterns include JMX RMI communication and MQ series.</longDescription>
+</rule>
+<rule>
+<id>SocketWrite</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires events to be available from the following event types: 'Socket Write'.</shortDescription>
+<longDescription>The Socket Write Peak Duration rule requires events to be available from the following event types: 'Socket Write'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>StackdepthSetting</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>No stack traces were truncated in this recording.</shortDescription>
+<longDescription>No stack traces were truncated in this recording.</longDescription>
+</rule>
+<rule>
+<id>StringDeduplication</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires events to be available from the following event types: 'Heap Summary'.</shortDescription>
+<longDescription>The String Deduplication rule requires events to be available from the following event types: 'Heap Summary'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>SystemGc</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires events to be available from the following event types: 'Garbage Collection'.</shortDescription>
+<longDescription>The GCs Caused by System.gc() rule requires events to be available from the following event types: 'Garbage Collection'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>TlabAllocationRatio</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>No object allocations outside of TLABs detected.</shortDescription>
+<longDescription>No object allocations outside of TLABs detected.</longDescription>
+</rule>
+<rule>
+<id>VMOperations</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>No excessively long VM operations were found in this recording (the longest was 0 s).</shortDescription>
+<longDescription>No excessively long VM operations were found in this recording (the longest was 0 s).</longDescription>
+</rule>
+<rule>
+<id>biasedLockingRevocation</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>The Biased Locking Revocation rule requires the following event types: 'jdk.BiasedLockClassRevocation'.</shortDescription>
+<longDescription>The Biased Locking Revocation rule requires the following event types: 'jdk.BiasedLockClassRevocation'.&lt;p&gt;They are either not available in this version of Java, or must be enabled in a third-party component. If you are using an older Java version, then you can consider upgrading.</longDescription>
+</rule>
+<rule>
+<id>biasedLockingRevocationPause</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>No revocation of biased locks found.</shortDescription>
+<longDescription>No revocation of biased locks found.</longDescription>
+</rule>
+</report>
+<report>
+<file>stringdedup_enabled_jdk9.jfr</file>
+<rule>
+<id>Allocations.class</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'Allocation in new TLAB', 'Allocation outside TLAB'.</shortDescription>
+<longDescription>The Allocated Classes rule requires that the following event types are enabled: 'Allocation in new TLAB', 'Allocation outside TLAB'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>Allocations.thread</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'Allocation in new TLAB', 'Allocation outside TLAB'.</shortDescription>
+<longDescription>The Threads Allocating rule requires that the following event types are enabled: 'Allocation in new TLAB', 'Allocation outside TLAB'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>ApplicationHalts</id>
+<severity>OK</severity>
+<score>0.4097173333333334</score>
+<shortDescription>Application efficiency was not highly affected by halts.</shortDescription>
+<longDescription>Application efficiency was not highly affected by halts.&lt;p&gt;The highest ratio of application halts to execution time was 0.082 % for 1 min at 4/24/18 10:08:52 AM. 51.552 % of the halts were for reasons other than GC.&lt;p&gt;The halts ratio for the entire recording was 1.003 %. 51.552 % of the total halts were for reasons other than GC.&lt;/p&gt;</longDescription>
+</rule>
+<rule>
+<id>BufferLost</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>No Flight Recorder buffers were lost during the recording.</shortDescription>
+<longDescription>No Flight Recorder buffers were lost during the recording.</longDescription>
+</rule>
+<rule>
+<id>BytecodeVerification</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>The application ran with bytecode verification enabled.</shortDescription>
+<longDescription>The application ran with bytecode verification enabled.</longDescription>
+</rule>
+<rule>
+<id>ClassLeak</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'Class Load', 'Class Unload'.</shortDescription>
+<longDescription>The Class Leak rule requires that the following event types are enabled: 'Class Load', 'Class Unload'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>ClassLoading</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'Class Load'.</shortDescription>
+<longDescription>The Class Loading Pressure rule requires that the following event types are enabled: 'Class Load'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>CodeCache</id>
+<severity>OK</severity>
+<score>21.734625758350106</score>
+<shortDescription>No problems with the code cache were detected in the recording.</shortDescription>
+<longDescription>No problems with the code cache were detected in the recording.</longDescription>
+</rule>
+<rule>
+<id>CompareCpu</id>
+<severity>OK</severity>
+<score>3.3944677554909966</score>
+<shortDescription>An average CPU load of 15 % was caused by other processes for 1.060 s at 4/24/18 10:08:54 AM.</shortDescription>
+<longDescription>An average CPU load of 15 % was caused by other processes for 1.060 s at 4/24/18 10:08:54 AM.</longDescription>
+</rule>
+<rule>
+<id>CompressedOops</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>The settings for Compressed Oops were OK.</shortDescription>
+<longDescription>The settings for Compressed Oops were OK.</longDescription>
+</rule>
+<rule>
+<id>ContextSwitch</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires events to be available from the following event types: 'Thread Context Switch Rate'.</shortDescription>
+<longDescription>The Context Switches rule requires events to be available from the following event types: 'Thread Context Switch Rate'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>DMSIncident</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>The DMS Incidents rule requires the following event types: 'http://www.oracle.com/dms/dfw/dms/dfw/DFW_Incident/DFW_Incident_state'.</shortDescription>
+<longDescription>The DMS Incidents rule requires the following event types: 'http://www.oracle.com/dms/dfw/dms/dfw/DFW_Incident/DFW_Incident_state'.&lt;p&gt;They are either not available in this version of Java, or must be enabled in a third-party component. If you are using an older Java version, then you can consider upgrading.</longDescription>
+</rule>
+<rule>
+<id>DebugNonSafepoints</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>DebugNonSafepoints was implicitly enabled in the JVM version used to create this recording.</shortDescription>
+<longDescription>DebugNonSafepoints was implicitly enabled in the JVM version used to create this recording.</longDescription>
+</rule>
+<rule>
+<id>DiscouragedVmOptions</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>No problems were found with the VM options.</shortDescription>
+<longDescription>No problems were found with the VM options.</longDescription>
+</rule>
+<rule>
+<id>DumpReason</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>This recording was not dumped for an exceptional reason.</shortDescription>
+<longDescription>This recording was not dumped for an exceptional reason.</longDescription>
+</rule>
+<rule>
+<id>DuplicateFlags</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>There were no duplicate JVM flags on the command line.</shortDescription>
+<longDescription>There were no duplicate JVM flags on the command line.</longDescription>
+</rule>
+<rule>
+<id>Errors</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires events to be available from the following event types: 'Java Error'.</shortDescription>
+<longDescription>The Thrown Errors rule requires events to be available from the following event types: 'Java Error'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>Exceptions</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>The program generated 0 exceptions per second for 1.054 s at 4/24/18 10:08:53 AM.</shortDescription>
+<longDescription>The program generated 0 exceptions per second for 1.054 s at 4/24/18 10:08:53 AM.</longDescription>
+</rule>
+<rule>
+<id>Fatal Errors</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>The Fatal Errors rule requires the following event types: 'jdk.Shutdown'.</shortDescription>
+<longDescription>The Fatal Errors rule requires the following event types: 'jdk.Shutdown'.&lt;p&gt;They are either not available in this version of Java, or must be enabled in a third-party component. If you are using an older Java version, then you can consider upgrading.</longDescription>
+</rule>
+<rule>
+<id>FewSampledThreads</id>
+<severity>Information</severity>
+<score>29.510744962334375</score>
+<shortDescription>There are fewer sampled threads than the total number of hardware threads (cores).</shortDescription>
+<longDescription>There are fewer sampled threads than the total number of hardware threads (cores).&lt;p&gt;1 threads with at least 4 method samples were found, but the machine has 32 hardware threads (cores). The application might benefit from a higher level of parallelism. This could also be caused by threads doing something else than running Java code, for example running native code or spending time in the JVM internals.&lt;p&gt;This recording is only 4.902 s long, consider creating a recording longer than 20 s for improved rule accuracy.</longDescription>
+</rule>
+<rule>
+<id>FileRead</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>There are no file read events in this recording.</shortDescription>
+<longDescription>There are no file read events in this recording.</longDescription>
+</rule>
+<rule>
+<id>FileWrite</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires events to be available from the following event types: 'File Write'.</shortDescription>
+<longDescription>The File Write Peak Duration rule requires events to be available from the following event types: 'File Write'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>FlightRecordingSupport</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>The JVM version used for this recording has full Flight Recorder support.</shortDescription>
+<longDescription>The JVM version used for this recording has full Flight Recorder support.</longDescription>
+</rule>
+<rule>
+<id>FullGc</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>No Stop-the-World, Full GC events detected.</shortDescription>
+<longDescription>No Stop-the-World, Full GC events detected.</longDescription>
+</rule>
+<rule>
+<id>GcFreedRatio</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>Only 6 heap summary events were found, this rule requires at least 10 events to be able to calculate a relevant result. This likely means that only a few garbage collections occurred during the recording. Having few garbage collections is generally a good sign.</shortDescription>
+<longDescription>Only 6 heap summary events were found, this rule requires at least 10 events to be able to calculate a relevant result. This likely means that only a few garbage collections occurred during the recording. Having few garbage collections is generally a good sign.</longDescription>
+</rule>
+<rule>
+<id>GcLocker</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>No GCs were affected by the GC Locker.</shortDescription>
+<longDescription>No GCs were affected by the GC Locker.</longDescription>
+</rule>
+<rule>
+<id>GcOptions</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>No problems were found with the GC configuration.</shortDescription>
+<longDescription>No problems were found with the GC configuration.</longDescription>
+</rule>
+<rule>
+<id>GcPauseRatio</id>
+<severity>OK</severity>
+<score>0.1985013333333333</score>
+<shortDescription>Application efficiency was not highly affected by GC pauses.</shortDescription>
+<longDescription>Application efficiency was not highly affected by GC pauses.&lt;p&gt;The highest ratio between garbage collection pauses and execution time was 0.04 % for 1 min at 4/24/18 10:08:52 AM. The garbage collection pause ratio of the entire recording was 0.486 %.</longDescription>
+</rule>
+<rule>
+<id>GcStall</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>No indications that the garbage collector could not keep up with the workload were detected.</shortDescription>
+<longDescription>No indications that the garbage collector could not keep up with the workload were detected.</longDescription>
+</rule>
+<rule>
+<id>HeapContent</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'Object Count'.</shortDescription>
+<longDescription>The Heap Content rule requires that the following event types are enabled: 'Object Count'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>HeapInspectionGc</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>The JVM did not perform any heap inspection GCs.</shortDescription>
+<longDescription>The JVM did not perform any heap inspection GCs. This is good since they usually take a lot of time.</longDescription>
+</rule>
+<rule>
+<id>HighGc</id>
+<severity>OK</severity>
+<score>2.054924803137792</score>
+<shortDescription>The JVM was paused for 100 % of the 9.017 ms at 4/24/18 10:08:53 AM.</shortDescription>
+<longDescription>The JVM was paused for 100 % of the 9.017 ms at 4/24/18 10:08:53 AM. The time spent performing garbage collection may be reduced by increasing the heap size or by trying to reduce allocation.&lt;p&gt;To improve rule accuracy and/or get more details for further investigation, it is recommended to enable the following event types: 'Allocation in new TLAB', 'Allocation outside TLAB'.</longDescription>
+</rule>
+<rule>
+<id>HighJvmCpu</id>
+<severity>OK</severity>
+<score>1.4885947328122275</score>
+<shortDescription>The JVM does not seem to cause a lot of CPU load.</shortDescription>
+<longDescription>The JVM does not seem to cause a lot of CPU load.</longDescription>
+</rule>
+<rule>
+<id>IncreasingLiveSet</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>Too few events to calculate the result.</shortDescription>
+<longDescription>Too few events to calculate the result.</longDescription>
+</rule>
+<rule>
+<id>IncreasingMetaSpaceLiveSet</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>The class data does not seem to increase during the recording.</shortDescription>
+<longDescription>The class data does not seem to increase during the recording.</longDescription>
+</rule>
+<rule>
+<id>JavaBlocking</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires events to be available from the following event types: 'Java Monitor Blocked'.</shortDescription>
+<longDescription>The Java Blocking rule requires events to be available from the following event types: 'Java Monitor Blocked'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>LongGcPause</id>
+<severity>OK</severity>
+<score>0.27457770686965866</score>
+<shortDescription>The longest GC pause was 9.017 ms.</shortDescription>
+<longDescription>The longest GC pause was 9.017 ms.</longDescription>
+</rule>
+<rule>
+<id>LowOnPhysicalMemory</id>
+<severity>Information</severity>
+<score>64.30361523113581</score>
+<shortDescription>The maximum amount of used memory was 91.8 % of the physical memory available.</shortDescription>
+<longDescription>The maximum amount of memory used was 29.3 GiB. This is 91.8 % of the 31.9 GiB of physical memory available. Having little free memory may lead to swapping, which is very expensive. To avoid this, either decrease the memory usage or increase the amount of available memory.</longDescription>
+</rule>
+<rule>
+<id>ManagementAgent</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'Initial System Property'.</shortDescription>
+<longDescription>The Discouraged Management Agent Settings rule requires that the following event types are enabled: 'Initial System Property'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>ManyRunningProcesses</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'System Process'.</shortDescription>
+<longDescription>The Competing Processes rule requires that the following event types are enabled: 'System Process'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>MetaspaceOom</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>The metaspace was not exhausted during this recording.</shortDescription>
+<longDescription>The metaspace was not exhausted during this recording.</longDescription>
+</rule>
+<rule>
+<id>MethodProfiling</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>No methods where optimization would be particularly efficient could be detected.</shortDescription>
+<longDescription>No methods where optimization would be particularly efficient could be detected.</longDescription>
+</rule>
+<rule>
+<id>Options</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>No undocumented, deprecated or non-recommended option flags were detected.</shortDescription>
+<longDescription>No undocumented, deprecated or non-recommended option flags were detected.</longDescription>
+</rule>
+<rule>
+<id>OverAggressiveRecordingSetting</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'Initial System Property'.</shortDescription>
+<longDescription>The Discouraged Recording Settings rule requires that the following event types are enabled: 'Initial System Property'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>PasswordsInArguments</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>The recording does not seem to contain passwords in the application arguments.</shortDescription>
+<longDescription>The recording does not seem to contain passwords in the application arguments.</longDescription>
+</rule>
+<rule>
+<id>PasswordsInEnvironment</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'Initial Environment Variable'.</shortDescription>
+<longDescription>The Passwords in Environment Variables rule requires that the following event types are enabled: 'Initial Environment Variable'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>PasswordsInSystemProperties</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'Initial System Property'.</shortDescription>
+<longDescription>The Passwords in System Properties rule requires that the following event types are enabled: 'Initial System Property'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>PrimitiveToObjectConversion</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'Allocation in new TLAB', 'Allocation outside TLAB'.</shortDescription>
+<longDescription>The Primitive To Object Conversion rule requires that the following event types are enabled: 'Allocation in new TLAB', 'Allocation outside TLAB'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>SocketRead</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires events to be available from the following event types: 'Socket Read'.</shortDescription>
+<longDescription>The Socket Read Peak Duration rule requires events to be available from the following event types: 'Socket Read'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>SocketWrite</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires events to be available from the following event types: 'Socket Write'.</shortDescription>
+<longDescription>The Socket Write Peak Duration rule requires events to be available from the following event types: 'Socket Write'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>StackdepthSetting</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>No stack traces were truncated in this recording.</shortDescription>
+<longDescription>No stack traces were truncated in this recording.</longDescription>
+</rule>
+<rule>
+<id>StringDeduplication</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>String deduplication is already enabled.</shortDescription>
+<longDescription>String deduplication is already enabled.</longDescription>
+</rule>
+<rule>
+<id>SystemGc</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>No garbage collections were caused by System.gc().</shortDescription>
+<longDescription>No garbage collections were caused by System.gc().</longDescription>
+</rule>
+<rule>
+<id>TlabAllocationRatio</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'Allocation in new TLAB', 'Allocation outside TLAB'.</shortDescription>
+<longDescription>The TLAB Allocation Ratio rule requires that the following event types are enabled: 'Allocation in new TLAB', 'Allocation outside TLAB'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>VMOperations</id>
+<severity>OK</severity>
+<score>0.6336485833333333</score>
+<shortDescription>No excessively long VM operations were found in this recording (the longest was 25.346 ms).</shortDescription>
+<longDescription>No excessively long VM operations were found in this recording (the longest was 25.346 ms).</longDescription>
+</rule>
+<rule>
+<id>biasedLockingRevocation</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>The Biased Locking Revocation rule requires the following event types: 'jdk.BiasedLockClassRevocation'.</shortDescription>
+<longDescription>The Biased Locking Revocation rule requires the following event types: 'jdk.BiasedLockClassRevocation'.&lt;p&gt;They are either not available in this version of Java, or must be enabled in a third-party component. If you are using an older Java version, then you can consider upgrading.</longDescription>
+</rule>
+<rule>
+<id>biasedLockingRevocationPause</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>No revocation of biased locks found.</shortDescription>
+<longDescription>No revocation of biased locks found.</longDescription>
+</rule>
+</report>
+<report>
+<file>wldf.jfr</file>
+<rule>
+<id>Allocations.class</id>
+<severity>Information</severity>
+<score>46.750432285649964</score>
+<shortDescription>The most allocated type is likely 'char[]', most commonly allocated by: &lt;ul&gt;&lt;li&gt;Arrays.copyOfRange(char[], int, int) (44.9 %)&lt;/li&gt;&lt;/ul&gt;</shortDescription>
+<longDescription>The most allocated type is likely 'char[]', most commonly allocated by: &lt;ul&gt;&lt;li&gt;Arrays.copyOfRange(char[], int, int) (44.9 %)&lt;/li&gt;&lt;/ul&gt;&lt;p&gt;Frequently allocated types are good places to start when trying to reduce garbage collections. Look at where the most common types are being allocated to see if many instances are created along the same call path. Try to reduce the number of instances created by invoking the most commonly taken paths less.</longDescription>
+</rule>
+<rule>
+<id>Allocations.thread</id>
+<severity>OK</severity>
+<score>24.595150095883856</score>
+<shortDescription>The most allocations were likely done by thread '[ACTIVE] ExecuteThread: &amp;#39;5&amp;#39; for queue: &amp;#39;weblogic.kernel.Default (self-tuning)&amp;#39;' at: &lt;ul&gt;&lt;li&gt;Arrays.copyOfRange(char[], int, int) (53.3 %)&lt;/li&gt;&lt;/ul&gt;</shortDescription>
+<longDescription>The most allocations were likely done by thread '[ACTIVE] ExecuteThread: &amp;#39;5&amp;#39; for queue: &amp;#39;weblogic.kernel.Default (self-tuning)&amp;#39;' at: &lt;ul&gt;&lt;li&gt;Arrays.copyOfRange(char[], int, int) (53.3 %)&lt;/li&gt;&lt;/ul&gt;&lt;p&gt;Many allocations performed by the same thread might indicate a problem in a multi-threaded program. Look at the stack traces for the thread with the highest allocation rate. See if the allocation rate can be brought down, or balanced among the active threads.</longDescription>
+</rule>
+<rule>
+<id>ApplicationHalts</id>
+<severity>OK</severity>
+<score>11.086075208333334</score>
+<shortDescription>Application efficiency was not highly affected by halts.</shortDescription>
+<longDescription>Application efficiency was not highly affected by halts.&lt;p&gt;The highest ratio of application halts to execution time was 2.217 % for 1 min at 9/24/15 10:08:56 AM. 0.027 % of the halts were for reasons other than GC.&lt;p&gt;The halts ratio for the entire recording was 1.882 %. 0.021 % of the total halts were for reasons other than GC.&lt;/p&gt;&lt;p&gt;Enabling the following event types would improve the accuracy of this rule: jdk.SafepointBegin</longDescription>
+</rule>
+<rule>
+<id>BufferLost</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>No Flight Recorder buffers were lost during the recording.</shortDescription>
+<longDescription>No Flight Recorder buffers were lost during the recording.</longDescription>
+</rule>
+<rule>
+<id>BytecodeVerification</id>
+<severity>OK</severity>
+<score>1.0</score>
+<shortDescription>The application ran WebLogic Server with bytecode verification disabled.</shortDescription>
+<longDescription>The application ran WebLogic Server with bytecode verification disabled. While not generally recommended, it is considered OK for WLS.</longDescription>
+</rule>
+<rule>
+<id>ClassLeak</id>
+<severity>Information</severity>
+<score>74.99995410111316</score>
+<shortDescription>The difference between the number of times a class has been loaded and the number it has been unloaded, has exceeded the user specified limit. Most loaded: java.lang.Object (258)</shortDescription>
+<longDescription>Some classes have been loaded multiple times, and the difference between the number of times a class have been loaded and the number of times it has been unloaded has exceeded the user specified limit. This in itself need not be a problem, but check to see if you expect these classes to be loaded multiple times to make sure that you do not have a class loader leak.&lt;p&gt;Top 5 loaded classes:&lt;/p&gt;&lt;p&gt;&lt;ul&gt;&lt;li&gt;java.lang.Object (258)&lt;/li&gt;&lt;li&gt;java.lang.String (95)&lt;/li&gt;&lt;li&gt;java.lang.Class (81)&lt;/li&gt;&lt;li&gt;java.lang.Integer (52)&lt;/li&gt;&lt;li&gt;oracle.jrockit.jfr.VMJFR (46)&lt;/li&gt;&lt;/ul&gt;&lt;/p&gt;</longDescription>
+</rule>
+<rule>
+<id>ClassLoading</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>No significant time was spent loading new classes during this recording.</shortDescription>
+<longDescription>No significant time was spent loading new classes during this recording.</longDescription>
+</rule>
+<rule>
+<id>CodeCache</id>
+<severity>OK</severity>
+<score>16.62089029947917</score>
+<shortDescription>No problems with the code cache were detected in the recording.</shortDescription>
+<longDescription>No problems with the code cache were detected in the recording.</longDescription>
+</rule>
+<rule>
+<id>CompareCpu</id>
+<severity>Warning</severity>
+<score>87.07809686085879</score>
+<shortDescription>An average CPU load of 54 % was caused by other processes for 4.938 s at 9/24/15 10:08:17 AM.</shortDescription>
+<longDescription>An average CPU load of 54 % was caused by other processes for 4.938 s at 9/24/15 10:08:17 AM.&lt;p&gt;The application performance can be affected when the machine is under heavy load and there are other processes that use CPU or other resources on the same computer. To profile representatively or get higher throughput, shut down other resource intensive processes running on the machine.</longDescription>
+</rule>
+<rule>
+<id>CompressedOops</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>The settings for Compressed Oops were OK.</shortDescription>
+<longDescription>The settings for Compressed Oops were OK.</longDescription>
+</rule>
+<rule>
+<id>ContextSwitch</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>The program did not context switch excessively during the recording.</shortDescription>
+<longDescription>The program did not context switch excessively during the recording.</longDescription>
+</rule>
+<rule>
+<id>DMSIncident</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>The DMS Incidents rule requires the following event types: 'http://www.oracle.com/dms/dfw/dms/dfw/DFW_Incident/DFW_Incident_state'.</shortDescription>
+<longDescription>The DMS Incidents rule requires the following event types: 'http://www.oracle.com/dms/dfw/dms/dfw/DFW_Incident/DFW_Incident_state'.&lt;p&gt;They are either not available in this version of Java, or must be enabled in a third-party component. If you are using an older Java version, then you can consider upgrading.</longDescription>
+</rule>
+<rule>
+<id>DebugNonSafepoints</id>
+<severity>Information</severity>
+<score>50.0</score>
+<shortDescription>DebugNonSafepoints was not enabled.</shortDescription>
+<longDescription>DebugNonSafepoints was not enabled.&lt;p&gt;If DebugNonSafepoints is not enabled, the method profiling data will be less accurate as threads that are not at safepoints will not be correctly sampled. Use the following JVM flags to enable this: '-XX:+UnlockDiagnosticVMOptions -XX:+DebugNonSafepoints'. There is a slight performance overhead when enabling these flags. For more information see &lt;a href="http://openjdk.java.net/groups/hotspot/docs/RuntimeOverview.html#Thread%20Management|outline"&gt;HotSpot Runtime Overview/Thread Management&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>DiscouragedVmOptions</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>No problems were found with the VM options.</shortDescription>
+<longDescription>No problems were found with the VM options.</longDescription>
+</rule>
+<rule>
+<id>DumpReason</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>This recording was not dumped for an exceptional reason.</shortDescription>
+<longDescription>This recording was not dumped for an exceptional reason.</longDescription>
+</rule>
+<rule>
+<id>DuplicateFlags</id>
+<severity>Information</severity>
+<score>50.0</score>
+<shortDescription>There were 2 JVM duplicated flags.</shortDescription>
+<longDescription>There were 2 JVM duplicated flags. Duplicated JVM flags may be caused by multiple layers of scripts used when launching the application. Having duplicate flags is dangerous as changing one of the flags in one of the scripts may not have the intended effect. This can be especially dangerous for security related system properties. Try to find all the places where the flag is defined and keep only one. The following flags were duplicated: &lt;ul&gt;&lt;li&gt;-Djava.endorsed.dirs=c:\java\JDK18~1.0_6\jre\lib\endorsed;C:\tmp\WLS-JFR\oracle_common\modules\endorsed, -Djava.endorsed.dirs=c:\java\JDK18~1.0_6\jre\lib\endorsed;C:\tmp\WLS-JFR\oracle_common\modules\endorsed&lt;/li&gt;&lt;li&gt;-Xverify:none, -Xverify:none&lt;/li&gt;&lt;/ul&gt;</longDescription>
+</rule>
+<rule>
+<id>Errors</id>
+<severity>OK</severity>
+<score>14.166666666666668</score>
+<shortDescription>The program generated an average of 17 errors per minute during 9/24/2015 10:08:14 AM – 10:09:14 AM.</shortDescription>
+<longDescription>The program generated an average of 17 errors per minute during 9/24/2015 10:08:14 AM – 10:09:14 AM. 17 errors were thrown in total.&lt;p&gt;The most common error was 'java.lang.NoSuchMethodError', which was thrown 13 times.&lt;p&gt;Investigate the thrown errors to see if they can be avoided. Errors indicate that something went wrong with the code execution and should never be used for flow control. The following regular expression was used to exclude 381 errors from this rule: '(com.sun.el.parser.ELParser\$LookaheadSuccess)'.</longDescription>
+</rule>
+<rule>
+<id>Exceptions</id>
+<severity>OK</severity>
+<score>2.573808918421875</score>
+<shortDescription>The program generated 515 exceptions per second for 28.060 s at 9/24/15 10:08:58 AM.</shortDescription>
+<longDescription>The program generated 515 exceptions per second for 28.060 s at 9/24/15 10:08:58 AM.</longDescription>
+</rule>
+<rule>
+<id>Fatal Errors</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>The Fatal Errors rule requires the following event types: 'jdk.Shutdown'.</shortDescription>
+<longDescription>The Fatal Errors rule requires the following event types: 'jdk.Shutdown'.&lt;p&gt;They are either not available in this version of Java, or must be enabled in a third-party component. If you are using an older Java version, then you can consider upgrading.</longDescription>
+</rule>
+<rule>
+<id>FewSampledThreads</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>There were no problems with the amount of sampled threads.</shortDescription>
+<longDescription>There were no problems with the amount of sampled threads.&lt;p&gt;There are more sampled threads than the amount of hardware threads. This indicates that the application has enough parallelism for the available hardware.</longDescription>
+</rule>
+<rule>
+<id>FileRead</id>
+<severity>OK</severity>
+<score>0.2033639625</score>
+<shortDescription>No long file read pauses were found in this recording (the longest was 16.269 ms).</shortDescription>
+<longDescription>No long file read pauses were found in this recording (the longest was 16.269 ms).</longDescription>
+</rule>
+<rule>
+<id>FileWrite</id>
+<severity>OK</severity>
+<score>2.1551020875</score>
+<shortDescription>No long file write pauses were found in this recording (the longest was 172.408 ms).</shortDescription>
+<longDescription>No long file write pauses were found in this recording (the longest was 172.408 ms).</longDescription>
+</rule>
+<rule>
+<id>FlightRecordingSupport</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>The JVM version used for this recording has full Flight Recorder support.</shortDescription>
+<longDescription>The JVM version used for this recording has full Flight Recorder support.</longDescription>
+</rule>
+<rule>
+<id>FullGc</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule is only valid for CMS and G1 Garbage Collectors, neither of which were detected for this JVM.</shortDescription>
+<longDescription>This rule is only valid for CMS and G1 Garbage Collectors, neither of which were detected for this JVM.</longDescription>
+</rule>
+<rule>
+<id>GcFreedRatio</id>
+<severity>OK</severity>
+<score>1.4318707405222828</score>
+<shortDescription>The ratio between memory freed by garbage collections per second and liveset is 0.5. This is likely a reasonable amount.</shortDescription>
+<longDescription>61.4 MiB per second was freed by garbage collections for 10 s at 9/24/15 10:09:18 AM. This is 0.474 times the average liveset which was 130 MiB. This is likely a reasonable amount.</longDescription>
+</rule>
+<rule>
+<id>GcLocker</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>No GCs were affected by the GC Locker.</shortDescription>
+<longDescription>No GCs were affected by the GC Locker.</longDescription>
+</rule>
+<rule>
+<id>GcOptions</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>No problems were found with the GC configuration.</shortDescription>
+<longDescription>No problems were found with the GC configuration.</longDescription>
+</rule>
+<rule>
+<id>GcPauseRatio</id>
+<severity>OK</severity>
+<score>11.083072308333335</score>
+<shortDescription>Application efficiency was not highly affected by GC pauses.</shortDescription>
+<longDescription>Application efficiency was not highly affected by GC pauses.&lt;p&gt;The highest ratio between garbage collection pauses and execution time was 2.217 % for 1 min at 9/24/15 10:08:56 AM. The garbage collection pause ratio of the entire recording was 1.882 %.</longDescription>
+</rule>
+<rule>
+<id>GcStall</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>No indications that the garbage collector could not keep up with the workload were detected.</shortDescription>
+<longDescription>No indications that the garbage collector could not keep up with the workload were detected.</longDescription>
+</rule>
+<rule>
+<id>HeapContent</id>
+<severity>Warning</severity>
+<score>91.23973830878204</score>
+<shortDescription>Most of the heap was used by only a few classes.</shortDescription>
+<longDescription>Most of the heap was used by only a few classes. If the heap usage needs to be reduced, then this would be a good place to start.</longDescription>
+</rule>
+<rule>
+<id>HeapInspectionGc</id>
+<severity>Information</severity>
+<score>59.77379177936154</score>
+<shortDescription>The JVM performed 4 heap inspection garbage collections.</shortDescription>
+<longDescription>The JVM performed 4 heap inspection garbage collections. Performing heap inspection garbage collections may be a problem since they usually take a lot of time.&lt;p&gt;Some of these inspections were caused by the 'Object Count' JFR event. It triggers a full garbage collection at the beginning and end of every recording where that event is enabled. If recordings are only made on demand or not too often, then these garbage collections are usually not a problem since the resulting pauses are not part of the normal application behavior. If recordings are collected often, for example by automatic scripts, or if the application is sensitive to pauses, then it might become an issue. In that case you can consider disabling the 'Object Count' event.</longDescription>
+</rule>
+<rule>
+<id>HighGc</id>
+<severity>Information</severity>
+<score>72.91379413109293</score>
+<shortDescription>The JVM was paused for 100 % of the 567.258 ms at 9/24/15 10:07:58 AM.</shortDescription>
+<longDescription>The JVM was paused for 100 % of the 567.258 ms at 9/24/15 10:07:58 AM. The time spent performing garbage collection may be reduced by increasing the heap size or by trying to reduce allocation.</longDescription>
+</rule>
+<rule>
+<id>HighJvmCpu</id>
+<severity>OK</severity>
+<score>13.536580012735357</score>
+<shortDescription>The JVM does not seem to cause a lot of CPU load.</shortDescription>
+<longDescription>The JVM does not seem to cause a lot of CPU load.</longDescription>
+</rule>
+<rule>
+<id>IncreasingLiveSet</id>
+<severity>Information</severity>
+<score>58.89187525739308</score>
+<shortDescription>The live set on the heap seems to increase with a speed of about 638 KiB per second during the recording.</shortDescription>
+<longDescription>The live set on the heap seems to increase with a speed of about 638 KiB per second during the recording.&lt;p&gt;This may be due to a memory leak in the application or it may be an artifact of a short recording if the JVM has recently been started. The recording began 3.249 s after the JVM was started. More information can be gathered by using the Old Object Sample event, if available.</longDescription>
+</rule>
+<rule>
+<id>IncreasingMetaSpaceLiveSet</id>
+<severity>Information</severity>
+<score>56.00212873123657</score>
+<shortDescription>The class data seems to increase constantly in the metaspace during the recording.</shortDescription>
+<longDescription>The class data seems to increase constantly in the metaspace during the recording. This behavior may indicate a memory leak in the metaspace, this could be due to the application not unloading classes as needed.</longDescription>
+</rule>
+<rule>
+<id>JavaBlocking</id>
+<severity>Information</severity>
+<score>62.051706560483375</score>
+<shortDescription>Threads in the application were blocked on locks for a total of 1 min 26 s.</shortDescription>
+<longDescription>Threads in the application were blocked on locks for a total of 1 min 26 s. The most blocking monitor class was 'Logger', which was blocked 1,612 times for a total of 1 min 23 s.&lt;p&gt;The following regular expression was used to exclude threads from this rule: '(.*weblogic\.socket\.Muxer.*)'</longDescription>
+</rule>
+<rule>
+<id>LongGcPause</id>
+<severity>OK</severity>
+<score>15.646056210732606</score>
+<shortDescription>The longest GC pause was 576.207 ms.</shortDescription>
+<longDescription>The longest GC pause was 576.207 ms.</longDescription>
+</rule>
+<rule>
+<id>LowOnPhysicalMemory</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>The system did not run low on physical memory during this recording.</shortDescription>
+<longDescription>The system did not run low on physical memory during this recording.</longDescription>
+</rule>
+<rule>
+<id>ManagementAgent</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>No problems were found with the management agent settings.</shortDescription>
+<longDescription>No problems were found with the management agent settings.</longDescription>
+</rule>
+<rule>
+<id>ManyRunningProcesses</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'System Process'.</shortDescription>
+<longDescription>The Competing Processes rule requires that the following event types are enabled: 'System Process'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>MetaspaceOom</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>The metaspace was not exhausted during this recording.</shortDescription>
+<longDescription>The metaspace was not exhausted during this recording.</longDescription>
+</rule>
+<rule>
+<id>MethodProfiling</id>
+<severity>OK</severity>
+<score>0.8005001984324781</score>
+<shortDescription>No methods where optimization would be particularly efficient could be detected.</shortDescription>
+<longDescription>No methods where optimization would be particularly efficient could be detected.</longDescription>
+</rule>
+<rule>
+<id>Options</id>
+<severity>Information</severity>
+<score>74.0</score>
+<shortDescription>Deprecated option flags were detected.</shortDescription>
+<longDescription>The following option flags are or will be deprecated. Deprecated option flags should be avoided. In some cases they enable legacy code and in other cases they are ignored completely. They will usually be removed in a later Java release.&lt;ul&gt;&lt;li&gt;-XX:PermSize=128m: Ignored in Java 8 and removed in Java 9. PermGen was removed in JDK 8, since Java users should not need to know up front how much memory to reserve for class metadata etc. Just like in the JRockit and J9 JVMs, native memory is now used for class metadata, and it will dynamically grow as needed. The equivalent of java.lang.OutOfMemoryError: PermGen will be much harder to provoke. To influence when to start attempting to reclaim metaspace memory, check out the &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;MaxMetaspaceSize flag&lt;/a&gt;.&lt;/li&gt;&lt;li&gt;-XX:MaxPermSize=256m: Ignored in Java 8 and removed in Java 9. PermGen was removed in JDK 8, since Java users should not need to know up front how much memory to reserve for class metadata etc. Just like in the JRockit and J9 JVMs, native memory is now used for class metadata, and it will dynamically grow as needed. The equivalent of java.lang.OutOfMemoryError: PermGen will be much harder to provoke. To influence when to start attempting to reclaim metaspace memory, check out the &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;MaxMetaspaceSize flag&lt;/a&gt;.&lt;/li&gt;&lt;/ul&gt;</longDescription>
+</rule>
+<rule>
+<id>OverAggressiveRecordingSetting</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>No problems were found with the recording settings.</shortDescription>
+<longDescription>No problems were found with the recording settings.</longDescription>
+</rule>
+<rule>
+<id>PasswordsInArguments</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>The recording does not seem to contain passwords in the application arguments.</shortDescription>
+<longDescription>The recording does not seem to contain passwords in the application arguments.</longDescription>
+</rule>
+<rule>
+<id>PasswordsInEnvironment</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires that the following event types are enabled: 'Initial Environment Variable'.</shortDescription>
+<longDescription>The Passwords in Environment Variables rule requires that the following event types are enabled: 'Initial Environment Variable'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>PasswordsInSystemProperties</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>The recording does not seem to contain passwords in the system properties.</shortDescription>
+<longDescription>The recording does not seem to contain passwords in the system properties.</longDescription>
+</rule>
+<rule>
+<id>PrimitiveToObjectConversion</id>
+<severity>OK</severity>
+<score>0.11127751568911523</score>
+<shortDescription>0 % of the total allocation (1.88 MiB) is caused by conversion from primitive types to object types. The most common object type that primitives are converted into is 'java.lang.Integer'.</shortDescription>
+<longDescription>0 % of the total allocation (1.88 MiB) is caused by conversion from primitive types to object types.&lt;p&gt;The most common object type that primitives are converted into is 'java.lang.Integer', which causes 1.11 MiB to be allocated. The most common call site is 'weblogic.socket.NIOSocketMuxer$NIOOutputStream.initPool():887'.&lt;p&gt;Conversion from primitives to the corresponding object types can either be done explicitly, or be caused by autoboxing. If a considerable amount of the total allocation is caused by such conversions, consider changing the application source code to avoid this behavior. Look at the allocation stack traces to see which parts of the code to change. This rule finds the calls to the valueOf method for any of the eight object types that have primitive counterparts.</longDescription>
+</rule>
+<rule>
+<id>SocketRead</id>
+<severity>OK</severity>
+<score>9.634721636363636</score>
+<shortDescription>No long socket read pauses were found in this recording (the longest was 105.982 ms).</shortDescription>
+<longDescription>No long socket read pauses were found in this recording (the longest was 105.982 ms).&lt;p&gt;Note that there are some socket read patterns with high duration reads that we consider to be normal and are therefore excluded. Such patterns include JMX RMI communication and MQ series.</longDescription>
+</rule>
+<rule>
+<id>SocketWrite</id>
+<severity>Information</severity>
+<score>28.486599569171002</score>
+<shortDescription>There are long socket write pauses in this recording (the longest is 349.745 ms).</shortDescription>
+<longDescription>The longest recorded socket write took 349.745 ms to write 81 B to the host at 10.161.190.213. Note that there are some socket write patterns with high duration writes that we consider to be normal and are therefore excluded. Such patterns include JMX RMI communication.</longDescription>
+</rule>
+<rule>
+<id>StackdepthSetting</id>
+<severity>Warning</severity>
+<score>99.99654514135385</score>
+<shortDescription>Some stack traces were truncated in this recording.</shortDescription>
+<longDescription>Some stack traces were truncated in this recording.&lt;p&gt;The Flight Recorder is configured with a maximum captured stack depth of 64. This is the default depth. 35.7 % of all traces were larger than this option, and were therefore truncated. If more detailed traces are required, increase the '-XX:FlightRecorderOptions=stackdepth=&amp;lt;value&amp;gt;' value.&lt;p&gt;Events of the following types have truncated stack traces:&lt;ul&gt;&lt;li&gt;Allocation Requiring GC (31.6 % truncated traces)&lt;/li&gt;&lt;li&gt;Allocation in new TLAB (42.4 % truncated traces)&lt;/li&gt;&lt;li&gt;Allocation outside TLAB (60.7 % truncated traces)&lt;/li&gt;&lt;li&gt;Class Load (42.8 % truncated traces)&lt;/li&gt;&lt;li&gt;EJB Business Method Invoke (47.1 % truncated traces)&lt;/li&gt;&lt;li&gt;EJB Business Method Post Invoke (44.4 % truncated traces)&lt;/li&gt;&lt;li&gt;EJB Business Method Post Invoke Cleanup (47.1 % truncated traces)&lt;/li&gt;&lt;li&gt;EJB Business Method Pre Invoke (44.4 % truncated traces)&lt;/li&gt;&lt;li&gt;EJB Pool Manager Post Invoke (47.1 % truncated traces)&lt;/li&gt;&lt;li&gt;EJB Pool Manager Pre Invoke (47.1 % truncated traces)&lt;/li&gt;&lt;li&gt;EJB PoolManager Create (32.7 % truncated traces)&lt;/li&gt;&lt;li&gt;File Read (100 % truncated traces)&lt;/li&gt;&lt;li&gt;File Write (32.6 % truncated traces)&lt;/li&gt;&lt;li&gt;JDBC Connection Close (73 % truncated traces)&lt;/li&gt;&lt;li&gt;JDBC Connection Prepare (54.4 % truncated traces)&lt;/li&gt;&lt;li&gt;JDBC Connection Release (65 % truncated traces)&lt;/li&gt;&lt;li&gt;JDBC Statement Creation (54.4 % truncated traces)&lt;/li&gt;&lt;li&gt;JDBC Statement Execute (54.4 % truncated traces)&lt;/li&gt;&lt;li&gt;JDBC Statement Execute Begin (54.4 % truncated traces)&lt;/li&gt;&lt;li&gt;JDBC Transaction Commit (65 % truncated traces)&lt;/li&gt;&lt;li&gt;JDBC Transaction End (65.6 % truncated traces)&lt;/li&gt;&lt;li&gt;JDBC Transaction Is Same RM (6.59 % truncated traces)&lt;/li&gt;&lt;li&gt;JDBC Transaction Start (100 % truncated traces)&lt;/li&gt;&lt;li&gt;JTA Transaction Commit (51 % truncated traces)&lt;/li&gt;&lt;li&gt;JTA Transaction End (51.5 % truncated traces)&lt;/li&gt;&lt;li&gt;JTA Transaction Start (80 % truncated traces)&lt;/li&gt;&lt;li&gt;Java Error (29.1 % truncated traces)&lt;/li&gt;&lt;li&gt;Java Monitor Blocked (1.09 % truncated traces)&lt;/li&gt;&lt;li&gt;Java Monitor Wait (0.134 % truncated traces)&lt;/li&gt;&lt;li&gt;Java Thread Park (0.223 % truncated traces)&lt;/li&gt;&lt;li&gt;Java Thread Sleep (33.3 % truncated traces)&lt;/li&gt;&lt;li&gt;Method Profiling Sample (24.3 % truncated traces)&lt;/li&gt;&lt;li&gt;Servlet Execute (26.2 % truncated traces)&lt;/li&gt;&lt;li&gt;Servlet Request Dispatch (45 % truncated traces)&lt;/li&gt;&lt;li&gt;Servlet Response Write Headers (0.753 % truncated traces)&lt;/li&gt;&lt;li&gt;Socket Read (41.6 % truncated traces)&lt;/li&gt;&lt;li&gt;Socket Write (20.6 % truncated traces)&lt;/li&gt;&lt;li&gt;Webservices JAXRPC Client Request (45.4 % truncated traces)&lt;/li&gt;&lt;li&gt;Webservices JAXRPC Client Response (100 % truncated traces)&lt;/li&gt;&lt;/ul&gt;</longDescription>
+</rule>
+<rule>
+<id>StringDeduplication</id>
+<severity>OK</severity>
+<score>11.944505390960535</score>
+<shortDescription>Approximately 17 % of the live set consists of the internal array type of strings ('char[]' for this JDK version).
 The heap is around 22 % full. There is likely no big benefit from enabling string deduplication.</shortDescription>
-            <longDescription>Approximately 17 % of the live set consists of the internal array type of strings ('char[]' for this JDK version).
+<longDescription>Approximately 17 % of the live set consists of the internal array type of strings ('char[]' for this JDK version).
 The heap is around 22 % full. There is likely no big benefit from enabling string deduplication.&lt;p&gt;String deduplication is enabled using the JVM flag '-XX:+UseStringDeduplication'. This flag can be used together with the G1 garbage collector in JDK 8u20 or later, or with the Shenandoah garbage collector.&lt;p&gt;To validate if this gives a performance improvement for your application, create flight recordings both with and without string deduplication. For the run with string deduplication enabled, also enable statistics with '-XX:+PrintStringDeduplicationStatistics' for JDK 8 or '-Xlog:stringdedup*=debug' for JDK 9. Check if the heap live set decrease in the recording with string deduplication enabled is larger than the size of the string deduplication metadata table. The size of the metadata table is printed in the statistics output as 'Table/Memory Usage: XX MB'&lt;p&gt;You can read more about string deduplication in the java options documentation or in &lt;a href="https://openjdk.java.net/jeps/192"&gt;JEP 192&lt;/a&gt;.&lt;p&gt;String deduplication is only supported when using the G1 (JDK 8u20+) or Shenandoah garbage collectors. If you want to use this feature you can enable G1 by using '-XX:+UseG1GC', or enable Shenandoah by using '-XX:+UseShenandoahGC'.</longDescription>
-        </rule>
-        <rule>
-            <id>SystemGc</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>No garbage collections were caused by System.gc().</shortDescription>
-            <longDescription>No garbage collections were caused by System.gc().</longDescription>
-        </rule>
-        <rule>
-            <id>TlabAllocationRatio</id>
-            <severity>OK</severity>
-            <score>3.561374583830773</score>
-            <shortDescription>The program allocated 2.39 % of the memory outside of TLABs.</shortDescription>
-            <longDescription>The program allocated 2.39 % of the memory outside of TLABs.</longDescription>
-        </rule>
-        <rule>
-            <id>VMOperations</id>
-            <severity>OK</severity>
-            <score>14.8241342</score>
-            <shortDescription>No excessively long VM operations were found in this recording (the longest was 592.965 ms).</shortDescription>
-            <longDescription>No excessively long VM operations were found in this recording (the longest was 592.965 ms).</longDescription>
-        </rule>
-        <rule>
-            <id>biasedLockingRevocation</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>The Biased Locking Revocation rule requires the following event types: 'jdk.BiasedLockClassRevocation'.</shortDescription>
-            <longDescription>The Biased Locking Revocation rule requires the following event types: 'jdk.BiasedLockClassRevocation'.&lt;p&gt;They are either not available in this version of Java, or must be enabled in a third-party component. If you are using an older Java version, then you can consider upgrading.</longDescription>
-        </rule>
-        <rule>
-            <id>biasedLockingRevocationPause</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>No revocation of biased locks found.</shortDescription>
-            <longDescription>No revocation of biased locks found.</longDescription>
-        </rule>
-    </report>
-    <report>
-        <file>wls-medrec-jdk9.jfr</file>
-        <rule>
-            <id>Allocations.class</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires events to be available from one of the following event types: jdk.ObjectAllocationInNewTLAB, jdk.ObjectAllocationOutsideTLAB.</shortDescription>
-            <longDescription>This rule requires events to be available from one of the following event types: jdk.ObjectAllocationInNewTLAB, jdk.ObjectAllocationOutsideTLAB.</longDescription>
-        </rule>
-        <rule>
-            <id>Allocations.thread</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires events to be available from one of the following event types: jdk.ObjectAllocationInNewTLAB, jdk.ObjectAllocationOutsideTLAB.</shortDescription>
-            <longDescription>This rule requires events to be available from one of the following event types: jdk.ObjectAllocationInNewTLAB, jdk.ObjectAllocationOutsideTLAB.</longDescription>
-        </rule>
-        <rule>
-            <id>ApplicationHalts</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires events to be available from the following event types: 'GC Phase Pause', 'VM Operation'.</shortDescription>
-            <longDescription>The Application Halts rule requires events to be available from the following event types: 'GC Phase Pause', 'VM Operation'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>BufferLost</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>No Flight Recorder buffers were lost during the recording.</shortDescription>
-            <longDescription>No Flight Recorder buffers were lost during the recording.</longDescription>
-        </rule>
-        <rule>
-            <id>BytecodeVerification</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>The application ran with bytecode verification enabled.</shortDescription>
-            <longDescription>The application ran with bytecode verification enabled.</longDescription>
-        </rule>
-        <rule>
-            <id>ClassLeak</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>No classes with identical names have been loaded more times than the limit.</shortDescription>
-            <longDescription>No classes with identical names have been loaded more times than the limit.</longDescription>
-        </rule>
-        <rule>
-            <id>ClassLoading</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>No significant time was spent loading new classes during this recording.</shortDescription>
-            <longDescription>No significant time was spent loading new classes during this recording.</longDescription>
-        </rule>
-        <rule>
-            <id>CodeCache</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires events to be available from the following event types: 'Code Cache Configuration', 'Code Cache Full', 'Code Cache Statistics', 'JVM Information'.</shortDescription>
-            <longDescription>The Code Cache rule requires events to be available from the following event types: 'Code Cache Configuration', 'Code Cache Full', 'Code Cache Statistics', 'JVM Information'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>CompareCpu</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires events to be available from the following event types: 'CPU Load'.</shortDescription>
-            <longDescription>The Competing CPU Ratio Usage rule requires events to be available from the following event types: 'CPU Load'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>CompressedOops</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires events to be available from the following event types: 'Boolean Flag', 'JVM Information', 'Unsigned Long Flag'.</shortDescription>
-            <longDescription>The Compressed Oops rule requires events to be available from the following event types: 'Boolean Flag', 'JVM Information', 'Unsigned Long Flag'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>ContextSwitch</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires events to be available from the following event types: 'Thread Context Switch Rate'.</shortDescription>
-            <longDescription>The Context Switches rule requires events to be available from the following event types: 'Thread Context Switch Rate'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>DMSIncident</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>The DMS Incidents rule requires the following event types: 'http://www.oracle.com/dms/dfw/dms/dfw/DFW_Incident/DFW_Incident_state'.</shortDescription>
-            <longDescription>The DMS Incidents rule requires the following event types: 'http://www.oracle.com/dms/dfw/dms/dfw/DFW_Incident/DFW_Incident_state'.&lt;p&gt;They are either not available in this version of Java, or must be enabled in a third-party component. If you are using an older Java version, then you can consider upgrading.</longDescription>
-        </rule>
-        <rule>
-            <id>DebugNonSafepoints</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>DebugNonSafepoints was implicitly enabled in the JVM version used to create this recording.</shortDescription>
-            <longDescription>DebugNonSafepoints was implicitly enabled in the JVM version used to create this recording.</longDescription>
-        </rule>
-        <rule>
-            <id>DiscouragedVmOptions</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>No problems were found with the VM options.</shortDescription>
-            <longDescription>No problems were found with the VM options.</longDescription>
-        </rule>
-        <rule>
-            <id>DumpReason</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>This recording was not dumped for an exceptional reason.</shortDescription>
-            <longDescription>This recording was not dumped for an exceptional reason.</longDescription>
-        </rule>
-        <rule>
-            <id>DuplicateFlags</id>
-            <severity>Information</severity>
-            <score>50.0</score>
-            <shortDescription>There were 5 JVM duplicated flags.</shortDescription>
-            <longDescription>There were 5 JVM duplicated flags. Duplicated JVM flags may be caused by multiple layers of scripts used when launching the application. Having duplicate flags is dangerous as changing one of the flags in one of the scripts may not have the intended effect. This can be especially dangerous for security related system properties. Try to find all the places where the flag is defined and keep only one. The following flags were duplicated: &lt;ul&gt;&lt;li&gt;-XX:NewSize=65m, -XX:NewSize=65m&lt;/li&gt;&lt;li&gt;-Dweblogic.home=C:\weblogic\src122130_build\Oracle_Home\wlserver/server, -Dweblogic.home=C:\weblogic\SRC122~1\ORACLE~1\wlserver\server&lt;/li&gt;&lt;li&gt;-Xmx500m, -Xmx500m&lt;/li&gt;&lt;li&gt;-Xms160m, -Xms160m&lt;/li&gt;&lt;li&gt;-XX:MaxNewSize=65m, -XX:MaxNewSize=65m&lt;/li&gt;&lt;/ul&gt;</longDescription>
-        </rule>
-        <rule>
-            <id>Errors</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires events to be available from the following event types: 'Java Error'.</shortDescription>
-            <longDescription>The Thrown Errors rule requires events to be available from the following event types: 'Java Error'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>Exceptions</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires events to be available from the following event types: 'Exception Statistics'.</shortDescription>
-            <longDescription>The Thrown Exceptions rule requires events to be available from the following event types: 'Exception Statistics'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>Fatal Errors</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>The Fatal Errors rule requires the following event types: 'jdk.Shutdown'.</shortDescription>
-            <longDescription>The Fatal Errors rule requires the following event types: 'jdk.Shutdown'.&lt;p&gt;They are either not available in this version of Java, or must be enabled in a third-party component. If you are using an older Java version, then you can consider upgrading.</longDescription>
-        </rule>
-        <rule>
-            <id>FewSampledThreads</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires events to be available from the following event types: 'CPU Information', 'Method Profiling Sample', 'Recording Setting'.</shortDescription>
-            <longDescription>The Parallel Threads rule requires events to be available from the following event types: 'CPU Information', 'Method Profiling Sample', 'Recording Setting'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>FileRead</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>There are no file read events in this recording.</shortDescription>
-            <longDescription>There are no file read events in this recording.</longDescription>
-        </rule>
-        <rule>
-            <id>FileWrite</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires events to be available from the following event types: 'File Write'.</shortDescription>
-            <longDescription>The File Write Peak Duration rule requires events to be available from the following event types: 'File Write'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>FlightRecordingSupport</id>
-            <severity>Warning</severity>
-            <score>80.0</score>
-            <shortDescription>The recording is from an early access build.</shortDescription>
-            <longDescription>This recording is from an early access build of the JRE (Java HotSpot(TM) 64-Bit Server VM (9-ea+148) for windows-amd64 JRE (9-ea+148), built on Dec  7 2016 18:47:38 by &amp;#34;javare&amp;#34; with MS VC++ 12.0 (VS2013)). The automated analysis is not supported, and you may see errors when attempting to analyze the recording.</longDescription>
-        </rule>
-        <rule>
-            <id>FullGc</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule is only valid for CMS and G1 Garbage Collectors, neither of which were detected for this JVM.</shortDescription>
-            <longDescription>This rule is only valid for CMS and G1 Garbage Collectors, neither of which were detected for this JVM.</longDescription>
-        </rule>
-        <rule>
-            <id>GcFreedRatio</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires events to be available from the following event types: 'Heap Summary'.</shortDescription>
-            <longDescription>The GC Freed Ratio rule requires events to be available from the following event types: 'Heap Summary'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>GcLocker</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>No GCs were affected by the GC Locker.</shortDescription>
-            <longDescription>No GCs were affected by the GC Locker.</longDescription>
-        </rule>
-        <rule>
-            <id>GcOptions</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>Too few events to calculate the result.</shortDescription>
-            <longDescription>Too few events to calculate the result.</longDescription>
-        </rule>
-        <rule>
-            <id>GcPauseRatio</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires events to be available from the following event types: 'GC Phase Pause'.</shortDescription>
-            <longDescription>The GC Pauses rule requires events to be available from the following event types: 'GC Phase Pause'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>GcStall</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires events to be available from the following event types: 'Garbage Collection'.</shortDescription>
-            <longDescription>The GC Stall rule requires events to be available from the following event types: 'Garbage Collection'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>HeapContent</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires events to be available from the following event types: 'Object Count'.</shortDescription>
-            <longDescription>The Heap Content rule requires events to be available from the following event types: 'Object Count'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>HeapInspectionGc</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires events to be available from the following event types: 'Garbage Collection'.</shortDescription>
-            <longDescription>The GCs Caused by Heap Inspection rule requires events to be available from the following event types: 'Garbage Collection'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>HighGc</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>The runtime did not spend much time performing garbage collections.</shortDescription>
-            <longDescription>The runtime did not spend much time performing garbage collections.</longDescription>
-        </rule>
-        <rule>
-            <id>HighJvmCpu</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires events to be available from the following event types: 'CPU Load'.</shortDescription>
-            <longDescription>The High JVM CPU Load rule requires events to be available from the following event types: 'CPU Load'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>IncreasingLiveSet</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>Too few events to calculate the result.</shortDescription>
-            <longDescription>Too few events to calculate the result.</longDescription>
-        </rule>
-        <rule>
-            <id>IncreasingMetaSpaceLiveSet</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>The class data does not seem to increase during the recording.</shortDescription>
-            <longDescription>The class data does not seem to increase during the recording.</longDescription>
-        </rule>
-        <rule>
-            <id>JavaBlocking</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires events to be available from the following event types: 'Java Monitor Blocked'.</shortDescription>
-            <longDescription>The Java Blocking rule requires events to be available from the following event types: 'Java Monitor Blocked'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>LongGcPause</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>The application did not cause any long GC pause times.</shortDescription>
-            <longDescription>The application did not cause any long GC pause times.</longDescription>
-        </rule>
-        <rule>
-            <id>LowOnPhysicalMemory</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires events to be available from the following event types: 'Physical Memory'.</shortDescription>
-            <longDescription>The Free Physical Memory rule requires events to be available from the following event types: 'Physical Memory'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>ManagementAgent</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>No problems were found with the management agent settings.</shortDescription>
-            <longDescription>No problems were found with the management agent settings.</longDescription>
-        </rule>
-        <rule>
-            <id>ManyRunningProcesses</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires events to be available from the following event types: 'System Process'.</shortDescription>
-            <longDescription>The Competing Processes rule requires events to be available from the following event types: 'System Process'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>MetaspaceOom</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>The metaspace was not exhausted during this recording.</shortDescription>
-            <longDescription>The metaspace was not exhausted during this recording.</longDescription>
-        </rule>
-        <rule>
-            <id>MethodProfiling</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires events to be available from the following event types: 'Method Profiling Sample', 'Recording Setting'.</shortDescription>
-            <longDescription>The Method Profiling rule requires events to be available from the following event types: 'Method Profiling Sample', 'Recording Setting'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>Options</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>No undocumented, deprecated or non-recommended option flags were detected.</shortDescription>
-            <longDescription>No undocumented, deprecated or non-recommended option flags were detected.</longDescription>
-        </rule>
-        <rule>
-            <id>OverAggressiveRecordingSetting</id>
-            <severity>Information</severity>
-            <score>50.0</score>
-            <shortDescription>These following event types had no threshold: &amp;#39;Java Monitor Blocked&amp;#39;, &amp;#39;Java Thread Park&amp;#39;.</shortDescription>
-            <longDescription>Event types without threshold can lead to quite a lot of events being generated, possibly translating to higher overhead. If this was not intended, please check the settings in the template for future recordings.</longDescription>
-        </rule>
-        <rule>
-            <id>PasswordsInArguments</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>The recording does not seem to contain passwords in the application arguments.</shortDescription>
-            <longDescription>The recording does not seem to contain passwords in the application arguments.</longDescription>
-        </rule>
-        <rule>
-            <id>PasswordsInEnvironment</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires events to be available from the following event types: 'Initial Environment Variable'.</shortDescription>
-            <longDescription>The Passwords in Environment Variables rule requires events to be available from the following event types: 'Initial Environment Variable'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>PasswordsInSystemProperties</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires events to be available from the following event types: 'Initial System Property'.</shortDescription>
-            <longDescription>The Passwords in System Properties rule requires events to be available from the following event types: 'Initial System Property'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>PrimitiveToObjectConversion</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires events to be available from the following event types: 'Allocation in new TLAB', 'Allocation outside TLAB'.</shortDescription>
-            <longDescription>The Primitive To Object Conversion rule requires events to be available from the following event types: 'Allocation in new TLAB', 'Allocation outside TLAB'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>SocketRead</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires events to be available from the following event types: 'Socket Read'.</shortDescription>
-            <longDescription>The Socket Read Peak Duration rule requires events to be available from the following event types: 'Socket Read'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>SocketWrite</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires events to be available from the following event types: 'Socket Write'.</shortDescription>
-            <longDescription>The Socket Write Peak Duration rule requires events to be available from the following event types: 'Socket Write'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>StackdepthSetting</id>
-            <severity>Warning</severity>
-            <score>99.35136572520041</score>
-            <shortDescription>Some stack traces were truncated in this recording.</shortDescription>
-            <longDescription>Some stack traces were truncated in this recording.&lt;p&gt;The Flight Recorder is configured with a maximum captured stack depth of 64. This is the default depth. 17.5 % of all traces were larger than this option, and were therefore truncated. If more detailed traces are required, increase the '-XX:FlightRecorderOptions=stackdepth=&amp;lt;value&amp;gt;' value.&lt;p&gt;Events of the following types have truncated stack traces:&lt;ul&gt;&lt;li&gt;EJB Pool Manager Pre Invoke (71.3 % truncated traces)&lt;/li&gt;&lt;li&gt;EJB Business Method Invoke (71.3 % truncated traces)&lt;/li&gt;&lt;li&gt;EJB Business Method Post Invoke Cleanup (71.3 % truncated traces)&lt;/li&gt;&lt;li&gt;EJB Pool Manager Post Invoke (71.3 % truncated traces)&lt;/li&gt;&lt;li&gt;EJB Business Method Post Invoke (71.3 % truncated traces)&lt;/li&gt;&lt;li&gt;EJB Business Method Pre Invoke (71.3 % truncated traces)&lt;/li&gt;&lt;li&gt;JDBC Connection Close (96.8 % truncated traces)&lt;/li&gt;&lt;li&gt;JDBC Statement Creation (100 % truncated traces)&lt;/li&gt;&lt;li&gt;JDBC Connection Prepare (100 % truncated traces)&lt;/li&gt;&lt;li&gt;JDBC Statement Execute (96.7 % truncated traces)&lt;/li&gt;&lt;li&gt;JDBC Statement Execute Begin (96.7 % truncated traces)&lt;/li&gt;&lt;li&gt;JTA Transaction Start (16.7 % truncated traces)&lt;/li&gt;&lt;li&gt;JDBC Transaction Start (100 % truncated traces)&lt;/li&gt;&lt;li&gt;EJB Pool Manager Create (75 % truncated traces)&lt;/li&gt;&lt;li&gt;JDBC Connection Release (85.7 % truncated traces)&lt;/li&gt;&lt;li&gt;Debug (1.59 % truncated traces)&lt;/li&gt;&lt;li&gt;JDBC Transaction Commit (45 % truncated traces)&lt;/li&gt;&lt;li&gt;JDBC Transaction End (45 % truncated traces)&lt;/li&gt;&lt;li&gt;JTA Transaction End (6.06 % truncated traces)&lt;/li&gt;&lt;li&gt;JTA Transaction Commit (36.4 % truncated traces)&lt;/li&gt;&lt;li&gt;JDBC Transaction Is Same RM (1.79 % truncated traces)&lt;/li&gt;&lt;li&gt;Webservices JAXWS Resource (50 % truncated traces)&lt;/li&gt;&lt;li&gt;Webservices JAXWS Endpoint (100 % truncated traces)&lt;/li&gt;&lt;li&gt;Servlet Response Write Headers (1.87 % truncated traces)&lt;/li&gt;&lt;li&gt;Webservices JAXRPC Client Request (50 % truncated traces)&lt;/li&gt;&lt;li&gt;Webservices JAXRPC Client Response (100 % truncated traces)&lt;/li&gt;&lt;/ul&gt;</longDescription>
-        </rule>
-        <rule>
-            <id>StringDeduplication</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires events to be available from the following event types: 'Heap Summary'.</shortDescription>
-            <longDescription>The String Deduplication rule requires events to be available from the following event types: 'Heap Summary'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>SystemGc</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>This rule requires events to be available from the following event types: 'Garbage Collection'.</shortDescription>
-            <longDescription>The GCs Caused by System.gc() rule requires events to be available from the following event types: 'Garbage Collection'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
-        </rule>
-        <rule>
-            <id>TlabAllocationRatio</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>No object allocations outside of TLABs detected.</shortDescription>
-            <longDescription>No object allocations outside of TLABs detected.</longDescription>
-        </rule>
-        <rule>
-            <id>VMOperations</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>No excessively long VM operations were found in this recording (the longest was 0 s).</shortDescription>
-            <longDescription>No excessively long VM operations were found in this recording (the longest was 0 s).</longDescription>
-        </rule>
-        <rule>
-            <id>biasedLockingRevocation</id>
-            <severity>Not Applicable</severity>
-            <score>-1.0</score>
-            <shortDescription>The Biased Locking Revocation rule requires the following event types: 'jdk.BiasedLockClassRevocation'.</shortDescription>
-            <longDescription>The Biased Locking Revocation rule requires the following event types: 'jdk.BiasedLockClassRevocation'.&lt;p&gt;They are either not available in this version of Java, or must be enabled in a third-party component. If you are using an older Java version, then you can consider upgrading.</longDescription>
-        </rule>
-        <rule>
-            <id>biasedLockingRevocationPause</id>
-            <severity>OK</severity>
-            <score>0.0</score>
-            <shortDescription>No revocation of biased locks found.</shortDescription>
-            <longDescription>No revocation of biased locks found.</longDescription>
-        </rule>
-    </report>
+</rule>
+<rule>
+<id>SystemGc</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>No garbage collections were caused by System.gc().</shortDescription>
+<longDescription>No garbage collections were caused by System.gc().</longDescription>
+</rule>
+<rule>
+<id>TlabAllocationRatio</id>
+<severity>OK</severity>
+<score>3.561374583830773</score>
+<shortDescription>The program allocated 2.39 % of the memory outside of TLABs.</shortDescription>
+<longDescription>The program allocated 2.39 % of the memory outside of TLABs.</longDescription>
+</rule>
+<rule>
+<id>VMOperations</id>
+<severity>OK</severity>
+<score>14.8241342</score>
+<shortDescription>No excessively long VM operations were found in this recording (the longest was 592.965 ms).</shortDescription>
+<longDescription>No excessively long VM operations were found in this recording (the longest was 592.965 ms).</longDescription>
+</rule>
+<rule>
+<id>biasedLockingRevocation</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>The Biased Locking Revocation rule requires the following event types: 'jdk.BiasedLockClassRevocation'.</shortDescription>
+<longDescription>The Biased Locking Revocation rule requires the following event types: 'jdk.BiasedLockClassRevocation'.&lt;p&gt;They are either not available in this version of Java, or must be enabled in a third-party component. If you are using an older Java version, then you can consider upgrading.</longDescription>
+</rule>
+<rule>
+<id>biasedLockingRevocationPause</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>No revocation of biased locks found.</shortDescription>
+<longDescription>No revocation of biased locks found.</longDescription>
+</rule>
+</report>
+<report>
+<file>wls-medrec-jdk9.jfr</file>
+<rule>
+<id>Allocations.class</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires events to be available from one of the following event types: jdk.ObjectAllocationInNewTLAB, jdk.ObjectAllocationOutsideTLAB.</shortDescription>
+<longDescription>This rule requires events to be available from one of the following event types: jdk.ObjectAllocationInNewTLAB, jdk.ObjectAllocationOutsideTLAB.</longDescription>
+</rule>
+<rule>
+<id>Allocations.thread</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires events to be available from one of the following event types: jdk.ObjectAllocationInNewTLAB, jdk.ObjectAllocationOutsideTLAB.</shortDescription>
+<longDescription>This rule requires events to be available from one of the following event types: jdk.ObjectAllocationInNewTLAB, jdk.ObjectAllocationOutsideTLAB.</longDescription>
+</rule>
+<rule>
+<id>ApplicationHalts</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires events to be available from the following event types: 'GC Phase Pause', 'VM Operation'.</shortDescription>
+<longDescription>The Application Halts rule requires events to be available from the following event types: 'GC Phase Pause', 'VM Operation'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>BufferLost</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>No Flight Recorder buffers were lost during the recording.</shortDescription>
+<longDescription>No Flight Recorder buffers were lost during the recording.</longDescription>
+</rule>
+<rule>
+<id>BytecodeVerification</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>The application ran with bytecode verification enabled.</shortDescription>
+<longDescription>The application ran with bytecode verification enabled.</longDescription>
+</rule>
+<rule>
+<id>ClassLeak</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>No classes with identical names have been loaded more times than the limit.</shortDescription>
+<longDescription>No classes with identical names have been loaded more times than the limit.</longDescription>
+</rule>
+<rule>
+<id>ClassLoading</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>No significant time was spent loading new classes during this recording.</shortDescription>
+<longDescription>No significant time was spent loading new classes during this recording.</longDescription>
+</rule>
+<rule>
+<id>CodeCache</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires events to be available from the following event types: 'Code Cache Configuration', 'Code Cache Full', 'Code Cache Statistics', 'JVM Information'.</shortDescription>
+<longDescription>The Code Cache rule requires events to be available from the following event types: 'Code Cache Configuration', 'Code Cache Full', 'Code Cache Statistics', 'JVM Information'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>CompareCpu</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires events to be available from the following event types: 'CPU Load'.</shortDescription>
+<longDescription>The Competing CPU Ratio Usage rule requires events to be available from the following event types: 'CPU Load'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>CompressedOops</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires events to be available from the following event types: 'Boolean Flag', 'JVM Information', 'Unsigned Long Flag'.</shortDescription>
+<longDescription>The Compressed Oops rule requires events to be available from the following event types: 'Boolean Flag', 'JVM Information', 'Unsigned Long Flag'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>ContextSwitch</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires events to be available from the following event types: 'Thread Context Switch Rate'.</shortDescription>
+<longDescription>The Context Switches rule requires events to be available from the following event types: 'Thread Context Switch Rate'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>DMSIncident</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>The DMS Incidents rule requires the following event types: 'http://www.oracle.com/dms/dfw/dms/dfw/DFW_Incident/DFW_Incident_state'.</shortDescription>
+<longDescription>The DMS Incidents rule requires the following event types: 'http://www.oracle.com/dms/dfw/dms/dfw/DFW_Incident/DFW_Incident_state'.&lt;p&gt;They are either not available in this version of Java, or must be enabled in a third-party component. If you are using an older Java version, then you can consider upgrading.</longDescription>
+</rule>
+<rule>
+<id>DebugNonSafepoints</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>DebugNonSafepoints was implicitly enabled in the JVM version used to create this recording.</shortDescription>
+<longDescription>DebugNonSafepoints was implicitly enabled in the JVM version used to create this recording.</longDescription>
+</rule>
+<rule>
+<id>DiscouragedVmOptions</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>No problems were found with the VM options.</shortDescription>
+<longDescription>No problems were found with the VM options.</longDescription>
+</rule>
+<rule>
+<id>DumpReason</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>This recording was not dumped for an exceptional reason.</shortDescription>
+<longDescription>This recording was not dumped for an exceptional reason.</longDescription>
+</rule>
+<rule>
+<id>DuplicateFlags</id>
+<severity>Information</severity>
+<score>50.0</score>
+<shortDescription>There were 5 JVM duplicated flags.</shortDescription>
+<longDescription>There were 5 JVM duplicated flags. Duplicated JVM flags may be caused by multiple layers of scripts used when launching the application. Having duplicate flags is dangerous as changing one of the flags in one of the scripts may not have the intended effect. This can be especially dangerous for security related system properties. Try to find all the places where the flag is defined and keep only one. The following flags were duplicated: &lt;ul&gt;&lt;li&gt;-XX:NewSize=65m, -XX:NewSize=65m&lt;/li&gt;&lt;li&gt;-Dweblogic.home=C:\weblogic\src122130_build\Oracle_Home\wlserver/server, -Dweblogic.home=C:\weblogic\SRC122~1\ORACLE~1\wlserver\server&lt;/li&gt;&lt;li&gt;-Xmx500m, -Xmx500m&lt;/li&gt;&lt;li&gt;-Xms160m, -Xms160m&lt;/li&gt;&lt;li&gt;-XX:MaxNewSize=65m, -XX:MaxNewSize=65m&lt;/li&gt;&lt;/ul&gt;</longDescription>
+</rule>
+<rule>
+<id>Errors</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires events to be available from the following event types: 'Java Error'.</shortDescription>
+<longDescription>The Thrown Errors rule requires events to be available from the following event types: 'Java Error'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>Exceptions</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires events to be available from the following event types: 'Exception Statistics'.</shortDescription>
+<longDescription>The Thrown Exceptions rule requires events to be available from the following event types: 'Exception Statistics'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>Fatal Errors</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>The Fatal Errors rule requires the following event types: 'jdk.Shutdown'.</shortDescription>
+<longDescription>The Fatal Errors rule requires the following event types: 'jdk.Shutdown'.&lt;p&gt;They are either not available in this version of Java, or must be enabled in a third-party component. If you are using an older Java version, then you can consider upgrading.</longDescription>
+</rule>
+<rule>
+<id>FewSampledThreads</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires events to be available from the following event types: 'CPU Information', 'Method Profiling Sample', 'Recording Setting'.</shortDescription>
+<longDescription>The Parallel Threads rule requires events to be available from the following event types: 'CPU Information', 'Method Profiling Sample', 'Recording Setting'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>FileRead</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>There are no file read events in this recording.</shortDescription>
+<longDescription>There are no file read events in this recording.</longDescription>
+</rule>
+<rule>
+<id>FileWrite</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires events to be available from the following event types: 'File Write'.</shortDescription>
+<longDescription>The File Write Peak Duration rule requires events to be available from the following event types: 'File Write'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>FlightRecordingSupport</id>
+<severity>Warning</severity>
+<score>80.0</score>
+<shortDescription>The recording is from an early access build.</shortDescription>
+<longDescription>This recording is from an early access build of the JRE (Java HotSpot(TM) 64-Bit Server VM (9-ea+148) for windows-amd64 JRE (9-ea+148), built on Dec  7 2016 18:47:38 by &amp;#34;javare&amp;#34; with MS VC++ 12.0 (VS2013)). The automated analysis is not supported, and you may see errors when attempting to analyze the recording.</longDescription>
+</rule>
+<rule>
+<id>FullGc</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule is only valid for CMS and G1 Garbage Collectors, neither of which were detected for this JVM.</shortDescription>
+<longDescription>This rule is only valid for CMS and G1 Garbage Collectors, neither of which were detected for this JVM.</longDescription>
+</rule>
+<rule>
+<id>GcFreedRatio</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires events to be available from the following event types: 'Heap Summary'.</shortDescription>
+<longDescription>The GC Freed Ratio rule requires events to be available from the following event types: 'Heap Summary'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>GcLocker</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>No GCs were affected by the GC Locker.</shortDescription>
+<longDescription>No GCs were affected by the GC Locker.</longDescription>
+</rule>
+<rule>
+<id>GcOptions</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>Too few events to calculate the result.</shortDescription>
+<longDescription>Too few events to calculate the result.</longDescription>
+</rule>
+<rule>
+<id>GcPauseRatio</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires events to be available from the following event types: 'GC Phase Pause'.</shortDescription>
+<longDescription>The GC Pauses rule requires events to be available from the following event types: 'GC Phase Pause'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>GcStall</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires events to be available from the following event types: 'Garbage Collection'.</shortDescription>
+<longDescription>The GC Stall rule requires events to be available from the following event types: 'Garbage Collection'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>HeapContent</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires events to be available from the following event types: 'Object Count'.</shortDescription>
+<longDescription>The Heap Content rule requires events to be available from the following event types: 'Object Count'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>HeapInspectionGc</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires events to be available from the following event types: 'Garbage Collection'.</shortDescription>
+<longDescription>The GCs Caused by Heap Inspection rule requires events to be available from the following event types: 'Garbage Collection'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>HighGc</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>The runtime did not spend much time performing garbage collections.</shortDescription>
+<longDescription>The runtime did not spend much time performing garbage collections.</longDescription>
+</rule>
+<rule>
+<id>HighJvmCpu</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires events to be available from the following event types: 'CPU Load'.</shortDescription>
+<longDescription>The High JVM CPU Load rule requires events to be available from the following event types: 'CPU Load'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>IncreasingLiveSet</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>Too few events to calculate the result.</shortDescription>
+<longDescription>Too few events to calculate the result.</longDescription>
+</rule>
+<rule>
+<id>IncreasingMetaSpaceLiveSet</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>The class data does not seem to increase during the recording.</shortDescription>
+<longDescription>The class data does not seem to increase during the recording.</longDescription>
+</rule>
+<rule>
+<id>JavaBlocking</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires events to be available from the following event types: 'Java Monitor Blocked'.</shortDescription>
+<longDescription>The Java Blocking rule requires events to be available from the following event types: 'Java Monitor Blocked'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>LongGcPause</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>The application did not cause any long GC pause times.</shortDescription>
+<longDescription>The application did not cause any long GC pause times.</longDescription>
+</rule>
+<rule>
+<id>LowOnPhysicalMemory</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires events to be available from the following event types: 'Physical Memory'.</shortDescription>
+<longDescription>The Free Physical Memory rule requires events to be available from the following event types: 'Physical Memory'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>ManagementAgent</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>No problems were found with the management agent settings.</shortDescription>
+<longDescription>No problems were found with the management agent settings.</longDescription>
+</rule>
+<rule>
+<id>ManyRunningProcesses</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires events to be available from the following event types: 'System Process'.</shortDescription>
+<longDescription>The Competing Processes rule requires events to be available from the following event types: 'System Process'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>MetaspaceOom</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>The metaspace was not exhausted during this recording.</shortDescription>
+<longDescription>The metaspace was not exhausted during this recording.</longDescription>
+</rule>
+<rule>
+<id>MethodProfiling</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires events to be available from the following event types: 'Method Profiling Sample', 'Recording Setting'.</shortDescription>
+<longDescription>The Method Profiling rule requires events to be available from the following event types: 'Method Profiling Sample', 'Recording Setting'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>Options</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>No undocumented, deprecated or non-recommended option flags were detected.</shortDescription>
+<longDescription>No undocumented, deprecated or non-recommended option flags were detected.</longDescription>
+</rule>
+<rule>
+<id>OverAggressiveRecordingSetting</id>
+<severity>Information</severity>
+<score>50.0</score>
+<shortDescription>These following event types had no threshold: &amp;#39;Java Monitor Blocked&amp;#39;, &amp;#39;Java Thread Park&amp;#39;.</shortDescription>
+<longDescription>Event types without threshold can lead to quite a lot of events being generated, possibly translating to higher overhead. If this was not intended, please check the settings in the template for future recordings.</longDescription>
+</rule>
+<rule>
+<id>PasswordsInArguments</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>The recording does not seem to contain passwords in the application arguments.</shortDescription>
+<longDescription>The recording does not seem to contain passwords in the application arguments.</longDescription>
+</rule>
+<rule>
+<id>PasswordsInEnvironment</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires events to be available from the following event types: 'Initial Environment Variable'.</shortDescription>
+<longDescription>The Passwords in Environment Variables rule requires events to be available from the following event types: 'Initial Environment Variable'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>PasswordsInSystemProperties</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires events to be available from the following event types: 'Initial System Property'.</shortDescription>
+<longDescription>The Passwords in System Properties rule requires events to be available from the following event types: 'Initial System Property'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>PrimitiveToObjectConversion</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires events to be available from the following event types: 'Allocation in new TLAB', 'Allocation outside TLAB'.</shortDescription>
+<longDescription>The Primitive To Object Conversion rule requires events to be available from the following event types: 'Allocation in new TLAB', 'Allocation outside TLAB'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>SocketRead</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires events to be available from the following event types: 'Socket Read'.</shortDescription>
+<longDescription>The Socket Read Peak Duration rule requires events to be available from the following event types: 'Socket Read'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>SocketWrite</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires events to be available from the following event types: 'Socket Write'.</shortDescription>
+<longDescription>The Socket Write Peak Duration rule requires events to be available from the following event types: 'Socket Write'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>StackdepthSetting</id>
+<severity>Warning</severity>
+<score>99.35136572520041</score>
+<shortDescription>Some stack traces were truncated in this recording.</shortDescription>
+<longDescription>Some stack traces were truncated in this recording.&lt;p&gt;The Flight Recorder is configured with a maximum captured stack depth of 64. This is the default depth. 17.5 % of all traces were larger than this option, and were therefore truncated. If more detailed traces are required, increase the '-XX:FlightRecorderOptions=stackdepth=&amp;lt;value&amp;gt;' value.&lt;p&gt;Events of the following types have truncated stack traces:&lt;ul&gt;&lt;li&gt;Debug (1.59 % truncated traces)&lt;/li&gt;&lt;li&gt;EJB Business Method Invoke (71.3 % truncated traces)&lt;/li&gt;&lt;li&gt;EJB Business Method Post Invoke (71.3 % truncated traces)&lt;/li&gt;&lt;li&gt;EJB Business Method Post Invoke Cleanup (71.3 % truncated traces)&lt;/li&gt;&lt;li&gt;EJB Business Method Pre Invoke (71.3 % truncated traces)&lt;/li&gt;&lt;li&gt;EJB Pool Manager Create (75 % truncated traces)&lt;/li&gt;&lt;li&gt;EJB Pool Manager Post Invoke (71.3 % truncated traces)&lt;/li&gt;&lt;li&gt;EJB Pool Manager Pre Invoke (71.3 % truncated traces)&lt;/li&gt;&lt;li&gt;JDBC Connection Close (96.8 % truncated traces)&lt;/li&gt;&lt;li&gt;JDBC Connection Prepare (100 % truncated traces)&lt;/li&gt;&lt;li&gt;JDBC Connection Release (85.7 % truncated traces)&lt;/li&gt;&lt;li&gt;JDBC Statement Creation (100 % truncated traces)&lt;/li&gt;&lt;li&gt;JDBC Statement Execute (96.7 % truncated traces)&lt;/li&gt;&lt;li&gt;JDBC Statement Execute Begin (96.7 % truncated traces)&lt;/li&gt;&lt;li&gt;JDBC Transaction Commit (45 % truncated traces)&lt;/li&gt;&lt;li&gt;JDBC Transaction End (45 % truncated traces)&lt;/li&gt;&lt;li&gt;JDBC Transaction Is Same RM (1.79 % truncated traces)&lt;/li&gt;&lt;li&gt;JDBC Transaction Start (100 % truncated traces)&lt;/li&gt;&lt;li&gt;JTA Transaction Commit (36.4 % truncated traces)&lt;/li&gt;&lt;li&gt;JTA Transaction End (6.06 % truncated traces)&lt;/li&gt;&lt;li&gt;JTA Transaction Start (16.7 % truncated traces)&lt;/li&gt;&lt;li&gt;Servlet Response Write Headers (1.87 % truncated traces)&lt;/li&gt;&lt;li&gt;Webservices JAXRPC Client Request (50 % truncated traces)&lt;/li&gt;&lt;li&gt;Webservices JAXRPC Client Response (100 % truncated traces)&lt;/li&gt;&lt;li&gt;Webservices JAXWS Endpoint (100 % truncated traces)&lt;/li&gt;&lt;li&gt;Webservices JAXWS Resource (50 % truncated traces)&lt;/li&gt;&lt;/ul&gt;</longDescription>
+</rule>
+<rule>
+<id>StringDeduplication</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires events to be available from the following event types: 'Heap Summary'.</shortDescription>
+<longDescription>The String Deduplication rule requires events to be available from the following event types: 'Heap Summary'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>SystemGc</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>This rule requires events to be available from the following event types: 'Garbage Collection'.</shortDescription>
+<longDescription>The GCs Caused by System.gc() rule requires events to be available from the following event types: 'Garbage Collection'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>TlabAllocationRatio</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>No object allocations outside of TLABs detected.</shortDescription>
+<longDescription>No object allocations outside of TLABs detected.</longDescription>
+</rule>
+<rule>
+<id>VMOperations</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>No excessively long VM operations were found in this recording (the longest was 0 s).</shortDescription>
+<longDescription>No excessively long VM operations were found in this recording (the longest was 0 s).</longDescription>
+</rule>
+<rule>
+<id>biasedLockingRevocation</id>
+<severity>Not Applicable</severity>
+<score>-1.0</score>
+<shortDescription>The Biased Locking Revocation rule requires the following event types: 'jdk.BiasedLockClassRevocation'.</shortDescription>
+<longDescription>The Biased Locking Revocation rule requires the following event types: 'jdk.BiasedLockClassRevocation'.&lt;p&gt;They are either not available in this version of Java, or must be enabled in a third-party component. If you are using an older Java version, then you can consider upgrading.</longDescription>
+</rule>
+<rule>
+<id>biasedLockingRevocationPause</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>No revocation of biased locks found.</shortDescription>
+<longDescription>No revocation of biased locks found.</longDescription>
+</rule>
+</report>
 </reportcollection>


### PR DESCRIPTION
Rewrites the stackdepth setting rule to complete in one pass over all events with stacktraces. Also sorts the resulting list of event types with truncated traces.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JMC-6801](https://bugs.openjdk.java.net/browse/JMC-6801): Improve stackdepth setting rule


### Reviewers
 * Marcus Hirt ([hirt](@thegreystone) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jmc pull/76/head:pull/76`
`$ git checkout pull/76`
