### PR TITLE
6908: Rule for warning about the starting of processes

### DIFF
--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/general/ProcessStartedRule.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/general/ProcessStartedRule.java
@@ -69,7 +69,8 @@ public class ProcessStartedRule implements IRule {
 		}
 		IQuantity processStartedCount = processStartEvents.getAggregate(Aggregators.count());
 		String message = Messages.getString(Messages.ProcessStartedRule_TEXT_INFO);
-		return new Result(this, 50, MessageFormat.format(message, processStartedCount.clampedLongValueIn(UnitLookup.NUMBER_UNITY)));
+		return new Result(this, 50,
+				MessageFormat.format(message, processStartedCount.clampedLongValueIn(UnitLookup.NUMBER_UNITY)));
 	}
 
 	@Override

--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/general/ProcessStartedRule.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/general/ProcessStartedRule.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, Datadog, Inc. All rights reserved.
+ *
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * The contents of this file are subject to the terms of either the Universal Permissive License
+ * v 1.0 as shown at http://oss.oracle.com/licenses/upl
+ *
+ * or the following license:
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted
+ * provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions
+ * and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other materials provided with
+ * the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to
+ * endorse or promote products derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+ * WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.openjdk.jmc.flightrecorder.rules.jdk.general;
+
+import java.text.MessageFormat;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.concurrent.Callable;
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.RunnableFuture;
+
+import org.openjdk.jmc.common.item.Aggregators;
+import org.openjdk.jmc.common.item.IItemCollection;
+import org.openjdk.jmc.common.item.ItemFilters;
+import org.openjdk.jmc.common.unit.IQuantity;
+import org.openjdk.jmc.common.unit.UnitLookup;
+import org.openjdk.jmc.common.util.IPreferenceValueProvider;
+import org.openjdk.jmc.common.util.TypedPreference;
+import org.openjdk.jmc.flightrecorder.jdk.JdkTypeIDs;
+import org.openjdk.jmc.flightrecorder.rules.IRule;
+import org.openjdk.jmc.flightrecorder.rules.Result;
+import org.openjdk.jmc.flightrecorder.rules.jdk.messages.internal.Messages;
+import org.openjdk.jmc.flightrecorder.rules.util.JfrRuleTopics;
+import org.openjdk.jmc.flightrecorder.rules.util.RulesToolkit;
+import org.openjdk.jmc.flightrecorder.rules.util.RulesToolkit.EventAvailability;
+
+public class ProcessStartedRule implements IRule {
+	private static final String PROCESS_STARTED_RESULT_ID = "ProcessStarted"; //$NON-NLS-1$
+
+	private Result getResult(IItemCollection items, IPreferenceValueProvider valueProvider) {
+		EventAvailability eventAvailability = RulesToolkit.getEventAvailability(items, JdkTypeIDs.PROCESS_START);
+		if (eventAvailability == EventAvailability.DISABLED) {
+			return RulesToolkit.getEventAvailabilityResult(this, items, eventAvailability, JdkTypeIDs.PROCESS_START);
+		}
+		IItemCollection processStartEvents = items.apply(ItemFilters.type(JdkTypeIDs.PROCESS_START));
+		if (!processStartEvents.hasItems()) {
+			return new Result(this, 0, Messages.getString(Messages.ProcessStartedRule_TEXT_OK));
+		}
+		IQuantity processStartedCount = processStartEvents.getAggregate(Aggregators.count());
+		String message = Messages.getString(Messages.ProcessStartedRule_TEXT_INFO);
+		return new Result(this, 50, MessageFormat.format(message, processStartedCount.clampedLongValueIn(UnitLookup.NUMBER_UNITY)));
+	}
+
+	@Override
+	public RunnableFuture<Result> evaluate(final IItemCollection items, final IPreferenceValueProvider valueProvider) {
+		FutureTask<Result> evaluationTask = new FutureTask<>(new Callable<Result>() {
+			@Override
+			public Result call() throws Exception {
+				return getResult(items, valueProvider);
+			}
+		});
+		return evaluationTask;
+	}
+
+	@Override
+	public Collection<TypedPreference<?>> getConfigurationAttributes() {
+		return Collections.emptyList();
+	}
+
+	@Override
+	public String getId() {
+		return PROCESS_STARTED_RESULT_ID;
+	}
+
+	@Override
+	public String getName() {
+		return Messages.getString(Messages.ProcessStartedRule_RULE_NAME);
+	}
+
+	@Override
+	public String getTopic() {
+		return JfrRuleTopics.PROCESSES;
+	}
+}

--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/messages/internal/Messages.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/messages/internal/Messages.java
@@ -474,6 +474,9 @@ public class Messages {
 	public static final String PasswordsInSystemPropertiesRule_TEXT_OK = "PasswordsInSystemPropertiesRule_TEXT_OK"; //$NON-NLS-1$
 	public static final String Preference_SHORT_RECORDING = "Preference_SHORT_RECORDING"; //$NON-NLS-1$
 	public static final String Preference_SHORT_RECORDING_LONG = "Preference_SHORT_RECORDING_LONG"; //$NON-NLS-1$
+	public static final String ProcessStartedRule_RULE_NAME = "ProcessStartedRule_RULE_NAME"; //$NON-NLS-1$
+	public static final String ProcessStartedRule_TEXT_INFO = "ProcessStartedRule_TEXT_INFO"; //$NON-NLS-1$
+	public static final String ProcessStartedRule_TEXT_OK = "ProcessStartedRule_TEXT_OK"; //$NON-NLS-1$
 	public static final String ReferenceStatisticsType_FINAL_REFERENCES = "ReferenceStatisticsType_FINAL_REFERENCES"; //$NON-NLS-1$
 	public static final String ReferenceStatisticsType_PHANTOM_REFERENCES = "ReferenceStatisticsType_PHANTOM_REFERENCES"; //$NON-NLS-1$
 	public static final String ReferenceStatisticsType_SOFT_REFERENCES = "ReferenceStatisticsType_SOFT_REFERENCES"; //$NON-NLS-1$

--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/resources/META-INF/services/org.openjdk.jmc.flightrecorder.rules.IRule
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/resources/META-INF/services/org.openjdk.jmc.flightrecorder.rules.IRule
@@ -53,6 +53,7 @@ org.openjdk.jmc.flightrecorder.rules.jdk.general.OptionsCheckRule
 org.openjdk.jmc.flightrecorder.rules.jdk.general.PasswordsInArgumentsRule
 org.openjdk.jmc.flightrecorder.rules.jdk.general.PasswordsInEnvironmentRule
 org.openjdk.jmc.flightrecorder.rules.jdk.general.PasswordsInSystemPropertiesRule
+org.openjdk.jmc.flightrecorder.rules.jdk.general.ProcessStartedRule
 org.openjdk.jmc.flightrecorder.rules.jdk.general.RecordingSettingsRule
 org.openjdk.jmc.flightrecorder.rules.jdk.general.StackDepthSettingRule
 org.openjdk.jmc.flightrecorder.rules.jdk.general.VerifyNoneRule

--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/resources/org/openjdk/jmc/flightrecorder/rules/jdk/messages/internal/messages.properties
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/resources/org/openjdk/jmc/flightrecorder/rules/jdk/messages/internal/messages.properties
@@ -543,6 +543,10 @@ PasswordsInSystemPropertiesRule_TEXT_INFO=The system properties in the recording
 # {0} is a list of system property names
 PasswordsInSystemPropertiesRule_TEXT_INFO_LONG=The following suspicious system properties were found in this recording: {0}<p>They may contain passwords. If you wish to keep having passwords in your system properties, but want to be able to share recordings without also sharing the passwords, please disable the ''Initial System Property'' event.
 PasswordsInSystemPropertiesRule_TEXT_OK=The recording does not seem to contain passwords in the system properties.
+ProcessStartedRule_RULE_NAME=Process Started
+# {0} is a number of processes
+ProcessStartedRule_TEXT_INFO={0} process(es) started.
+ProcessStartedRule_TEXT_OK=No process started.
 ReferenceStatisticsType_FINAL_REFERENCES=Final References
 ReferenceStatisticsType_PHANTOM_REFERENCES=Phantom References
 ReferenceStatisticsType_SOFT_REFERENCES=Soft References

--- a/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/jdk/JdkTypeIDs.java
+++ b/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/jdk/JdkTypeIDs.java
@@ -200,4 +200,6 @@ public final class JdkTypeIDs {
 	public static final String NATIVE_LIBRARY = PREFIX + "NativeLibrary";
 
 	public static final String HEAP_DUMP = PREFIX + "HeapDump";
+	
+	public static final String PROCESS_START = PREFIX + "ProcessStart";
 }

--- a/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/jdk/JdkTypeIDs.java
+++ b/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/jdk/JdkTypeIDs.java
@@ -200,6 +200,6 @@ public final class JdkTypeIDs {
 	public static final String NATIVE_LIBRARY = PREFIX + "NativeLibrary";
 
 	public static final String HEAP_DUMP = PREFIX + "HeapDump";
-	
+
 	public static final String PROCESS_START = PREFIX + "ProcessStart";
 }

--- a/core/tests/org.openjdk.jmc.flightrecorder.rules.jdk.test/src/test/resources/baseline/JfrRuleBaseline.xml
+++ b/core/tests/org.openjdk.jmc.flightrecorder.rules.jdk.test/src/test/resources/baseline/JfrRuleBaseline.xml
@@ -346,6 +346,13 @@
 <longDescription>The Primitive To Object Conversion rule requires events to be available from the following event types: 'Allocation in new TLAB', 'Allocation outside TLAB'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
 </rule>
 <rule>
+<id>ProcessStarted</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>No process started.</shortDescription>
+<longDescription>No process started.</longDescription>
+</rule>
+<rule>
 <id>SocketRead</id>
 <severity>Not Applicable</severity>
 <score>-1.0</score>
@@ -753,6 +760,13 @@
 <score>-1.0</score>
 <shortDescription>This rule requires events to be available from the following event types: 'Allocation in new TLAB', 'Allocation outside TLAB'.</shortDescription>
 <longDescription>The Primitive To Object Conversion rule requires events to be available from the following event types: 'Allocation in new TLAB', 'Allocation outside TLAB'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>ProcessStarted</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>No process started.</shortDescription>
+<longDescription>No process started.</longDescription>
 </rule>
 <rule>
 <id>SocketRead</id>
@@ -1164,6 +1178,13 @@
 <longDescription>The Primitive To Object Conversion rule requires that the following event types are enabled: 'Allocation in new TLAB', 'Allocation outside TLAB'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
 </rule>
 <rule>
+<id>ProcessStarted</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>No process started.</shortDescription>
+<longDescription>No process started.</longDescription>
+</rule>
+<rule>
 <id>SocketRead</id>
 <severity>Not Applicable</severity>
 <score>-1.0</score>
@@ -1571,6 +1592,13 @@
 <score>-1.0</score>
 <shortDescription>This rule requires events to be available from the following event types: 'Allocation in new TLAB', 'Allocation outside TLAB'.</shortDescription>
 <longDescription>The Primitive To Object Conversion rule requires events to be available from the following event types: 'Allocation in new TLAB', 'Allocation outside TLAB'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>ProcessStarted</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>No process started.</shortDescription>
+<longDescription>No process started.</longDescription>
 </rule>
 <rule>
 <id>SocketRead</id>
@@ -1982,6 +2010,13 @@
 <longDescription>The Primitive To Object Conversion rule requires that the following event types are enabled: 'Allocation in new TLAB', 'Allocation outside TLAB'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
 </rule>
 <rule>
+<id>ProcessStarted</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>No process started.</shortDescription>
+<longDescription>No process started.</longDescription>
+</rule>
+<rule>
 <id>SocketRead</id>
 <severity>Not Applicable</severity>
 <score>-1.0</score>
@@ -2391,6 +2426,13 @@
 <longDescription>The Primitive To Object Conversion rule requires that the following event types are enabled: 'Allocation in new TLAB', 'Allocation outside TLAB'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
 </rule>
 <rule>
+<id>ProcessStarted</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>No process started.</shortDescription>
+<longDescription>No process started.</longDescription>
+</rule>
+<rule>
 <id>SocketRead</id>
 <severity>Not Applicable</severity>
 <score>-1.0</score>
@@ -2798,6 +2840,13 @@
 <score>-1.0</score>
 <shortDescription>This rule requires that the following event types are enabled: 'Allocation in new TLAB', 'Allocation outside TLAB'.</shortDescription>
 <longDescription>The Primitive To Object Conversion rule requires that the following event types are enabled: 'Allocation in new TLAB', 'Allocation outside TLAB'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>ProcessStarted</id>
+<severity>Information</severity>
+<score>50.0</score>
+<shortDescription>1 process(es) started.</shortDescription>
+<longDescription>1 process(es) started.</longDescription>
 </rule>
 <rule>
 <id>SocketRead</id>
@@ -3210,6 +3259,13 @@
 <longDescription>The Primitive To Object Conversion rule requires events to be available from the following event types: 'Allocation in new TLAB', 'Allocation outside TLAB'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
 </rule>
 <rule>
+<id>ProcessStarted</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>No process started.</shortDescription>
+<longDescription>No process started.</longDescription>
+</rule>
+<rule>
 <id>SocketRead</id>
 <severity>OK</severity>
 <score>0.0</score>
@@ -3617,6 +3673,13 @@
 <score>-1.0</score>
 <shortDescription>This rule requires events to be available from the following event types: 'Allocation in new TLAB', 'Allocation outside TLAB'.</shortDescription>
 <longDescription>The Primitive To Object Conversion rule requires events to be available from the following event types: 'Allocation in new TLAB', 'Allocation outside TLAB'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>ProcessStarted</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>No process started.</shortDescription>
+<longDescription>No process started.</longDescription>
 </rule>
 <rule>
 <id>SocketRead</id>
@@ -4028,6 +4091,13 @@
 <longDescription>The Primitive To Object Conversion rule requires that the following event types are enabled: 'Allocation in new TLAB', 'Allocation outside TLAB'.&lt;p&gt;If you are using JMC to create a flight recording, then you can enable event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
 </rule>
 <rule>
+<id>ProcessStarted</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>No process started.</shortDescription>
+<longDescription>No process started.</longDescription>
+</rule>
+<rule>
 <id>SocketRead</id>
 <severity>Not Applicable</severity>
 <score>-1.0</score>
@@ -4435,6 +4505,13 @@
 <score>0.11127751568911523</score>
 <shortDescription>0 % of the total allocation (1.88 MiB) is caused by conversion from primitive types to object types. The most common object type that primitives are converted into is 'java.lang.Integer'.</shortDescription>
 <longDescription>0 % of the total allocation (1.88 MiB) is caused by conversion from primitive types to object types.&lt;p&gt;The most common object type that primitives are converted into is 'java.lang.Integer', which causes 1.11 MiB to be allocated. The most common call site is 'weblogic.socket.NIOSocketMuxer$NIOOutputStream.initPool():887'.&lt;p&gt;Conversion from primitives to the corresponding object types can either be done explicitly, or be caused by autoboxing. If a considerable amount of the total allocation is caused by such conversions, consider changing the application source code to avoid this behavior. Look at the allocation stack traces to see which parts of the code to change. This rule finds the calls to the valueOf method for any of the eight object types that have primitive counterparts.</longDescription>
+</rule>
+<rule>
+<id>ProcessStarted</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>No process started.</shortDescription>
+<longDescription>No process started.</longDescription>
 </rule>
 <rule>
 <id>SocketRead</id>
@@ -4846,6 +4923,13 @@ The heap is around 22 % full. There is likely no big benefit from enabling strin
 <score>-1.0</score>
 <shortDescription>This rule requires events to be available from the following event types: 'Allocation in new TLAB', 'Allocation outside TLAB'.</shortDescription>
 <longDescription>The Primitive To Object Conversion rule requires events to be available from the following event types: 'Allocation in new TLAB', 'Allocation outside TLAB'.&lt;p&gt;They were either disabled during the recording or there might not have happened anything to trigger an event. Event settings like period and threshold may also prevent some events from being emitted. If you are using JMC to create a flight recording, then you can enable and configure event types in the Start Flight Recording wizard. If you are starting the flight recording from the command line, then you can use the settings parameter of &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html"&gt;-XX:FlightRecorderOptions&lt;/a&gt;.</longDescription>
+</rule>
+<rule>
+<id>ProcessStarted</id>
+<severity>OK</severity>
+<score>0.0</score>
+<shortDescription>No process started.</shortDescription>
+<longDescription>No process started.</longDescription>
 </rule>
 <rule>
 <id>SocketRead</id>


### PR DESCRIPTION
When a new process was started from the current JVM, we inform with a 50 score
that 1 or more processes was started
based on new JDK15 ProcessStart event

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JMC-6908](https://bugs.openjdk.java.net/browse/JMC-6908): Rule for warning about the starting of processes


### Reviewers
 * [Marcus Hirt](https://openjdk.java.net/census#hirt) (@thegreystone - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jmc pull/121/head:pull/121`
`$ git checkout pull/121`
