### PR TITLE
6852: Extracted layout for the JMC RCP binaries look not the same for Linux/Windows

### DIFF
--- a/application/org.openjdk.jmc.rcp.product/pom.xml
+++ b/application/org.openjdk.jmc.rcp.product/pom.xml
@@ -72,7 +72,9 @@
 						<product>
 							<id>org.openjdk.jmc</id>
 							<rootFolders>
+								<win32>${productName}</win32>
 								<macosx>${productName}.app</macosx>
+								<linux>${productName}</linux>
 							</rootFolders>
 						</product>
 					</products>


### PR DESCRIPTION
Signed-off-by: Patrick Reinhart <patrick@reini.net>
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JMC-6852](https://bugs.openjdk.java.net/browse/JMC-6852): Extracted layout for the JMC RCP binaries look not the same for Linux/Windows


### Reviewers
 * Guru Hb ([ghb](@guruhb) - **Reviewer**)
 * Mario Torre ([neugens](@neugens) - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/jmc pull/87/head:pull/87`
`$ git checkout pull/87`
