### PR TITLE
6173: jmc -open requires full path

### DIFF
--- a/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/MCPathEditorInput.java
+++ b/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/MCPathEditorInput.java
@@ -42,8 +42,9 @@ import org.eclipse.ui.IEditorInput;
 import org.eclipse.ui.IMemento;
 import org.eclipse.ui.IPathEditorInput;
 import org.eclipse.ui.IPersistableElement;
-
 import org.openjdk.jmc.ui.common.util.AdapterUtil;
+import org.openjdk.jmc.ui.common.util.Environment;
+import org.openjdk.jmc.ui.common.util.Environment.OSType;
 
 /**
  * Class for inputs that consists of a path
@@ -102,7 +103,19 @@ public class MCPathEditorInput implements IPathEditorInput, IPersistableElement 
 
 	@Override
 	public IPath getPath() {
-		return Path.fromOSString(m_file.getAbsolutePath());
+		String absPath = m_file.getAbsolutePath();
+		if (Environment.getOSType() == OSType.MAC) {
+			if (!m_file.isAbsolute()) {
+				String pwd = System.getenv().get("PWD");
+				if (pwd != null) {
+					File absFile = new File(pwd, m_file.getName());
+					if (absFile.exists()) {
+						absPath = absFile.getAbsolutePath();
+					}
+				}
+			}
+		}
+		return Path.fromOSString(absPath);
 	}
 
 	@Override


### PR DESCRIPTION
Handle special Mac case where user.dir is set by mac eclipse launcher
to the directory where is jmc binary.
Hopfully, PWD env var is kept where the program was launched so we can use it
to prepend to the providing filename.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JMC-6173](https://bugs.openjdk.java.net/browse/JMC-6173): jmc -open requires full path


### Reviewers
 * [Marcus Hirt](https://openjdk.java.net/census#hirt) (@thegreystone - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jmc pull/123/head:pull/123`
`$ git checkout pull/123`
