### PR TITLE
6897: Remove unused javax imports

### DIFF
--- a/application/org.openjdk.jmc.console.ui/META-INF/MANIFEST.MF
+++ b/application/org.openjdk.jmc.console.ui/META-INF/MANIFEST.MF
@@ -10,7 +10,6 @@ Bundle-Localization: plugin
 Require-Bundle: org.openjdk.jmc.rjmx.ui;visibility:=reexport,
  org.eclipse.e4.core.contexts;bundle-version="1.3.0",
  org.eclipse.e4.core.di;bundle-version="1.3.0";visibility:=reexport,
- javax.annotation;bundle-version="1.0.0";visibility:=reexport,
  javax.inject;bundle-version="1.0.0";visibility:=reexport,
  org.openjdk.jmc.commands
 Bundle-ActivationPolicy: lazy
@@ -24,7 +23,6 @@ Export-Package: org.openjdk.jmc.console.ui.actions;
  org.openjdk.jmc.console.ui.messages.internal;x-friends:="org.openjdk.jmc.console.uitest",
  org.openjdk.jmc.console.ui.preferences;x-friends:="org.openjdk.jmc.console.uitest"
 Bundle-ClassPath: .
-Import-Package: javax.annotation;version="1.0.0",
- javax.inject;version="1.0.0"
+Import-Package: javax.inject;version="1.0.0"
 Automatic-Module-Name: org.openjdk.jmc.console.ui
 

--- a/application/org.openjdk.jmc.feature.rcp/feature.xml
+++ b/application/org.openjdk.jmc.feature.rcp/feature.xml
@@ -88,7 +88,6 @@
       <import plugin="org.eclipse.ui.intro"/>
       <import plugin="org.eclipse.ui.net"/>
       <import plugin="org.eclipse.equinox.event"/>
-      <import plugin="javax.el"/>
       <import plugin="org.eclipse.equinox.p2.director.app"/>
    </requires>
 


### PR DESCRIPTION
JMC seemed to run fine with this patch. I was able to use the MXBeanBrowser, dump a flight recording of JMC and view the flight recording.