### PR TITLE
6940: build.sh test arguments wrong

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -29,8 +29,8 @@ trap 'exitTrap' EXIT
 function printHelp() {
     echo "usage: call ./$(basename "$0") with the following options:"
     {
-        printf " \t%s\t%s\n" "--runTests" "to run the tests"
-        printf " \t%s\t%s\n" "--runUiTests" "to run the tests including UI tests"
+        printf " \t%s\t%s\n" "--test" "to run the tests"
+        printf " \t%s\t%s\n" "--testUi" "to run the tests including UI tests"
         printf " \t%s\t%s\n" "--packageJmc" "to package JMC"
         printf " \t%s\t%s\n" "--clean" "to run maven clean"
         printf " \t%s\t%s\n" "--run" "to run JMC once it was packaged"


### PR DESCRIPTION
Align the help with the actual accepted arguments

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | linux | mac | win |
| --- | ----- | ----- | ----- |
| Build / test | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (1/1 passed) |

### Issue
 * [JMC-6940](https://bugs.openjdk.java.net/browse/JMC-6940): build.sh test arguments wrong


### Reviewers
 * [Marcus Hirt](https://openjdk.java.net/census#hirt) (@thegreystone - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jmc pull/129/head:pull/129`
`$ git checkout pull/129`
