### PR TITLE
6899: Upgrade core to 8

### DIFF
--- a/core/org.openjdk.jmc.common/.classpath
+++ b/core/org.openjdk.jmc.common/.classpath
@@ -11,7 +11,7 @@
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7">
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8">
 		<attributes>
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>

--- a/core/org.openjdk.jmc.common/META-INF/MANIFEST.MF
+++ b/core/org.openjdk.jmc.common/META-INF/MANIFEST.MF
@@ -1,6 +1,6 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-RequiredExecutionEnvironment: JavaSE-1.7
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-Name: Common Plug-in
 Bundle-SymbolicName: org.openjdk.jmc.common;singleton:=true
 Bundle-Version: 8.0.0.qualifier

--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/.classpath
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/.classpath
@@ -11,7 +11,7 @@
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7">
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8">
 		<attributes>
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>

--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/.settings/org.eclipse.jdt.core.prefs
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/.settings/org.eclipse.jdt.core.prefs
@@ -1,8 +1,8 @@
 eclipse.preferences.version=1
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.7
-org.eclipse.jdt.core.compiler.compliance=1.7
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
+org.eclipse.jdt.core.compiler.compliance=1.8
 org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
 org.eclipse.jdt.core.compiler.problem.forbiddenReference=warning
 org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=ignore
 org.eclipse.jdt.core.compiler.release=disabled
-org.eclipse.jdt.core.compiler.source=1.7
+org.eclipse.jdt.core.compiler.source=1.8

--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/META-INF/MANIFEST.MF
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: Mission Control Flight Recorder Rules
 Bundle-SymbolicName: org.openjdk.jmc.flightrecorder.rules.jdk;singleton:=true
 Bundle-Version: 8.0.0.qualifier
 Bundle-Vendor: Oracle Corporation
-Bundle-RequiredExecutionEnvironment: JavaSE-1.7
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: org.openjdk.jmc.flightrecorder.rules.jdk.cpu;x-friends:="org.openjdk.jmc.flightrecorder.ui",
  org.openjdk.jmc.flightrecorder.rules.jdk.dataproviders,
  org.openjdk.jmc.flightrecorder.rules.jdk.exceptions;x-friends:="org.openjdk.jmc.flightrecorder.ui",

--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/compilation/CodeCacheRule.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/compilation/CodeCacheRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -44,6 +44,7 @@ import java.util.concurrent.RunnableFuture;
 
 import org.openjdk.jmc.common.IDisplayable;
 import org.openjdk.jmc.common.item.Aggregators;
+import org.openjdk.jmc.common.item.IAggregator;
 import org.openjdk.jmc.common.item.IItem;
 import org.openjdk.jmc.common.item.IItemCollection;
 import org.openjdk.jmc.common.item.IType;
@@ -167,31 +168,32 @@ public class CodeCacheRule implements IRule {
 			if (!ccType.hasAttribute(JdkAttributes.PROFILED_SIZE)) {
 				return RulesToolkit.getMissingAttributeResult(this, ccType, JdkAttributes.PROFILED_SIZE);
 			}
-			IQuantity profiledAggregate = items
-					.getAggregate(Aggregators.filter(Aggregators.min(JdkAttributes.UNALLOCATED),
+			IQuantity profiledAggregate = items.getAggregate(
+					(IAggregator<IQuantity, ?>) Aggregators.filter(Aggregators.min(JdkAttributes.UNALLOCATED),
 							ItemFilters.matches(JdkAttributes.CODE_HEAP, PROFILED_NAME)));
 			IQuantity profiledRatio = null;
 			if (profiledAggregate != null) {
-				profiledRatio = UnitLookup.PERCENT_UNITY.quantity(
-						profiledAggregate.ratioTo(items.getAggregate(Aggregators.min(JdkAttributes.PROFILED_SIZE))));
+				profiledRatio = UnitLookup.PERCENT_UNITY.quantity(profiledAggregate.ratioTo(
+						items.getAggregate((IAggregator<IQuantity, ?>) Aggregators.min(JdkAttributes.PROFILED_SIZE))));
 			} else {
 				profiledRatio = UnitLookup.PERCENT_UNITY.quantity(1.0);
 			}
-			IQuantity nonProfiledAggregate = items
-					.getAggregate(Aggregators.filter(Aggregators.min(JdkAttributes.UNALLOCATED),
+			IQuantity nonProfiledAggregate = items.getAggregate(
+					(IAggregator<IQuantity, ?>) Aggregators.filter(Aggregators.min(JdkAttributes.UNALLOCATED),
 							ItemFilters.matches(JdkAttributes.CODE_HEAP, NON_PROFILED_NAME)));
 			IQuantity nonProfiledRatio = null;
 			if (nonProfiledAggregate != null) {
-				nonProfiledRatio = UnitLookup.PERCENT_UNITY.quantity(nonProfiledAggregate
-						.ratioTo(items.getAggregate(Aggregators.min(JdkAttributes.NON_PROFILED_SIZE))));
+				nonProfiledRatio = UnitLookup.PERCENT_UNITY.quantity(nonProfiledAggregate.ratioTo(items
+						.getAggregate((IAggregator<IQuantity, ?>) Aggregators.min(JdkAttributes.NON_PROFILED_SIZE))));
 			} else {
 				nonProfiledRatio = UnitLookup.PERCENT_UNITY.quantity(1.0);
 			}
-
 			IQuantity nonNMethodsRatio = UnitLookup.PERCENT_UNITY.quantity(items
-					.getAggregate(Aggregators.filter(Aggregators.min(JdkAttributes.UNALLOCATED),
-							ItemFilters.matches(JdkAttributes.CODE_HEAP, NON_NMETHODS_NAME)))
-					.ratioTo(items.getAggregate(Aggregators.min(JdkAttributes.NON_NMETHOD_SIZE))));
+					.getAggregate(
+							(IAggregator<IQuantity, ?>) Aggregators.filter(Aggregators.min(JdkAttributes.UNALLOCATED),
+									ItemFilters.matches(JdkAttributes.CODE_HEAP, NON_NMETHODS_NAME)))
+					.ratioTo(items.getAggregate(
+							(IAggregator<IQuantity, ?>) Aggregators.min(JdkAttributes.NON_NMETHOD_SIZE))));
 			List<CodeHeapData> heaps = new ArrayList<>();
 			addIfHalfFull(profiledRatio, heaps, PROFILED_NAME);
 			addIfHalfFull(nonProfiledRatio, heaps, NON_PROFILED_NAME);
@@ -230,10 +232,10 @@ public class CodeCacheRule implements IRule {
 			if (!ccType.hasAttribute(JdkAttributes.RESERVED_SIZE)) {
 				return RulesToolkit.getMissingAttributeResult(this, ccType, JdkAttributes.RESERVED_SIZE);
 			}
-			IQuantity codeCacheReserved = items
-					.getAggregate(Aggregators.min(JdkTypeIDs.CODE_CACHE_CONFIG, JdkAttributes.RESERVED_SIZE));
-			IQuantity unallocated = items
-					.getAggregate(Aggregators.min(JdkTypeIDs.CODE_CACHE_STATISTICS, JdkAttributes.UNALLOCATED));
+			IQuantity codeCacheReserved = items.getAggregate((IAggregator<IQuantity, ?>) Aggregators
+					.min(JdkTypeIDs.CODE_CACHE_CONFIG, JdkAttributes.RESERVED_SIZE));
+			IQuantity unallocated = items.getAggregate((IAggregator<IQuantity, ?>) Aggregators
+					.min(JdkTypeIDs.CODE_CACHE_STATISTICS, JdkAttributes.UNALLOCATED));
 			IQuantity unallocatedCodeCachePercent = UnitLookup.PERCENT_UNITY
 					.quantity(unallocated.ratioTo(codeCacheReserved));
 			allocationRatioScore = RulesToolkit.mapExp100(

--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/exceptions/ErrorRule.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/exceptions/ErrorRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -51,6 +51,7 @@ import org.openjdk.jmc.common.IDisplayable;
 import org.openjdk.jmc.common.IMCType;
 import org.openjdk.jmc.common.collection.MapToolkit.IntEntry;
 import org.openjdk.jmc.common.item.Aggregators;
+import org.openjdk.jmc.common.item.IAggregator;
 import org.openjdk.jmc.common.item.IItemCollection;
 import org.openjdk.jmc.common.item.IItemFilter;
 import org.openjdk.jmc.common.item.ItemFilters;
@@ -116,8 +117,9 @@ public class ErrorRule implements IRule {
 			IItemFilter errorsExcludingExclude = ItemFilters.and(ItemFilters.type(JdkTypeIDs.ERRORS_THROWN),
 					ItemFilters.not(matchesExclude));
 			errorItems = errorItems.apply(errorsExcludingExclude);
-			excludedErrors = items.getAggregate(
-					Aggregators.filter(Aggregators.count(), ItemFilters.and(ItemFilters.type(JdkTypeIDs.ERRORS_THROWN),
+
+			excludedErrors = items.getAggregate((IAggregator<IQuantity, ?>) Aggregators.filter(Aggregators.count(),
+					ItemFilters.and(ItemFilters.type(JdkTypeIDs.ERRORS_THROWN),
 							ItemFilters.matches(JdkAttributes.EXCEPTION_THROWNCLASS_NAME, errorExcludeRegexp))));
 		}
 		IQuantity errorCount = errorItems.getAggregate(JdkAggregators.ERROR_COUNT);

--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/general/BufferLostRule.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/general/BufferLostRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -44,6 +44,7 @@ import java.util.concurrent.FutureTask;
 import java.util.concurrent.RunnableFuture;
 
 import org.openjdk.jmc.common.IDisplayable;
+import org.openjdk.jmc.common.item.IAggregator;
 import org.openjdk.jmc.common.item.IItemCollection;
 import org.openjdk.jmc.common.unit.IQuantity;
 import org.openjdk.jmc.common.util.IPreferenceValueProvider;
@@ -77,7 +78,8 @@ public class BufferLostRule implements IRule {
 		 */
 
 		IItemCollection filtered = items.apply(JdkFilters.JFR_DATA_LOST);
-		IQuantity startTime = filtered.getAggregate(JdkAggregators.first(JfrAttributes.START_TIME));
+		IQuantity startTime = filtered
+				.getAggregate((IAggregator<IQuantity, ?>) JdkAggregators.first(JfrAttributes.START_TIME));
 
 		if (startTime != null) {
 			IQuantity droppedCount = filtered.getAggregate(JdkAggregators.JFR_DATA_LOST_COUNT);

--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/general/ClassLoadingRule.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/general/ClassLoadingRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -42,6 +42,7 @@ import java.util.concurrent.RunnableFuture;
 
 import org.openjdk.jmc.common.IDisplayable;
 import org.openjdk.jmc.common.item.Aggregators;
+import org.openjdk.jmc.common.item.IAggregator;
 import org.openjdk.jmc.common.item.IItemCollection;
 import org.openjdk.jmc.common.unit.IQuantity;
 import org.openjdk.jmc.common.unit.UnitLookup;
@@ -90,7 +91,7 @@ public class ClassLoadingRule implements IRule {
 		IQuantity endTime = RulesToolkit.getLatestEndTime(events);
 		if (startTime != null && endTime != null) {
 			IQuantity totalTime = endTime.subtract(startTime);
-			IQuantity max = events.getAggregate(Aggregators.max(JfrAttributes.DURATION));
+			IQuantity max = events.getAggregate((IAggregator<IQuantity, ?>) Aggregators.max(JfrAttributes.DURATION));
 			IQuantity sum = events.getAggregate(Aggregators.sum(JfrAttributes.DURATION));
 			// FIXME: Consider using a score function instead of set value.
 			if ((max.compareTo(maxDurationLimit) > 0) || (sum.ratioTo(totalTime) > ratioOfTotalLimit.doubleValue())) {

--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/general/DuplicateFlagsRule.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/general/DuplicateFlagsRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -42,6 +42,7 @@ import java.util.concurrent.FutureTask;
 import java.util.concurrent.RunnableFuture;
 
 import org.openjdk.jmc.common.item.Aggregators;
+import org.openjdk.jmc.common.item.IAggregator;
 import org.openjdk.jmc.common.item.IItemCollection;
 import org.openjdk.jmc.common.util.IPreferenceValueProvider;
 import org.openjdk.jmc.common.util.StringToolkit;
@@ -72,7 +73,8 @@ public class DuplicateFlagsRule implements IRule {
 		IItemCollection jvmInfoItems = items.apply(JdkFilters.VM_INFO);
 
 		// FIXME: Should we check if there are different jvm args in different chunks?
-		Set<String> args = jvmInfoItems.getAggregate(Aggregators.distinct(JdkAttributes.JVM_ARGUMENTS));
+		Set<String> args = jvmInfoItems
+				.getAggregate((IAggregator<Set<String>, ?>) Aggregators.distinct(JdkAttributes.JVM_ARGUMENTS));
 		if (args != null && !args.isEmpty()) {
 
 			Collection<ArrayList<String>> dupes = JvmInternalsDataProvider.checkDuplicates(args.iterator().next());

--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/general/FewSampledThreadsRule.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/general/FewSampledThreadsRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -228,7 +228,7 @@ public class FewSampledThreadsRule extends AbstractRule {
 
 			// How much cpu could max be used if this is a single threaded application (not counting the JVM threads though...)
 			IQuantity cores = items.apply(ItemFilters.type(JdkTypeIDs.CPU_INFORMATION))
-					.getAggregate(Aggregators.max(JdkAttributes.NUMBER_OF_CORES));
+					.getAggregate((IAggregator<IQuantity, ?>) Aggregators.max(JdkAttributes.NUMBER_OF_CORES));
 			IQuantity maxSingleThreadedCpu = PERCENT.quantity(100 / cores.doubleValue());
 
 			IQuantity maxCpuForSampledThreads = PERCENT
@@ -286,6 +286,6 @@ public class FewSampledThreadsRule extends AbstractRule {
 
 	private static IQuantity getHardwareThreads(IItemCollection items) {
 		return items.apply(ItemFilters.type(JdkTypeIDs.CPU_INFORMATION))
-				.getAggregate(Aggregators.max(JdkAttributes.HW_THREADS));
+				.getAggregate((IAggregator<IQuantity, ?>) Aggregators.max(JdkAttributes.HW_THREADS));
 	}
 }

--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/general/FlightRecordingSupportRule.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/general/FlightRecordingSupportRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -42,6 +42,7 @@ import java.util.concurrent.FutureTask;
 import java.util.concurrent.RunnableFuture;
 
 import org.openjdk.jmc.common.item.Aggregators;
+import org.openjdk.jmc.common.item.IAggregator;
 import org.openjdk.jmc.common.item.IItemCollection;
 import org.openjdk.jmc.common.unit.IQuantity;
 import org.openjdk.jmc.common.unit.UnitLookup;
@@ -164,7 +165,7 @@ public class FlightRecordingSupportRule implements IRule {
 		// Check time conversion error
 		IItemCollection timeConversionItems = items.apply(JdkFilters.TIME_CONVERSION);
 		IQuantity conversionFactor = timeConversionItems
-				.getAggregate(Aggregators.max(attr("fastTimeConversionAdjustments", null, //$NON-NLS-1$
+				.getAggregate((IAggregator<IQuantity, ?>) Aggregators.max(attr("fastTimeConversionAdjustments", null, //$NON-NLS-1$
 						UnitLookup.NUMBER)));
 		Boolean fastTimeEnabled = timeConversionItems
 				.getAggregate(Aggregators.and(JdkTypeIDs.TIME_CONVERSION, attr("fastTimeEnabled", null, //$NON-NLS-1$

--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/general/ManagementAgentRule.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/general/ManagementAgentRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -40,6 +40,7 @@ import java.util.concurrent.FutureTask;
 import java.util.concurrent.RunnableFuture;
 
 import org.openjdk.jmc.common.item.Aggregators;
+import org.openjdk.jmc.common.item.IAggregator;
 import org.openjdk.jmc.common.item.IItemCollection;
 import org.openjdk.jmc.common.item.ItemFilters;
 import org.openjdk.jmc.common.util.IPreferenceValueProvider;
@@ -70,13 +71,13 @@ public class ManagementAgentRule implements IRule {
 
 		Set<String> portStr = properties
 				.apply(ItemFilters.equals(JdkAttributes.ENVIRONMENT_KEY, "com.sun.management.jmxremote.port")) //$NON-NLS-1$
-				.getAggregate(Aggregators.distinct(JdkAttributes.ENVIRONMENT_VALUE));
+				.getAggregate((IAggregator<Set<String>, ?>) Aggregators.distinct(JdkAttributes.ENVIRONMENT_VALUE));
 		Set<String> authStr = properties
 				.apply(ItemFilters.equals(JdkAttributes.ENVIRONMENT_KEY, "com.sun.management.jmxremote.authenticate")) //$NON-NLS-1$
-				.getAggregate(Aggregators.distinct(JdkAttributes.ENVIRONMENT_VALUE));
+				.getAggregate((IAggregator<Set<String>, ?>) Aggregators.distinct(JdkAttributes.ENVIRONMENT_VALUE));
 		Set<String> sslStr = properties
 				.apply(ItemFilters.equals(JdkAttributes.ENVIRONMENT_KEY, "com.sun.management.jmxremote.ssl")) //$NON-NLS-1$
-				.getAggregate(Aggregators.distinct(JdkAttributes.ENVIRONMENT_VALUE));
+				.getAggregate((IAggregator<Set<String>, ?>) Aggregators.distinct(JdkAttributes.ENVIRONMENT_VALUE));
 
 		if (size(portStr) > 1 || size(authStr) > 1 || size(sslStr) > 1) {
 			return new Result(this, 50, Messages.getString(Messages.ManagementAgentRule_TEXT_INFO),

--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/latency/BiasedLockingRevocationRule.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/latency/BiasedLockingRevocationRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -54,6 +54,7 @@ import java.util.logging.Logger;
 
 import org.openjdk.jmc.common.IMCType;
 import org.openjdk.jmc.common.item.Aggregators;
+import org.openjdk.jmc.common.item.IAggregator;
 import org.openjdk.jmc.common.item.IAttribute;
 import org.openjdk.jmc.common.item.IItemCollection;
 import org.openjdk.jmc.common.item.IItemFilter;
@@ -124,8 +125,8 @@ public final class BiasedLockingRevocationRule implements IRule {
 		IItemCollection revokedClassesEvents = revokationEvents
 				.apply(ItemFilters.and(ItemFilters.hasAttribute(JdkAttributes.BIASED_REVOCATION_CLASS),
 						ItemFilters.equals(JdkAttributes.BIASED_REVOCATION_DISABLE_BIASING, Boolean.TRUE)));
-		Set<IMCType> revokedTypes = filter(filteredTypes,
-				revokedClassesEvents.getAggregate(Aggregators.distinct(JdkAttributes.BIASED_REVOCATION_CLASS)));
+		Set<IMCType> revokedTypes = filter(filteredTypes, revokedClassesEvents.getAggregate(
+				(IAggregator<Set<IMCType>, ?>) Aggregators.distinct(JdkAttributes.BIASED_REVOCATION_CLASS)));
 
 		StringBuilder shortMessage = new StringBuilder();
 		StringBuilder longMessage = new StringBuilder();

--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/latency/MethodProfilingRule.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/latency/MethodProfilingRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -354,8 +354,8 @@ public class MethodProfilingRule implements IRule {
 								resultPair.right, resultPair.left.left, resultPair.left.right, windowRange));
 					}
 				} else {
-					Set<IQuantity> settingTimes = items.apply(settingsFilter)
-							.getAggregate(Aggregators.distinct(JfrAttributes.START_TIME));
+					Set<IQuantity> settingTimes = items.apply(settingsFilter).getAggregate(
+							(IAggregator<Set<IQuantity>, ?>) Aggregators.distinct(JfrAttributes.START_TIME));
 					IQuantity start = startTime;
 					List<Pair<Pair<IQuantity, IQuantity>, IMCStackTrace>> scores = new ArrayList<>(settingTimes.size());
 					for (IQuantity settingTime : settingTimes) {

--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/memory/GcFreedRatioRule.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/memory/GcFreedRatioRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -42,6 +42,7 @@ import java.util.Set;
 
 import org.openjdk.jmc.common.IDisplayable;
 import org.openjdk.jmc.common.item.Aggregators;
+import org.openjdk.jmc.common.item.IAggregator;
 import org.openjdk.jmc.common.item.IItemCollection;
 import org.openjdk.jmc.common.item.ItemFilters;
 import org.openjdk.jmc.common.unit.IQuantity;
@@ -212,7 +213,8 @@ public class GcFreedRatioRule extends AbstractRule {
 				IQuantity newEndTime = null;
 				IItemCollection heapSummaryWindowItems = windowItems.apply(JdkFilters.HEAP_SUMMARY);
 				IItemCollection heapSummaryAllItems = allItems.apply(JdkFilters.HEAP_SUMMARY);
-				IQuantity lowestGcId = heapSummaryWindowItems.getAggregate(Aggregators.min(JdkAttributes.GC_ID));
+				IQuantity lowestGcId = heapSummaryWindowItems
+						.getAggregate((IAggregator<IQuantity, ?>) Aggregators.min(JdkAttributes.GC_ID));
 				IItemCollection lowestGcIdWindowItems = heapSummaryWindowItems
 						.apply(ItemFilters.equals(JdkAttributes.GC_ID, lowestGcId));
 				IItemCollection lowestGcIdAllItems = heapSummaryAllItems
@@ -228,7 +230,8 @@ public class GcFreedRatioRule extends AbstractRule {
 						newStartTime = RulesToolkit.getEarliestEndTime(lowestGcIdBeforeAllItems);
 					}
 				}
-				IQuantity highestGcId = heapSummaryWindowItems.getAggregate(Aggregators.max(JdkAttributes.GC_ID));
+				IQuantity highestGcId = heapSummaryWindowItems
+						.getAggregate((IAggregator<IQuantity, ?>) Aggregators.max(JdkAttributes.GC_ID));
 				IItemCollection highestGcIdWindowItems = heapSummaryWindowItems
 						.apply(ItemFilters.equals(JdkAttributes.GC_ID, highestGcId));
 				IItemCollection highestGcIdAllItems = heapSummaryAllItems
@@ -257,7 +260,7 @@ public class GcFreedRatioRule extends AbstractRule {
 
 				// Filter out those that don't have matching before/after pairs
 				Set<IQuantity> gcIds = windowItems.apply(JdkFilters.HEAP_SUMMARY)
-						.getAggregate(Aggregators.distinct(JdkAttributes.GC_ID));
+						.getAggregate((IAggregator<Set<IQuantity>, ?>) Aggregators.distinct(JdkAttributes.GC_ID));
 				for (Iterator<IQuantity> iterator = gcIds.iterator(); iterator.hasNext();) {
 					IQuantity gcId = iterator.next();
 					IItemCollection gcItems = windowItems.apply(ItemFilters.equals(JdkAttributes.GC_ID, gcId));

--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/memory/IncreasingLiveSetRule.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/memory/IncreasingLiveSetRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -51,6 +51,7 @@ import org.openjdk.jmc.common.IDisplayable;
 import org.openjdk.jmc.common.IMCType;
 import org.openjdk.jmc.common.collection.MapToolkit.IntEntry;
 import org.openjdk.jmc.common.item.Aggregators;
+import org.openjdk.jmc.common.item.IAggregator;
 import org.openjdk.jmc.common.item.IItem;
 import org.openjdk.jmc.common.item.IItemCollection;
 import org.openjdk.jmc.common.item.IItemIterable;
@@ -126,7 +127,7 @@ public class IncreasingLiveSetRule implements IRule {
 			IQuantity postWarmupHeapSize = items
 					.apply(ItemFilters.and(JdkFilters.HEAP_SUMMARY_AFTER_GC,
 							ItemFilters.moreOrEqual(JfrAttributes.START_TIME, postWarmupTime)))
-					.getAggregate(JdkAggregators.first(JdkAttributes.HEAP_USED));
+					.getAggregate((IAggregator<IQuantity, ?>) JdkAggregators.first(JdkAttributes.HEAP_USED));
 			if (postWarmupHeapSize == null) {
 				return RulesToolkit.getTooFewEventsResult(this);
 			}
@@ -259,14 +260,14 @@ public class IncreasingLiveSetRule implements IRule {
 	private IQuantity getPostWarmupTime(IItemCollection items, IQuantity classesLoadedPercent) {
 		IItemCollection classLoadItems = items.apply(JdkFilters.CLASS_LOAD_STATISTICS);
 		IQuantity maxLoadedClasses = classLoadItems
-				.getAggregate(Aggregators.max(JdkAttributes.CLASSLOADER_LOADED_COUNT));
+				.getAggregate((IAggregator<IQuantity, ?>) Aggregators.max(JdkAttributes.CLASSLOADER_LOADED_COUNT));
 		if (maxLoadedClasses == null) {
 			return null;
 		}
 		double doubleValue = classesLoadedPercent.doubleValueIn(PERCENT_UNITY);
 		IQuantity loadedClassesLimit = maxLoadedClasses.multiply(doubleValue);
 		return classLoadItems.apply(ItemFilters.more(JdkAttributes.CLASSLOADER_LOADED_COUNT, loadedClassesLimit))
-				.getAggregate(Aggregators.min(JfrAttributes.START_TIME));
+				.getAggregate((IAggregator<IQuantity, ?>) Aggregators.min(JfrAttributes.START_TIME));
 	}
 
 	@Override

--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/memory/LongGcPauseRule.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/memory/LongGcPauseRule.java
@@ -143,9 +143,9 @@ public class LongGcPauseRule implements IRule {
 	}
 
 	private static String getSemiRefsMessage(IItemCollection items) {
-		IQuantity aggregate = items
-				.getAggregate((IAggregator<IQuantity, ?>) Aggregators.filter(Aggregators.max(JdkTypeIDs.GC_PAUSE_L1, JfrAttributes.DURATION),
-						ItemFilters.equals(JdkAttributes.GC_PHASE_NAME, "References"))); //$NON-NLS-1$
+		IQuantity aggregate = items.getAggregate((IAggregator<IQuantity, ?>) Aggregators.filter(
+				Aggregators.max(JdkTypeIDs.GC_PAUSE_L1, JfrAttributes.DURATION),
+				ItemFilters.equals(JdkAttributes.GC_PHASE_NAME, "References"))); //$NON-NLS-1$
 		if (aggregate == null) {
 			return null;
 		}

--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/memory/LongGcPauseRule.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/memory/LongGcPauseRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -45,6 +45,7 @@ import java.util.concurrent.RunnableFuture;
 
 import org.openjdk.jmc.common.IDisplayable;
 import org.openjdk.jmc.common.item.Aggregators;
+import org.openjdk.jmc.common.item.IAggregator;
 import org.openjdk.jmc.common.item.IItemCollection;
 import org.openjdk.jmc.common.item.ItemFilters;
 import org.openjdk.jmc.common.unit.IQuantity;
@@ -143,7 +144,7 @@ public class LongGcPauseRule implements IRule {
 
 	private static String getSemiRefsMessage(IItemCollection items) {
 		IQuantity aggregate = items
-				.getAggregate(Aggregators.filter(Aggregators.max(JdkTypeIDs.GC_PAUSE_L1, JfrAttributes.DURATION),
+				.getAggregate((IAggregator<IQuantity, ?>) Aggregators.filter(Aggregators.max(JdkTypeIDs.GC_PAUSE_L1, JfrAttributes.DURATION),
 						ItemFilters.equals(JdkAttributes.GC_PHASE_NAME, "References"))); //$NON-NLS-1$
 		if (aggregate == null) {
 			return null;

--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/memory/StringDeduplicationRule.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/memory/StringDeduplicationRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -38,6 +38,7 @@ import java.text.MessageFormat;
 import java.util.Set;
 
 import org.openjdk.jmc.common.item.Aggregators;
+import org.openjdk.jmc.common.item.IAggregator;
 import org.openjdk.jmc.common.item.IItemCollection;
 import org.openjdk.jmc.common.item.IItemFilter;
 import org.openjdk.jmc.common.item.ItemFilters;
@@ -212,7 +213,8 @@ public class StringDeduplicationRule extends AbstractRule {
 		double stringMaxRatio = 0;
 
 		// Check the string internal array ratio for each set of ObjectCount events = each gc.
-		Set<IQuantity> gcIds = objectCountItems.getAggregate(Aggregators.distinct(JdkAttributes.GC_ID));
+		Set<IQuantity> gcIds = objectCountItems
+				.getAggregate((IAggregator<Set<IQuantity>, ?>) Aggregators.distinct(JdkAttributes.GC_ID));
 		for (IQuantity gcId : gcIds) {
 			IItemCollection livesetForGc = objectCountItems.apply(ItemFilters.equals(JdkAttributes.GC_ID, gcId));
 			IItemCollection stringObjectCountItems = livesetForGc.apply(STRING_FILTER);

--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/util/DefaultIItemResultSet.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/util/DefaultIItemResultSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -93,7 +93,8 @@ final class DefaultIItemResultSet implements IItemResultSet {
 				}
 			}
 		} else {
-			Set<?> aggregate = input.getAggregate(Aggregators.distinct(query.getGroupBy()));
+			IAggregator<?, ?> aggregator = Aggregators.distinct(query.getGroupBy());
+			Set<?> aggregate = input.getAggregate((IAggregator<Set<?>, ?>) aggregator);
 			if (aggregate != null) {
 				for (Object o : aggregate) {
 					IItemCollection rowCollection = input.apply(ItemFilters.equals((IAttribute) query.getGroupBy(), o));
@@ -101,8 +102,7 @@ final class DefaultIItemResultSet implements IItemResultSet {
 					int column = 0;
 					for (; column < attributes.size(); column++) {
 						// Optimization - it is too expensive to do aggregation for these. You simply
-						// get first non-null
-						// matching attribute - we're only using this for the group by today.
+						// get first non-null matching attribute - we're only using this for the group by today.
 						row[column] = getFirstNonNull(rowCollection, attributes.get(column));
 					}
 					for (int j = 0; j < aggregators.size(); j++) {

--- a/core/org.openjdk.jmc.flightrecorder.rules/.classpath
+++ b/core/org.openjdk.jmc.flightrecorder.rules/.classpath
@@ -11,7 +11,7 @@
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7">
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8">
 		<attributes>
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>

--- a/core/org.openjdk.jmc.flightrecorder.rules/.settings/org.eclipse.jdt.core.prefs
+++ b/core/org.openjdk.jmc.flightrecorder.rules/.settings/org.eclipse.jdt.core.prefs
@@ -1,8 +1,8 @@
 eclipse.preferences.version=1
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.7
-org.eclipse.jdt.core.compiler.compliance=1.7
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
+org.eclipse.jdt.core.compiler.compliance=1.8
 org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
 org.eclipse.jdt.core.compiler.problem.forbiddenReference=warning
 org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=ignore
 org.eclipse.jdt.core.compiler.release=disabled
-org.eclipse.jdt.core.compiler.source=1.7
+org.eclipse.jdt.core.compiler.source=1.8

--- a/core/org.openjdk.jmc.flightrecorder.rules/META-INF/MANIFEST.MF
+++ b/core/org.openjdk.jmc.flightrecorder.rules/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: Mission Control Flight Recorder Rules
 Bundle-SymbolicName: org.openjdk.jmc.flightrecorder.rules;singleton:=true
 Bundle-Version: 8.0.0.qualifier
 Bundle-Vendor: Oracle Corporation
-Bundle-RequiredExecutionEnvironment: JavaSE-1.7
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: org.openjdk.jmc.flightrecorder.rules,
  org.openjdk.jmc.flightrecorder.rules.report, 
  org.openjdk.jmc.flightrecorder.rules.report.html,

--- a/core/org.openjdk.jmc.flightrecorder.rules/src/main/java/org/openjdk/jmc/flightrecorder/rules/util/RulesToolkit.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules/src/main/java/org/openjdk/jmc/flightrecorder/rules/util/RulesToolkit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -62,6 +62,7 @@ import org.openjdk.jmc.common.collection.MapToolkit;
 import org.openjdk.jmc.common.collection.MapToolkit.IntEntry;
 import org.openjdk.jmc.common.item.Aggregators;
 import org.openjdk.jmc.common.item.IAccessorFactory;
+import org.openjdk.jmc.common.item.IAggregator;
 import org.openjdk.jmc.common.item.IAttribute;
 import org.openjdk.jmc.common.item.IItem;
 import org.openjdk.jmc.common.item.IItemCollection;
@@ -143,26 +144,26 @@ public class RulesToolkit {
 	 * Knowledge about the state of affairs of an event type in an IItemCollection.
 	 */
 	public enum EventAvailability {
-				/**
-				 * The type has events available in the collection.
-				 */
-				AVAILABLE(4),
-				/**
-				 * The type was actively enabled in the collection.
-				 */
-				ENABLED(3),
-				/**
-				 * The type was actively disabled in the collection.
-				 */
-				DISABLED(2),
-				/**
-				 * The type is known in the collection, but no events were found.
-				 */
-				NONE(1),
-				/**
-				 * The type is unknown in the collection.
-				 */
-				UNKNOWN(0);
+		/**
+		 * The type has events available in the collection.
+		 */
+		AVAILABLE(4),
+		/**
+		 * The type was actively enabled in the collection.
+		 */
+		ENABLED(3),
+		/**
+		 * The type was actively disabled in the collection.
+		 */
+		DISABLED(2),
+		/**
+		 * The type is known in the collection, but no events were found.
+		 */
+		NONE(1),
+		/**
+		 * The type is unknown in the collection.
+		 */
+		UNKNOWN(0);
 
 		/*
 		 * Used to determine the ordering of availabilities.
@@ -237,8 +238,9 @@ public class RulesToolkit {
 	public static String findMatches(
 		String typeId, IItemCollection items, IAttribute<String> attribute, String match, boolean ignoreCase) {
 		String regexp = ".*(" + (ignoreCase ? "?i:" : "") + match + ").*"; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		return items.getAggregate(Aggregators.filter(Aggregators.distinctAsString(typeId, attribute),
-				ItemFilters.and(ItemFilters.type(typeId), ItemFilters.matches(attribute, regexp))));
+		return items.getAggregate(
+				(IAggregator<String, ?>) Aggregators.filter(Aggregators.distinctAsString(typeId, attribute),
+						ItemFilters.and(ItemFilters.type(typeId), ItemFilters.matches(attribute, regexp))));
 	}
 
 	/**
@@ -659,7 +661,7 @@ public class RulesToolkit {
 		IItemCollection versionProperties = items.apply(ItemFilters.and(JdkFilters.SYSTEM_PROPERTIES,
 				ItemFilters.equals(JdkAttributes.ENVIRONMENT_KEY, "java.vm.specification.version"))); //$NON-NLS-1$
 		Set<String> vmSpecificationVersions = versionProperties
-				.getAggregate(Aggregators.distinct(JdkAttributes.ENVIRONMENT_VALUE));
+				.getAggregate((IAggregator<Set<String>, ?>) Aggregators.distinct(JdkAttributes.ENVIRONMENT_VALUE));
 		if (vmSpecificationVersions != null && vmSpecificationVersions.size() >= 1) {
 			return new JavaVersion(vmSpecificationVersions.iterator().next());
 		}
@@ -940,7 +942,8 @@ public class RulesToolkit {
 
 	private static Set<String> getPeriodSettings(IItemCollection items, String ... typeIds) {
 		IItemFilter filter = getSettingsFilter(REC_SETTING_NAME_PERIOD, typeIds);
-		return items.apply(filter).getAggregate(Aggregators.distinct(JdkAttributes.REC_SETTING_VALUE));
+		return items.apply(filter)
+				.getAggregate((IAggregator<Set<String>, ?>) Aggregators.distinct(JdkAttributes.REC_SETTING_VALUE));
 	}
 
 	/*
@@ -955,7 +958,8 @@ public class RulesToolkit {
 	}
 
 	private static String getEventTypeNames(IItemCollection items) {
-		Set<String> names = items.getAggregate(Aggregators.distinct("", TYPE_NAME_ACCESSOR_FACTORY)); //$NON-NLS-1$
+		Set<String> names = items
+				.getAggregate((IAggregator<Set<String>, ?>) Aggregators.distinct("", TYPE_NAME_ACCESSOR_FACTORY)); //$NON-NLS-1$
 		if (names == null) {
 			return null;
 		}
@@ -1294,7 +1298,8 @@ public class RulesToolkit {
 		IItemFilter stringFlagsFilter = ItemFilters.type(JdkTypeIDs.STRING_FLAG);
 		IItemFilter optionsFilter = ItemFilters.matches(JdkAttributes.FLAG_NAME, "FlightRecorderOptions"); //$NON-NLS-1$
 		IItemCollection optionsFlag = items.apply(ItemFilters.and(stringFlagsFilter, optionsFilter));
-		Set<String> optionsValues = optionsFlag.getAggregate(Aggregators.distinct(JdkAttributes.FLAG_VALUE_TEXT));
+		Set<String> optionsValues = optionsFlag
+				.getAggregate((IAggregator<Set<String>, ?>) Aggregators.distinct(JdkAttributes.FLAG_VALUE_TEXT));
 		if (optionsValues != null && optionsValues.size() > 0) {
 			String optionsValue = optionsValues.iterator().next();
 			String[] allOptions = optionsValue.split(","); //$NON-NLS-1$

--- a/core/org.openjdk.jmc.flightrecorder.rules/src/main/java/org/openjdk/jmc/flightrecorder/rules/util/RulesToolkit.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules/src/main/java/org/openjdk/jmc/flightrecorder/rules/util/RulesToolkit.java
@@ -144,26 +144,26 @@ public class RulesToolkit {
 	 * Knowledge about the state of affairs of an event type in an IItemCollection.
 	 */
 	public enum EventAvailability {
-		/**
-		 * The type has events available in the collection.
-		 */
-		AVAILABLE(4),
-		/**
-		 * The type was actively enabled in the collection.
-		 */
-		ENABLED(3),
-		/**
-		 * The type was actively disabled in the collection.
-		 */
-		DISABLED(2),
-		/**
-		 * The type is known in the collection, but no events were found.
-		 */
-		NONE(1),
-		/**
-		 * The type is unknown in the collection.
-		 */
-		UNKNOWN(0);
+				/**
+				 * The type has events available in the collection.
+				 */
+				AVAILABLE(4),
+				/**
+				 * The type was actively enabled in the collection.
+				 */
+				ENABLED(3),
+				/**
+				 * The type was actively disabled in the collection.
+				 */
+				DISABLED(2),
+				/**
+				 * The type is known in the collection, but no events were found.
+				 */
+				NONE(1),
+				/**
+				 * The type is unknown in the collection.
+				 */
+				UNKNOWN(0);
 
 		/*
 		 * Used to determine the ordering of availabilities.

--- a/core/org.openjdk.jmc.flightrecorder/.classpath
+++ b/core/org.openjdk.jmc.flightrecorder/.classpath
@@ -11,7 +11,7 @@
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7">
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8">
 		<attributes>
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>

--- a/core/org.openjdk.jmc.flightrecorder/META-INF/MANIFEST.MF
+++ b/core/org.openjdk.jmc.flightrecorder/META-INF/MANIFEST.MF
@@ -1,6 +1,6 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-RequiredExecutionEnvironment: JavaSE-1.7
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-Name: Flight Recorder Model Plug-in
 Bundle-SymbolicName: org.openjdk.jmc.flightrecorder;singleton:=true
 Bundle-Version: 8.0.0.qualifier

--- a/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/EventCollection.java
+++ b/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/EventCollection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -55,9 +55,7 @@ import org.openjdk.jmc.flightrecorder.internal.EventArray;
 import org.openjdk.jmc.flightrecorder.internal.EventArrays;
 
 /**
- * Java 1.7 based implementation of {@link IItemCollection} using {@link IItemIterable} iterators.
- * This class is only intended to be used as an IItemCollection outside of the usage in
- * {@link JfrLoaderToolkit}.
+ * Implementation of {@link IItemCollection} using {@link IItemIterable} iterators.
  */
 class EventCollection implements IItemCollection {
 

--- a/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/JfrLoaderToolkit.java
+++ b/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/JfrLoaderToolkit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/JfrLoaderToolkit.java
+++ b/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/JfrLoaderToolkit.java
@@ -48,8 +48,8 @@ import org.openjdk.jmc.flightrecorder.parser.IParserExtension;
 import org.openjdk.jmc.flightrecorder.parser.ParserExtensionRegistry;
 
 /**
- * A Java 1.7 compatible collection of methods used to load binary JFR data into
- * {@link IItemCollection} implementations.
+ * A collection of methods used to load binary JFR data into {@link IItemCollection}
+ * implementations.
  */
 public class JfrLoaderToolkit {
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--   
-   Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+   Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
    
    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
    
@@ -41,8 +41,8 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-		<maven.compiler.source>1.7</maven.compiler.source>
-		<maven.compiler.target>1.7</maven.compiler.target>
+		<maven.compiler.source>1.8</maven.compiler.source>
+		<maven.compiler.target>1.8</maven.compiler.target>
 		<manifest-location>META-INF</manifest-location>
 		<maven.bundle.plugin.version>3.5.1</maven.bundle.plugin.version>
 		<spotless.version>1.26.0</spotless.version>

--- a/core/tests/org.openjdk.jmc.common.test/.classpath
+++ b/core/tests/org.openjdk.jmc.common.test/.classpath
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" output="target/test-classes" path="src/test/java"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="output" path="target/test-classes"/>
 </classpath>

--- a/core/tests/org.openjdk.jmc.common.test/.settings/org.eclipse.jdt.core.prefs
+++ b/core/tests/org.openjdk.jmc.common.test/.settings/org.eclipse.jdt.core.prefs
@@ -1,9 +1,9 @@
 eclipse.preferences.version=1
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.7
-org.eclipse.jdt.core.compiler.compliance=1.7
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
+org.eclipse.jdt.core.compiler.compliance=1.8
 org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
 org.eclipse.jdt.core.compiler.problem.forbiddenReference=warning
 org.eclipse.jdt.core.compiler.problem.nonExternalizedStringLiteral=ignore
 org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=ignore
 org.eclipse.jdt.core.compiler.release=disabled
-org.eclipse.jdt.core.compiler.source=1.7
+org.eclipse.jdt.core.compiler.source=1.8

--- a/core/tests/org.openjdk.jmc.common.test/META-INF/MANIFEST.MF
+++ b/core/tests/org.openjdk.jmc.common.test/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: Common Test
 Bundle-SymbolicName: org.openjdk.jmc.common.test;singleton:=true
 Bundle-Version: 8.0.0.qualifier
 Bundle-Vendor: Oracle Corporation
-Bundle-RequiredExecutionEnvironment: JavaSE-1.7
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.junit,
  org.openjdk.jmc.common

--- a/core/tests/org.openjdk.jmc.flightrecorder.rules.jdk.test/.classpath
+++ b/core/tests/org.openjdk.jmc.flightrecorder.rules.jdk.test/.classpath
@@ -2,7 +2,7 @@
 <classpath>
 	<classpathentry kind="src" output="target/test-classes" path="src/test/java"/>
 	<classpathentry kind="src" output="target/test-classes" path="src/test/resources"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="output" path="target/test-classes"/>
 </classpath>

--- a/core/tests/org.openjdk.jmc.flightrecorder.rules.jdk.test/.settings/org.eclipse.jdt.core.prefs
+++ b/core/tests/org.openjdk.jmc.flightrecorder.rules.jdk.test/.settings/org.eclipse.jdt.core.prefs
@@ -1,6 +1,6 @@
 eclipse.preferences.version=1
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.7
-org.eclipse.jdt.core.compiler.compliance=1.7
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
+org.eclipse.jdt.core.compiler.compliance=1.8
 org.eclipse.jdt.core.compiler.problem.forbiddenReference=warning
 org.eclipse.jdt.core.compiler.release=disabled
-org.eclipse.jdt.core.compiler.source=1.7
+org.eclipse.jdt.core.compiler.source=1.8

--- a/core/tests/org.openjdk.jmc.flightrecorder.rules.jdk.test/META-INF/MANIFEST.MF
+++ b/core/tests/org.openjdk.jmc.flightrecorder.rules.jdk.test/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: Flight Recorder Test
 Bundle-SymbolicName: org.openjdk.jmc.flightrecorder.rules.jdk.test;singleton:=true
 Bundle-Version: 8.0.0.qualifier
 Bundle-Vendor: Oracle Corporation
-Bundle-RequiredExecutionEnvironment: JavaSE-1.7
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.junit,
  org.openjdk.jmc.common.test,

--- a/core/tests/org.openjdk.jmc.flightrecorder.rules.test/.classpath
+++ b/core/tests/org.openjdk.jmc.flightrecorder.rules.test/.classpath
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" output="target/test-classes" path="src/test/java"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="output" path="target/test-classes"/>
 </classpath>

--- a/core/tests/org.openjdk.jmc.flightrecorder.rules.test/.settings/org.eclipse.jdt.core.prefs
+++ b/core/tests/org.openjdk.jmc.flightrecorder.rules.test/.settings/org.eclipse.jdt.core.prefs
@@ -1,6 +1,6 @@
 eclipse.preferences.version=1
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.7
-org.eclipse.jdt.core.compiler.compliance=1.7
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
+org.eclipse.jdt.core.compiler.compliance=1.8
 org.eclipse.jdt.core.compiler.problem.forbiddenReference=warning
 org.eclipse.jdt.core.compiler.release=disabled
-org.eclipse.jdt.core.compiler.source=1.7
+org.eclipse.jdt.core.compiler.source=1.8

--- a/core/tests/org.openjdk.jmc.flightrecorder.rules.test/META-INF/MANIFEST.MF
+++ b/core/tests/org.openjdk.jmc.flightrecorder.rules.test/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: Flight Recorder Test
 Bundle-SymbolicName: org.openjdk.jmc.flightrecorder.rules.test;singleton:=true
 Bundle-Version: 8.0.0.qualifier
 Bundle-Vendor: Oracle Corporation
-Bundle-RequiredExecutionEnvironment: JavaSE-1.7
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.junit,
  org.openjdk.jmc.common.test,

--- a/core/tests/org.openjdk.jmc.flightrecorder.test/.classpath
+++ b/core/tests/org.openjdk.jmc.flightrecorder.test/.classpath
@@ -2,7 +2,7 @@
 <classpath>
 	<classpathentry kind="src" output="target/test-classes" path="src/test/java"/>
 	<classpathentry kind="src" output="target/test-classes" path="src/test/resources"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="output" path="target/test-classes"/>
 </classpath>

--- a/core/tests/org.openjdk.jmc.flightrecorder.test/META-INF/MANIFEST.MF
+++ b/core/tests/org.openjdk.jmc.flightrecorder.test/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: Flight Recorder Test
 Bundle-SymbolicName: org.openjdk.jmc.flightrecorder.test;singleton:=true
 Bundle-Version: 8.0.0.qualifier
 Bundle-Vendor: Oracle Corporation
-Bundle-RequiredExecutionEnvironment: JavaSE-1.7
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.junit,
  org.openjdk.jmc.common.test,

--- a/core/tests/org.openjdk.jmc.jdp.test/.classpath
+++ b/core/tests/org.openjdk.jmc.jdp.test/.classpath
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" output="target/test-classes" path="src/test/java"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="output" path="target/test-classes"/>
 </classpath>

--- a/core/tests/pom.xml
+++ b/core/tests/pom.xml
@@ -51,8 +51,8 @@
 		<test.includes.default>**/Test*.java,**/*Test.java,**/*TestCase.java</test.includes.default>
 		<test.excludes.default>**/*$*</test.excludes.default>
 		<fail.if.no.tests>true</fail.if.no.tests>
-		<maven.compiler.source>1.7</maven.compiler.source>
-		<maven.compiler.target>1.7</maven.compiler.target>
+		<maven.compiler.source>1.8</maven.compiler.source>
+		<maven.compiler.target>1.8</maven.compiler.target>
 		<spotless.config.path>${basedir}/../../configuration/ide/eclipse/formatting/formatting.xml</spotless.config.path>
 	</properties>
 	<profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -331,8 +331,8 @@
 						<configuration>
 							<rules>
 								<requireJavaVersion>
-									<version>[1.8.0-40,)</version>
-									<message>Building JMC requires Java 8 version JDK 1.8.0_40 or later</message>
+									<version>[11,)</version>
+									<message>Building JMC requires Java 11 or later</message>
 								</requireJavaVersion>
 							</rules>
 						</configuration>


### PR DESCRIPTION
For some reason the Eclipse compiler fails some type inferences when switching to JDK 8, so had to add some (unnecessary) casts. (Also set JDK 11 as required for running the application builds.)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JMC-6899](https://bugs.openjdk.java.net/browse/JMC-6899): Upgrade core to 8


### Reviewers
 * [Guru Hb](https://openjdk.java.net/census#ghb) (@guruhb - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jmc pull/120/head:pull/120`
`$ git checkout pull/120`
