### PR TITLE
6942: The README is showing the wrong syntax for the build script

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,8 +220,8 @@ Prerequisites for building Mission Control:
 On Linux you can use the build.sh script to build JMC:
 ```
 usage: call ./build.sh with the following options:
-   --runTests    to run the tests
-   --runUiTests  to run the tests including UI tests
+   --test        to run the tests
+   --testUi      to run the tests including UI tests
    --packageJmc  to package JMC
    --clean       to run maven clean
 ```


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JMC-6942](https://bugs.openjdk.java.net/browse/JMC-6942): The README is showing the wrong syntax for the build script


### Reviewers
 * [Marcus Hirt](https://openjdk.java.net/census#hirt) (@thegreystone - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jmc pull/132/head:pull/132`
`$ git checkout pull/132`
