### PR TITLE
6858: Thread dump does not show complete call stack based for all threads (grouped by time)

### DIFF
--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/ThreadDumpsPage.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/ThreadDumpsPage.java
@@ -439,7 +439,7 @@ public class ThreadDumpsPage extends AbstractDataPage {
 		if (parts.length > 2) {
 			ThreadDump[] dumps = new ThreadDump[parts.length - 2];
 			ThreadDumpCollection parent = new ThreadDumpCollection(title,
-					parts[0] + SEPARATOR + parts[parts.length - 1], dumps);
+					str, dumps);
 			for (int i = 0; i < dumps.length; i++) {
 				dumps[i] = parseThreadDump(parts[i + 1], parent);
 			}


### PR DESCRIPTION
Thread dump does not show complete call stack based on all threads (grouped by time) in first shot. 

The user need to click on each sub sections of the sub-tree to see the corresponding thread dumps. But the user wanted to see full thread dump in one shot as soon as they click on timestamp mentioned. Attached the screenshots of the functionality before and after fix.


Before fix


<img width="690" alt="JMC_6170" src="https://user-images.githubusercontent.com/11155712/85997486-2bd39980-ba27-11ea-824c-958c3adc0c96.png">

After fix

<img width="960" alt="JMC_6170_Fixed" src="https://user-images.githubusercontent.com/11155712/85997520-35f59800-ba27-11ea-9cd5-73efe83a7102.png">
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JMC-6858](https://bugs.openjdk.java.net/browse/JMC-6858): Thread dump does not show complete call stack based for all threads (grouped by time)


### Reviewers
 * Guru Hb ([ghb](@guruhb) - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jmc pull/90/head:pull/90`
`$ git checkout pull/90`
