### PR TITLE
6902: Console plug-ins with icons not found will fail

### DIFF
--- a/application/org.openjdk.jmc.console.ui/src/main/java/org/openjdk/jmc/console/ui/editor/internal/ConsoleFormPage.java
+++ b/application/org.openjdk.jmc.console.ui/src/main/java/org/openjdk/jmc/console/ui/editor/internal/ConsoleFormPage.java
@@ -33,6 +33,7 @@
 package org.openjdk.jmc.console.ui.editor.internal;
 
 import java.io.StringReader;
+import java.util.logging.Level;
 
 import javax.inject.Inject;
 
@@ -53,6 +54,7 @@ import org.eclipse.ui.forms.IManagedForm;
 import org.eclipse.ui.forms.IMessageManager;
 import org.eclipse.ui.forms.editor.FormPage;
 import org.eclipse.ui.forms.widgets.Form;
+import org.openjdk.jmc.console.ui.ConsolePlugin;
 import org.openjdk.jmc.console.ui.editor.IConsolePageContainer;
 import org.openjdk.jmc.console.ui.editor.IConsolePageStateHandler;
 import org.openjdk.jmc.rjmx.IConnectionHandle;
@@ -174,7 +176,12 @@ public class ConsoleFormPage extends FormPage implements IConsolePageContainer {
 		if (iconName != null) {
 			String pluginId = config.getDeclaringExtension().getContributor().getName();
 			ImageDescriptor iconDesc = ResourceLocator.imageDescriptorFromBundle(pluginId, iconName).orElse(null);
-			icon = (Image) JFaceResources.getResources().get(iconDesc);
+			if (iconDesc != null) {
+				icon = (Image) JFaceResources.getResources().get(iconDesc);
+			} else {
+				ConsolePlugin.getDefault().getLogger().log(Level.WARNING,
+						"Could not load icon " + iconName + " for plug-in " + pluginId);
+			}
 		}
 	}
 


### PR DESCRIPTION
The tab will get a null pointer during initialization and not show up at all. Currently the PDE plug-in will not properly include icon resources in the generated projects. That's a separate issue that will have to be looked into.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JMC-6902](https://bugs.openjdk.java.net/browse/JMC-6902): Console plug-ins with icons not found will fail


### Reviewers
 * [Henrik Dafgård](https://openjdk.java.net/census#hdafgard) (@Gunde - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jmc pull/108/head:pull/108`
`$ git checkout pull/108`
