### PR TITLE
6825: JMX defineEventProbes fails when no events in XMLDescriptor

### DIFF
--- a/agent/src/main/java/org/openjdk/jmc/agent/jmx/AgentController.java
+++ b/agent/src/main/java/org/openjdk/jmc/agent/jmx/AgentController.java
@@ -80,7 +80,7 @@ public class AgentController implements AgentControllerMXBean {
 	}
 
 	private Class<?>[] revertAllTransforms() {
-		HashSet<Class<?>> classesToRetransform = new HashSet<Class<?>>();
+		Set<Class<?>> classesToRetransform = new HashSet<>();
 		List<String> classNames = registry.clearAllTransformData();
 		for (String className : classNames ) {
 			try {
@@ -94,7 +94,7 @@ public class AgentController implements AgentControllerMXBean {
 	}
 
 	private Class<?>[] defineSpecificTransforms(List<TransformDescriptor> descriptors) {
-		HashSet<Class<?>> classesToRetransform = new HashSet<Class<?>>();
+		Set<Class<?>> classesToRetransform = new HashSet<>();
 		for (TransformDescriptor descriptor : descriptors) {
 			try {
 				Class<?> classToRetransform = Class.forName(descriptor.getClassName().replace('/', '.'));

--- a/agent/src/main/java/org/openjdk/jmc/agent/jmx/AgentController.java
+++ b/agent/src/main/java/org/openjdk/jmc/agent/jmx/AgentController.java
@@ -59,40 +59,51 @@ public class AgentController implements AgentControllerMXBean {
 
 	public void defineEventProbes(String xmlDescription) throws Exception{
 		checkSecurity();
-		HashSet<Class<?>> classesToRetransform = new HashSet<Class<?>>();
+		Class<?>[] classesToRetransformArray;
 		boolean revertAll = xmlDescription == null ? true : xmlDescription.isEmpty();
 		if (revertAll) {
-			List<String> classNames = registry.clearAllTransformData();
-			for (String className : classNames ) {
-				try {
-					Class<?> classToRetransform = Class.forName(className.replace('/', '.'));
-					classesToRetransform.add(classToRetransform);
-				} catch (ClassNotFoundException cnfe) {
-					logger.log(Level.SEVERE, "Unable to find class: " + className, cnfe);
-				}
-			}
+			classesToRetransformArray = revertAllTransforms();
 		} else {
 			List<TransformDescriptor> descriptors = registry.modify(xmlDescription);
-			boolean noDescriptors = descriptors == null ? true : descriptors.isEmpty();
-			if (noDescriptors) {
+			if (descriptors == null) {
 				logger.log(Level.SEVERE, "Failed to identify transformations: " + xmlDescription);
 				return;
-			}
-			for (TransformDescriptor descriptor : descriptors) {
-				try {
-					Class<?> classToRetransform = Class.forName(descriptor.getClassName().replace('/', '.'));
-					classesToRetransform.add(classToRetransform);
-				} catch (ClassNotFoundException cnfe) {
-					logger.log(Level.SEVERE, "Unable to find class: " + descriptor.getClassName(), cnfe);
-				}
+			} else if (descriptors.isEmpty()) {
+				classesToRetransformArray = revertAllTransforms();
+			} else {
+				classesToRetransformArray = defineSpecificTransforms(descriptors);
 			}
 		}
-
-		Class<?>[] classesToRetransformArray = classesToRetransform.toArray(new Class<?>[0]);
-
 		registry.setRevertInstrumentation(true);
 		instrumentation.retransformClasses(classesToRetransformArray);
 		registry.setRevertInstrumentation(false);
+	}
+
+	private Class<?>[] revertAllTransforms() {
+		HashSet<Class<?>> classesToRetransform = new HashSet<Class<?>>();
+		List<String> classNames = registry.clearAllTransformData();
+		for (String className : classNames ) {
+			try {
+				Class<?> classToRetransform = Class.forName(className.replace('/', '.'));
+				classesToRetransform.add(classToRetransform);
+			} catch (ClassNotFoundException cnfe) {
+				logger.log(Level.SEVERE, "Unable to find class: " + className, cnfe);
+			}
+		}
+		return classesToRetransform.toArray(new Class<?>[0]);
+	}
+
+	private Class<?>[] defineSpecificTransforms(List<TransformDescriptor> descriptors) {
+		HashSet<Class<?>> classesToRetransform = new HashSet<Class<?>>();
+		for (TransformDescriptor descriptor : descriptors) {
+			try {
+				Class<?> classToRetransform = Class.forName(descriptor.getClassName().replace('/', '.'));
+				classesToRetransform.add(classToRetransform);
+			} catch (ClassNotFoundException cnfe) {
+				logger.log(Level.SEVERE, "Unable to find class: " + descriptor.getClassName(), cnfe);
+			}
+		}
+		return classesToRetransform.toArray(new Class<?>[0]);
 	}
 
 	public JFRTransformDescriptor[] retrieveCurrentTransforms() {


### PR DESCRIPTION
This patch makes the agent JMX operation 'defineEventProbes' accept an xmlDecsription with no event tags.  Previously, the only way you could clear all current transforms was to supply the operation with an empty or null xmlDescription.  

Now a file with the following structure will also clear all current transforms: 
`<jfragent><events></events></jfragent>`
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JMC-6825](https://bugs.openjdk.java.net/browse/JMC-6825): JMX defineEventProbes fails when no events in XMLDescriptor


### Reviewers
 * Marcus Hirt ([hirt](@thegreystone) - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jmc pull/80/head:pull/80`
`$ git checkout pull/80`
