### PR TITLE
6855: Should add information about where to get builds to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Binary distributions of JDK Mission Control are provided by different downstream
 ### Red Hat
 * Released version
 
-Red Hat distributes JDK Mission Control as RPMs in Fedora and RHEL. JMC is also included in the OpenJDK [developer builds](https://developers.redhat.com/products/openjdk/download) (Windows and Linux).
+Red Hat distributes JDK Mission Control as RPMs in Fedora and RHEL. JMC is also included in the OpenJDK [developer builds](https://developers.redhat.com/products/openjdk/download) for Windows.
 
 ## Mission Control Features
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,6 @@ Binary distributions of JDK Mission Control are provided by different downstream
 * Released version
 * Integrated (in-app) update site
 * Eclipse update site
-* Downloadable Eclipse update site archive
 
 [http://jdk.java.net/jmc](http://jdk.java.net/jmc)
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Binary distributions of JDK Mission Control are provided by different downstream
 ### Red Hat
 * Released version
 
-Red Hat distributes JDK Mission Control as RMPs in Fedora and RHEL.
+Red Hat distributes JDK Mission Control as RPMs in Fedora and RHEL. JMC is also included in the OpenJDK [developer builds](https://developers.redhat.com/products/openjdk/download) (Windows and Linux).
 
 ## Mission Control Features
 

--- a/README.md
+++ b/README.md
@@ -6,28 +6,64 @@ Builds of Mission Control can currently be found in the Oracle JDK on supported 
 
 For more information on Mission Control, see http://www.oracle.com/missioncontrol.
 
-### Core API Features
+## Downloading Builds
+Binary distributions of JDK Mission Control are provided by different downstream vendors.
 
-* Core APIs for parsing and processing Java flight recordings 
+### AdoptOpenJDK
+* Released version
+* EA builds of upcoming release
+* Downloadable Eclipse update site archive
 
-* Core API can *read* recordings from JDK 7 and above
+[http://adoptopenjdk.net/jmc](http://adoptopenjdk.net/jmc)
 
-* Core API can *run* on JDK 7 and above
 
-* Core API contains a framework for handling units of measurement and physical quantities
+### Azul (Zulu Mission Control)
+* Released version
 
-* Core API supports headless analysis of Java flight recordings
+[https://www.azul.com/products/zulu-mission-control](https://www.azul.com/products/zulu-mission-control)
 
+
+### Bell-Soft (Liberica Mission Control)
+* Released version
+
+[https://bell-sw.com/downloads](https://bell-sw.com/downloads)
+
+### Oracle
+* Released version
+* Integrated (in-app) update site
+* Eclipse update site
+* Downloadable Eclipse update site archive
+
+[http://jdk.java.net/jmc](http://jdk.java.net/jmc)
+
+### Red Hat
+* Released version
+
+Red Hat distributes JDK Mission Control as RMPs in Fedora and RHEL.
+
+## Mission Control Features
 
 ### Application Features
 
-* An application supporting framework for hosting various useful Java tools 
+* A framework for hosting various useful Java tools 
 
 * A tool for visualizing the contents of Java flight recordings, and the results of an automated analysis of the contents
 
 * A JMX Console 
 
 * A tool for heap waste analysis
+
+### Core API Features
+
+* Core APIs for parsing and processing Java flight recordings 
+
+* Core API can *read* recordings from JDK 7 and above
+
+* Core API can *run* on JDK 8 and above
+
+* Core API contains a framework for handling units of measurement and physical quantities
+
+* Core API supports headless analysis of Java flight recordings
 
 
 ### Core API Example
@@ -103,7 +139,7 @@ public class RunRulesOnFileSimple {
 ```
 
 
-Example for programmatically running rules in parallel (requires JDK8):
+Example for programmatically running rules in parallel:
 
 ```java
 import java.io.File;
@@ -177,6 +213,7 @@ public class RunRulesOnFile {
 ## Building Mission Control from Source
 
 Prerequisites for building Mission Control:
+
 1. Install JDK 8, and make sure it is the JDK in use (java -version)
 
 2. Install Maven (version 3.3.x. or above)


### PR DESCRIPTION
Adding binary download info and cleaning up a bit
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JMC-6855](https://bugs.openjdk.java.net/browse/JMC-6855): Should add information about where to get builds to README


### Reviewers
 * Mario Torre ([neugens](@neugens) - Committer) ⚠️ Review applies to 29c8578d16ac1c7617738e06ff575811437f27c4
 * Guru Hb ([ghb](@guruhb) - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jmc pull/91/head:pull/91`
`$ git checkout pull/91`
