### PR TITLE
6000: Get rid of build warnings in the JMC agent

### DIFF
--- a/agent/pom.xml
+++ b/agent/pom.xml
@@ -52,7 +52,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-shade-plugin</artifactId>
-				<version>3.1.1</version>
+				<version>3.2.4</version>
 				<configuration>
 					<artifactSet>
 						<includes>
@@ -65,6 +65,15 @@
 							<shadedPattern>org.openjdk.jmc.internal.org.objectweb.asm.</shadedPattern>
 						</relocation>
 					</relocations>
+					<filters>
+						<filter>
+							<artifact>*:*</artifact>
+							<excludes>
+								<exclude>module-info.class</exclude>
+								<exclude>META-INF/MANIFEST.MF</exclude>
+							</excludes>
+						</filter>
+					</filters>
 				</configuration>
 				<executions>
 					<execution>


### PR DESCRIPTION
Solution : excluded "module-info.class" and META-INF/MANIFEST.MF (maven-shade-plugin has detected that some class files are present in two or more jars).
for below warnings

[WARNING] Discovered module-info.class. Shading will break its strong encapsulation.