### PR TITLE
6870: defineEventProbes is incorrect when probes occupy different classes

### DIFF
--- a/agent/src/main/java/org/openjdk/jmc/agent/TransformRegistry.java
+++ b/agent/src/main/java/org/openjdk/jmc/agent/TransformRegistry.java
@@ -67,16 +67,16 @@ public interface TransformRegistry {
 	 * @param xmlDescription
 	 *           an XML snippet describing the wanted modifications.
 	 *
-	 * @return a list of {@link TransformDescriptor}s corresponding to the wanted transformations.
+	 * @return a set of class names associated with modified {@link TransformDescriptor}s.
 	 */
-	List<TransformDescriptor> modify(String xmlDescription);
+	Set<String> modify(String xmlDescription);
 
 	/**
 	 * Clears all classes and their corresponding transforms in the registry.
 	 *
 	 * @return the set of class names that were cleared.
 	 */
-	List<String> clearAllTransformData();
+	Set<String> clearAllTransformData();
 
 	/**
 	 * Signify classes are or are not being reverted to their pre instrumentation versions.

--- a/agent/src/main/java/org/openjdk/jmc/agent/impl/DefaultTransformRegistry.java
+++ b/agent/src/main/java/org/openjdk/jmc/agent/impl/DefaultTransformRegistry.java
@@ -39,6 +39,7 @@ import java.io.StringReader;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -468,29 +469,26 @@ public class DefaultTransformRegistry implements TransformRegistry {
 		return builder.toString();
 	}
 
-	public List<TransformDescriptor> modify(String xmlDescription) {
+	public Set<String> modify(String xmlDescription) {
 		try  {
 			validateProbeDefinition(xmlDescription);
 
-			List<TransformDescriptor> tds = new ArrayList<TransformDescriptor>();
 			StringReader reader = new StringReader(xmlDescription);
 			XMLInputFactory inputFactory = XMLInputFactory.newInstance();
 			XMLStreamReader streamReader = inputFactory.createXMLStreamReader(reader);
 			HashMap<String, String> globalDefaults = new HashMap<String, String>();
-			List<String> removedOldClasses = new ArrayList<String>();
+			Set<String> modifiedClasses = new HashSet<>();
 			logger.info(xmlDescription);
 			while (streamReader.hasNext()) {
 				if (streamReader.isStartElement()) {
 					QName element = streamReader.getName();
 					if (XML_ELEMENT_NAME_EVENT.equals(element.getLocalPart())) {
 						TransformDescriptor td = parseTransformData(streamReader, globalDefaults);
-						if(!removedOldClasses.contains(td.getClassName())) {
+						if(modifiedClasses.add(td.getClassName())) {
 							transformData.remove(td.getClassName());
-							removedOldClasses.add(td.getClassName());
 						}
 						if (validate(this,td)) {
 							add(this, td);
-							tds.add(td);
 						}
 						continue;
 					} else if (XML_ELEMENT_CONFIGURATION.equals(element.getLocalPart())) {
@@ -499,15 +497,25 @@ public class DefaultTransformRegistry implements TransformRegistry {
 				}
 				streamReader.next();
 			}
-			return tds;
+			clearAllOtherTransformData(modifiedClasses);
+			return modifiedClasses;
 		} catch (XMLStreamException xse) {
 			logger.log(Level.SEVERE, "Failed to create XML Stream Reader", xse);
 			return null;
 		}
 	}
 
-	public List<String> clearAllTransformData() {
-		List<String> classNames = new ArrayList<>(transformData.keySet());
+	private void clearAllOtherTransformData(Set<String> classesToKeep) {
+		Set<String> classNames = new HashSet<>(getClassNames());
+		for (String className : classNames) {
+			if (!classesToKeep.contains(className)) {
+				transformData.remove(className);
+			}
+		}
+	}
+
+	public Set<String> clearAllTransformData() {
+		Set<String> classNames = new HashSet<>(getClassNames());
 		transformData.clear();
 		return classNames;
 	}

--- a/agent/src/test/java/org/openjdk/jmc/agent/test/TestDefaultTransformRegistry.java
+++ b/agent/src/test/java/org/openjdk/jmc/agent/test/TestDefaultTransformRegistry.java
@@ -39,6 +39,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Set;
 
 import javax.xml.stream.XMLStreamException;
 
@@ -52,7 +53,7 @@ import org.openjdk.jmc.agent.test.util.TestToolkit;
 public class TestDefaultTransformRegistry {
 
 	private static final String XML_EVENT_DESCRIPTION = "<event id=\"demo.jfr.test1\">"
-			+ "<name>JFR Hello World Event 1 Modify </name>"
+			+ "<name>JFR Hello World Event 1 %TEST_NAME% </name>"
 			+ "<description>Defined in the xml file and added by the agent.</description>"
 			+ "<path>demo/jfrhelloworldevent1</path>"
 			+ "<stacktrace>true</stacktrace>"
@@ -104,12 +105,11 @@ public class TestDefaultTransformRegistry {
 		TransformRegistry registry = DefaultTransformRegistry
 				.from(TestToolkit.getProbesXMLFromTemplate(getTemplate(), "Modify")); //$NON-NLS-1$
 		assertNotNull(registry);
-		List<TransformDescriptor> descriptors = registry.modify(getXMLDescription(XML_EVENT_DESCRIPTION));
-		assertNotNull(descriptors);
-		assertTrue(descriptors.size() == 1);
-		assertEquals(descriptors.get(0).getClassName(), "org/openjdk/jmc/agent/test/InstrumentMe");
-		assertEquals(descriptors.get(0).getMethod().toString(), "printHelloWorldJFR1()V");
-		assertTrue(registry.hasPendingTransforms("org/openjdk/jmc/agent/test/InstrumentMe"));
+		Set<String> modifiedClassNames = registry.modify(getXMLDescription(XML_EVENT_DESCRIPTION));
+		assertNotNull(modifiedClassNames);
+		assertTrue(modifiedClassNames.size() == 1);
+		assertEquals(modifiedClassNames.iterator().next(), Type.getInternalName(InstrumentMe.class));
+		assertTrue(registry.hasPendingTransforms(Type.getInternalName(InstrumentMe.class)));
 	}
 
 	@Test
@@ -117,19 +117,20 @@ public class TestDefaultTransformRegistry {
 		TransformRegistry registry = DefaultTransformRegistry
 				.from(TestToolkit.getProbesXMLFromTemplate(getTemplate(), "Modify")); //$NON-NLS-1$
 		assertNotNull(registry);
-		final String collisionDescirption = getXMLDescription(XML_EVENT_DESCRIPTION.concat(XML_EVENT_DESCRIPTION));
-		List<TransformDescriptor> descriptors = registry.modify(collisionDescirption);
-		assertNotNull(descriptors);
-		assertTrue(descriptors.size() == 1);
+		final String collisionDescription = getXMLDescription(XML_EVENT_DESCRIPTION.concat(XML_EVENT_DESCRIPTION));
+		Set<String> modifiedClassNames = registry.modify(collisionDescription);
+		assertNotNull(modifiedClassNames);
+		assertTrue(modifiedClassNames.size() == 1);
 	}
 
 	@Test
 	public void testClearAllTransformData() throws XMLStreamException, IOException {
 		TransformRegistry registry = DefaultTransformRegistry
-				.from(TestToolkit.getProbesXMLFromTemplate(getTemplate(), "clearAllTransformData")); //$NON-NLS-1$
+				.from(TestToolkit.getProbesXMLFromTemplate(getXMLDescription(XML_EVENT_DESCRIPTION), "clearAllTransformData")); //$NON-NLS-1$
 		assertNotNull(registry);
-		List<String> classesCleared = registry.clearAllTransformData();
-		assertEquals(classesCleared.get(0),Type.getInternalName(InstrumentMe.class));
+		Set<String> classesCleared = registry.clearAllTransformData();
+		assertTrue(classesCleared.size() == 1);
+		assertEquals(classesCleared.iterator().next(),Type.getInternalName(InstrumentMe.class));
 		assertNull(registry.getTransformData(Type.getInternalName(InstrumentMe.class)));
 	}
 


### PR DESCRIPTION
Previously, when the agent MXBean operation `defineEventProbes(xmlDescription)` was called with an XML description only containing probes from new classes, existing probes in other classes were not reverted. This patch fixes `TransformRegistry.modify(xmlDescription)` so that this does not happen.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JMC-6870](https://bugs.openjdk.java.net/browse/JMC-6870): defineEventProbes is incorrect when probes occupy different classes


### Reviewers
 * Alex Macdonald ([aptmac](@aptmac) - Committer)
 * Marcus Hirt ([hirt](@thegreystone) - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jmc pull/97/head:pull/97`
`$ git checkout pull/97`
