### PR TITLE
6913: Add daemon thread information to the console threads view

### DIFF
--- a/application/org.openjdk.jmc.console.ui/src/main/java/org/openjdk/jmc/console/ui/messages/internal/Messages.java
+++ b/application/org.openjdk.jmc.console.ui/src/main/java/org/openjdk/jmc/console/ui/messages/internal/Messages.java
@@ -97,6 +97,7 @@ public class Messages extends NLS {
 	public static String IS_SUSPENDED_DESCRIPTION_TEXT;
 	public static String IS_SUSPENDED_NAME_TEXT;
 	public static String IS_DAEMON_NAME_TEXT;
+	public static String IS_DAEMON_ERROR_VALUE;
 	public static String IS_DAEMON_DESCRIPTION_TEXT;
 	public static String LIBRARY_PATH_LABEL;
 	public static String LOCK_NAME_DESCRIPTION_TEXT;

--- a/application/org.openjdk.jmc.console.ui/src/main/java/org/openjdk/jmc/console/ui/messages/internal/Messages.java
+++ b/application/org.openjdk.jmc.console.ui/src/main/java/org/openjdk/jmc/console/ui/messages/internal/Messages.java
@@ -96,6 +96,8 @@ public class Messages extends NLS {
 	public static String IS_NATIVE_NAME_TEXT;
 	public static String IS_SUSPENDED_DESCRIPTION_TEXT;
 	public static String IS_SUSPENDED_NAME_TEXT;
+	public static String IS_DAEMON_NAME_TEXT;
+	public static String IS_DAEMON_DESCRIPTION_TEXT;
 	public static String LIBRARY_PATH_LABEL;
 	public static String LOCK_NAME_DESCRIPTION_TEXT;
 	public static String LOCK_NAME_NAME_TEXT;

--- a/application/org.openjdk.jmc.console.ui/src/main/java/org/openjdk/jmc/console/ui/tabs/threads/ThreadInfoCompositeSupport.java
+++ b/application/org.openjdk.jmc.console.ui/src/main/java/org/openjdk/jmc/console/ui/tabs/threads/ThreadInfoCompositeSupport.java
@@ -207,7 +207,15 @@ public class ThreadInfoCompositeSupport {
 
 	public static final IMemberAccessor<Object, ThreadInfoCompositeSupport> IS_IN_NATIVE = new Getter(IN_NATIVE);
 
-	public static final IMemberAccessor<Object, ThreadInfoCompositeSupport> IS_DAEMON = new Getter(DAEMON);
+	public static final IMemberAccessor<Object, ThreadInfoCompositeSupport> IS_DAEMON = new IMemberAccessor<Object, ThreadInfoCompositeSupport>() {
+
+		@Override
+		public Object getMember(ThreadInfoCompositeSupport inObject) {
+			return inObject.compositeData.containsKey(DAEMON) ? inObject.compositeData.get(DAEMON)
+					: Messages.IS_DAEMON_ERROR_VALUE;
+		}
+
+	};
 
 	public static final IMemberAccessor<Object, ThreadInfoCompositeSupport> IS_SUSPENDED = new Getter(SUSPENDED);
 

--- a/application/org.openjdk.jmc.console.ui/src/main/java/org/openjdk/jmc/console/ui/tabs/threads/ThreadInfoCompositeSupport.java
+++ b/application/org.openjdk.jmc.console.ui/src/main/java/org/openjdk/jmc/console/ui/tabs/threads/ThreadInfoCompositeSupport.java
@@ -63,6 +63,7 @@ public class ThreadInfoCompositeSupport {
 	private static final String STACK_TRACE = "stackTrace"; //$NON-NLS-1$
 	private static final String SUSPENDED = "suspended"; //$NON-NLS-1$
 	private static final String IN_NATIVE = "inNative"; //$NON-NLS-1$
+	private static final String DAEMON = "daemon"; //$NON-NLS-1$
 
 	private static final String CLASS_NAME = "className"; //$NON-NLS-1$
 	private static final String METHOD_NAME = "methodName"; //$NON-NLS-1$
@@ -205,6 +206,8 @@ public class ThreadInfoCompositeSupport {
 			LOCK_OWNER_NAME);
 
 	public static final IMemberAccessor<Object, ThreadInfoCompositeSupport> IS_IN_NATIVE = new Getter(IN_NATIVE);
+
+	public static final IMemberAccessor<Object, ThreadInfoCompositeSupport> IS_DAEMON = new Getter(DAEMON);
 
 	public static final IMemberAccessor<Object, ThreadInfoCompositeSupport> IS_SUSPENDED = new Getter(SUSPENDED);
 

--- a/application/org.openjdk.jmc.console.ui/src/main/java/org/openjdk/jmc/console/ui/tabs/threads/ThreadTableSectionPart.java
+++ b/application/org.openjdk.jmc.console.ui/src/main/java/org/openjdk/jmc/console/ui/tabs/threads/ThreadTableSectionPart.java
@@ -174,9 +174,11 @@ public class ThreadTableSectionPart extends MCSectionPart implements Pollable, I
 				ThreadInfoCompositeSupport.IS_IN_NATIVE).description(Messages.IS_NATIVE_DESCRIPTION_TEXT).build();
 		IColumn isSuspended = new ColumnBuilder(Messages.IS_SUSPENDED_NAME_TEXT, "isSuspended", //$NON-NLS-1$
 				ThreadInfoCompositeSupport.IS_SUSPENDED).description(Messages.IS_SUSPENDED_DESCRIPTION_TEXT).build();
+		IColumn isDaemon = new ColumnBuilder(Messages.IS_DAEMON_NAME_TEXT, "isDaemon", //$NON-NLS-1$
+				ThreadInfoCompositeSupport.IS_DAEMON).description(Messages.IS_DAEMON_DESCRIPTION_TEXT).build();
 
 		List<IColumn> columns = Arrays.asList(name, blockedCount, blockedTime, lockName, lockOwnerId, lockOwnerName,
-				threadId, threadState, waitCount, waitTime, isInNative, isSuspended, isDeadlocked, cpuUsage, alloc);
+				threadId, threadState, waitCount, waitTime, isInNative, isSuspended, isDeadlocked, isDaemon, cpuUsage, alloc);
 		return ColumnManager.build(viewer, columns, TableSettings.forState(MementoToolkit.asState(state)));
 
 	}

--- a/application/org.openjdk.jmc.console.ui/src/main/java/org/openjdk/jmc/console/ui/tabs/threads/ThreadTableSectionPart.java
+++ b/application/org.openjdk.jmc.console.ui/src/main/java/org/openjdk/jmc/console/ui/tabs/threads/ThreadTableSectionPart.java
@@ -178,7 +178,8 @@ public class ThreadTableSectionPart extends MCSectionPart implements Pollable, I
 				ThreadInfoCompositeSupport.IS_DAEMON).description(Messages.IS_DAEMON_DESCRIPTION_TEXT).build();
 
 		List<IColumn> columns = Arrays.asList(name, blockedCount, blockedTime, lockName, lockOwnerId, lockOwnerName,
-				threadId, threadState, waitCount, waitTime, isInNative, isSuspended, isDeadlocked, isDaemon, cpuUsage, alloc);
+				threadId, threadState, waitCount, waitTime, isInNative, isSuspended, isDeadlocked, isDaemon, cpuUsage,
+				alloc);
 		return ColumnManager.build(viewer, columns, TableSettings.forState(MementoToolkit.asState(state)));
 
 	}

--- a/application/org.openjdk.jmc.console.ui/src/main/resources/org/openjdk/jmc/console/ui/messages/internal/messages.properties
+++ b/application/org.openjdk.jmc.console.ui/src/main/resources/org/openjdk/jmc/console/ui/messages/internal/messages.properties
@@ -175,7 +175,7 @@ IS_DEADLOCKED_NAME_TEXT=Deadlocked
 IS_DEADLOCKED_DESCRIPTION_TEXT=True if the thread is deadlocked. Use the toolbar icon to enable or disable deadlock detection
 IS_DAEMON_NAME_TEXT=Daemon
 IS_DAEMON_ERROR_VALUE=Data not available
-IS_DAEMON_DESCRIPTION_TEXT=True if the thread is a daemon thread.
+IS_DAEMON_DESCRIPTION_TEXT=True if the thread is a daemon thread
 CPU_USAGE_NAME_TEXT=Total CPU Usage
 CPU_USAGE_DESCRIPTION_TEXT=The CPU usage for the thread (both in user and kernel mode) as percent of total CPU usage available on the machine
 

--- a/application/org.openjdk.jmc.console.ui/src/main/resources/org/openjdk/jmc/console/ui/messages/internal/messages.properties
+++ b/application/org.openjdk.jmc.console.ui/src/main/resources/org/openjdk/jmc/console/ui/messages/internal/messages.properties
@@ -173,6 +173,8 @@ IS_SUSPENDED_NAME_TEXT=Suspended
 IS_SUSPENDED_DESCRIPTION_TEXT=True if the thread is suspended
 IS_DEADLOCKED_NAME_TEXT=Deadlocked
 IS_DEADLOCKED_DESCRIPTION_TEXT=True if the thread is deadlocked. Use the toolbar icon to enable or disable deadlock detection
+IS_DAEMON_NAME_TEXT=Daemon
+IS_DAEMON_DESCRIPTION_TEXT=True if the thread is a daemon thread.
 CPU_USAGE_NAME_TEXT=Total CPU Usage
 CPU_USAGE_DESCRIPTION_TEXT=The CPU usage for the thread (both in user and kernel mode) as percent of total CPU usage available on the machine
 

--- a/application/org.openjdk.jmc.console.ui/src/main/resources/org/openjdk/jmc/console/ui/messages/internal/messages.properties
+++ b/application/org.openjdk.jmc.console.ui/src/main/resources/org/openjdk/jmc/console/ui/messages/internal/messages.properties
@@ -174,6 +174,7 @@ IS_SUSPENDED_DESCRIPTION_TEXT=True if the thread is suspended
 IS_DEADLOCKED_NAME_TEXT=Deadlocked
 IS_DEADLOCKED_DESCRIPTION_TEXT=True if the thread is deadlocked. Use the toolbar icon to enable or disable deadlock detection
 IS_DAEMON_NAME_TEXT=Daemon
+IS_DAEMON_ERROR_VALUE=Data not available
 IS_DAEMON_DESCRIPTION_TEXT=True if the thread is a daemon thread.
 CPU_USAGE_NAME_TEXT=Total CPU Usage
 CPU_USAGE_DESCRIPTION_TEXT=The CPU usage for the thread (both in user and kernel mode) as percent of total CPU usage available on the machine


### PR DESCRIPTION
I had an Java application which did not exit because of a non-daemon thread still running. Therefore I added a column to the treads view that displays if a thread is a daemon thread or not.

oca: has been signed on 2019-01-17 (got positive response from Dalibor Topic on 2019-01-23).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JMC-6913](https://bugs.openjdk.java.net/browse/JMC-6913): Add daemon thread information to the console threads view


### Reviewers
 * [Alex Macdonald](https://openjdk.java.net/census#aptmac) (@aptmac - Committer)
 * [Guru Hb](https://openjdk.java.net/census#ghb) (@guruhb - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jmc pull/110/head:pull/110`
`$ git checkout pull/110`
