### PR TITLE
6886: Agent ASM components are constructed with the wrong version of …

### DIFF
--- a/agent/src/main/java/org/openjdk/jmc/agent/jfr/impl/JFRClassVisitor.java
+++ b/agent/src/main/java/org/openjdk/jmc/agent/jfr/impl/JFRClassVisitor.java
@@ -53,7 +53,7 @@ public class JFRClassVisitor extends ClassVisitor implements Opcodes {
 	public JFRClassVisitor(ClassWriter cv, JFRTransformDescriptor descriptor, ClassLoader definingLoader,
 			Class<?> classBeingRedefined, ProtectionDomain protectionDomain,
 			InspectionClassLoader inspectionClassLoader) {
-		super(Opcodes.ASM5, cv);
+		super(Opcodes.ASM8, cv);
 		this.transformDescriptor = descriptor;
 		this.definingClassLoader = definingLoader;
 		this.protectionDomain = protectionDomain;
@@ -73,7 +73,7 @@ public class JFRClassVisitor extends ClassVisitor implements Opcodes {
 		MethodVisitor mv = super.visitMethod(access, name, desc, signature, exceptions);
 		if (name.equals(transformDescriptor.getMethod().getName())
 				&& desc.equals(transformDescriptor.getMethod().getSignature())) {
-			return new JFRMethodAdvisor(transformDescriptor, inspectionClass, Opcodes.ASM5, mv, access, name, desc);
+			return new JFRMethodAdvisor(transformDescriptor, inspectionClass, Opcodes.ASM8, mv, access, name, desc);
 		}
 		return mv;
 	}

--- a/agent/src/main/java/org/openjdk/jmc/agent/jfrnext/impl/JFRNextClassVisitor.java
+++ b/agent/src/main/java/org/openjdk/jmc/agent/jfrnext/impl/JFRNextClassVisitor.java
@@ -54,7 +54,7 @@ public class JFRNextClassVisitor extends ClassVisitor {
 	public JFRNextClassVisitor(ClassWriter cv, JFRTransformDescriptor descriptor, ClassLoader definingLoader,
 			Class<?> classBeingRedefined, ProtectionDomain protectionDomain,
 			InspectionClassLoader inspectionClassLoader) {
-		super(Opcodes.ASM5, cv);
+		super(Opcodes.ASM8, cv);
 		this.transformDescriptor = descriptor;
 		this.definingClassLoader = definingLoader;
 		this.protectionDomain = protectionDomain;
@@ -74,7 +74,7 @@ public class JFRNextClassVisitor extends ClassVisitor {
 		MethodVisitor mv = super.visitMethod(access, name, desc, signature, exceptions);
 		if (name.equals(transformDescriptor.getMethod().getName())
 				&& desc.equals(transformDescriptor.getMethod().getSignature())) {
-			return new JFRNextMethodAdvisor(transformDescriptor, inspectionClass, Opcodes.ASM5, mv, access, name, desc);
+			return new JFRNextMethodAdvisor(transformDescriptor, inspectionClass, Opcodes.ASM8, mv, access, name, desc);
 		}
 		return mv;
 	}

--- a/agent/src/test/java/org/openjdk/jmc/agent/test/TestDefineEventProbes.java
+++ b/agent/src/test/java/org/openjdk/jmc/agent/test/TestDefineEventProbes.java
@@ -144,7 +144,7 @@ public class TestDefineEventProbes {
 				if (!name.equals("<init>")) {
 					return mv;
 				}
-				return new AdviceAdapter(Opcodes.ASM5, mv, access, name, "()V") {
+				return new AdviceAdapter(Opcodes.ASM8, mv, access, name, "()V") {
 					@Override
 					protected void onMethodExit(int opcode) {
 						mv.visitTypeInsn(Opcodes.NEW, "java/lang/RuntimeException");


### PR DESCRIPTION
This PR addresses JMC-6886. When we bumped the version of ASM up to 8.0.1 it broke the agent since some of the calls we were using started to enforce opcodes above ASM7. This PR updates the constructed ASM components to use Opcodes.ASM8 instead  of Opcodes.ASM5.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JMC-6886](https://bugs.openjdk.java.net/browse/JMC-6886): Agent ASM components are constructed with the wrong version of Opcodes ⚠️ Title mismatch between PR and JBS.


### Reviewers
 * Guru Hb ([ghb](@guruhb) - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jmc pull/104/head:pull/104`
`$ git checkout pull/104`
