### PR TITLE
6911: Third Party Upgrade to HdrHistogram 2.1.12

### DIFF
--- a/releng/platform-definitions/platform-definition-2019-12/platform-definition-2019-12.target
+++ b/releng/platform-definitions/platform-definition-2019-12/platform-definition-2019-12.target
@@ -41,7 +41,7 @@
             <unit id="org.owasp.encoder" version="1.2.2"/>
             <unit id="org.lz4.lz4-java" version="1.7.1"/>
             <unit id="org.twitter4j.core" version="4.0.7"/>
-            <unit id="org.hdrhistogram.HdrHistogram" version="2.1.11"/>
+            <unit id="org.hdrhistogram.HdrHistogram" version="2.1.12"/>
             <unit id="org.adoptopenjdk.jemmy-awt-input" version="2.0.0"/>
             <unit id="org.adoptopenjdk.jemmy-browser" version="2.0.0"/>
             <unit id="org.adoptopenjdk.jemmy-core" version="2.0.0"/>

--- a/releng/platform-definitions/platform-definition-2020-03/platform-definition-2020-03.target
+++ b/releng/platform-definitions/platform-definition-2020-03/platform-definition-2020-03.target
@@ -41,7 +41,7 @@
             <unit id="org.owasp.encoder" version="1.2.2"/>
             <unit id="org.lz4.lz4-java" version="1.7.1"/>
             <unit id="org.twitter4j.core" version="4.0.7"/>
-            <unit id="org.hdrhistogram.HdrHistogram" version="2.1.11"/>
+            <unit id="org.hdrhistogram.HdrHistogram" version="2.1.12"/>
             <unit id="org.adoptopenjdk.jemmy-awt-input" version="2.0.0"/>
             <unit id="org.adoptopenjdk.jemmy-browser" version="2.0.0"/>
             <unit id="org.adoptopenjdk.jemmy-core" version="2.0.0"/>

--- a/releng/platform-definitions/platform-definition-2020-06/platform-definition-2020-06.target
+++ b/releng/platform-definitions/platform-definition-2020-06/platform-definition-2020-06.target
@@ -41,7 +41,7 @@
             <unit id="org.owasp.encoder" version="1.2.2"/>
             <unit id="org.lz4.lz4-java" version="1.7.1"/>
             <unit id="org.twitter4j.core" version="4.0.7"/>
-            <unit id="org.hdrhistogram.HdrHistogram" version="2.1.11"/>
+            <unit id="org.hdrhistogram.HdrHistogram" version="2.1.12"/>
             <unit id="org.adoptopenjdk.jemmy-awt-input" version="2.0.0"/>
             <unit id="org.adoptopenjdk.jemmy-browser" version="2.0.0"/>
             <unit id="org.adoptopenjdk.jemmy-core" version="2.0.0"/>

--- a/releng/platform-definitions/platform-definition-2020-09/platform-definition-2020-09.target
+++ b/releng/platform-definitions/platform-definition-2020-09/platform-definition-2020-09.target
@@ -41,7 +41,7 @@
             <unit id="org.owasp.encoder" version="1.2.2"/>
             <unit id="org.lz4.lz4-java" version="1.7.1"/>
             <unit id="org.twitter4j.core" version="4.0.7"/>
-            <unit id="org.hdrhistogram.HdrHistogram" version="2.1.11"/>
+            <unit id="org.hdrhistogram.HdrHistogram" version="2.1.12"/>
             <unit id="org.adoptopenjdk.jemmy-awt-input" version="2.0.0"/>
             <unit id="org.adoptopenjdk.jemmy-browser" version="2.0.0"/>
             <unit id="org.adoptopenjdk.jemmy-core" version="2.0.0"/>

--- a/releng/third-party/pom.xml
+++ b/releng/third-party/pom.xml
@@ -84,7 +84,7 @@
 									</instructions>
 								</artifact>
 								<artifact>
-									<id>org.hdrhistogram:HdrHistogram:2.1.11</id>
+									<id>org.hdrhistogram:HdrHistogram:2.1.12</id>
 								</artifact>
 								<artifact>
 									<id>org.adoptopenjdk:jemmy-awt-input:2.0.0</id>


### PR DESCRIPTION
As part of this enhancement, the third party HdrHistogram is upgraded from 2.1.11 to 2.1.12 (latest).

Please review the change.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JMC-6911](https://bugs.openjdk.java.net/browse/JMC-6911): Third Party Upgrade to HdrHistogram 2.1.12


### Reviewers
 * [Marcus Hirt](https://openjdk.java.net/census#hirt) (@thegreystone - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jmc pull/134/head:pull/134`
`$ git checkout pull/134`
