### PR TITLE
6847: Upgrading to the Eclipse 2020-06 platform

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,6 +110,30 @@
 	</distributionManagement>
 	<profiles>
 		<profile>
+			<id>2020-06</id>
+			<activation>
+				<activeByDefault>true</activeByDefault>
+			</activation>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.eclipse.tycho</groupId>
+						<artifactId>target-platform-configuration</artifactId>
+						<version>${tycho.version}</version>
+						<configuration>
+							<target>
+								<artifact>
+									<groupId>org.openjdk.jmc</groupId>
+									<artifactId>platform-definition-2020-06</artifactId>
+									<version>8.0.0-SNAPSHOT</version>
+								</artifact>
+							</target>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+		<profile>
 			<id>2020-03</id>
 			<build>
 				<plugins>
@@ -132,9 +156,6 @@
 		</profile>
 		<profile>
 			<id>2019-12</id>
-			<activation>
-				<activeByDefault>true</activeByDefault>
-			</activation>
 			<build>
 				<plugins>
 					<plugin>

--- a/releng/platform-definitions/platform-definition-2020-06/.project
+++ b/releng/platform-definitions/platform-definition-2020-06/.project
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>platform-definition-2020-06</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+	</natures>
+</projectDescription>

--- a/releng/platform-definitions/platform-definition-2020-06/platform-definition-2020-06.target
+++ b/releng/platform-definitions/platform-definition-2020-06/platform-definition-2020-06.target
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+   Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+   Copyright (c) 2020, Datadog, Inc. All rights reserved.
+
+   DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+
+   The contents of this file are subject to the terms of either the Universal Permissive License
+   v 1.0 as shown at http://oss.oracle.com/licenses/upl
+
+   or the following license:
+
+   Redistribution and use in source and binary forms, with or without modification, are permitted
+   provided that the following conditions are met:
+
+   1. Redistributions of source code must retain the above copyright notice, this list of conditions
+   and the following disclaimer.
+
+   2. Redistributions in binary form must reproduce the above copyright notice, this list of
+   conditions and the following disclaimer in the documentation and/or other materials provided with
+   the distribution.
+
+   3. Neither the name of the copyright holder nor the names of its contributors may be used to
+   endorse or promote products derived from this software without specific prior written permission.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+   IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+   FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+   DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+   DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+   WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+   WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+-->
+<?pde version="3.8"?>
+<target name="jmc-target-2020-06" sequenceNumber="47">
+    <locations>
+        <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+            <unit id="com.sun.mail.jakarta.mail" version="1.6.5"/>
+            <unit id="com.sun.activation.jakarta.activation" version="1.2.1"/>
+            <unit id="org.owasp.encoder" version="1.2.2"/>
+            <unit id="org.lz4.lz4-java" version="1.7.1"/>
+            <unit id="org.twitter4j.core" version="4.0.7"/>
+            <unit id="org.hdrhistogram.HdrHistogram" version="2.1.11"/>
+            <unit id="org.adoptopenjdk.jemmy-awt-input" version="2.0.0"/>
+            <unit id="org.adoptopenjdk.jemmy-browser" version="2.0.0"/>
+            <unit id="org.adoptopenjdk.jemmy-core" version="2.0.0"/>
+            <unit id="org.adoptopenjdk.jemmy-swt" version="2.0.0"/>
+            <repository location="http://localhost:8080/site"/>
+        </location>
+        <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+            <unit id="org.eclipse.equinox.executable.feature.group" version="3.8.800.v20200514-1529"/>
+            <unit id="org.eclipse.pde.feature.group" version="3.14.400.v20200604-0540"/>
+            <unit id="org.eclipse.platform.sdk" version="4.16.0.I20200604-0540"/>
+            <repository location="http://download.eclipse.org/releases/2020-06/"/>
+        </location>
+        <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+            <unit id="org.eclipse.babel.nls_eclipse_ja.feature.group" version="4.14.0.v20200113020001"/>
+            <unit id="org.eclipse.babel.nls_eclipse_zh.feature.group" version="4.14.0.v20200113020001"/>
+            <repository location="https://archive.eclipse.org/technology/babel/update-site/R0.17.1/2019-12/"/>
+        </location>
+    </locations>
+    <targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+</target>

--- a/releng/platform-definitions/platform-definition-2020-06/pom.xml
+++ b/releng/platform-definitions/platform-definition-2020-06/pom.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-   Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+   Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+   Copyright (c) 2020, Datadog, Inc. All rights reserved.
 
    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
@@ -35,21 +36,13 @@
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.openjdk.jmc</groupId>
-		<artifactId>missioncontrol.releng</artifactId>
+		<artifactId>platform-definitions</artifactId>
 		<version>8.0.0-SNAPSHOT</version>
 	</parent>
-	<artifactId>platform-definitions</artifactId>
-	<packaging>pom</packaging>
+	<artifactId>platform-definition-2020-06</artifactId>
+	<packaging>eclipse-target-definition</packaging>
 
 	<properties>
-		<spotless.config.path>${basedir}/../../configuration/ide/eclipse/formatting/formatting.xml</spotless.config.path>
+		<spotless.config.path>${basedir}/../../../configuration/ide/eclipse/formatting/formatting.xml</spotless.config.path>
 	</properties>
-
-	<modules>
-		<!-- Photon will be deprecated eventually - don't use it! -->
-		<module>platform-definition-photon</module>
-		<module>platform-definition-2019-12</module>
-		<module>platform-definition-2020-03</module>
-		<module>platform-definition-2020-06</module>
-	</modules>
 </project>


### PR DESCRIPTION
Note that this one should probably go in after we get JMC-6838 in. That said, we can review it and get it ready for show-time.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JMC-6847](https://bugs.openjdk.java.net/browse/JMC-6847): Add 2020-06 platform ⚠️ Title mismatch between PR and JBS.


### Reviewers
 * Henrik Dafgård ([hdafgard](@Gunde) - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jmc pull/85/head:pull/85`
`$ git checkout pull/85`
