### PR TITLE
6947: Allow executable name to show up in JPS

### DIFF
--- a/application/org.openjdk.jmc.rcp.product/jmc.product
+++ b/application/org.openjdk.jmc.rcp.product/jmc.product
@@ -57,6 +57,7 @@
       <programArgsWin>
       </programArgsWin>
       <vmArgs>-XX:+IgnoreUnrecognizedVMOptions -XX:+UnlockDiagnosticVMOptions -XX:+DebugNonSafepoints -XX:FlightRecorderOptions=stackdepth=128 -XX:+FlightRecorder -XX:StartFlightRecording=name=JMC_Default,maxsize=100m -Djava.net.preferIPv4Stack=true -Djdk.attach.allowAttachSelf=true --add-exports=java.xml/com.sun.org.apache.xerces.internal.parsers=ALL-UNNAMED --add-exports=jdk.internal.jvmstat/sun.jvmstat.monitor=ALL-UNNAMED --add-exports=java.management/sun.management=ALL-UNNAMED --add-exports=java.management/sun.management.counter.perf=ALL-UNNAMED --add-exports=jdk.management.agent/jdk.internal.agent=ALL-UNNAMED --add-exports=jdk.attach/sun.tools.attach=ALL-UNNAMED --add-opens=java.base/java.net=ALL-UNNAMED --add-opens=jdk.attach/sun.tools.attach=ALL-UNNAMED 
+      -Dsun.java.command=JMC
       </vmArgs>
       <vmArgsLin>--add-exports=java.desktop/sun.awt.X11=ALL-UNNAMED
       </vmArgsLin>


### PR DESCRIPTION
When executing `jps` to view running Java applications, the displayed name
comes from a `sun.java.command` property. This is usually the name of the
Main-Class when executing it with `java` directly, but Eclipse starts the JVM
by using the native calls which bypasses this setting.

By adding a property definition `sun.java.command=JMC` then the application
will show up appropriately in JPS.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JMC-6947](https://bugs.openjdk.java.net/browse/JMC-6947): Allow executable name to show up in JPS


### Reviewers
 * [Marcus Hirt](https://openjdk.java.net/census#hirt) (@thegreystone - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jmc pull/137/head:pull/137`
`$ git checkout pull/137`
