### PR TITLE
6819: Agent instrumentation causing stack map frame verification error

### DIFF
--- a/agent/src/main/java/org/openjdk/jmc/agent/Transformer.java
+++ b/agent/src/main/java/org/openjdk/jmc/agent/Transformer.java
@@ -108,7 +108,7 @@ public class Transformer implements ClassFileTransformer {
 					new JFRClassVisitor(classWriter, td, definingClassLoader, classBeingRedefined, protectionDomain,
 							inspectionClassLoader); 
 			ClassReader reader = new ClassReader(classfileBuffer);
-			reader.accept(visitor, 0);
+			reader.accept(visitor, ClassReader.EXPAND_FRAMES);
 			return classWriter.toByteArray();
 		} catch (Throwable t) {
 			Logger.getLogger(getClass().getName()).log(Level.SEVERE,

--- a/agent/src/main/java/org/openjdk/jmc/agent/jfr/impl/JFRMethodAdvisor.java
+++ b/agent/src/main/java/org/openjdk/jmc/agent/jfr/impl/JFRMethodAdvisor.java
@@ -262,10 +262,4 @@ public class JFRMethodAdvisor extends AdviceAdapter {
 		mv.visitMethodInsn(INVOKEVIRTUAL, transformDescriptor.getEventClassName(), "end", "()V", false); //$NON-NLS-1$ //$NON-NLS-2$
 		mv.visitMethodInsn(INVOKEVIRTUAL, transformDescriptor.getEventClassName(), "commit", "()V", false); //$NON-NLS-1$ //$NON-NLS-2$
 	}
-
-    @Override
-    public void visitFrame(int type, int numLocal, Object[] local, int numStack, Object[] stack) {
-        // force to always use expanded frames
-        super.visitFrame(Opcodes.F_NEW, numLocal, local, numStack, stack);
-    }
 }

--- a/agent/src/main/java/org/openjdk/jmc/agent/jfrnext/impl/JFRNextMethodAdvisor.java
+++ b/agent/src/main/java/org/openjdk/jmc/agent/jfrnext/impl/JFRNextMethodAdvisor.java
@@ -260,10 +260,4 @@ public class JFRNextMethodAdvisor extends AdviceAdapter {
 		mv.visitVarInsn(ALOAD, eventLocal);
 		mv.visitMethodInsn(INVOKEVIRTUAL, transformDescriptor.getEventClassName(), "commit", "()V", false); //$NON-NLS-1$ //$NON-NLS-2$
 	}
-
-	@Override
-	public void visitFrame(int type, int numLocal, Object[] local, int numStack, Object[] stack) {
-		// force to always use expanded frames
-		super.visitFrame(Opcodes.F_NEW, numLocal, local, numStack, stack);
-	}
 }

--- a/agent/src/test/java/org/openjdk/jmc/agent/test/AllTests.java
+++ b/agent/src/test/java/org/openjdk/jmc/agent/test/AllTests.java
@@ -38,7 +38,7 @@ import org.junit.runners.Suite.SuiteClasses;
 import org.openjdk.jmc.agent.converters.test.TestConverterTransforms;
 
 @RunWith(Suite.class)
-@SuiteClasses({TestDefaultTransformRegistry.class, TestUtils.class, TestJFRTransformer.class, TestConverterTransforms.class, TestProbeDefinitionValidation.class})
+@SuiteClasses({TestDefaultTransformRegistry.class, TestUtils.class, TestJFRTransformer.class, TestConverterTransforms.class, TestProbeDefinitionValidation.class, TestCompressedFrameTransformation.class})
 
 public class AllTests {
 }

--- a/agent/src/test/java/org/openjdk/jmc/agent/test/TestCompressedFrameTransformation.java
+++ b/agent/src/test/java/org/openjdk/jmc/agent/test/TestCompressedFrameTransformation.java
@@ -1,0 +1,158 @@
+package org.openjdk.jmc.agent.test;
+
+import org.junit.Test;
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.Label;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+import org.openjdk.jmc.agent.TransformRegistry;
+import org.openjdk.jmc.agent.Transformer;
+import org.openjdk.jmc.agent.impl.DefaultTransformRegistry;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class TestCompressedFrameTransformation implements Opcodes {
+
+	private static final String XML_EVENT_DESCRIPTION = "<jfragent>" //
+			+ "<events>" // 
+			+ "<event id=\"test.compressed.frame.transformation\">" // 
+			+ "<name>Test Compressed Frame Transformation</name>" //
+			+ "<description>agent instrumentation should be compatible with compressed frame types</description>" //
+			+ "<path>test/frames</path>" //
+			+ "<class>Target</class>" //
+			+ "<method>" //
+			+ "<name>echo</name>" //
+			+ "<descriptor>(I)I</descriptor>" // 
+			+ "</method>" //
+			+ "</event>" //
+			+ "</events>" //
+			+ "</jfragent>";
+
+	// Class generator using asm lib. This makes sure we get the original bytecode that really consists a compressed frame.
+	public static byte[] generateClassBuffer(int frameType) {
+		ClassWriter classWriter = new ClassWriter(0);
+		MethodVisitor methodVisitor;
+
+		// class Target {
+		classWriter.visit(V11, ACC_PUBLIC | ACC_SUPER, "Target", null, "java/lang/Object", null);
+
+		{
+			// public Target() {
+			methodVisitor = classWriter.visitMethod(ACC_PUBLIC, "<init>", "()V", null, null);
+			methodVisitor.visitCode();
+			Label label0 = new Label();
+			methodVisitor.visitLabel(label0);
+			methodVisitor.visitVarInsn(ALOAD, 0);
+			methodVisitor.visitMethodInsn(INVOKESPECIAL, "java/lang/Object", "<init>", "()V", false); // super()
+			methodVisitor.visitInsn(RETURN);
+			Label label1 = new Label();
+			methodVisitor.visitLabel(label1);
+			methodVisitor.visitLocalVariable("this", "LTarget;", null, label0, label1, 0);
+			methodVisitor.visitMaxs(1, 1);
+			methodVisitor.visitEnd(); // }
+		}
+		{
+			// public int echo(int arg)
+			methodVisitor = classWriter.visitMethod(ACC_PUBLIC, "echo", "(I)I", null, null);
+			methodVisitor.visitCode();
+			Label label0 = new Label();
+			methodVisitor.visitLabel(label0);
+			methodVisitor.visitVarInsn(ILOAD, 1);
+			methodVisitor.visitIntInsn(BIPUSH, 42);
+			Label label1 = new Label();
+			methodVisitor.visitJumpInsn(IF_ICMPLE, label1); // if (arg > 42) {
+			Label label2 = new Label();
+			methodVisitor.visitLabel(label2);
+			methodVisitor.visitIntInsn(BIPUSH, 42); // return 42
+			methodVisitor.visitInsn(IRETURN); // }
+			methodVisitor.visitLabel(label1);
+			methodVisitor.visitFrame(frameType, 0, null, 0, null);
+			methodVisitor.visitVarInsn(ILOAD, 1); // return arg
+			methodVisitor.visitInsn(IRETURN); // }
+			Label label3 = new Label();
+			methodVisitor.visitLabel(label3);
+			methodVisitor.visitLocalVariable("this", "LTarget;", null, label0, label3, 0);
+			methodVisitor.visitLocalVariable("arg", "I", null, label0, label3, 1);
+			methodVisitor.visitMaxs(2, 2);
+			methodVisitor.visitEnd();
+		}
+		classWriter.visitEnd(); // }
+
+		return classWriter.toByteArray();
+	}
+
+	private void testCompressedFrameNoVerificationError(int frameType) throws Exception {
+		TestClassLoader tcl = new TestClassLoader(TestCompressedFrameTransformation.class.getClassLoader());
+		byte[] classBuffer = generateClassBuffer(frameType);
+
+		TransformRegistry registry = DefaultTransformRegistry.empty();
+		Transformer transformer = new Transformer(registry);
+
+		registry.modify(XML_EVENT_DESCRIPTION);
+		classBuffer = transformer.transform(tcl, "Target", null, null, classBuffer);
+
+		tcl.putClassBuffer("Target", classBuffer);
+		tcl.loadClass("Target");
+
+		// No need to run the actual code as we're just making sure there is no verification errors
+	}
+
+	@Test
+	public void testSameFrameNoVerificationError() throws Exception {
+		testCompressedFrameNoVerificationError(F_SAME);
+	}
+
+	@Test
+	public void testChopFrameNoVerificationError() throws Exception {
+		testCompressedFrameNoVerificationError(F_CHOP);
+	}
+
+	@Test
+	public void testAppendFrameNoVerificationError() throws Exception {
+		testCompressedFrameNoVerificationError(F_APPEND);
+	}
+
+	static class TestClassLoader extends ClassLoader {
+
+		private Map<String, byte[]> classBuffers = new HashMap<>();
+
+		public TestClassLoader(ClassLoader parent) {
+			super(parent);
+		}
+
+		public void putClassBuffer(String name, byte[] bytes) {
+			classBuffers.put(name, bytes);
+		}
+
+		@Override
+		public Class<?> loadClass(String name) throws ClassNotFoundException {
+			if (classBuffers.containsKey(name)) {
+				return loadClass(name, false);
+			}
+
+			return getParent().loadClass(name);
+		}
+
+		@Override
+		protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+			Class<?> clazz = findClass(name);
+
+			if (resolve) {
+				resolveClass(clazz);
+			}
+
+			return clazz;
+		}
+
+		@Override
+		protected Class<?> findClass(String name) throws ClassNotFoundException {
+			byte[] bytes = classBuffers.get(name);
+			return defineClass(name, bytes, 0, bytes.length);
+		}
+	}
+
+	public void test() {
+		//Dummy method for instrumentation
+	}
+}


### PR DESCRIPTION
This pr fixes [JMC-6819: Agent instrumentation causing stack map frame verification error](https://bugs.openjdk.java.net/browse/JMC-6819). 

The issue is reproducible when the target function consists of multiple exit points, and a compressed stack map frame describing a jump target, followed by a function exit (eg. `*return` instructions). A simple example could be something like(, given `javac` writes a compressed frame instead of a new expanded frame): 
```java
public int echo(int arg) {
    if (arg > 42) {
        return 42;
    }
    return arg;
}
```

When fixing [JMC-6532: Instrumentation fails for methods containing try-catch clauses](https://bugs.openjdk.java.net/browse/JMC-6532), compressed frames were [forcefully expanded](https://github.com/thegreystone/jmc-old/commit/e4acc9c93bfb21317caeead2d7646c7677c7a4a6#diff-af337d6e5f3fd3b585e66e0cebcb056fR132), but the method was faulty. It turns out the ASM lib supports expanding frames automatically, which this pr adopts.

This pr comes with test cases generating bytecode for the example above. The generation is done by ASM lib manually to make sure various compressed frame types (`same_frame`, `chop_frame`, `append_frame`) are tested.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JMC-6819](https://bugs.openjdk.java.net/browse/JMC-6819): Agent instrumentation causing stack map frame verification error


### Reviewers
 * Marcus Hirt ([hirt](@thegreystone) - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jmc pull/79/head:pull/79`
`$ git checkout pull/79`
