### PR TITLE
6487: The TOPIC word in topic constants should either be the first word or removed

### DIFF
--- a/application/org.openjdk.jmc.flightrecorder.pde/templates_3.4/simpleruletemplate/java/$className$.java
+++ b/application/org.openjdk.jmc.flightrecorder.pde/templates_3.4/simpleruletemplate/java/$className$.java
@@ -124,6 +124,6 @@ public class $className$ implements IRule {
 
 	@Override
 	public String getTopic() {
-		return JfrRuleTopics.ENVIRONMENT_VARIABLES_TOPIC;
+		return JfrRuleTopics.ENVIRONMENT_VARIABLES;
 	}
 }

--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/ClassLoadingPage.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/ClassLoadingPage.java
@@ -118,7 +118,7 @@ public class ClassLoadingPage extends AbstractDataPage {
 
 		@Override
 		public String[] getTopics(IState state) {
-			return new String[] {JfrRuleTopics.CLASS_LOADING_TOPIC};
+			return new String[] {JfrRuleTopics.CLASS_LOADING};
 		}
 
 		@Override

--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/CodeCachePage.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/CodeCachePage.java
@@ -132,7 +132,7 @@ public class CodeCachePage extends AbstractDataPage {
 
 		@Override
 		public String[] getTopics(IState state) {
-			return new String[] {JfrRuleTopics.CODE_CACHE_TOPIC};
+			return new String[] {JfrRuleTopics.CODE_CACHE};
 		}
 
 		@Override

--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/CompilationsPage.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/CompilationsPage.java
@@ -125,7 +125,7 @@ public class CompilationsPage extends AbstractDataPage {
 
 		@Override
 		public String[] getTopics(IState state) {
-			return new String[] {JfrRuleTopics.COMPILATIONS_TOPIC};
+			return new String[] {JfrRuleTopics.COMPILATIONS};
 		}
 
 		@Override

--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/EnvironmentVariablesPage.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/EnvironmentVariablesPage.java
@@ -65,7 +65,7 @@ public class EnvironmentVariablesPage extends DistinctItemsPage {
 
 		@Override
 		public String[] getTopics(IState state) {
-			return new String[] {JfrRuleTopics.ENVIRONMENT_VARIABLES_TOPIC};
+			return new String[] {JfrRuleTopics.ENVIRONMENT_VARIABLES};
 		}
 
 		@Override

--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/ExceptionsPage.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/ExceptionsPage.java
@@ -129,7 +129,7 @@ public class ExceptionsPage extends AbstractDataPage {
 
 		@Override
 		public String[] getTopics(IState state) {
-			return new String[] {JfrRuleTopics.EXCEPTIONS_TOPIC};
+			return new String[] {JfrRuleTopics.EXCEPTIONS};
 		}
 
 		@Override

--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/FileIOPage.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/FileIOPage.java
@@ -116,7 +116,7 @@ public class FileIOPage extends AbstractDataPage {
 
 		@Override
 		public String[] getTopics(IState state) {
-			return new String[] {JfrRuleTopics.FILE_IO_TOPIC};
+			return new String[] {JfrRuleTopics.FILE_IO};
 		}
 
 		@Override

--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/GCConfigurationPage.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/GCConfigurationPage.java
@@ -75,7 +75,7 @@ public class GCConfigurationPage extends AbstractDataPage {
 
 		@Override
 		public String[] getTopics(IState state) {
-			return new String[] {JfrRuleTopics.GC_CONFIGURATION_TOPIC};
+			return new String[] {JfrRuleTopics.GC_CONFIGURATION};
 		}
 
 		@Override

--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/GarbageCollectionsPage.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/GarbageCollectionsPage.java
@@ -151,7 +151,7 @@ public class GarbageCollectionsPage extends AbstractDataPage {
 
 		@Override
 		public String[] getTopics(IState state) {
-			return new String[] {JfrRuleTopics.GARBAGE_COLLECTION_TOPIC};
+			return new String[] {JfrRuleTopics.GARBAGE_COLLECTION};
 		}
 
 		@Override

--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/HeapPage.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/HeapPage.java
@@ -110,7 +110,7 @@ public class HeapPage extends AbstractDataPage {
 
 		@Override
 		public String[] getTopics(IState state) {
-			return new String[] {JfrRuleTopics.HEAP_TOPIC};
+			return new String[] {JfrRuleTopics.HEAP};
 		}
 
 		@Override

--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/JVMInformationPage.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/JVMInformationPage.java
@@ -97,7 +97,7 @@ public class JVMInformationPage extends AbstractDataPage {
 
 		@Override
 		public String[] getTopics(IState state) {
-			return new String[] {JfrRuleTopics.JVM_INFORMATION_TOPIC};
+			return new String[] {JfrRuleTopics.JVM_INFORMATION};
 		}
 
 		@Override

--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/JavaApplicationPage.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/JavaApplicationPage.java
@@ -115,7 +115,7 @@ public class JavaApplicationPage extends AbstractDataPage {
 
 		@Override
 		public String[] getTopics(IState state) {
-			return new String[] {JfrRuleTopics.JAVA_APPLICATION_TOPIC, JfrRuleTopics.METHOD_PROFILING_TOPIC};
+			return new String[] {JfrRuleTopics.JAVA_APPLICATION, JfrRuleTopics.METHOD_PROFILING};
 		}
 
 		@Override

--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/LockInstancesPage.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/LockInstancesPage.java
@@ -107,7 +107,7 @@ public class LockInstancesPage extends AbstractDataPage {
 
 		@Override
 		public String[] getTopics(IState state) {
-			return new String[] {JfrRuleTopics.LOCK_INSTANCES_TOPIC};
+			return new String[] {JfrRuleTopics.LOCK_INSTANCES};
 		}
 
 		@Override

--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/MemoryLeakPage.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/MemoryLeakPage.java
@@ -124,7 +124,7 @@ public class MemoryLeakPage extends AbstractDataPage {
 
 		@Override
 		public String[] getTopics(IState state) {
-			return new String[] {JfrRuleTopics.MEMORY_LEAK_TOPIC};
+			return new String[] {JfrRuleTopics.MEMORY_LEAK};
 		}
 
 		@Override

--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/MethodProfilingPage.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/MethodProfilingPage.java
@@ -92,7 +92,7 @@ public class MethodProfilingPage extends AbstractDataPage {
 
 		@Override
 		public String[] getTopics(IState state) {
-			return new String[] {JfrRuleTopics.METHOD_PROFILING_TOPIC};
+			return new String[] {JfrRuleTopics.METHOD_PROFILING};
 		}
 
 		@Override

--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/NativeLibraryPage.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/NativeLibraryPage.java
@@ -64,7 +64,7 @@ public class NativeLibraryPage extends DistinctItemsPage {
 
 		@Override
 		public String[] getTopics(IState state) {
-			return new String[] {JfrRuleTopics.NATIVE_LIBRARY_TOPIC};
+			return new String[] {JfrRuleTopics.NATIVE_LIBRARY};
 		}
 
 		@Override

--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/ProcessesPage.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/ProcessesPage.java
@@ -102,7 +102,7 @@ public class ProcessesPage extends AbstractDataPage {
 
 		@Override
 		public String[] getTopics(IState state) {
-			return new String[] {JfrRuleTopics.PROCESSES_TOPIC};
+			return new String[] {JfrRuleTopics.PROCESSES};
 		}
 
 		@Override

--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/RecordingPage.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/RecordingPage.java
@@ -97,7 +97,7 @@ public class RecordingPage extends AbstractDataPage {
 
 		@Override
 		public String[] getTopics(IState state) {
-			return new String[] {JfrRuleTopics.RECORDING_TOPIC};
+			return new String[] {JfrRuleTopics.RECORDING};
 		}
 
 		@Override

--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/SocketIOPage.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/SocketIOPage.java
@@ -133,7 +133,7 @@ public class SocketIOPage extends AbstractDataPage {
 
 		@Override
 		public String[] getTopics(IState state) {
-			return new String[] {JfrRuleTopics.SOCKET_IO_TOPIC};
+			return new String[] {JfrRuleTopics.SOCKET_IO};
 		}
 
 		@Override

--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/SystemPage.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/SystemPage.java
@@ -71,7 +71,7 @@ public class SystemPage extends AbstractDataPage {
 
 		@Override
 		public String[] getTopics(IState state) {
-			return new String[] {JfrRuleTopics.SYSTEM_INFORMATION_TOPIC};
+			return new String[] {JfrRuleTopics.SYSTEM_INFORMATION};
 		}
 
 		@Override

--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/SystemPropertiesPage.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/SystemPropertiesPage.java
@@ -64,7 +64,7 @@ public class SystemPropertiesPage extends DistinctItemsPage {
 
 		@Override
 		public String[] getTopics(IState state) {
-			return new String[] {JfrRuleTopics.SYSTEM_PROPERTIES_TOPIC};
+			return new String[] {JfrRuleTopics.SYSTEM_PROPERTIES};
 		}
 
 		@Override

--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/ThreadDumpsPage.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/ThreadDumpsPage.java
@@ -121,7 +121,7 @@ public class ThreadDumpsPage extends AbstractDataPage {
 
 		@Override
 		public String[] getTopics(IState state) {
-			return new String[] {JfrRuleTopics.THREAD_DUMPS_TOPIC};
+			return new String[] {JfrRuleTopics.THREAD_DUMPS};
 		}
 
 		@Override

--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/ThreadsPage.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/ThreadsPage.java
@@ -98,7 +98,7 @@ public class ThreadsPage extends AbstractDataPage {
 
 		@Override
 		public String[] getTopics(IState state) {
-			return new String[] {JfrRuleTopics.THREADS_TOPIC};
+			return new String[] {JfrRuleTopics.THREADS};
 		}
 
 		@Override

--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/TlabPage.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/TlabPage.java
@@ -94,7 +94,7 @@ public class TlabPage extends AbstractDataPage {
 
 		@Override
 		public String[] getTopics(IState state) {
-			return new String[] {JfrRuleTopics.TLAB_TOPIC};
+			return new String[] {JfrRuleTopics.TLAB};
 		}
 
 		@Override

--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/VMOperationPage.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/VMOperationPage.java
@@ -135,7 +135,7 @@ public class VMOperationPage extends AbstractDataPage {
 
 		@Override
 		public String[] getTopics(IState state) {
-			return new String[] {JfrRuleTopics.VM_OPERATIONS_TOPIC};
+			return new String[] {JfrRuleTopics.VM_OPERATIONS};
 		}
 
 		@Override

--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/compilation/CodeCacheRule.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/compilation/CodeCacheRule.java
@@ -286,6 +286,6 @@ public class CodeCacheRule implements IRule {
 
 	@Override
 	public String getTopic() {
-		return JfrRuleTopics.CODE_CACHE_TOPIC;
+		return JfrRuleTopics.CODE_CACHE;
 	}
 }

--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/cpu/CompareCpuRule.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/cpu/CompareCpuRule.java
@@ -70,7 +70,7 @@ public class CompareCpuRule extends AbstractRule {
 			UnitLookup.PERCENT.quantity(20));
 
 	public CompareCpuRule() {
-		super("CompareCpu", Messages.getString(Messages.CompareCpuRule_RULE_NAME), JfrRuleTopics.PROCESSES_TOPIC, //$NON-NLS-1$
+		super("CompareCpu", Messages.getString(Messages.CompareCpuRule_RULE_NAME), JfrRuleTopics.PROCESSES, //$NON-NLS-1$
 				OTHER_CPU_INFO_LIMIT, OTHER_CPU_WARNING_LIMIT);
 	}
 

--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/cpu/HighJvmCpuRule.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/cpu/HighJvmCpuRule.java
@@ -182,6 +182,6 @@ public class HighJvmCpuRule implements IRule {
 
 	@Override
 	public String getTopic() {
-		return JfrRuleTopics.JAVA_APPLICATION_TOPIC;
+		return JfrRuleTopics.JAVA_APPLICATION;
 	}
 }

--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/cpu/ManyRunningProcessesRule.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/cpu/ManyRunningProcessesRule.java
@@ -119,6 +119,6 @@ public class ManyRunningProcessesRule implements IRule {
 
 	@Override
 	public String getTopic() {
-		return JfrRuleTopics.PROCESSES_TOPIC;
+		return JfrRuleTopics.PROCESSES;
 	}
 }

--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/exceptions/ErrorRule.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/exceptions/ErrorRule.java
@@ -201,6 +201,6 @@ public class ErrorRule implements IRule {
 
 	@Override
 	public String getTopic() {
-		return JfrRuleTopics.EXCEPTIONS_TOPIC;
+		return JfrRuleTopics.EXCEPTIONS;
 	}
 }

--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/exceptions/ExceptionRule.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/exceptions/ExceptionRule.java
@@ -142,6 +142,6 @@ public class ExceptionRule implements IRule {
 
 	@Override
 	public String getTopic() {
-		return JfrRuleTopics.EXCEPTIONS_TOPIC;
+		return JfrRuleTopics.EXCEPTIONS;
 	}
 }

--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/exceptions/FatalErrorRule.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/exceptions/FatalErrorRule.java
@@ -114,6 +114,6 @@ public class FatalErrorRule implements IRule {
 
 	@Override
 	public String getTopic() {
-		return JfrRuleTopics.JVM_INFORMATION_TOPIC;
+		return JfrRuleTopics.JVM_INFORMATION;
 	}
 }

--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/exceptions/LuceneVersionRule.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/exceptions/LuceneVersionRule.java
@@ -119,7 +119,7 @@ public class LuceneVersionRule implements IRule {
 
 	@Override
 	public String getTopic() {
-		return JfrRuleTopics.EXCEPTIONS_TOPIC;
+		return JfrRuleTopics.EXCEPTIONS;
 	}
 
 }

--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/general/BufferLostRule.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/general/BufferLostRule.java
@@ -127,6 +127,6 @@ public class BufferLostRule implements IRule {
 
 	@Override
 	public String getTopic() {
-		return JfrRuleTopics.RECORDING_TOPIC;
+		return JfrRuleTopics.RECORDING;
 	}
 }

--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/general/ClassLeakingRule.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/general/ClassLeakingRule.java
@@ -233,7 +233,7 @@ public final class ClassLeakingRule implements IRule {
 
 	@Override
 	public String getTopic() {
-		return JfrRuleTopics.CLASS_LOADING_TOPIC;
+		return JfrRuleTopics.CLASS_LOADING;
 	}
 
 }

--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/general/ClassLoadingRule.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/general/ClassLoadingRule.java
@@ -136,7 +136,7 @@ public class ClassLoadingRule implements IRule {
 
 	@Override
 	public String getTopic() {
-		return JfrRuleTopics.CLASS_LOADING_TOPIC;
+		return JfrRuleTopics.CLASS_LOADING;
 	}
 
 }

--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/general/DebugNonSafepointsRule.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/general/DebugNonSafepointsRule.java
@@ -114,6 +114,6 @@ public class DebugNonSafepointsRule implements IRule {
 
 	@Override
 	public String getTopic() {
-		return JfrRuleTopics.JVM_INFORMATION_TOPIC;
+		return JfrRuleTopics.JVM_INFORMATION;
 	}
 }

--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/general/DiscouragedGcOptionsRule.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/general/DiscouragedGcOptionsRule.java
@@ -128,6 +128,6 @@ public class DiscouragedGcOptionsRule implements IRule {
 
 	@Override
 	public String getTopic() {
-		return JfrRuleTopics.JVM_INFORMATION_TOPIC;
+		return JfrRuleTopics.JVM_INFORMATION;
 	}
 }

--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/general/DiscouragedVmOptionsRule.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/general/DiscouragedVmOptionsRule.java
@@ -108,6 +108,6 @@ public class DiscouragedVmOptionsRule implements IRule {
 
 	@Override
 	public String getTopic() {
-		return JfrRuleTopics.JVM_INFORMATION_TOPIC;
+		return JfrRuleTopics.JVM_INFORMATION;
 	}
 }

--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/general/DumpReasonRule.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/general/DumpReasonRule.java
@@ -150,6 +150,6 @@ public class DumpReasonRule implements IRule {
 
 	@Override
 	public String getTopic() {
-		return JfrRuleTopics.RECORDING_TOPIC;
+		return JfrRuleTopics.RECORDING;
 	}
 }

--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/general/DuplicateFlagsRule.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/general/DuplicateFlagsRule.java
@@ -124,6 +124,6 @@ public class DuplicateFlagsRule implements IRule {
 
 	@Override
 	public String getTopic() {
-		return JfrRuleTopics.JVM_INFORMATION_TOPIC;
+		return JfrRuleTopics.JVM_INFORMATION;
 	}
 }

--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/general/FewSampledThreadsRule.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/general/FewSampledThreadsRule.java
@@ -120,7 +120,7 @@ public class FewSampledThreadsRule extends AbstractRule {
 
 	public FewSampledThreadsRule() {
 		super("FewSampledThreads", Messages.getString(Messages.FewSampledThreadsRule_RULE_NAME), //$NON-NLS-1$
-				JfrRuleTopics.JAVA_APPLICATION_TOPIC, SAMPLED_THREADS_RATIO_LIMIT, MIN_CPU_RATIO_LIMIT,
+				JfrRuleTopics.JAVA_APPLICATION, SAMPLED_THREADS_RATIO_LIMIT, MIN_CPU_RATIO_LIMIT,
 				SHORT_RECORDING_LIMIT, CPU_WINDOW_SIZE, MIN_SAMPLE_COUNT, MIN_SAMPLE_COUNT_PER_THREAD);
 	}
 

--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/general/FewSampledThreadsRule.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/general/FewSampledThreadsRule.java
@@ -120,8 +120,8 @@ public class FewSampledThreadsRule extends AbstractRule {
 
 	public FewSampledThreadsRule() {
 		super("FewSampledThreads", Messages.getString(Messages.FewSampledThreadsRule_RULE_NAME), //$NON-NLS-1$
-				JfrRuleTopics.JAVA_APPLICATION, SAMPLED_THREADS_RATIO_LIMIT, MIN_CPU_RATIO_LIMIT,
-				SHORT_RECORDING_LIMIT, CPU_WINDOW_SIZE, MIN_SAMPLE_COUNT, MIN_SAMPLE_COUNT_PER_THREAD);
+				JfrRuleTopics.JAVA_APPLICATION, SAMPLED_THREADS_RATIO_LIMIT, MIN_CPU_RATIO_LIMIT, SHORT_RECORDING_LIMIT,
+				CPU_WINDOW_SIZE, MIN_SAMPLE_COUNT, MIN_SAMPLE_COUNT_PER_THREAD);
 	}
 
 	@Override

--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/general/FlightRecordingSupportRule.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/general/FlightRecordingSupportRule.java
@@ -115,7 +115,7 @@ public class FlightRecordingSupportRule implements IRule {
 
 	@Override
 	public String getTopic() {
-		return JfrRuleTopics.JVM_INFORMATION_TOPIC;
+		return JfrRuleTopics.JVM_INFORMATION;
 	}
 
 	private Result getVersionResult(String versionString) {

--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/general/ManagementAgentRule.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/general/ManagementAgentRule.java
@@ -138,6 +138,6 @@ public class ManagementAgentRule implements IRule {
 
 	@Override
 	public String getTopic() {
-		return JfrRuleTopics.JVM_INFORMATION_TOPIC;
+		return JfrRuleTopics.JVM_INFORMATION;
 	}
 }

--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/general/OptionsCheckRule.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/general/OptionsCheckRule.java
@@ -607,6 +607,6 @@ public class OptionsCheckRule implements IRule {
 
 	@Override
 	public String getTopic() {
-		return JfrRuleTopics.JVM_INFORMATION_TOPIC;
+		return JfrRuleTopics.JVM_INFORMATION;
 	}
 }

--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/general/PasswordsInArgumentsRule.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/general/PasswordsInArgumentsRule.java
@@ -120,6 +120,6 @@ public class PasswordsInArgumentsRule implements IRule {
 
 	@Override
 	public String getTopic() {
-		return JfrRuleTopics.JVM_INFORMATION_TOPIC;
+		return JfrRuleTopics.JVM_INFORMATION;
 	}
 }

--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/general/PasswordsInEnvironmentRule.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/general/PasswordsInEnvironmentRule.java
@@ -111,6 +111,6 @@ public class PasswordsInEnvironmentRule implements IRule {
 
 	@Override
 	public String getTopic() {
-		return JfrRuleTopics.ENVIRONMENT_VARIABLES_TOPIC;
+		return JfrRuleTopics.ENVIRONMENT_VARIABLES;
 	}
 }

--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/general/PasswordsInSystemPropertiesRule.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/general/PasswordsInSystemPropertiesRule.java
@@ -112,6 +112,6 @@ public class PasswordsInSystemPropertiesRule implements IRule {
 
 	@Override
 	public String getTopic() {
-		return JfrRuleTopics.SYSTEM_PROPERTIES_TOPIC;
+		return JfrRuleTopics.SYSTEM_PROPERTIES;
 	}
 }

--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/general/RecordingSettingsRule.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/general/RecordingSettingsRule.java
@@ -103,6 +103,6 @@ public class RecordingSettingsRule implements IRule {
 
 	@Override
 	public String getTopic() {
-		return JfrRuleTopics.RECORDING_TOPIC;
+		return JfrRuleTopics.RECORDING;
 	}
 }

--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/general/StackDepthSettingRule.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/general/StackDepthSettingRule.java
@@ -162,6 +162,6 @@ public class StackDepthSettingRule implements IRule {
 
 	@Override
 	public String getTopic() {
-		return JfrRuleTopics.JVM_INFORMATION_TOPIC;
+		return JfrRuleTopics.JVM_INFORMATION;
 	}
 }

--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/general/VerifyNoneRule.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/general/VerifyNoneRule.java
@@ -107,6 +107,6 @@ public class VerifyNoneRule implements IRule {
 
 	@Override
 	public String getTopic() {
-		return JfrRuleTopics.JVM_INFORMATION_TOPIC;
+		return JfrRuleTopics.JVM_INFORMATION;
 	}
 }

--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/io/FileReadRule.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/io/FileReadRule.java
@@ -146,6 +146,6 @@ public class FileReadRule implements IRule {
 
 	@Override
 	public String getTopic() {
-		return JfrRuleTopics.FILE_IO_TOPIC;
+		return JfrRuleTopics.FILE_IO;
 	}
 }

--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/io/FileWriteRule.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/io/FileWriteRule.java
@@ -138,7 +138,7 @@ public class FileWriteRule implements IRule {
 
 	@Override
 	public String getTopic() {
-		return JfrRuleTopics.FILE_IO_TOPIC;
+		return JfrRuleTopics.FILE_IO;
 	}
 
 }

--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/io/SocketReadRule.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/io/SocketReadRule.java
@@ -161,7 +161,7 @@ public class SocketReadRule implements IRule {
 
 	@Override
 	public String getTopic() {
-		return JfrRuleTopics.SOCKET_IO_TOPIC;
+		return JfrRuleTopics.SOCKET_IO;
 	}
 
 }

--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/io/SocketWriteRule.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/io/SocketWriteRule.java
@@ -147,6 +147,6 @@ public class SocketWriteRule implements IRule {
 
 	@Override
 	public String getTopic() {
-		return JfrRuleTopics.SOCKET_IO_TOPIC;
+		return JfrRuleTopics.SOCKET_IO;
 	}
 }

--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/latency/BiasedLockingRevocationPauseRule.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/latency/BiasedLockingRevocationPauseRule.java
@@ -124,7 +124,7 @@ public final class BiasedLockingRevocationPauseRule implements IRule {
 
 	@Override
 	public String getTopic() {
-		return JfrRuleTopics.VM_OPERATIONS_TOPIC;
+		return JfrRuleTopics.VM_OPERATIONS;
 	}
 
 }

--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/latency/BiasedLockingRevocationRule.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/latency/BiasedLockingRevocationRule.java
@@ -320,6 +320,6 @@ public final class BiasedLockingRevocationRule implements IRule {
 
 	@Override
 	public String getTopic() {
-		return JfrRuleTopics.BIASED_LOCKING_TOPIC;
+		return JfrRuleTopics.BIASED_LOCKING;
 	}
 }

--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/latency/ContextSwitchRule.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/latency/ContextSwitchRule.java
@@ -144,6 +144,6 @@ public class ContextSwitchRule implements IRule {
 
 	@Override
 	public String getTopic() {
-		return JfrRuleTopics.LOCK_INSTANCES_TOPIC;
+		return JfrRuleTopics.LOCK_INSTANCES;
 	}
 }

--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/latency/JavaBlockingRule.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/latency/JavaBlockingRule.java
@@ -189,6 +189,6 @@ public class JavaBlockingRule implements IRule {
 
 	@Override
 	public String getTopic() {
-		return JfrRuleTopics.LOCK_INSTANCES_TOPIC;
+		return JfrRuleTopics.LOCK_INSTANCES;
 	}
 }

--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/latency/MethodProfilingRule.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/latency/MethodProfilingRule.java
@@ -568,7 +568,7 @@ public class MethodProfilingRule implements IRule {
 
 	@Override
 	public String getTopic() {
-		return JfrRuleTopics.METHOD_PROFILING_TOPIC;
+		return JfrRuleTopics.METHOD_PROFILING;
 	}
 
 }

--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/latency/VMOperationRule.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/latency/VMOperationRule.java
@@ -221,6 +221,6 @@ public class VMOperationRule implements IRule {
 
 	@Override
 	public String getTopic() {
-		return JfrRuleTopics.VM_OPERATIONS_TOPIC;
+		return JfrRuleTopics.VM_OPERATIONS;
 	}
 }

--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/memory/AllocationByClassRule.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/memory/AllocationByClassRule.java
@@ -136,6 +136,6 @@ public class AllocationByClassRule implements IRule {
 
 	@Override
 	public String getTopic() {
-		return JfrRuleTopics.HEAP_TOPIC;
+		return JfrRuleTopics.HEAP;
 	}
 }

--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/memory/AllocationByThreadRule.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/memory/AllocationByThreadRule.java
@@ -134,6 +134,6 @@ public class AllocationByThreadRule implements IRule {
 
 	@Override
 	public String getTopic() {
-		return JfrRuleTopics.JAVA_APPLICATION_TOPIC;
+		return JfrRuleTopics.JAVA_APPLICATION;
 	}
 }

--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/memory/ApplicationHaltsRule.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/memory/ApplicationHaltsRule.java
@@ -72,7 +72,7 @@ public class ApplicationHaltsRule extends AbstractRule {
 
 	public ApplicationHaltsRule() {
 		super("ApplicationHalts", Messages.getString(Messages.ApplicationHaltsRule_RULE_NAME), //$NON-NLS-1$
-				JfrRuleTopics.JAVA_APPLICATION_TOPIC, APP_HALTS_INFO_LIMIT, APP_HALTS_WARNING_LIMIT, WINDOW_SIZE);
+				JfrRuleTopics.JAVA_APPLICATION, APP_HALTS_INFO_LIMIT, APP_HALTS_WARNING_LIMIT, WINDOW_SIZE);
 	}
 
 	@Override

--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/memory/AutoBoxingRule.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/memory/AutoBoxingRule.java
@@ -120,7 +120,7 @@ public class AutoBoxingRule extends AbstractRule {
 
 	public AutoBoxingRule() {
 		super("PrimitiveToObjectConversion", Messages.getString(Messages.AutoboxingRule_RULE_NAME), //$NON-NLS-1$
-				JfrRuleTopics.HEAP_TOPIC, AUTOBOXING_RATIO_INFO_LIMIT, AUTOBOXING_RATIO_WARNING_LIMIT);
+				JfrRuleTopics.HEAP, AUTOBOXING_RATIO_INFO_LIMIT, AUTOBOXING_RATIO_WARNING_LIMIT);
 	}
 
 	@Override

--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/memory/CompressedOopsRule.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/memory/CompressedOopsRule.java
@@ -111,6 +111,6 @@ public class CompressedOopsRule implements IRule {
 
 	@Override
 	public String getTopic() {
-		return JfrRuleTopics.GC_CONFIGURATION_TOPIC;
+		return JfrRuleTopics.GC_CONFIGURATION;
 	}
 }

--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/memory/FullGcRule.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/memory/FullGcRule.java
@@ -129,7 +129,7 @@ public class FullGcRule implements IRule {
 
 	@Override
 	public String getTopic() {
-		return JfrRuleTopics.GARBAGE_COLLECTION_TOPIC;
+		return JfrRuleTopics.GARBAGE_COLLECTION;
 	}
 
 	private static class G1Aggregator extends MergingAggregator<G1FullGCInfo, G1FullGCInfo> {

--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/memory/GcFreedRatioRule.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/memory/GcFreedRatioRule.java
@@ -91,7 +91,7 @@ public class GcFreedRatioRule extends AbstractRule {
 			UnitLookup.NUMBER_UNITY.quantity(10));
 
 	public GcFreedRatioRule() {
-		super("GcFreedRatio", Messages.getString(Messages.GcFreedRatioRule_RULE_NAME), JfrRuleTopics.HEAP_TOPIC, //$NON-NLS-1$
+		super("GcFreedRatio", Messages.getString(Messages.GcFreedRatioRule_RULE_NAME), JfrRuleTopics.HEAP, //$NON-NLS-1$
 				GC_FREED_PER_SECOND_TO_LIVESET_RATIO_INFO_LIMIT, WINDOW_SIZE, FEW_GCS_LIMIT, SHORT_RECORDING_LIMIT);
 	}
 

--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/memory/GcLockerRule.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/memory/GcLockerRule.java
@@ -125,6 +125,6 @@ public class GcLockerRule implements IRule {
 
 	@Override
 	public String getTopic() {
-		return JfrRuleTopics.GARBAGE_COLLECTION_TOPIC;
+		return JfrRuleTopics.GARBAGE_COLLECTION;
 	}
 }

--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/memory/GcPauseRatioRule.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/memory/GcPauseRatioRule.java
@@ -69,7 +69,7 @@ public class GcPauseRatioRule extends AbstractRule {
 
 	public GcPauseRatioRule() {
 		super("GcPauseRatio", Messages.getString(Messages.GcPauseRatioRule_RULE_NAME), //$NON-NLS-1$
-				JfrRuleTopics.GARBAGE_COLLECTION_TOPIC, INFO_LIMIT, WARNING_LIMIT, WINDOW_SIZE);
+				JfrRuleTopics.GARBAGE_COLLECTION, INFO_LIMIT, WARNING_LIMIT, WINDOW_SIZE);
 	}
 
 	@Override

--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/memory/GcStallRule.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/memory/GcStallRule.java
@@ -121,6 +121,6 @@ public class GcStallRule implements IRule {
 
 	@Override
 	public String getTopic() {
-		return JfrRuleTopics.GARBAGE_COLLECTION_TOPIC;
+		return JfrRuleTopics.GARBAGE_COLLECTION;
 	}
 }

--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/memory/HeapContentRule.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/memory/HeapContentRule.java
@@ -132,6 +132,6 @@ public class HeapContentRule implements IRule {
 
 	@Override
 	public String getTopic() {
-		return JfrRuleTopics.HEAP_TOPIC;
+		return JfrRuleTopics.HEAP;
 	}
 }

--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/memory/HeapInspectionRule.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/memory/HeapInspectionRule.java
@@ -119,6 +119,6 @@ public class HeapInspectionRule implements IRule {
 
 	@Override
 	public String getTopic() {
-		return JfrRuleTopics.GARBAGE_COLLECTION_TOPIC;
+		return JfrRuleTopics.GARBAGE_COLLECTION;
 	}
 }

--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/memory/HighGcRule.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/memory/HighGcRule.java
@@ -126,6 +126,6 @@ public class HighGcRule implements IRule {
 
 	@Override
 	public String getTopic() {
-		return JfrRuleTopics.HEAP_TOPIC;
+		return JfrRuleTopics.HEAP;
 	}
 }

--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/memory/IncreasingLiveSetRule.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/memory/IncreasingLiveSetRule.java
@@ -297,6 +297,6 @@ public class IncreasingLiveSetRule implements IRule {
 
 	@Override
 	public String getTopic() {
-		return JfrRuleTopics.MEMORY_LEAK_TOPIC;
+		return JfrRuleTopics.MEMORY_LEAK;
 	}
 }

--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/memory/IncreasingMetaspaceLiveSetRule.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/memory/IncreasingMetaspaceLiveSetRule.java
@@ -124,6 +124,6 @@ public class IncreasingMetaspaceLiveSetRule implements IRule {
 
 	@Override
 	public String getTopic() {
-		return JfrRuleTopics.GARBAGE_COLLECTION_TOPIC;
+		return JfrRuleTopics.GARBAGE_COLLECTION;
 	}
 }

--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/memory/LongGcPauseRule.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/memory/LongGcPauseRule.java
@@ -172,6 +172,6 @@ public class LongGcPauseRule implements IRule {
 
 	@Override
 	public String getTopic() {
-		return JfrRuleTopics.GARBAGE_COLLECTION_TOPIC;
+		return JfrRuleTopics.GARBAGE_COLLECTION;
 	}
 }

--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/memory/LowOnPhysicalMemoryRule.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/memory/LowOnPhysicalMemoryRule.java
@@ -114,6 +114,6 @@ public class LowOnPhysicalMemoryRule implements IRule {
 
 	@Override
 	public String getTopic() {
-		return JfrRuleTopics.HEAP_TOPIC;
+		return JfrRuleTopics.HEAP;
 	}
 }

--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/memory/MetaspaceOomRule.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/memory/MetaspaceOomRule.java
@@ -104,6 +104,6 @@ public class MetaspaceOomRule implements IRule {
 
 	@Override
 	public String getTopic() {
-		return JfrRuleTopics.GARBAGE_COLLECTION_TOPIC;
+		return JfrRuleTopics.GARBAGE_COLLECTION;
 	}
 }

--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/memory/StringDeduplicationRule.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/memory/StringDeduplicationRule.java
@@ -107,7 +107,7 @@ public class StringDeduplicationRule extends AbstractRule {
 
 	public StringDeduplicationRule() {
 		super("StringDeduplication", Messages.getString(Messages.StringDeduplicationRule_RULE_NAME), //$NON-NLS-1$
-				JfrRuleTopics.HEAP_TOPIC, STRING_ARRAY_LIVESET_RATIO_AND_HEAP_USAGE_LIMIT,
+				JfrRuleTopics.HEAP, STRING_ARRAY_LIVESET_RATIO_AND_HEAP_USAGE_LIMIT,
 				STRING_ARRAY_ALLOCATION_RATIO_AND_HEAP_USAGE_LIMIT, STRING_ARRAY_ALLOCATION_FRAMES);
 	}
 

--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/memory/SystemGcRule.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/memory/SystemGcRule.java
@@ -116,6 +116,6 @@ public class SystemGcRule implements IRule {
 
 	@Override
 	public String getTopic() {
-		return JfrRuleTopics.GARBAGE_COLLECTION_TOPIC;
+		return JfrRuleTopics.GARBAGE_COLLECTION;
 	}
 }

--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/memory/TlabAllocationRatioRule.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/memory/TlabAllocationRatioRule.java
@@ -124,7 +124,7 @@ public class TlabAllocationRatioRule implements IRule {
 
 	@Override
 	public String getTopic() {
-		return JfrRuleTopics.TLAB_TOPIC;
+		return JfrRuleTopics.TLAB;
 	}
 
 }

--- a/core/org.openjdk.jmc.flightrecorder.rules/src/main/java/org/openjdk/jmc/flightrecorder/rules/util/JfrRuleTopics.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules/src/main/java/org/openjdk/jmc/flightrecorder/rules/util/JfrRuleTopics.java
@@ -35,36 +35,31 @@ package org.openjdk.jmc.flightrecorder.rules.util;
 /**
  * A number of constant strings that are used as topics by JMC rules and pages. These are only used
  * as a convenience, you are by no means limited to these strings.
- * <p>
- * NOTE: If we want the word TOPIC in these constants, it should be the first word. Let's consider
- * this for 8.0.0. See JMC-6487.
  */
 public final class JfrRuleTopics {
-	public static final String CLASS_LOADING_TOPIC = "classloading"; //$NON-NLS-1$
-	public static final String CODE_CACHE_TOPIC = "code_cache"; //$NON-NLS-1$
-	public static final String COMPILATIONS_TOPIC = "compilations"; //$NON-NLS-1$
-	public static final String ENVIRONMENT_VARIABLES_TOPIC = "environment_variables"; //$NON-NLS-1$
-	public static final String EXCEPTIONS_TOPIC = "exceptions"; //$NON-NLS-1$
-	public static final String FILE_IO_TOPIC = "file_io"; //$NON-NLS-1$
-	public static final String SOCKET_IO_TOPIC = "socket_io"; //$NON-NLS-1$
-	public static final String GARBAGE_COLLECTION_TOPIC = "garbage_collection"; //$NON-NLS-1$
-	public static final String GC_CONFIGURATION_TOPIC = "gc_configuration"; //$NON-NLS-1$
-	public static final String TLAB_TOPIC = "tlab"; //$NON-NLS-1$
-	public static final String HEAP_TOPIC = "heap"; //$NON-NLS-1$
-	public static final String LOCK_INSTANCES_TOPIC = "lock_instances"; //$NON-NLS-1$
-	public static final String JAVA_APPLICATION_TOPIC = "java_application"; //$NON-NLS-1$
-	public static final String METHOD_PROFILING_TOPIC = "method_profiling"; //$NON-NLS-1$
-	public static final String JVM_INFORMATION_TOPIC = "jvm_information"; //$NON-NLS-1$
-	public static final String SYSTEM_PROPERTIES_TOPIC = "system_properties"; //$NON-NLS-1$
-	public static final String SYSTEM_INFORMATION_TOPIC = "system_information"; //$NON-NLS-1$
-	public static final String PROCESSES_TOPIC = "processes"; //$NON-NLS-1$
-	public static final String RECORDING_TOPIC = "recording"; //$NON-NLS-1$
-	public static final String THREAD_DUMPS_TOPIC = "thread_dumps"; //$NON-NLS-1$
-	public static final String THREADS_TOPIC = "threads"; //$NON-NLS-1$
-	public static final String VM_OPERATIONS_TOPIC = "vm_operations"; //$NON-NLS-1$
-	public static final String MEMORY_LEAK_TOPIC = "memoryleak"; //$NON-NLS-1$
-	public static final String BIASED_LOCKING_TOPIC = "biased_locking"; //$NON-NLS-1$
-	public static final String NATIVE_LIBRARY_TOPIC = "native_library"; //$NON-NLS-1$
-	@Deprecated
 	public static final String BIASED_LOCKING = "biased_locking"; //$NON-NLS-1$
+	public static final String CLASS_LOADING = "classloading"; //$NON-NLS-1$
+	public static final String CODE_CACHE = "code_cache"; //$NON-NLS-1$
+	public static final String COMPILATIONS = "compilations"; //$NON-NLS-1$
+	public static final String ENVIRONMENT_VARIABLES = "environment_variables"; //$NON-NLS-1$
+	public static final String EXCEPTIONS = "exceptions"; //$NON-NLS-1$
+	public static final String FILE_IO = "file_io"; //$NON-NLS-1$
+	public static final String GARBAGE_COLLECTION = "garbage_collection"; //$NON-NLS-1$
+	public static final String GC_CONFIGURATION = "gc_configuration"; //$NON-NLS-1$
+	public static final String HEAP = "heap"; //$NON-NLS-1$
+	public static final String JAVA_APPLICATION = "java_application"; //$NON-NLS-1$
+	public static final String JVM_INFORMATION = "jvm_information"; //$NON-NLS-1$
+	public static final String LOCK_INSTANCES = "lock_instances"; //$NON-NLS-1$
+	public static final String MEMORY_LEAK = "memoryleak"; //$NON-NLS-1$
+	public static final String METHOD_PROFILING = "method_profiling"; //$NON-NLS-1$
+	public static final String NATIVE_LIBRARY = "native_library"; //$NON-NLS-1$
+	public static final String PROCESSES = "processes"; //$NON-NLS-1$
+	public static final String RECORDING = "recording"; //$NON-NLS-1$
+	public static final String SOCKET_IO = "socket_io"; //$NON-NLS-1$
+	public static final String SYSTEM_INFORMATION = "system_information"; //$NON-NLS-1$
+	public static final String SYSTEM_PROPERTIES = "system_properties"; //$NON-NLS-1$
+	public static final String THREAD_DUMPS = "thread_dumps"; //$NON-NLS-1$
+	public static final String THREADS = "threads"; //$NON-NLS-1$
+	public static final String TLAB = "tlab"; //$NON-NLS-1$
+	public static final String VM_OPERATIONS = "vm_operations"; //$NON-NLS-1$
 }


### PR DESCRIPTION
Simply removed "_TOPIC".
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JMC-6487](https://bugs.openjdk.java.net/browse/JMC-6487): The TOPIC word in topic constants should either be the first word or removed


### Reviewers
 * [Henrik Dafgård](https://openjdk.java.net/census#hdafgard) (@Gunde - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jmc pull/102/head:pull/102`
`$ git checkout pull/102`
