### PR TITLE
6941: build.sh does not terminate jetty after executing '--packageJmc'

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -15,7 +15,7 @@ function err_report() {
 function exitTrap() {
     if [ -n "${JETTY_PID}" ]; then
         echo "$(date +%T) terminating jetty server"
-        pkill -P "${JETTY_PID}"
+        kill "${JETTY_PID}"
     fi
 }
 
@@ -80,7 +80,7 @@ function packageJmc() {
         echo "$(date +%T) waiting for jetty server to start"
         sleep 1
     done
-    echo "$(date +%T) jetty server up and running"
+    echo "$(date +%T) jetty server up and running on pid ${JETTY_PID}"
 
     popd 1> /dev/null || {
         err_log "could not go to project root directory"


### PR DESCRIPTION
stopping jetty instance using kill command working on Mac & Linux

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | linux | mac | win |
| --- | ----- | ----- | ----- |
| Build / test | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (1/1 passed) |

### Issue
 * [JMC-6941](https://bugs.openjdk.java.net/browse/JMC-6941): build.sh does not terminate jetty after executing '--packageJmc'


### Reviewers
 * [Marcus Hirt](https://openjdk.java.net/census#hirt) (@thegreystone - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jmc pull/130/head:pull/130`
`$ git checkout pull/130`
