### PR TITLE
6871: Upgrade to ASM 8.0.1

### DIFF
--- a/agent/.classpath
+++ b/agent/.classpath
@@ -30,7 +30,7 @@
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7">
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8">
 		<attributes>
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>

--- a/agent/pom.xml
+++ b/agent/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--   
-   Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+   Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
    
    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
    
@@ -42,7 +42,7 @@
 	<properties>
 		<maven.compiler.source>1.7</maven.compiler.source>
 		<maven.compiler.target>1.7</maven.compiler.target>
-		<asm.version>7.1</asm.version>
+		<asm.version>8.0.1</asm.version>
 		<junit.version>4.12</junit.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<spotless.config.path>${basedir}/../../configuration/ide/eclipse/formatting/formatting.xml</spotless.config.path>
@@ -86,7 +86,7 @@
 							<Agent-Class>org.openjdk.jmc.agent.Agent</Agent-Class>
 							<Premain-Class>org.openjdk.jmc.agent.Agent</Premain-Class>
 							<Can-Retransform-Classes>true</Can-Retransform-Classes>
-							<Bundle-RequiredExecutionEnvironment>JavaSE-1.7</Bundle-RequiredExecutionEnvironment>
+							<Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
 							<Built-By></Built-By>
 						</manifestEntries>
 					</archive>


### PR DESCRIPTION
Also, updating expectations to (at least) JDK 8, as core and the rest of JMC 8 will require 8.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JMC-6871](https://bugs.openjdk.java.net/browse/JMC-6871): Upgrade to ASM 8.0.1


### Reviewers
 * Guru Hb ([ghb](@guruhb) - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jmc pull/96/head:pull/96`
`$ git checkout pull/96`
