### PR TITLE
6831: Add chunk ranges to IItemCollection

### DIFF
--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/ItemCollectionToolkit.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/ItemCollectionToolkit.java
@@ -34,11 +34,13 @@ package org.openjdk.jmc.flightrecorder.ui;
 
 import java.text.MessageFormat;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
+import java.util.Set;
 import java.util.Spliterator;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -56,6 +58,8 @@ import org.openjdk.jmc.common.item.IMemberAccessor;
 import org.openjdk.jmc.common.item.IType;
 import org.openjdk.jmc.common.item.ItemFilters;
 import org.openjdk.jmc.common.item.ItemToolkit;
+import org.openjdk.jmc.common.unit.IQuantity;
+import org.openjdk.jmc.common.unit.IRange;
 import org.openjdk.jmc.flightrecorder.ui.messages.internal.Messages;
 
 /**
@@ -66,9 +70,11 @@ public class ItemCollectionToolkit {
 	private static class StreamBackedItemCollection implements IItemCollection {
 
 		private final Supplier<Stream<IItemIterable>> items;
+		private final Set<IRange<IQuantity>> chunkRanges;
 
-		StreamBackedItemCollection(Supplier<Stream<IItemIterable>> items) {
+		StreamBackedItemCollection(Supplier<Stream<IItemIterable>> items, Set<IRange<IQuantity>> chunkRanges) {
 			this.items = items;
+			this.chunkRanges = chunkRanges;
 		}
 
 		@Override
@@ -83,7 +89,7 @@ public class ItemCollectionToolkit {
 
 		@Override
 		public StreamBackedItemCollection apply(IItemFilter filter) {
-			return new StreamBackedItemCollection(() -> ItemIterableToolkit.filter(items.get(), filter));
+			return new StreamBackedItemCollection(() -> ItemIterableToolkit.filter(items.get(), filter), chunkRanges);
 		}
 
 		@Override
@@ -96,23 +102,39 @@ public class ItemCollectionToolkit {
 			return items.get().anyMatch(IItemIterable::hasItems);
 		}
 
+		@Override
+		public Set<IRange<IQuantity>> getChunkRanges() {
+			return chunkRanges;
+		}
+
 	}
 
-	public static final IItemCollection EMPTY = new StreamBackedItemCollection(() -> Stream.empty());
+	public static final IItemCollection EMPTY = new StreamBackedItemCollection(() -> Stream.empty(),
+			Collections.emptySet());
 
-	public static IItemCollection build(Stream<? extends IItem> items) {
+	public static IItemCollection build(Stream<? extends IItem> items, Set<IRange<IQuantity>> chunkRanges) {
 		Map<IType<IItem>, List<IItem>> byTypeMap = items.collect(Collectors.groupingBy(ItemToolkit::getItemType));
 		List<Entry<IType<IItem>, List<IItem>>> entryList = new ArrayList<>(byTypeMap.entrySet());
 		return ItemCollectionToolkit
 				.build(() -> entryList.stream().map(e -> ItemIterableToolkit.build(e.getValue()::stream, e.getKey())));
 	}
 
+	public static IItemCollection build(Stream<? extends IItem> items) {
+		return build(items, Collections.emptySet());
+	}
+
+	public static IItemCollection build(Supplier<Stream<IItemIterable>> items, Set<IRange<IQuantity>> chunkRanges) {
+		return new StreamBackedItemCollection(items, Collections.emptySet());
+	}
+
 	public static IItemCollection build(Supplier<Stream<IItemIterable>> items) {
-		return new StreamBackedItemCollection(items);
+		return build(items, Collections.emptySet());
 	}
 
 	public static IItemCollection merge(Supplier<Stream<IItemCollection>> items) {
-		return ItemCollectionToolkit.build(() -> items.get().flatMap(ItemCollectionToolkit::stream));
+		Set<IRange<IQuantity>> chunkRanges = items.get().flatMap(i -> i.getChunkRanges().stream())
+				.collect(Collectors.toSet());
+		return ItemCollectionToolkit.build(() -> items.get().flatMap(ItemCollectionToolkit::stream), chunkRanges);
 	}
 
 	public static <V> Optional<IItemIterable> join(IItemCollection items, String withTypeId) {

--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/ItemCollectionToolkit.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/ItemCollectionToolkit.java
@@ -103,7 +103,7 @@ public class ItemCollectionToolkit {
 		}
 
 		@Override
-		public Set<IRange<IQuantity>> getChunkRanges() {
+		public Set<IRange<IQuantity>> getTimeRanges() {
 			return chunkRanges;
 		}
 
@@ -132,7 +132,7 @@ public class ItemCollectionToolkit {
 	}
 
 	public static IItemCollection merge(Supplier<Stream<IItemCollection>> items) {
-		Set<IRange<IQuantity>> chunkRanges = items.get().flatMap(i -> i.getChunkRanges().stream())
+		Set<IRange<IQuantity>> chunkRanges = items.get().flatMap(i -> i.getTimeRanges().stream())
 				.collect(Collectors.toSet());
 		return ItemCollectionToolkit.build(() -> items.get().flatMap(ItemCollectionToolkit::stream), chunkRanges);
 	}

--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/JfrEditor.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/JfrEditor.java
@@ -78,6 +78,7 @@ import org.openjdk.jmc.common.unit.IQuantity;
 import org.openjdk.jmc.common.unit.IRange;
 import org.openjdk.jmc.common.util.ExceptionToolkit;
 import org.openjdk.jmc.flightrecorder.internal.EventArray;
+import org.openjdk.jmc.flightrecorder.internal.EventArrays;
 import org.openjdk.jmc.flightrecorder.ui.common.ImageConstants;
 import org.openjdk.jmc.flightrecorder.ui.messages.internal.Messages;
 import org.openjdk.jmc.flightrecorder.ui.preferences.PreferenceKeys;
@@ -373,7 +374,7 @@ public class JfrEditor extends EditorPart implements INavigationLocationProvider
 		setPartName(ei.getName());
 	}
 
-	void repositoryLoaded(EventArray[] repo, IRange<IQuantity> fullRange) {
+	void repositoryLoaded(EventArrays repo, IRange<IQuantity> fullRange) {
 		if (!resultContainer.isDisposed()) {
 			items = new StreamModel(repo);
 			this.fullRange = fullRange;

--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/RecordingLoader.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/RecordingLoader.java
@@ -64,6 +64,7 @@ import org.openjdk.jmc.flightrecorder.CouldNotLoadRecordingException;
 import org.openjdk.jmc.flightrecorder.JfrAttributes;
 import org.openjdk.jmc.flightrecorder.internal.ChunkInfo;
 import org.openjdk.jmc.flightrecorder.internal.EventArray;
+import org.openjdk.jmc.flightrecorder.internal.EventArrays;
 import org.openjdk.jmc.flightrecorder.internal.FlightRecordingLoader;
 import org.openjdk.jmc.flightrecorder.internal.NotEnoughMemoryException;
 import org.openjdk.jmc.flightrecorder.internal.VersionNotSupportedException;
@@ -93,7 +94,7 @@ public class RecordingLoader extends Job {
 		boolean closeEditor = true;
 		try {
 			File file = MCPathEditorInput.getFile(ei);
-			EventArray[] events = doCreateRecording(file, new ProgressMonitor(monitor, ui));
+			EventArrays events = doCreateRecording(file, new ProgressMonitor(monitor, ui));
 			checkForJRockitRecording(events);
 			onRecordingLoaded(events);
 			closeEditor = false;
@@ -114,10 +115,10 @@ public class RecordingLoader extends Job {
 		}
 	}
 
-	private void onRecordingLoaded(EventArray[] events) {
+	private void onRecordingLoaded(EventArrays events) {
 		IQuantity startTime = null;
 		IQuantity endTime = null;
-		for (EventArray typeEntry : events) {
+		for (EventArray typeEntry : events.getArrays()) {
 			IItem[] ea = typeEntry.getEvents();
 			IMemberAccessor<IQuantity, IItem> stAccessor = JfrAttributes.START_TIME.getAccessor(typeEntry.getType());
 			IMemberAccessor<IQuantity, IItem> etAccessor = JfrAttributes.END_TIME.getAccessor(typeEntry.getType());
@@ -159,7 +160,7 @@ public class RecordingLoader extends Job {
 		});
 	}
 
-	private EventArray[] doCreateRecording(File file, ProgressMonitor lm)
+	private EventArrays doCreateRecording(File file, ProgressMonitor lm)
 			throws CouldNotLoadRecordingException, IOException {
 		// FIXME: Can we calculate available memory without resorting to System.gc?
 		System.gc();
@@ -181,8 +182,8 @@ public class RecordingLoader extends Job {
 		return loadFromUnzippedFile(file, fileName, lm, availableMemory);
 	}
 
-	private static void checkForJRockitRecording(EventArray[] events) {
-		for (EventArray ea : events) {
+	private static void checkForJRockitRecording(EventArrays events) {
+		for (EventArray ea : events.getArrays()) {
 			if (ea.getType().getIdentifier().startsWith("http://www.oracle.com/jrockit/")) { //$NON-NLS-1$
 				DisplayToolkit.safeSyncExec(new Runnable() {
 					@Override
@@ -196,7 +197,7 @@ public class RecordingLoader extends Job {
 		}
 	}
 
-	private EventArray[] loadFromUnzippedFile(
+	private EventArrays loadFromUnzippedFile(
 		File unzippedFile, String recordingFileName, ProgressMonitor lm, long availableMemory)
 			throws IOException, CouldNotLoadRecordingException {
 		boolean hideExperimentals = !FlightRecorderUI.getDefault().includeExperimentalEventsAndFields();

--- a/application/uitests/org.openjdk.jmc.flightrecorder.uitest/src/test/java/org/openjdk/jmc/flightrecorder/uitest/JfrMetadataToolkit.java
+++ b/application/uitests/org.openjdk.jmc.flightrecorder.uitest/src/test/java/org/openjdk/jmc/flightrecorder/uitest/JfrMetadataToolkit.java
@@ -41,6 +41,7 @@ import java.util.TreeMap;
 import org.openjdk.jmc.common.io.IOToolkit;
 import org.openjdk.jmc.common.item.IAccessorKey;
 import org.openjdk.jmc.flightrecorder.internal.EventArray;
+import org.openjdk.jmc.flightrecorder.internal.EventArrays;
 import org.openjdk.jmc.flightrecorder.internal.FlightRecordingLoader;
 
 @SuppressWarnings("restriction")
@@ -49,8 +50,8 @@ public class JfrMetadataToolkit {
 	protected static SortedMap<String, SortedMap<String, String>> parseRecordingFile(File recordingFile) {
 		SortedMap<String, SortedMap<String, String>> eventTypeMap = new TreeMap<>();
 		try (InputStream stream = IOToolkit.openUncompressedStream(recordingFile)) {
-			EventArray[] eventArrays = FlightRecordingLoader.loadStream(stream, false, false);
-			for (EventArray entry : eventArrays) {
+			EventArrays eventArrays = FlightRecordingLoader.loadStream(stream, false, false);
+			for (EventArray entry : eventArrays.getArrays()) {
 				SortedMap<String, String> attrs = new TreeMap<>();
 				for (IAccessorKey<?> a : entry.getType().getAccessorKeys().keySet()) {
 					attrs.put(a.getIdentifier(), a.getContentType().getIdentifier());

--- a/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/item/IItemCollection.java
+++ b/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/item/IItemCollection.java
@@ -32,6 +32,11 @@
  */
 package org.openjdk.jmc.common.item;
 
+import java.util.Set;
+
+import org.openjdk.jmc.common.unit.IQuantity;
+import org.openjdk.jmc.common.unit.IRange;
+
 /**
  * An immutable collection of items.
  */
@@ -63,4 +68,14 @@ public interface IItemCollection extends Iterable<IItemIterable> {
 	 * @return {@code true} if the collections contains items, {@code false} otherwise
 	 */
 	boolean hasItems();
+
+	/**
+	 * Returns a set of IRange representations of the time ranges of all chunks represented by this
+	 * item collection. This set is not affected by any filtering operations on the item collection
+	 * since its use is to show the time ranges in which events could possibly have been emitted.
+	 * 
+	 * @return a set of IRange objects representing the time ranges of the chunks represented by
+	 *         this IItemCollection
+	 */
+	Set<IRange<IQuantity>> getChunkRanges();
 }

--- a/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/item/IItemCollection.java
+++ b/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/item/IItemCollection.java
@@ -70,12 +70,12 @@ public interface IItemCollection extends Iterable<IItemIterable> {
 	boolean hasItems();
 
 	/**
-	 * Returns a set of IRange representations of the time ranges of all chunks represented by this
-	 * item collection. This set is not affected by any filtering operations on the item collection
-	 * since its use is to show the time ranges in which events could possibly have been emitted.
+	 * Returns a set of IRange representations of the time ranges represented by this item
+	 * collection. This set is not affected by any filtering operations on the item collection since
+	 * its use is to show the time ranges in which events could possibly have been occurred.
 	 * 
-	 * @return a set of IRange objects representing the time ranges of the chunks represented by
-	 *         this IItemCollection
+	 * @return a set of IRange objects representing the time ranges of represented by this
+	 *         IItemCollection
 	 */
-	Set<IRange<IQuantity>> getChunkRanges();
+	Set<IRange<IQuantity>> getTimeRanges();
 }

--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/util/DefaultIItemResultSet.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/util/DefaultIItemResultSet.java
@@ -86,7 +86,8 @@ final class DefaultIItemResultSet implements IItemResultSet {
 						row[column] = accessors[column].getMember(item);
 					}
 					for (int j = 0; j < aggregators.size(); j++) {
-						row[column + j] = new SingleEntryItemCollection(item).getAggregate(aggregators.get(j));
+						row[column + j] = new SingleEntryItemCollection(item, input.getChunkRanges())
+								.getAggregate(aggregators.get(j));
 					}
 					data.add(row);
 				}

--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/util/DefaultIItemResultSet.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/util/DefaultIItemResultSet.java
@@ -86,7 +86,7 @@ final class DefaultIItemResultSet implements IItemResultSet {
 						row[column] = accessors[column].getMember(item);
 					}
 					for (int j = 0; j < aggregators.size(); j++) {
-						row[column + j] = new SingleEntryItemCollection(item, input.getChunkRanges())
+						row[column + j] = new SingleEntryItemCollection(item, input.getTimeRanges())
 								.getAggregate(aggregators.get(j));
 					}
 					data.add(row);

--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/util/SingleEntryItemCollection.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/util/SingleEntryItemCollection.java
@@ -75,7 +75,7 @@ final class SingleEntryItemCollection implements IItemCollection {
 		}
 
 		@Override
-		public Set<IRange<IQuantity>> getChunkRanges() {
+		public Set<IRange<IQuantity>> getTimeRanges() {
 			return null;
 		}
 	};
@@ -229,7 +229,7 @@ final class SingleEntryItemCollection implements IItemCollection {
 	}
 
 	@Override
-	public Set<IRange<IQuantity>> getChunkRanges() {
+	public Set<IRange<IQuantity>> getTimeRanges() {
 		return chunkRanges;
 	}
 }

--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/util/SingleEntryItemCollection.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/util/SingleEntryItemCollection.java
@@ -36,6 +36,7 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.Set;
 
 import org.openjdk.jmc.common.IPredicate;
 import org.openjdk.jmc.common.item.IAggregator;
@@ -45,6 +46,8 @@ import org.openjdk.jmc.common.item.IItemConsumer;
 import org.openjdk.jmc.common.item.IItemFilter;
 import org.openjdk.jmc.common.item.IItemIterable;
 import org.openjdk.jmc.common.item.IType;
+import org.openjdk.jmc.common.unit.IQuantity;
+import org.openjdk.jmc.common.unit.IRange;
 
 /**
  * Implementation helper class for handling a singular {@link IItem} as an {@link IItemCollection}.
@@ -69,6 +72,11 @@ final class SingleEntryItemCollection implements IItemCollection {
 		@Override
 		public IItemCollection apply(IItemFilter filter) {
 			return this;
+		}
+
+		@Override
+		public Set<IRange<IQuantity>> getChunkRanges() {
+			return null;
 		}
 	};
 
@@ -168,9 +176,11 @@ final class SingleEntryItemCollection implements IItemCollection {
 	}
 
 	private final IItem item;
+	private final Set<IRange<IQuantity>> chunkRanges;
 
-	SingleEntryItemCollection(IItem item) {
+	SingleEntryItemCollection(IItem item, Set<IRange<IQuantity>> chunkRanges) {
 		this.item = item;
+		this.chunkRanges = chunkRanges;
 	}
 
 	@Override
@@ -216,5 +226,10 @@ final class SingleEntryItemCollection implements IItemCollection {
 	@Override
 	public boolean hasItems() {
 		return true;
+	}
+
+	@Override
+	public Set<IRange<IQuantity>> getChunkRanges() {
+		return chunkRanges;
 	}
 }

--- a/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/EventCollection.java
+++ b/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/EventCollection.java
@@ -221,7 +221,7 @@ class EventCollection implements IItemCollection {
 	}
 
 	@Override
-	public Set<IRange<IQuantity>> getChunkRanges() {
+	public Set<IRange<IQuantity>> getTimeRanges() {
 		return chunkRanges;
 	}
 }

--- a/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/EventCollection.java
+++ b/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/EventCollection.java
@@ -48,8 +48,11 @@ import org.openjdk.jmc.common.item.IItemConsumer;
 import org.openjdk.jmc.common.item.IItemFilter;
 import org.openjdk.jmc.common.item.IItemIterable;
 import org.openjdk.jmc.common.item.IType;
+import org.openjdk.jmc.common.unit.IQuantity;
+import org.openjdk.jmc.common.unit.IRange;
 import org.openjdk.jmc.common.util.PredicateToolkit;
 import org.openjdk.jmc.flightrecorder.internal.EventArray;
+import org.openjdk.jmc.flightrecorder.internal.EventArrays;
 
 /**
  * Java 1.7 based implementation of {@link IItemCollection} using {@link IItemIterable} iterators.
@@ -112,18 +115,20 @@ class EventCollection implements IItemCollection {
 
 	private final Set<IType<IItem>> types = new HashSet<>();
 	private final ArrayList<EventTypeEntry> items;
+	private final Set<IRange<IQuantity>> chunkRanges;
 
-	static IItemCollection build(EventArray[] events) {
-		ArrayList<EventTypeEntry> items = new ArrayList<>(events.length);
-		for (EventArray ea : events) {
+	static IItemCollection build(EventArrays events) {
+		ArrayList<EventTypeEntry> items = new ArrayList<>(events.getArrays().length);
+		for (EventArray ea : events.getArrays()) {
 			EventTypeEntry entry = new EventTypeEntry(ea);
 			items.add(entry);
 		}
-		return new EventCollection(items);
+		return new EventCollection(items, events.getChunkTimeranges());
 	}
 
-	private EventCollection(ArrayList<EventTypeEntry> items) {
+	private EventCollection(ArrayList<EventTypeEntry> items, Set<IRange<IQuantity>> chunkRanges) {
 		this.items = items;
+		this.chunkRanges = chunkRanges;
 		for (EventTypeEntry e : items) {
 			types.add(e.events.getType());
 		}
@@ -140,7 +145,7 @@ class EventCollection implements IItemCollection {
 				newEntries.add(newEntry);
 			}
 		}
-		return new EventCollection(newEntries);
+		return new EventCollection(newEntries, chunkRanges);
 	}
 
 	private static Iterator<IItem> buildIterator(IItem[] array, IPredicate<? super IItem> filter) {
@@ -213,5 +218,10 @@ class EventCollection implements IItemCollection {
 				throw new UnsupportedOperationException();
 			}
 		});
+	}
+
+	@Override
+	public Set<IRange<IQuantity>> getChunkRanges() {
+		return chunkRanges;
 	}
 }

--- a/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/JfrLoaderToolkit.java
+++ b/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/JfrLoaderToolkit.java
@@ -43,6 +43,7 @@ import java.util.List;
 import org.openjdk.jmc.common.io.IOToolkit;
 import org.openjdk.jmc.common.item.IItemCollection;
 import org.openjdk.jmc.flightrecorder.internal.EventArray;
+import org.openjdk.jmc.flightrecorder.internal.EventArrays;
 import org.openjdk.jmc.flightrecorder.internal.FlightRecordingLoader;
 import org.openjdk.jmc.flightrecorder.parser.IParserExtension;
 import org.openjdk.jmc.flightrecorder.parser.ParserExtensionRegistry;
@@ -58,9 +59,9 @@ public class JfrLoaderToolkit {
 	 *            the files to read the recording from
 	 * @param extensions
 	 *            the extensions to use when parsing the file
-	 * @return an array of EventArrays (one event type per EventArray)
+	 * @return an object holding an array of EventArrays (one event type per EventArray)
 	 */
-	private static EventArray[] loadFile(List<File> files, List<? extends IParserExtension> extensions)
+	private static EventArrays loadFile(List<File> files, List<? extends IParserExtension> extensions)
 			throws IOException, CouldNotLoadRecordingException {
 		List<InputStream> streams = new ArrayList<>(files.size());
 		for (File file : files) {

--- a/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/internal/EventArrays.java
+++ b/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/internal/EventArrays.java
@@ -1,0 +1,26 @@
+package org.openjdk.jmc.flightrecorder.internal;
+
+import java.util.Set;
+
+import org.openjdk.jmc.common.unit.IQuantity;
+import org.openjdk.jmc.common.unit.IRange;
+
+public class EventArrays {
+
+	private final EventArray[] arrays;
+	private final Set<IRange<IQuantity>> chunkTimeranges;
+
+	public EventArrays(EventArray[] arrays, Set<IRange<IQuantity>> ranges) {
+		this.arrays = arrays;
+		this.chunkTimeranges = ranges;
+	}
+
+	public EventArray[] getArrays() {
+		return arrays;
+	}
+
+	public Set<IRange<IQuantity>> getChunkTimeranges() {
+		return chunkTimeranges;
+	}
+
+}

--- a/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/internal/FlightRecordingLoader.java
+++ b/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/internal/FlightRecordingLoader.java
@@ -72,7 +72,7 @@ public final class FlightRecordingLoader {
 	private static final short VERSION_2 = 2; // JDK11
 	private static final byte[] FLIGHT_RECORDER_MAGIC = {'F', 'L', 'R', '\0'};
 
-	public static EventArray[] loadStream(InputStream stream, boolean hideExperimentals, boolean ignoreTruncatedChunk)
+	public static EventArrays loadStream(InputStream stream, boolean hideExperimentals, boolean ignoreTruncatedChunk)
 			throws CouldNotLoadRecordingException, IOException {
 		return loadStream(stream, ParserExtensionRegistry.getParserExtensions(), hideExperimentals,
 				ignoreTruncatedChunk);
@@ -90,7 +90,7 @@ public final class FlightRecordingLoader {
 	 *            reading the data
 	 * @return an array of EventArrays (one event type per EventArray)
 	 */
-	public static EventArray[] loadStream(
+	public static EventArrays loadStream(
 		InputStream stream, List<? extends IParserExtension> extensions, boolean hideExperimentals,
 		boolean ignoreTruncatedChunk) throws CouldNotLoadRecordingException, IOException {
 		return readChunks(null, extensions, createChunkSupplier(stream), hideExperimentals, ignoreTruncatedChunk);
@@ -185,14 +185,14 @@ public final class FlightRecordingLoader {
 		}
 	}
 
-	public static EventArray[] readChunks(
+	public static EventArrays readChunks(
 		Runnable monitor, IChunkSupplier chunkSupplier, boolean hideExperimentals, boolean ignoreTruncatedChunk)
 			throws CouldNotLoadRecordingException, IOException {
 		return readChunks(monitor, ParserExtensionRegistry.getParserExtensions(), chunkSupplier, hideExperimentals,
 				ignoreTruncatedChunk);
 	}
 
-	public static EventArray[] readChunks(
+	public static EventArrays readChunks(
 		Runnable monitor, List<? extends IParserExtension> extensions, IChunkSupplier chunkSupplier,
 		boolean hideExperimentals, boolean ignoreTruncatedChunk) throws CouldNotLoadRecordingException, IOException {
 		LoaderContext context = new LoaderContext(extensions, hideExperimentals);

--- a/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/internal/parser/LoaderContext.java
+++ b/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/internal/parser/LoaderContext.java
@@ -34,15 +34,20 @@ package org.openjdk.jmc.flightrecorder.internal.parser;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.openjdk.jmc.common.item.IAttribute;
 import org.openjdk.jmc.common.item.IItem;
+import org.openjdk.jmc.common.unit.IQuantity;
+import org.openjdk.jmc.common.unit.IRange;
 import org.openjdk.jmc.flightrecorder.CouldNotLoadRecordingException;
 import org.openjdk.jmc.flightrecorder.JfrAttributes;
 import org.openjdk.jmc.flightrecorder.internal.EventArray;
+import org.openjdk.jmc.flightrecorder.internal.EventArrays;
 import org.openjdk.jmc.flightrecorder.internal.parser.RepositoryBuilder.EventTypeEntry;
 import org.openjdk.jmc.flightrecorder.internal.util.CanonicalConstantMap;
 import org.openjdk.jmc.flightrecorder.parser.IEventSinkFactory;
@@ -58,6 +63,7 @@ public class LoaderContext {
 	private final ConcurrentHashMap<Object, CanonicalConstantMap<Object>> constantsByType = new ConcurrentHashMap<>();
 	private final boolean hideExperimentals;
 	private final List<? extends IParserExtension> extensions;
+	private final Set<IRange<IQuantity>> chunkRanges;
 
 	public LoaderContext(List<? extends IParserExtension> extensions, boolean hideExperimentals) {
 		this.extensions = extensions;
@@ -68,6 +74,7 @@ public class LoaderContext {
 			sinkFactory = extensions.get(i).getEventSinkFactory(sinkFactory);
 		}
 		this.sinkFactory = sinkFactory;
+		this.chunkRanges = new HashSet<>();
 	}
 
 	public CanonicalConstantMap<Object> getConstantPool(Object poolKey) {
@@ -94,8 +101,12 @@ public class LoaderContext {
 		return sinkFactory;
 	}
 
+	public void addChunkRange(IRange<IQuantity> chunkRange) {
+		this.chunkRanges.add(chunkRange);
+	}
+
 	@SuppressWarnings("deprecation")
-	public EventArray[] buildEventArrays() throws CouldNotLoadRecordingException {
+	public EventArrays buildEventArrays() throws CouldNotLoadRecordingException {
 		sinkFactory.flush();
 		Iterator<EventTypeEntry> eventTypes = repositoryBuilder.getEventTypes();
 		ArrayList<EventArray> eventArrays = new ArrayList<>();
@@ -123,7 +134,7 @@ public class LoaderContext {
 			}
 
 		}
-		return eventArrays.toArray(new EventArray[eventArrays.size()]);
+		return new EventArrays(eventArrays.toArray(new EventArray[eventArrays.size()]), chunkRanges);
 	}
 
 }

--- a/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/internal/parser/v0/ChunkLoaderV0.java
+++ b/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/internal/parser/v0/ChunkLoaderV0.java
@@ -54,6 +54,7 @@ public class ChunkLoaderV0 implements IChunkLoader {
 		this.context = context;
 		// Read metadata
 		metadata = new ChunkMetadata(data, structure.getMetadataOffset());
+		context.addChunkRange(QuantityRange.createWithEnd(metadata.getStartTime(), metadata.getEndTime()));
 	}
 
 	@Override

--- a/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/internal/parser/v1/ChunkLoaderV1.java
+++ b/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/internal/parser/v1/ChunkLoaderV1.java
@@ -56,6 +56,7 @@ public class ChunkLoaderV1 implements IChunkLoader {
 		this.header = header;
 		this.data = data;
 		this.context = context;
+		context.addChunkRange(header.getChunkRange());
 	}
 
 	@Override

--- a/core/tests/org.openjdk.jmc.common.test/src/test/java/org/openjdk/jmc/common/test/mock/item/MockItemCollection.java
+++ b/core/tests/org.openjdk.jmc.common.test/src/test/java/org/openjdk/jmc/common/test/mock/item/MockItemCollection.java
@@ -33,8 +33,10 @@
 package org.openjdk.jmc.common.test.mock.item;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Set;
 
 import org.openjdk.jmc.common.collection.IteratorToolkit;
 import org.openjdk.jmc.common.item.IAggregator;
@@ -44,6 +46,8 @@ import org.openjdk.jmc.common.item.IItemConsumer;
 import org.openjdk.jmc.common.item.IItemFilter;
 import org.openjdk.jmc.common.item.IItemIterable;
 import org.openjdk.jmc.common.item.IType;
+import org.openjdk.jmc.common.unit.IQuantity;
+import org.openjdk.jmc.common.unit.IRange;
 
 public class MockItemCollection<T, CT extends IType<?>> implements IItemCollection {
 	private List<IItem> items = new ArrayList<>();
@@ -120,5 +124,10 @@ public class MockItemCollection<T, CT extends IType<?>> implements IItemCollecti
 				throw new UnsupportedOperationException();
 			}
 		});
+	}
+
+	@Override
+	public Set<IRange<IQuantity>> getChunkRanges() {
+		return Collections.emptySet();
 	}
 }

--- a/core/tests/org.openjdk.jmc.common.test/src/test/java/org/openjdk/jmc/common/test/mock/item/MockItemCollection.java
+++ b/core/tests/org.openjdk.jmc.common.test/src/test/java/org/openjdk/jmc/common/test/mock/item/MockItemCollection.java
@@ -127,7 +127,7 @@ public class MockItemCollection<T, CT extends IType<?>> implements IItemCollecti
 	}
 
 	@Override
-	public Set<IRange<IQuantity>> getChunkRanges() {
+	public Set<IRange<IQuantity>> getTimeRanges() {
 		return Collections.emptySet();
 	}
 }


### PR DESCRIPTION
This PR adds the timeranges for all chunks that make up an IItemCollection, thus allowing downstream consumers, rules and the JMC UI (with plugins) to make accurate inferences with regards to the timespans when events could possibly have been emitted.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JMC-6831](https://bugs.openjdk.java.net/browse/JMC-6831): Add chunk ranges to IItemCollections ⚠️ Title mismatch between PR and JBS.


### Reviewers
 * Marcus Hirt ([hirt](@thegreystone) - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jmc pull/81/head:pull/81`
`$ git checkout pull/81`
