### PR TITLE
6925: Cache the local maven repo between runs

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -11,6 +11,13 @@ jobs:
       with:
         java-version: '11'
         java-package: jdk
+    - name: Cache local Maven repository
+      uses: actions/cache@v2
+      with:
+        path: ~/.m2/repository
+        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+        restore-keys: |
+          ${{ runner.os }}-maven-
     - name: Check formatting
       run: ./scripts/checkformatting.sh
     - name: Run core tests
@@ -26,6 +33,13 @@ jobs:
       with:
         java-version: '11'
         java-package: jdk
+    - name: Cache local Maven repository
+      uses: actions/cache@v2
+      with:
+        path: ~/.m2/repository
+        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+        restore-keys: |
+          ${{ runner.os }}-maven-
     - name: Check formatting
       run: ./scripts/checkformatting.sh
     - name: Run core tests
@@ -41,6 +55,13 @@ jobs:
       with:
         java-version: '11'
         java-package: jdk
+    - name: Cache local Maven repository
+      uses: actions/cache@v2
+      with:
+        path: ~/.m2/repository
+        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+        restore-keys: |
+          ${{ runner.os }}-maven-
     - name: Check formatting
       run: .\scripts\checkformatting.bat
       shell: cmd


### PR DESCRIPTION
So this adds the caching of Maven dependencies we discussed in the other PR. While testing this in my fork, it reduced the build time from ~30 min to ~23 min. I'll reword the commit message if there's agreement on this and a Jira issue exists. Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | linux | mac | win |
| --- | ----- | ----- | ----- |
| Build / test | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ⏳ (1/1 running) |

### Issue
 * [JMC-6925](https://bugs.openjdk.java.net/browse/JMC-6925): Cache the local maven repo between runs


### Reviewers
 * [Marcus Hirt](https://openjdk.java.net/census#hirt) (@thegreystone - **Reviewer**) ⚠️ Review applies to b17143b18456931d55b850f08609e0eba4e57129


### Download
`$ git fetch https://git.openjdk.java.net/jmc pull/124/head:pull/124`
`$ git checkout pull/124`
