### PR TITLE
6710: Add rule to detect if an old version of Lucene is in use

### DIFF
--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/exceptions/LuceneVersionRule.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/exceptions/LuceneVersionRule.java
@@ -1,0 +1,123 @@
+package org.openjdk.jmc.flightrecorder.rules.jdk.exceptions;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.concurrent.Callable;
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.RunnableFuture;
+
+import org.openjdk.jmc.common.IMCFrame;
+import org.openjdk.jmc.common.IMCPackage;
+import org.openjdk.jmc.common.IMCStackTrace;
+import org.openjdk.jmc.common.item.Aggregators;
+import org.openjdk.jmc.common.item.IItem;
+import org.openjdk.jmc.common.item.IItemCollection;
+import org.openjdk.jmc.common.item.IItemIterable;
+import org.openjdk.jmc.common.item.IMemberAccessor;
+import org.openjdk.jmc.common.item.ItemFilters;
+import org.openjdk.jmc.common.unit.IQuantity;
+import org.openjdk.jmc.common.util.IPreferenceValueProvider;
+import org.openjdk.jmc.common.util.TypedPreference;
+import org.openjdk.jmc.flightrecorder.JfrAttributes;
+import org.openjdk.jmc.flightrecorder.jdk.JdkAttributes;
+import org.openjdk.jmc.flightrecorder.jdk.JdkFilters;
+import org.openjdk.jmc.flightrecorder.rules.IRule;
+import org.openjdk.jmc.flightrecorder.rules.Result;
+import org.openjdk.jmc.flightrecorder.rules.jdk.messages.internal.Messages;
+import org.openjdk.jmc.flightrecorder.rules.util.JfrRuleTopics;
+import org.openjdk.jmc.flightrecorder.rules.util.RulesToolkit;
+
+public class LuceneVersionRule implements IRule {
+	
+	private static final String RESULT_ID = "LuceneVersion"; //$NON-NLS-1$
+
+	private enum LuceneConsumer {
+		LUCENE,
+		SOLR,
+		ELASTIC_SEARCH;
+	}
+
+	@Override
+	public RunnableFuture<Result> evaluate(final IItemCollection items, IPreferenceValueProvider valueProvider) {
+		return new FutureTask<>(new Callable<Result>() {
+			@Override
+			public Result call() throws Exception {
+				return getResult(items);
+			}
+		});
+	}
+
+	private static final String LOOKAHEAD_SUCCESS_NAME = "org.apache.lucene.queryparser.classic.QueryParser$LookaheadSuccess"; //$NON-NLS-1$
+
+	private Result getResult(IItemCollection items) {
+		IItemCollection throwables = items.apply(JdkFilters.THROWABLES)
+				.apply(ItemFilters.equals(JdkAttributes.EXCEPTION_THROWNCLASS_NAME, LOOKAHEAD_SUCCESS_NAME));
+		IQuantity lookaheadSuccessErrors = throwables.getAggregate(Aggregators.count());
+		LuceneConsumer consumerType = isElasticSearch(throwables);
+		// Lucene post 7.1.0 still creates a LookaheadSuccess error, but only on class load
+		if (lookaheadSuccessErrors.longValue() > 1) {
+			double score = RulesToolkit.mapExp100(lookaheadSuccessErrors.longValue(), 2, 20);
+			switch (consumerType) {
+			case ELASTIC_SEARCH:
+				return new Result(this, score, Messages.getString(Messages.LuceneVersionRule_SHORT_DESCRIPTION_ES), Messages.getString(Messages.LuceneVersionRule_LONG_DESCRIPTION_ES));
+			case SOLR:
+				return new Result(this, score, Messages.getString(Messages.LuceneVersionRule_SHORT_DESCRIPTION_SOLR), Messages.getString(Messages.LuceneVersionRule_LONG_DESCRIPTION_SOLR));
+			default:
+				return new Result(this, score, Messages.getString(Messages.LuceneVersionRule_SHORT_DESCRIPTION_LUCENE), Messages.getString(Messages.LuceneVersionRule_LONG_DESCRIPTION_LUCENE));
+			}
+		} else if (lookaheadSuccessErrors.longValue() == 1) {
+			switch (consumerType) {
+			case ELASTIC_SEARCH:
+				return new Result(this, 0, Messages.getString(Messages.LuceneVersionRule_OK_TEXT_ES));
+			case SOLR:
+				return new Result(this, 0, Messages.getString(Messages.LuceneVersionRule_OK_TEXT_SOLR));
+			default:
+				return new Result(this, 0, Messages.getString(Messages.LuceneVersionRule_OK_TEXT_LUCENE));
+			}
+		}
+		return RulesToolkit.getNotApplicableResult(this, Messages.getString(Messages.LuceneVersionRule_NA_TEXT));
+	}
+
+	private LuceneConsumer isElasticSearch(IItemCollection items) {
+		for (IItemIterable itemIterable : items) {
+			IMemberAccessor<IMCStackTrace, IItem> stacktraceAccessor = JfrAttributes.EVENT_STACKTRACE.getAccessor(itemIterable.getType());
+			for (IItem item : itemIterable) {
+				IMCStackTrace member = stacktraceAccessor.getMember(item);
+				for (IMCFrame frame : member.getFrames()) {
+					IMCPackage aPackage = frame.getMethod().getType().getPackage();
+					if (aPackage != null) {
+						if (aPackage.getName().startsWith("org.elasticsearch")) { //$NON-NLS-1$
+							return LuceneConsumer.ELASTIC_SEARCH;
+						}
+						if (aPackage.getName().startsWith("org.apache.solr")) { //$NON-NLS-1$
+							return LuceneConsumer.SOLR;
+						}
+					}
+				}
+
+			}
+		}
+		return LuceneConsumer.LUCENE;
+	}
+
+	@Override
+	public Collection<TypedPreference<?>> getConfigurationAttributes() {
+		return Collections.emptyList();
+	}
+
+	@Override
+	public String getId() {
+		return RESULT_ID;
+	}
+
+	@Override
+	public String getName() {
+		return Messages.getString(Messages.LuceneVersionRule_RULE_NAME);
+	}
+
+	@Override
+	public String getTopic() {
+		return JfrRuleTopics.EXCEPTIONS_TOPIC;
+	}
+
+}

--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/exceptions/LuceneVersionRule.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/exceptions/LuceneVersionRule.java
@@ -28,13 +28,11 @@ import org.openjdk.jmc.flightrecorder.rules.util.JfrRuleTopics;
 import org.openjdk.jmc.flightrecorder.rules.util.RulesToolkit;
 
 public class LuceneVersionRule implements IRule {
-	
+
 	private static final String RESULT_ID = "LuceneVersion"; //$NON-NLS-1$
 
 	private enum LuceneConsumer {
-		LUCENE,
-		SOLR,
-		ELASTIC_SEARCH;
+		LUCENE, SOLR, ELASTIC_SEARCH;
 	}
 
 	@Override
@@ -59,11 +57,14 @@ public class LuceneVersionRule implements IRule {
 			double score = RulesToolkit.mapExp100(lookaheadSuccessErrors.longValue(), 2, 20);
 			switch (consumerType) {
 			case ELASTIC_SEARCH:
-				return new Result(this, score, Messages.getString(Messages.LuceneVersionRule_SHORT_DESCRIPTION_ES), Messages.getString(Messages.LuceneVersionRule_LONG_DESCRIPTION_ES));
+				return new Result(this, score, Messages.getString(Messages.LuceneVersionRule_SHORT_DESCRIPTION_ES),
+						Messages.getString(Messages.LuceneVersionRule_LONG_DESCRIPTION_ES));
 			case SOLR:
-				return new Result(this, score, Messages.getString(Messages.LuceneVersionRule_SHORT_DESCRIPTION_SOLR), Messages.getString(Messages.LuceneVersionRule_LONG_DESCRIPTION_SOLR));
+				return new Result(this, score, Messages.getString(Messages.LuceneVersionRule_SHORT_DESCRIPTION_SOLR),
+						Messages.getString(Messages.LuceneVersionRule_LONG_DESCRIPTION_SOLR));
 			default:
-				return new Result(this, score, Messages.getString(Messages.LuceneVersionRule_SHORT_DESCRIPTION_LUCENE), Messages.getString(Messages.LuceneVersionRule_LONG_DESCRIPTION_LUCENE));
+				return new Result(this, score, Messages.getString(Messages.LuceneVersionRule_SHORT_DESCRIPTION_LUCENE),
+						Messages.getString(Messages.LuceneVersionRule_LONG_DESCRIPTION_LUCENE));
 			}
 		} else if (lookaheadSuccessErrors.longValue() == 1) {
 			switch (consumerType) {
@@ -80,7 +81,8 @@ public class LuceneVersionRule implements IRule {
 
 	private LuceneConsumer isElasticSearch(IItemCollection items) {
 		for (IItemIterable itemIterable : items) {
-			IMemberAccessor<IMCStackTrace, IItem> stacktraceAccessor = JfrAttributes.EVENT_STACKTRACE.getAccessor(itemIterable.getType());
+			IMemberAccessor<IMCStackTrace, IItem> stacktraceAccessor = JfrAttributes.EVENT_STACKTRACE
+					.getAccessor(itemIterable.getType());
 			for (IItem item : itemIterable) {
 				IMCStackTrace member = stacktraceAccessor.getMember(item);
 				for (IMCFrame frame : member.getFrames()) {

--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/messages/internal/Messages.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/messages/internal/Messages.java
@@ -373,6 +373,17 @@ public class Messages {
 	public static final String LowOnPhysicalMemoryFactory_TEXT_INFO = "LowOnPhysicalMemoryFactory_TEXT_INFO"; //$NON-NLS-1$
 	public static final String LowOnPhysicalMemoryFactory_TEXT_INFO_LONG = "LowOnPhysicalMemoryFactory_TEXT_INFO_LONG"; //$NON-NLS-1$
 	public static final String LowOnPhysicalMemoryFactory_TEXT_OK = "LowOnPhysicalMemoryFactory_TEXT_OK"; //$NON-NLS-1$
+	public static final String LuceneVersionRule_LONG_DESCRIPTION_LUCENE = "LuceneVersionRule_LONG_DESCRIPTION_LUCENE"; //$NON-NLS-1$
+	public static final String LuceneVersionRule_LONG_DESCRIPTION_ES = "LuceneVersionRule_LONG_DESCRIPTION_ES"; //$NON-NLS-1$
+	public static final String LuceneVersionRule_LONG_DESCRIPTION_SOLR = "LuceneVersionRule_LONG_DESCRIPTION_SOLR"; //$NON-NLS-1$
+	public static final String LuceneVersionRule_SHORT_DESCRIPTION_LUCENE = "LuceneVersionRule_SHORT_DESCRIPTION_LUCENE"; //$NON-NLS-1$
+	public static final String LuceneVersionRule_SHORT_DESCRIPTION_ES = "LuceneVersionRule_SHORT_DESCRIPTION_ES"; //$NON-NLS-1$
+	public static final String LuceneVersionRule_SHORT_DESCRIPTION_SOLR = "LuceneVersionRule_SHORT_DESCRIPTION_SOLR"; //$NON-NLS-1$
+	public static final String LuceneVersionRule_OK_TEXT_LUCENE = "LuceneVersionRule_OK_TEXT_LUCENE"; //$NON-NLS-1$
+	public static final String LuceneVersionRule_OK_TEXT_ES = "LuceneVersionRule_OK_TEXT_ES"; //$NON-NLS-1$
+	public static final String LuceneVersionRule_OK_TEXT_SOLR = "LuceneVersionRule_OK_TEXT_SOLR"; //$NON-NLS-1$
+	public static final String LuceneVersionRule_NA_TEXT = "LuceneVersionRule_NA_TEXT"; //$NON-NLS-1$
+	public static final String LuceneVersionRule_RULE_NAME = "LuceneVersionRule_RULE_NAME"; //$NON-NLS-1$
 	public static final String ManagementAgentRule_TEXT_INFO = "ManagementAgentRule_TEXT_INFO"; //$NON-NLS-1$
 	public static final String ManagementAgentRule_TEXT_INFO_LONG = "ManagementAgentRule_TEXT_INFO_LONG"; //$NON-NLS-1$
 	public static final String ManagmentAgentRuleFactory_RULE_NAME = "ManagmentAgentRuleFactory_RULE_NAME"; //$NON-NLS-1$

--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/resources/org/openjdk/jmc/flightrecorder/rules/jdk/messages/internal/messages.properties
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/resources/org/openjdk/jmc/flightrecorder/rules/jdk/messages/internal/messages.properties
@@ -412,6 +412,17 @@ LowOnPhysicalMemoryFactory_TEXT_INFO=The maximum amount of used memory was {0} o
 # {0} is a size in bytes, {1} is a percentage, {2} is a size in bytes
 LowOnPhysicalMemoryFactory_TEXT_INFO_LONG=The maximum amount of memory used was {0}. This is {1} of the {2} of physical memory available. Having little free memory may lead to swapping, which is very expensive. To avoid this, either decrease the memory usage or increase the amount of available memory.
 LowOnPhysicalMemoryFactory_TEXT_OK=The system did not run low on physical memory during this recording.
+LuceneVersionRule_LONG_DESCRIPTION_LUCENE=Older versions of Apache Lucene unnecessarily create new LookaheadSuccess error instances for each query parser. This causes additional work to unroll the stack and slows down application performance. The issue was fixed in Lucene 7.1.0.
+LuceneVersionRule_LONG_DESCRIPTION_ES=Older versions of ElasticSearch used an older version of Apache Lucene which unnecessarily create new LookaheadSuccess error instances for each query parser. This causes additional work to unroll the stack and slows down application performance. The issue was fixed in ElasticSearch 6.2.0.
+LuceneVersionRule_LONG_DESCRIPTION_SOLR=Older versions of Apache Solr used an older version of Apache Lucene which unnecessarily create new LookaheadSuccess error instances for each query parser. This causes additional work to unroll the stack and slows down application performance. The issue was fixed in Apache Solr 7.1.0.
+LuceneVersionRule_SHORT_DESCRIPTION_LUCENE=Consider upgrading Apache Lucene to version 7.1.0 or higher to reduce overhead.
+LuceneVersionRule_SHORT_DESCRIPTION_ES=Consider upgrading ElasticSearch to version 6.2.0 or higher to reduce overhead.
+LuceneVersionRule_SHORT_DESCRIPTION_SOLR=Consider upgrading Apache Solr to version 7.1.0 or higher to reduce overhead.
+LuceneVersionRule_OK_TEXT_LUCENE=No problems detected with Apache Lucene.
+LuceneVersionRule_OK_TEXT_ES=No problems detected with ElasticSearch.
+LuceneVersionRule_OK_TEXT_SOLR=No problems detected with Apache Solr.
+LuceneVersionRule_NA_TEXT=Could not detect usage of Apache Lucene.
+LuceneVersionRule_RULE_NAME=Lucene Version
 ManagementAgentRule_TEXT_INFO=Management agent settings (port, authentication and/or SSL) were changed during runtime.
 ManagementAgentRule_TEXT_INFO_LONG=Management agent settings (port, authentication and/or SSL) were changed during runtime, this is not likely to have had any effect, but could be useful to investigate.
 ManagmentAgentRuleFactory_RULE_NAME=Discouraged Management Agent Settings


### PR DESCRIPTION
JMC has a few hard coded checks to exclude LookaheadSuccess Error instances, we should instead point out to users if they're using an older version of Lucene (or Solr/ElasticSearch) before they started re-using the same Error instance.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JMC-6710](https://bugs.openjdk.java.net/browse/JMC-6710): Add rule to detect if an old version of Lucene is in use


### Reviewers
 * Marcus Hirt ([hirt](@thegreystone) - **Reviewer**) ⚠️ Review applies to e211880ffebcce6794bd34ad2de3fec00c0b6dd2


### Download
`$ git fetch https://git.openjdk.java.net/jmc pull/89/head:pull/89`
`$ git checkout pull/89`
