### PR TITLE
6885: VM_OPERATION_DURATION aggregator does not filter on type

### DIFF
--- a/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/jdk/JdkAggregators.java
+++ b/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/jdk/JdkAggregators.java
@@ -389,7 +389,7 @@ public final class JdkAggregators {
 			Messages.getString(Messages.AGGR_VM_OPERATION_COUNT_DESC), JdkFilters.VM_OPERATIONS);
 	public static final IAggregator<IQuantity, ?> VM_OPERATION_DURATION = Aggregators.sum(
 			Messages.getString(Messages.AGGR_VM_OPERATION_DURATION),
-			Messages.getString(Messages.AGGR_VM_OPERATION_DURATION_DESC), JfrAttributes.DURATION);
+			Messages.getString(Messages.AGGR_VM_OPERATION_DURATION_DESC), JdkTypeIDs.VM_OPERATIONS, JfrAttributes.DURATION);
 
 	public static final IAggregator<IQuantity, ?> COMPILATIONS_COUNT = Aggregators.count(
 			Messages.getString(Messages.AGGR_COMPILATIONS_COUNT),

--- a/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/jdk/JdkAggregators.java
+++ b/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/jdk/JdkAggregators.java
@@ -389,7 +389,8 @@ public final class JdkAggregators {
 			Messages.getString(Messages.AGGR_VM_OPERATION_COUNT_DESC), JdkFilters.VM_OPERATIONS);
 	public static final IAggregator<IQuantity, ?> VM_OPERATION_DURATION = Aggregators.sum(
 			Messages.getString(Messages.AGGR_VM_OPERATION_DURATION),
-			Messages.getString(Messages.AGGR_VM_OPERATION_DURATION_DESC), JdkTypeIDs.VM_OPERATIONS, JfrAttributes.DURATION);
+			Messages.getString(Messages.AGGR_VM_OPERATION_DURATION_DESC), JdkTypeIDs.VM_OPERATIONS,
+			JfrAttributes.DURATION);
 
 	public static final IAggregator<IQuantity, ?> COMPILATIONS_COUNT = Aggregators.count(
 			Messages.getString(Messages.AGGR_COMPILATIONS_COUNT),


### PR DESCRIPTION
Missing VM_OPERATION type to filter only on VM operations
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JMC-6885](https://bugs.openjdk.java.net/browse/JMC-6885): VM_OPERATION_DURATION aggregator does not filter on type


### Reviewers
 * Marcus Hirt ([hirt](@thegreystone) - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jmc pull/101/head:pull/101`
`$ git checkout pull/101`
