### PR TITLE
6898: Installing from IDE update site complains about missing LZ4 plug-in

### DIFF
--- a/application/org.openjdk.jmc.feature.core/feature.xml
+++ b/application/org.openjdk.jmc.feature.core/feature.xml
@@ -84,6 +84,13 @@
          unpack="false"/>
 
    <plugin
+         id="org.lz4.lz4-java"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
          id="org.openjdk.jmc.ui"
          download-size="0"
          install-size="0"

--- a/application/org.openjdk.jmc.feature.flightrecorder/feature.xml
+++ b/application/org.openjdk.jmc.feature.flightrecorder/feature.xml
@@ -130,6 +130,13 @@
          unpack="false"/>
 
    <plugin
+         id="org.lz4.lz4-java"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
          id="org.hdrhistogram.HdrHistogram"
          download-size="0"
          install-size="0"


### PR DESCRIPTION
This is due to the LZ4 plug-in not included in the appropriate features.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JMC-6898](https://bugs.openjdk.java.net/browse/JMC-6898): Installing from IDE update site complains about missing LZ4 plug-in


### Reviewers
 * Guru Hb ([ghb](@guruhb) - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jmc pull/107/head:pull/107`
`$ git checkout pull/107`
