### PR TITLE
6916: JOverflow treemap listener depending on internal SWT class

### DIFF
--- a/application/org.openjdk.jmc.joverflow.ui/src/main/java/org/openjdk/jmc/joverflow/ui/TreemapAction.java
+++ b/application/org.openjdk.jmc.joverflow.ui/src/main/java/org/openjdk/jmc/joverflow/ui/TreemapAction.java
@@ -39,8 +39,6 @@ import org.eclipse.jface.resource.ImageDescriptor;
 import org.openjdk.jmc.ui.CoreImages;
 
 class TreemapAction extends Action {
-	private static final String ICON_RESET = "reset.gif"; //$NON-NLS-1$
-
 	private final TreemapActionType actionType;
 	private Runnable runnable = () -> {
 	};

--- a/application/org.openjdk.jmc.joverflow.ui/src/main/java/org/openjdk/jmc/joverflow/ui/swt/events/TreemapListener.java
+++ b/application/org.openjdk.jmc.joverflow.ui/src/main/java/org/openjdk/jmc/joverflow/ui/swt/events/TreemapListener.java
@@ -33,16 +33,16 @@
  */
 package org.openjdk.jmc.joverflow.ui.swt.events;
 
-import org.eclipse.swt.internal.SWTEventListener;
-import org.openjdk.jmc.joverflow.ui.swt.Treemap;
-
+import java.util.EventListener;
 import java.util.function.Consumer;
+
+import org.openjdk.jmc.joverflow.ui.swt.Treemap;
 
 /**
  * Classes which implement this interface provide methods that deal with setting new item as top for
  * a treemap.
  */
-public interface TreemapListener extends SWTEventListener {
+public interface TreemapListener extends EventListener {
 
 	/**
 	 * Sent when a treemap becomes the new top.


### PR DESCRIPTION
Also removing unused constant.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JMC-6916](https://bugs.openjdk.java.net/browse/JMC-6916): JOverflow treemap listener depending on internal SWT class


### Reviewers
 * [Alex Macdonald](https://openjdk.java.net/census#aptmac) (@aptmac - Committer)
 * [Guru Hb](https://openjdk.java.net/census#ghb) (@guruhb - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jmc pull/116/head:pull/116`
`$ git checkout pull/116`
