### PR TITLE
6833: Tolerate exceptions when loading images

### DIFF
--- a/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/misc/ActionUiToolkit.java
+++ b/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/misc/ActionUiToolkit.java
@@ -38,6 +38,7 @@ import org.eclipse.jface.action.ActionContributionItem;
 import org.eclipse.jface.action.IAction;
 import org.eclipse.jface.action.ToolBarManager;
 import org.eclipse.jface.preference.JFacePreferences;
+import org.eclipse.jface.resource.DeviceResourceException;
 import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.jface.resource.JFaceResources;
 import org.eclipse.jface.resource.LocalResourceManager;
@@ -77,7 +78,14 @@ public class ActionUiToolkit {
 		@Override
 		public Image getImage(Object element) {
 			ImageDescriptor icon = ((IAction) element).getImageDescriptor();
-			return icon == null ? null : manager.createImage(icon);
+			try {
+				if (icon != null) {
+					return manager.createImage(icon);
+				}
+			} catch (DeviceResourceException e) {
+				return null;
+			}
+			return null;
 		}
 
 		@Override


### PR DESCRIPTION
This PR fixes the crash reported in [6833](https://bugs.openjdk.java.net/projects/JMC/issues/JMC-6833?filter=allopenissues) by returning null in case there's an error reading UI images. 

During manual testing I noticed that the icon for Method Profiling can't be loaded on my system and this was causing the application to crash. I didn't find other resources with this problem.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JMC-6833](https://bugs.openjdk.java.net/browse/JMC-6833): Error when viewing the Java Application page ⚠️ Title mismatch between PR and JBS.


### Reviewers
 * Marcus Hirt ([hirt](@thegreystone) - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jmc pull/86/head:pull/86`
`$ git checkout pull/86`
