### PR TITLE
6864: Schema definition doesn't have optional ReturnValue "name" property

### DIFF
--- a/agent/src/main/resources/org/openjdk/jmc/agent/impl/jfrprobes_schema.xsd
+++ b/agent/src/main/resources/org/openjdk/jmc/agent/impl/jfrprobes_schema.xsd
@@ -166,6 +166,7 @@
 			<xs:documentation>This will only work if we allow toString</xs:documentation>
 		</xs:annotation>
 		<xs:all>
+			<xs:element type="xs:string" name="name" minOccurs="0" />
 			<xs:element type="xs:string" name="description" minOccurs="0" />
 			<xs:element type="contentTypeType" name="contenttype" minOccurs="0" />
 			<xs:element type="relationKeyType" name="relationkey" minOccurs="0" />

--- a/agent/src/test/java/org/openjdk/jmc/agent/test/TestProbeDefinitionValidation.java
+++ b/agent/src/test/java/org/openjdk/jmc/agent/test/TestProbeDefinitionValidation.java
@@ -42,6 +42,7 @@ public class TestProbeDefinitionValidation {
 				+ "                        <converter>com.company.project.MyConverter</converter>\n"
 				+ "                    </parameter>\n" + "                </parameters>\n"
 				+ "                <returnvalue>\n"
+				+ "                    <name>returnValue</name>\n"
 				+ "                    <description>the return value</description>\n"
 				+ "                    <contenttype>None</contenttype>\n"
 				+ "                    <relationkey>http://project.company.com/relation_id/parameter#0</relationkey>\n"


### PR DESCRIPTION
This patch adds an optional return value "name" property to the Agent schema.  You are currently able to add this "name" property to your event probe, however, adding it to the schema was missed in the reviewing process of [JMC-6725](https://bugs.openjdk.java.net/browse/JMC-6725).
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JMC-6864](https://bugs.openjdk.java.net/browse/JMC-6864): Schema definition doesn't have optional ReturnValue "name" property


### Reviewers
 * Marcus Hirt ([hirt](@thegreystone) - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jmc pull/94/head:pull/94`
`$ git checkout pull/94`
