### PR TITLE
5700: Improve file and socket IO rule result texts

### DIFF
--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/io/FileReadRule.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/io/FileReadRule.java
@@ -44,6 +44,7 @@ import org.openjdk.jmc.common.IDisplayable;
 import org.openjdk.jmc.common.item.Aggregators;
 import org.openjdk.jmc.common.item.IItem;
 import org.openjdk.jmc.common.item.IItemCollection;
+import org.openjdk.jmc.common.item.ItemFilters;
 import org.openjdk.jmc.common.unit.IQuantity;
 import org.openjdk.jmc.common.unit.UnitLookup;
 import org.openjdk.jmc.common.util.IPreferenceValueProvider;
@@ -83,8 +84,8 @@ public class FileReadRule implements IRule {
 		IQuantity warningLimit = vp.getPreferenceValue(READ_WARNING_LIMIT);
 		IQuantity infoLimit = warningLimit.multiply(0.5);
 
-		IItem longestEvent = items.apply(JdkFilters.FILE_READ)
-				.getAggregate(Aggregators.itemWithMax(JfrAttributes.DURATION));
+		IItemCollection fileReadEvents = items.apply(JdkFilters.FILE_READ);
+		IItem longestEvent = fileReadEvents.getAggregate(Aggregators.itemWithMax(JfrAttributes.DURATION));
 
 		// Aggregate of all file read events - if null, then we had no events
 		if (longestEvent == null) {
@@ -97,13 +98,25 @@ public class FileReadRule implements IRule {
 				infoLimit.doubleValueIn(UnitLookup.SECOND), warningLimit.doubleValueIn(UnitLookup.SECOND));
 
 		if (Severity.get(score) == Severity.WARNING || Severity.get(score) == Severity.INFO) {
-			String fileName = sanitizeFileName(RulesToolkit.getValue(longestEvent, JdkAttributes.IO_PATH));
+			String longestIOPath = RulesToolkit.getValue(longestEvent, JdkAttributes.IO_PATH);
+			String fileName = sanitizeFileName(longestIOPath);
 			String amountRead = RulesToolkit.getValue(longestEvent, JdkAttributes.IO_FILE_BYTES_READ)
+					.displayUsing(IDisplayable.AUTO);
+			String avgDuration = fileReadEvents
+					.getAggregate(Aggregators.avg(JdkTypeIDs.FILE_READ, JfrAttributes.DURATION))
+					.displayUsing(IDisplayable.AUTO);
+			String totalDuration = fileReadEvents
+					.getAggregate(Aggregators.sum(JdkTypeIDs.FILE_READ, JfrAttributes.DURATION))
+					.displayUsing(IDisplayable.AUTO);
+			IItemCollection eventsFromLongestIOPath = fileReadEvents
+					.apply(ItemFilters.equals(JdkAttributes.IO_PATH, longestIOPath));
+			String totalLongestIOPath = eventsFromLongestIOPath
+					.getAggregate(Aggregators.sum(JdkTypeIDs.FILE_READ, JfrAttributes.DURATION))
 					.displayUsing(IDisplayable.AUTO);
 			return new Result(this, score,
 					MessageFormat.format(Messages.getString(Messages.FileReadRuleFactory_TEXT_WARN), peakDuration),
 					MessageFormat.format(Messages.getString(Messages.FileReadRuleFactory_TEXT_WARN_LONG), peakDuration,
-							fileName, amountRead),
+							fileName, amountRead, avgDuration, totalDuration, totalLongestIOPath),
 					JdkQueries.FILE_READ);
 		}
 		return new Result(this, score,

--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/io/SocketWriteRule.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/io/SocketWriteRule.java
@@ -44,6 +44,7 @@ import org.openjdk.jmc.common.IDisplayable;
 import org.openjdk.jmc.common.item.Aggregators;
 import org.openjdk.jmc.common.item.IItem;
 import org.openjdk.jmc.common.item.IItemCollection;
+import org.openjdk.jmc.common.item.ItemFilters;
 import org.openjdk.jmc.common.unit.IQuantity;
 import org.openjdk.jmc.common.unit.UnitLookup;
 import org.openjdk.jmc.common.util.IPreferenceValueProvider;
@@ -97,8 +98,8 @@ public class SocketWriteRule implements IRule {
 			return RulesToolkit.getEventAvailabilityResult(this, items, eventAvailability, JdkTypeIDs.SOCKET_WRITE);
 		}
 
-		IItem longestEvent = items.apply(JdkFilters.NO_RMI_SOCKET_WRITE)
-				.getAggregate(Aggregators.itemWithMax(JfrAttributes.DURATION));
+		IItemCollection writeItems = items.apply(JdkFilters.NO_RMI_SOCKET_WRITE);
+		IItem longestEvent = writeItems.getAggregate(Aggregators.itemWithMax(JfrAttributes.DURATION));
 		// We had events, but all got filtered out - say ok, duration 0. Perhaps say "no matching" or something similar.
 		if (longestEvent == null) {
 			String shortMessage = Messages.getString(Messages.SocketWriteRuleFactory_TEXT_NO_EVENTS);
@@ -113,15 +114,27 @@ public class SocketWriteRule implements IRule {
 				infoLimit.doubleValueIn(UnitLookup.SECOND), warningLimit.doubleValueIn(UnitLookup.SECOND));
 
 		if (Severity.get(score) == Severity.WARNING || Severity.get(score) == Severity.INFO) {
-			String address = SocketReadRule
-					.sanitizeAddress(RulesToolkit.getValue(longestEvent, JdkAttributes.IO_ADDRESS));
+			String longestIOAddress = RulesToolkit.getValue(longestEvent, JdkAttributes.IO_ADDRESS);
+			String address = SocketReadRule.sanitizeAddress(longestIOAddress);
 			String amountWritten = RulesToolkit.getValue(longestEvent, JdkAttributes.IO_SOCKET_BYTES_WRITTEN)
+					.displayUsing(IDisplayable.AUTO);
+			String avgDuration = writeItems
+					.getAggregate(Aggregators.avg(JdkTypeIDs.SOCKET_WRITE, JfrAttributes.DURATION))
+					.displayUsing(IDisplayable.AUTO);
+			String totalDuration = writeItems
+					.getAggregate(Aggregators.sum(JdkTypeIDs.SOCKET_WRITE, JfrAttributes.DURATION))
+					.displayUsing(IDisplayable.AUTO);
+			IItemCollection eventsFromLongestAddress = writeItems
+					.apply(ItemFilters.equals(JdkAttributes.IO_ADDRESS, longestIOAddress));
+			String totalLongestIOAddress = eventsFromLongestAddress
+					.getAggregate(Aggregators.sum(JdkTypeIDs.SOCKET_WRITE, JfrAttributes.DURATION))
 					.displayUsing(IDisplayable.AUTO);
 			String shortMessage = MessageFormat.format(Messages.getString(Messages.SocketWriteRuleFactory_TEXT_WARN),
 					peakDuration);
 			String longMessage = MessageFormat.format(
 					Messages.getString(Messages.SocketWriteRuleFactory_TEXT_WARN_LONG), peakDuration, address,
-					amountWritten) + " " + Messages.getString(Messages.SocketWriteRuleFactory_TEXT_RMI_NOTE); //$NON-NLS-1$
+					amountWritten, avgDuration, totalDuration, totalLongestIOAddress) + " " //$NON-NLS-1$
+					+ Messages.getString(Messages.SocketWriteRuleFactory_TEXT_RMI_NOTE);
 			return new Result(this, score, shortMessage, longMessage);
 		}
 		String shortMessage = MessageFormat.format(Messages.getString(Messages.SocketWriteRuleFactory_TEXT_OK),

--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/resources/org/openjdk/jmc/flightrecorder/rules/jdk/messages/internal/messages.properties
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/resources/org/openjdk/jmc/flightrecorder/rules/jdk/messages/internal/messages.properties
@@ -241,7 +241,7 @@ FileReadRuleFactory_TEXT_NO_EVENTS=There are no file read events in this recordi
 # {0} is a time period
 FileReadRuleFactory_TEXT_WARN=There are long file read pauses in this recording (the longest is {0}).
 # {0} is a time period, {1} is a time stamp, {2} is a size in bytes
-FileReadRuleFactory_TEXT_WARN_LONG=The longest recorded file read took {0} to read {2} from {1}. Average time of all IO of the recording: {3}. Total time of all IO of the recording: {4}. Total time of all IO of the file {1}: {5}.
+FileReadRuleFactory_TEXT_WARN_LONG=The longest recorded file read took {0} to read {2} from {1}. Average time of recorded IO: {3}. Total time of recorded IO: {4}. Total time of recorded IO for the file {1}: {5}.
 FileWriteRule_CONFIG_WARNING_LIMIT=File write duration warning limit
 FileWriteRule_CONFIG_WARNING_LIMIT_LONG=The shortest file write duration that should trigger a warning
 FileWriteRuleFactory_RULE_NAME=File Write Peak Duration
@@ -251,7 +251,7 @@ FileWriteRuleFactory_TEXT_NO_EVENTS=There are no file write events in this recor
 # {0} is a time period
 FileWriteRuleFactory_TEXT_WARN=There are long file write pauses in this recording (the longest is {0}).
 # {0} is a time period, {1} is a time stamp, {2} is a size in bytes
-FileWriteRuleFactory_TEXT_WARN_LONG=The longest recorded file write took {0} to write {2} to {1}. Average time of all IO of the recording: {3}. Total time of all IO of the recording: {4}. Total time of all IO of the file {1}: {5}.
+FileWriteRuleFactory_TEXT_WARN_LONG=The longest recorded file write took {0} to write {2} to {1}. Average time of recorded IO: {3}. Total time of recoded IO: {4}. Total time of recoded IO for the file {1}: {5}.
 FlightRecordingSupportRule_RULE_NAME=Flight Recording Support
 FlightRecordingSupportRule_TEXT_OK=The JVM version used for this recording has full Flight Recorder support.
 FlightRecordingSupportRule_EA_TEXT_WARN_SHORT=The recording is from an early access build.
@@ -569,7 +569,7 @@ SocketReadRuleFactory_TEXT_RMI_NOTE=Note that there are some socket read pattern
 # {0} is a time period
 SocketReadRuleFactory_TEXT_WARN=There are long socket read pauses in this recording (the longest is {0}).
 # {0} is a time period, {1} is a host name, {2} is a size in bytes
-SocketReadRuleFactory_TEXT_WARN_LONG=The longest recorded socket read took {0} to read {2} from the host at {1}. Average time of all IO of the recording: {3}. Total time of all IO of the recording: {4}. Total time of all IO of the host {1}: {5}.
+SocketReadRuleFactory_TEXT_WARN_LONG=The longest recorded socket read took {0} to read {2} from the host at {1}. Average time of recorded IO: {3}. Total time of recoded IO: {4}. Total time of recoded IO for the host {1}: {5}.
 SocketWriteRule_CONFIG_INFO_LIMIT=Socket write duration info limit
 SocketWriteRule_CONFIG_INFO_LIMIT_LONG=The shortest socket write duration that should trigger an info notice
 SocketWriteRule_CONFIG_WARNING_LIMIT=Socket write duration warning limit
@@ -582,7 +582,7 @@ SocketWriteRuleFactory_TEXT_RMI_NOTE=Note that there are some socket write patte
 # {0} is a time period
 SocketWriteRuleFactory_TEXT_WARN=There are long socket write pauses in this recording (the longest is {0}).
 # {0} is a time period, {1} is a host name, {2} is a size in bytes
-SocketWriteRuleFactory_TEXT_WARN_LONG=The longest recorded socket write took {0} to write {2} to the host at {1}. Average time of all IO of the recording: {3}. Total time of all IO of the recording: {4}. Total time of all IO of the host {1}: {5}.
+SocketWriteRuleFactory_TEXT_WARN_LONG=The longest recorded socket write took {0} to write {2} to the host at {1}. Average time of recroded IO: {3}. Total time of recorded IO: {4}. Total time of recorded IO for the host {1}: {5}.
 StackdepthSettingRule_RULE_NAME=Stackdepth Setting
 StackdepthSettingRule_TEXT_INFO=Some stack traces were truncated in this recording.
 # {0} is a number, {1} is an empty String or StackdepthSettingRule_TEXT_INFO_LONG_DEFAULT, {2} is a percentage, {3} is an HTML list of event type names

--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/resources/org/openjdk/jmc/flightrecorder/rules/jdk/messages/internal/messages.properties
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/resources/org/openjdk/jmc/flightrecorder/rules/jdk/messages/internal/messages.properties
@@ -241,7 +241,7 @@ FileReadRuleFactory_TEXT_NO_EVENTS=There are no file read events in this recordi
 # {0} is a time period
 FileReadRuleFactory_TEXT_WARN=There are long file read pauses in this recording (the longest is {0}).
 # {0} is a time period, {1} is a time stamp, {2} is a size in bytes
-FileReadRuleFactory_TEXT_WARN_LONG=The longest recorded file read took {0} to read {2} from {1}.
+FileReadRuleFactory_TEXT_WARN_LONG=The longest recorded file read took {0} to read {2} from {1}. Average time of all IO of the recording: {3}. Total time of all IO of the recording: {4}. Total time of all IO of the file {1}: {5}.
 FileWriteRule_CONFIG_WARNING_LIMIT=File write duration warning limit
 FileWriteRule_CONFIG_WARNING_LIMIT_LONG=The shortest file write duration that should trigger a warning
 FileWriteRuleFactory_RULE_NAME=File Write Peak Duration
@@ -251,7 +251,7 @@ FileWriteRuleFactory_TEXT_NO_EVENTS=There are no file write events in this recor
 # {0} is a time period
 FileWriteRuleFactory_TEXT_WARN=There are long file write pauses in this recording (the longest is {0}).
 # {0} is a time period, {1} is a time stamp, {2} is a size in bytes
-FileWriteRuleFactory_TEXT_WARN_LONG=The longest recorded file write took {0} to write {2} to {1}.
+FileWriteRuleFactory_TEXT_WARN_LONG=The longest recorded file write took {0} to write {2} to {1}. Average time of all IO of the recording: {3}. Total time of all IO of the recording: {4}. Total time of all IO of the file {1}: {5}.
 FlightRecordingSupportRule_RULE_NAME=Flight Recording Support
 FlightRecordingSupportRule_TEXT_OK=The JVM version used for this recording has full Flight Recorder support.
 FlightRecordingSupportRule_EA_TEXT_WARN_SHORT=The recording is from an early access build.
@@ -569,7 +569,7 @@ SocketReadRuleFactory_TEXT_RMI_NOTE=Note that there are some socket read pattern
 # {0} is a time period
 SocketReadRuleFactory_TEXT_WARN=There are long socket read pauses in this recording (the longest is {0}).
 # {0} is a time period, {1} is a host name, {2} is a size in bytes
-SocketReadRuleFactory_TEXT_WARN_LONG=The longest recorded socket read took {0} to read {2} from the host at {1}.
+SocketReadRuleFactory_TEXT_WARN_LONG=The longest recorded socket read took {0} to read {2} from the host at {1}. Average time of all IO of the recording: {3}. Total time of all IO of the recording: {4}. Total time of all IO of the host {1}: {5}.
 SocketWriteRule_CONFIG_INFO_LIMIT=Socket write duration info limit
 SocketWriteRule_CONFIG_INFO_LIMIT_LONG=The shortest socket write duration that should trigger an info notice
 SocketWriteRule_CONFIG_WARNING_LIMIT=Socket write duration warning limit
@@ -582,7 +582,7 @@ SocketWriteRuleFactory_TEXT_RMI_NOTE=Note that there are some socket write patte
 # {0} is a time period
 SocketWriteRuleFactory_TEXT_WARN=There are long socket write pauses in this recording (the longest is {0}).
 # {0} is a time period, {1} is a host name, {2} is a size in bytes
-SocketWriteRuleFactory_TEXT_WARN_LONG=The longest recorded socket write took {0} to write {2} to the host at {1}.
+SocketWriteRuleFactory_TEXT_WARN_LONG=The longest recorded socket write took {0} to write {2} to the host at {1}. Average time of all IO of the recording: {3}. Total time of all IO of the recording: {4}. Total time of all IO of the host {1}: {5}.
 StackdepthSettingRule_RULE_NAME=Stackdepth Setting
 StackdepthSettingRule_TEXT_INFO=Some stack traces were truncated in this recording.
 # {0} is a number, {1} is an empty String or StackdepthSettingRule_TEXT_INFO_LONG_DEFAULT, {2} is a percentage, {3} is an HTML list of event type names

--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/resources/org/openjdk/jmc/flightrecorder/rules/jdk/messages/internal/messages.properties
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/resources/org/openjdk/jmc/flightrecorder/rules/jdk/messages/internal/messages.properties
@@ -251,7 +251,7 @@ FileWriteRuleFactory_TEXT_NO_EVENTS=There are no file write events in this recor
 # {0} is a time period
 FileWriteRuleFactory_TEXT_WARN=There are long file write pauses in this recording (the longest is {0}).
 # {0} is a time period, {1} is a time stamp, {2} is a size in bytes
-FileWriteRuleFactory_TEXT_WARN_LONG=The longest recorded file write took {0} to write {2} to {1}. Average time of recorded IO: {3}. Total time of recoded IO: {4}. Total time of recoded IO for the file {1}: {5}.
+FileWriteRuleFactory_TEXT_WARN_LONG=The longest recorded file write took {0} to write {2} to {1}. Average time of recorded IO: {3}. Total time of recorded IO: {4}. Total time of recorded IO for the file {1}: {5}.
 FlightRecordingSupportRule_RULE_NAME=Flight Recording Support
 FlightRecordingSupportRule_TEXT_OK=The JVM version used for this recording has full Flight Recorder support.
 FlightRecordingSupportRule_EA_TEXT_WARN_SHORT=The recording is from an early access build.
@@ -569,7 +569,7 @@ SocketReadRuleFactory_TEXT_RMI_NOTE=Note that there are some socket read pattern
 # {0} is a time period
 SocketReadRuleFactory_TEXT_WARN=There are long socket read pauses in this recording (the longest is {0}).
 # {0} is a time period, {1} is a host name, {2} is a size in bytes
-SocketReadRuleFactory_TEXT_WARN_LONG=The longest recorded socket read took {0} to read {2} from the host at {1}. Average time of recorded IO: {3}. Total time of recoded IO: {4}. Total time of recoded IO for the host {1}: {5}.
+SocketReadRuleFactory_TEXT_WARN_LONG=The longest recorded socket read took {0} to read {2} from the host at {1}. Average time of recorded IO: {3}. Total time of recorded IO: {4}. Total time of recorded IO for the host {1}: {5}.
 SocketWriteRule_CONFIG_INFO_LIMIT=Socket write duration info limit
 SocketWriteRule_CONFIG_INFO_LIMIT_LONG=The shortest socket write duration that should trigger an info notice
 SocketWriteRule_CONFIG_WARNING_LIMIT=Socket write duration warning limit
@@ -582,7 +582,7 @@ SocketWriteRuleFactory_TEXT_RMI_NOTE=Note that there are some socket write patte
 # {0} is a time period
 SocketWriteRuleFactory_TEXT_WARN=There are long socket write pauses in this recording (the longest is {0}).
 # {0} is a time period, {1} is a host name, {2} is a size in bytes
-SocketWriteRuleFactory_TEXT_WARN_LONG=The longest recorded socket write took {0} to write {2} to the host at {1}. Average time of recroded IO: {3}. Total time of recorded IO: {4}. Total time of recorded IO for the host {1}: {5}.
+SocketWriteRuleFactory_TEXT_WARN_LONG=The longest recorded socket write took {0} to write {2} to the host at {1}. Average time of recorded IO: {3}. Total time of recorded IO: {4}. Total time of recorded IO for the host {1}: {5}.
 StackdepthSettingRule_RULE_NAME=Stackdepth Setting
 StackdepthSettingRule_TEXT_INFO=Some stack traces were truncated in this recording.
 # {0} is a number, {1} is an empty String or StackdepthSettingRule_TEXT_INFO_LONG_DEFAULT, {2} is a percentage, {3} is an HTML list of event type names

--- a/core/tests/org.openjdk.jmc.flightrecorder.rules.jdk.test/src/test/java/org/openjdk/jmc/flightrecorder/test/rules/jdk/FileTestEvent.java
+++ b/core/tests/org.openjdk.jmc.flightrecorder.rules.jdk.test/src/test/java/org/openjdk/jmc/flightrecorder/test/rules/jdk/FileTestEvent.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, Datadog, Inc. All rights reserved.
+ *
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * The contents of this file are subject to the terms of either the Universal Permissive License
+ * v 1.0 as shown at http://oss.oracle.com/licenses/upl
+ *
+ * or the following license:
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted
+ * provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions
+ * and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other materials provided with
+ * the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to
+ * endorse or promote products derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+ * WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.openjdk.jmc.flightrecorder.test.rules.jdk;
+
+import org.openjdk.jmc.common.item.IAccessorKey;
+import org.openjdk.jmc.common.item.IItem;
+import org.openjdk.jmc.common.item.IMemberAccessor;
+import org.openjdk.jmc.common.unit.IQuantity;
+import org.openjdk.jmc.common.unit.UnitLookup;
+import org.openjdk.jmc.common.util.MemberAccessorToolkit;
+
+public class FileTestEvent extends TestEvent {
+	private final String fileName;
+	private final long duration;
+	private final long bytesProcessed;
+
+	public FileTestEvent(String eventType, String fileName, long duration, long bytesProcessed) {
+		super(eventType);
+		this.fileName = fileName;
+		this.duration = duration;
+		this.bytesProcessed = bytesProcessed;
+	}
+
+	@Override
+	public <M> IMemberAccessor<M, IItem> getAccessor(IAccessorKey<M> attribute) {
+		if ("duration".equals(attribute.getIdentifier())) {
+			return (IMemberAccessor<M, IItem>) MemberAccessorToolkit
+					.<IItem, IQuantity, IQuantity> constant(UnitLookup.MILLISECOND.quantity(duration));
+		}
+		if ("path".equals(attribute.getIdentifier())) {
+			return (IMemberAccessor<M, IItem>) MemberAccessorToolkit.<IItem, String, String> constant(fileName);
+		}
+		if ("bytesRead".equals(attribute.getIdentifier())) {
+			return (IMemberAccessor<M, IItem>) MemberAccessorToolkit
+					.<IItem, IQuantity, IQuantity> constant(UnitLookup.BYTE.quantity(bytesProcessed));
+		}
+		if ("bytesWritten".equals(attribute.getIdentifier())) {
+			return (IMemberAccessor<M, IItem>) MemberAccessorToolkit
+					.<IItem, IQuantity, IQuantity> constant(UnitLookup.BYTE.quantity(bytesProcessed));
+		}
+		return null;
+	}
+}

--- a/core/tests/org.openjdk.jmc.flightrecorder.rules.jdk.test/src/test/java/org/openjdk/jmc/flightrecorder/test/rules/jdk/MockEventCollection.java
+++ b/core/tests/org.openjdk.jmc.flightrecorder.rules.jdk.test/src/test/java/org/openjdk/jmc/flightrecorder/test/rules/jdk/MockEventCollection.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, Datadog, Inc. All rights reserved.
+ *
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * The contents of this file are subject to the terms of either the Universal Permissive License
+ * v 1.0 as shown at http://oss.oracle.com/licenses/upl
+ *
+ * or the following license:
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted
+ * provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions
+ * and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other materials provided with
+ * the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to
+ * endorse or promote products derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+ * WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.openjdk.jmc.flightrecorder.test.rules.jdk;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+
+import org.openjdk.jmc.common.item.IAggregator;
+import org.openjdk.jmc.common.item.IItem;
+import org.openjdk.jmc.common.item.IItemCollection;
+import org.openjdk.jmc.common.item.IItemConsumer;
+import org.openjdk.jmc.common.item.IItemFilter;
+import org.openjdk.jmc.common.item.IItemIterable;
+import org.openjdk.jmc.common.unit.IQuantity;
+import org.openjdk.jmc.common.unit.IRange;
+
+public class MockEventCollection implements IItemCollection {
+	private final List<TestEventItem> items = new ArrayList<>();
+
+	public MockEventCollection(TestEvent[] values) {
+		for (TestEvent value : values) {
+			items.add(new TestEventItem(value));
+		}
+	}
+
+	@Override
+	public IItemCollection apply(IItemFilter filter) {
+		ArrayList<TestEvent> newEntries = new ArrayList<>();
+		for (TestEventItem item : items) {
+			if (filter.getPredicate(item.getType()).test(item)) {
+				newEntries.add(item.getEvent());
+			}
+		}
+		return new MockEventCollection(newEntries.toArray(new TestEvent[0]));
+	}
+
+	@Override
+	public Iterator<IItemIterable> iterator() {
+		return Collections.<IItemIterable> unmodifiableList(items).iterator();
+	}
+
+	@Override
+	public <V, C extends IItemConsumer<C>> V getAggregate(IAggregator<V, C> aggregator) {
+		return aggregate(aggregator, items.iterator());
+	}
+
+	private static <V, C extends IItemConsumer<C>> V aggregate(
+		final IAggregator<V, C> aggregator, final Iterator<? extends IItem> items) {
+		return aggregator.getValue(new Iterator<C>() {
+
+			TestEventItem next = findNext();
+
+			@Override
+			public boolean hasNext() {
+				return next != null;
+			}
+
+			@Override
+			public C next() {
+				C calc = aggregator.newItemConsumer(next.getType());
+				calc.consume(next);
+				next = findNext();
+				return calc;
+			}
+
+			TestEventItem findNext() {
+				while (items.hasNext()) {
+					TestEventItem ii = (TestEventItem) items.next();
+					if (aggregator.acceptType(ii.getType())) {
+						return ii;
+					}
+				}
+				return null;
+			}
+
+			@Override
+			public void remove() {
+				throw new UnsupportedOperationException();
+			}
+		});
+	}
+
+	@Override
+	public boolean hasItems() {
+		return !items.isEmpty();
+	}
+
+	@Override
+	public Set<IRange<IQuantity>> getTimeRanges() {
+		return null;
+	}
+}

--- a/core/tests/org.openjdk.jmc.flightrecorder.rules.jdk.test/src/test/java/org/openjdk/jmc/flightrecorder/test/rules/jdk/SocketTestEvent.java
+++ b/core/tests/org.openjdk.jmc.flightrecorder.rules.jdk.test/src/test/java/org/openjdk/jmc/flightrecorder/test/rules/jdk/SocketTestEvent.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, Datadog, Inc. All rights reserved.
+ *
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * The contents of this file are subject to the terms of either the Universal Permissive License
+ * v 1.0 as shown at http://oss.oracle.com/licenses/upl
+ *
+ * or the following license:
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted
+ * provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions
+ * and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other materials provided with
+ * the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to
+ * endorse or promote products derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+ * WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.openjdk.jmc.flightrecorder.test.rules.jdk;
+
+import org.openjdk.jmc.common.item.IAccessorKey;
+import org.openjdk.jmc.common.item.ICanonicalAccessorFactory;
+import org.openjdk.jmc.common.item.IItem;
+import org.openjdk.jmc.common.item.IMemberAccessor;
+import org.openjdk.jmc.common.unit.IQuantity;
+import org.openjdk.jmc.common.unit.UnitLookup;
+import org.openjdk.jmc.common.util.MemberAccessorToolkit;
+
+public class SocketTestEvent extends TestEvent {
+	private final String address;
+	private final long duration;
+	private final long bytesProcessed;
+
+	public SocketTestEvent(String eventType, String address, long duration, long bytesProcessed) {
+		super(eventType);
+		this.address = address;
+		this.duration = duration;
+		this.bytesProcessed = bytesProcessed;
+	}
+
+	@Override
+	public <M> IMemberAccessor<M, IItem> getAccessor(IAccessorKey<M> attribute) {
+		if ("duration".equals(attribute.getIdentifier())) {
+			return (IMemberAccessor<M, IItem>) MemberAccessorToolkit
+					.<IItem, IQuantity, IQuantity> constant(UnitLookup.MILLISECOND.quantity(duration));
+		}
+		if ("address".equals(attribute.getIdentifier())) {
+			return (IMemberAccessor<M, IItem>) MemberAccessorToolkit.<IItem, String, String> constant(address);
+		}
+		if ("bytesRead".equals(attribute.getIdentifier())) {
+			return (IMemberAccessor<M, IItem>) MemberAccessorToolkit
+					.<IItem, IQuantity, IQuantity> constant(UnitLookup.BYTE.quantity(bytesProcessed));
+		}
+		if ("bytesWritten".equals(attribute.getIdentifier())) {
+			return (IMemberAccessor<M, IItem>) MemberAccessorToolkit
+					.<IItem, IQuantity, IQuantity> constant(UnitLookup.BYTE.quantity(bytesProcessed));
+		}
+		return null;
+	}
+
+	@Override
+	public boolean hasAttribute(ICanonicalAccessorFactory<?> attribute) {
+		if ("duration".equals(attribute.getIdentifier())) {
+			return true;
+		}
+		if ("address".equals(attribute.getIdentifier())) {
+			return true;
+		}
+		if ("bytesRead".equals(attribute.getIdentifier())) {
+			return true;
+		}
+		if ("bytesWritten".equals(attribute.getIdentifier())) {
+			return true;
+		}
+		return false;
+	}
+
+}

--- a/core/tests/org.openjdk.jmc.flightrecorder.rules.jdk.test/src/test/java/org/openjdk/jmc/flightrecorder/test/rules/jdk/TestEvent.java
+++ b/core/tests/org.openjdk.jmc.flightrecorder.rules.jdk.test/src/test/java/org/openjdk/jmc/flightrecorder/test/rules/jdk/TestEvent.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, Datadog, Inc. All rights reserved.
+ *
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * The contents of this file are subject to the terms of either the Universal Permissive License
+ * v 1.0 as shown at http://oss.oracle.com/licenses/upl
+ *
+ * or the following license:
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted
+ * provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions
+ * and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other materials provided with
+ * the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to
+ * endorse or promote products derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+ * WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.openjdk.jmc.flightrecorder.test.rules.jdk;
+
+import java.util.List;
+import java.util.Map;
+
+import org.openjdk.jmc.common.IDescribable;
+import org.openjdk.jmc.common.item.IAccessorKey;
+import org.openjdk.jmc.common.item.IAttribute;
+import org.openjdk.jmc.common.item.ICanonicalAccessorFactory;
+import org.openjdk.jmc.common.item.IItem;
+import org.openjdk.jmc.common.item.IMemberAccessor;
+import org.openjdk.jmc.common.item.IType;
+
+public class TestEvent implements IType<IItem> {
+	private final String eventName;
+
+	public TestEvent(String eventName) {
+		this.eventName = eventName;
+	}
+
+	@Override
+	public String getName() {
+		return eventName;
+	}
+
+	@Override
+	public String getDescription() {
+		return null;
+	}
+
+	@Override
+	public List<IAttribute<?>> getAttributes() {
+		return null;
+	}
+
+	@Override
+	public Map<IAccessorKey<?>, ? extends IDescribable> getAccessorKeys() {
+		return null;
+	}
+
+	@Override
+	public boolean hasAttribute(ICanonicalAccessorFactory<?> attribute) {
+		return false;
+	}
+
+	@Override
+	public <M> IMemberAccessor<M, IItem> getAccessor(IAccessorKey<M> attribute) {
+		return null;
+	}
+
+	@Override
+	public String getIdentifier() {
+		return eventName;
+	}
+}

--- a/core/tests/org.openjdk.jmc.flightrecorder.rules.jdk.test/src/test/java/org/openjdk/jmc/flightrecorder/test/rules/jdk/TestEventItem.java
+++ b/core/tests/org.openjdk.jmc.flightrecorder.rules.jdk.test/src/test/java/org/openjdk/jmc/flightrecorder/test/rules/jdk/TestEventItem.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, Datadog, Inc. All rights reserved.
+ *
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * The contents of this file are subject to the terms of either the Universal Permissive License
+ * v 1.0 as shown at http://oss.oracle.com/licenses/upl
+ *
+ * or the following license:
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted
+ * provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions
+ * and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other materials provided with
+ * the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to
+ * endorse or promote products derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+ * WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.openjdk.jmc.flightrecorder.test.rules.jdk;
+
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.function.Predicate;
+
+import org.openjdk.jmc.common.item.IItem;
+import org.openjdk.jmc.common.item.IItemIterable;
+import org.openjdk.jmc.common.item.IType;
+
+public class TestEventItem implements IItem, IItemIterable {
+	private final TestEvent event;
+
+	public TestEventItem(TestEvent event) {
+		this.event = event;
+	}
+
+	@Override
+	public IType<IItem> getType() {
+		return event;
+	}
+
+	TestEvent getEvent() {
+		return event;
+	}
+
+	@Override
+	public Iterator<IItem> iterator() {
+		return Collections.singleton((IItem) event).iterator();
+	}
+
+	@Override
+	public boolean hasItems() {
+		return true;
+	}
+
+	@Override
+	public long getItemCount() {
+		// TODO Auto-generated method stub
+		return 0;
+	}
+
+	@Override
+	public IItemIterable apply(Predicate<IItem> predicate) {
+		// TODO Auto-generated method stub
+		return null;
+	}
+}

--- a/core/tests/org.openjdk.jmc.flightrecorder.rules.jdk.test/src/test/java/org/openjdk/jmc/flightrecorder/test/rules/jdk/TestFileReadWriteRule.java
+++ b/core/tests/org.openjdk.jmc.flightrecorder.rules.jdk.test/src/test/java/org/openjdk/jmc/flightrecorder/test/rules/jdk/TestFileReadWriteRule.java
@@ -53,13 +53,13 @@ public class TestFileReadWriteRule {
 	@Test
 	public void testReadRule() {
 		testFileRule(JdkTypeIDs.FILE_READ, new FileReadRule(),
-				"The longest recorded file read took 5 s to read 4 KiB from /user/dir/file1.dat. Average time of all IO of the recording: 4.500 s. Total time of all IO of the recording: 13.500 s. Total time of all IO of the file /user/dir/file1.dat: 9.500 s."); //$NON-NLS-1$
+				"The longest recorded file read took 5 s to read 4 KiB from /user/dir/file1.dat. Average time of recorded IO: 4.500 s. Total time of recorded IO: 13.500 s. Total time of recorded IO for the file /user/dir/file1.dat: 9.500 s."); //$NON-NLS-1$
 	}
 
 	@Test
 	public void testWriteRule() {
 		testFileRule(JdkTypeIDs.FILE_WRITE, new FileWriteRule(),
-				"The longest recorded file write took 5 s to write 4 KiB to /user/dir/file1.dat. Average time of all IO of the recording: 4.500 s. Total time of all IO of the recording: 13.500 s. Total time of all IO of the file /user/dir/file1.dat: 9.500 s."); //$NON-NLS-1$
+				"The longest recorded file write took 5 s to write 4 KiB to /user/dir/file1.dat. Average time of recorded IO: 4.500 s. Total time of recoded IO: 13.500 s. Total time of recoded IO for the file /user/dir/file1.dat: 9.500 s."); //$NON-NLS-1$
 	}
 
 	private void testFileRule(String eventType, IRule rule, String expectedLongDesc) {

--- a/core/tests/org.openjdk.jmc.flightrecorder.rules.jdk.test/src/test/java/org/openjdk/jmc/flightrecorder/test/rules/jdk/TestFileReadWriteRule.java
+++ b/core/tests/org.openjdk.jmc.flightrecorder.rules.jdk.test/src/test/java/org/openjdk/jmc/flightrecorder/test/rules/jdk/TestFileReadWriteRule.java
@@ -59,7 +59,7 @@ public class TestFileReadWriteRule {
 	@Test
 	public void testWriteRule() {
 		testFileRule(JdkTypeIDs.FILE_WRITE, new FileWriteRule(),
-				"The longest recorded file write took 5 s to write 4 KiB to /user/dir/file1.dat. Average time of recorded IO: 4.500 s. Total time of recoded IO: 13.500 s. Total time of recoded IO for the file /user/dir/file1.dat: 9.500 s."); //$NON-NLS-1$
+				"The longest recorded file write took 5 s to write 4 KiB to /user/dir/file1.dat. Average time of recorded IO: 4.500 s. Total time of recorded IO: 13.500 s. Total time of recorded IO for the file /user/dir/file1.dat: 9.500 s."); //$NON-NLS-1$
 	}
 
 	private void testFileRule(String eventType, IRule rule, String expectedLongDesc) {

--- a/core/tests/org.openjdk.jmc.flightrecorder.rules.jdk.test/src/test/java/org/openjdk/jmc/flightrecorder/test/rules/jdk/TestFileReadWriteRule.java
+++ b/core/tests/org.openjdk.jmc.flightrecorder.rules.jdk.test/src/test/java/org/openjdk/jmc/flightrecorder/test/rules/jdk/TestFileReadWriteRule.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, Datadog, Inc. All rights reserved.
+ *
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * The contents of this file are subject to the terms of either the Universal Permissive License
+ * v 1.0 as shown at http://oss.oracle.com/licenses/upl
+ *
+ * or the following license:
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted
+ * provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions
+ * and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other materials provided with
+ * the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to
+ * endorse or promote products derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+ * WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.openjdk.jmc.flightrecorder.test.rules.jdk;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.RunnableFuture;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openjdk.jmc.common.item.IItemCollection;
+import org.openjdk.jmc.common.util.IPreferenceValueProvider;
+import org.openjdk.jmc.flightrecorder.jdk.JdkTypeIDs;
+import org.openjdk.jmc.flightrecorder.rules.IRule;
+import org.openjdk.jmc.flightrecorder.rules.Result;
+import org.openjdk.jmc.flightrecorder.rules.jdk.io.FileReadRule;
+import org.openjdk.jmc.flightrecorder.rules.jdk.io.FileWriteRule;
+
+public class TestFileReadWriteRule {
+	private static final String FILE_NAME_1 = "/user/dir/file1.dat";
+	private static final String FILE_NAME_2 = "/user/dir/file2.dat";
+
+	@Test
+	public void testReadRule() {
+		testFileRule(JdkTypeIDs.FILE_READ, new FileReadRule(),
+				"The longest recorded file read took 5 s to read 4 KiB from /user/dir/file1.dat. Average time of all IO of the recording: 4.500 s. Total time of all IO of the recording: 13.500 s. Total time of all IO of the file /user/dir/file1.dat: 9.500 s."); //$NON-NLS-1$
+	}
+
+	@Test
+	public void testWriteRule() {
+		testFileRule(JdkTypeIDs.FILE_WRITE, new FileWriteRule(),
+				"The longest recorded file write took 5 s to write 4 KiB to /user/dir/file1.dat. Average time of all IO of the recording: 4.500 s. Total time of all IO of the recording: 13.500 s. Total time of all IO of the file /user/dir/file1.dat: 9.500 s."); //$NON-NLS-1$
+	}
+
+	private void testFileRule(String eventType, IRule rule, String expectedLongDesc) {
+		TestEvent[] testEvents = new TestEvent[] {new FileTestEvent(eventType, FILE_NAME_1, 4500, 4096),
+				new FileTestEvent(eventType, FILE_NAME_1, 5000, 4096),
+				new FileTestEvent(eventType, FILE_NAME_2, 4000, 4096)};
+		IItemCollection events = new MockEventCollection(testEvents);
+		RunnableFuture<Result> future = rule.evaluate(events, IPreferenceValueProvider.DEFAULT_VALUES);
+		try {
+			future.run();
+			Result res = future.get();
+			String longDesc = res.getLongDescription();
+			Assert.assertEquals(expectedLongDesc, longDesc);
+		} catch (InterruptedException | ExecutionException e) {
+			e.printStackTrace();
+		}
+
+	}
+}

--- a/core/tests/org.openjdk.jmc.flightrecorder.rules.jdk.test/src/test/java/org/openjdk/jmc/flightrecorder/test/rules/jdk/TestSocketReadWriteRule.java
+++ b/core/tests/org.openjdk.jmc.flightrecorder.rules.jdk.test/src/test/java/org/openjdk/jmc/flightrecorder/test/rules/jdk/TestSocketReadWriteRule.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, Datadog, Inc. All rights reserved.
+ *
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * The contents of this file are subject to the terms of either the Universal Permissive License
+ * v 1.0 as shown at http://oss.oracle.com/licenses/upl
+ *
+ * or the following license:
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted
+ * provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions
+ * and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other materials provided with
+ * the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to
+ * endorse or promote products derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+ * WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.openjdk.jmc.flightrecorder.test.rules.jdk;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.RunnableFuture;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openjdk.jmc.common.item.IItemCollection;
+import org.openjdk.jmc.common.util.IPreferenceValueProvider;
+import org.openjdk.jmc.flightrecorder.jdk.JdkTypeIDs;
+import org.openjdk.jmc.flightrecorder.rules.IRule;
+import org.openjdk.jmc.flightrecorder.rules.Result;
+import org.openjdk.jmc.flightrecorder.rules.jdk.io.SocketReadRule;
+import org.openjdk.jmc.flightrecorder.rules.jdk.io.SocketWriteRule;
+
+public class TestSocketReadWriteRule {
+	private static final String ADDRESS_1 = "123.45.67.78";
+	private static final String ADDRESS_2 = "123.102.103.104";
+
+	@Test
+	public void testReadRule() {
+		testSocketRule(JdkTypeIDs.SOCKET_READ, new SocketReadRule(),
+				"The longest recorded socket read took 5 s to read 4 KiB from the host at 123.45.67.78. Average time of all IO of the recording: 4.500 s. Total time of all IO of the recording: 13.500 s. Total time of all IO of the host 123.45.67.78: 9.500 s. Note that there are some socket read patterns with high duration reads that we consider to be normal and are therefore excluded. Such patterns include JMX RMI communication and MQ series."); //$NON-NLS-1$
+	}
+
+	@Test
+	public void testWriteRule() {
+		testSocketRule(JdkTypeIDs.SOCKET_WRITE, new SocketWriteRule(),
+				"The longest recorded socket write took 5 s to write 4 KiB to the host at 123.45.67.78. Average time of all IO of the recording: 4.500 s. Total time of all IO of the recording: 13.500 s. Total time of all IO of the host 123.45.67.78: 9.500 s. Note that there are some socket write patterns with high duration writes that we consider to be normal and are therefore excluded. Such patterns include JMX RMI communication."); //$NON-NLS-1$
+	}
+
+	private void testSocketRule(String eventType, IRule rule, String expectedLongDesc) {
+		TestEvent[] testEvents = new TestEvent[] {new SocketTestEvent(eventType, ADDRESS_1, 4500, 4096),
+				new SocketTestEvent(eventType, ADDRESS_1, 5000, 4096),
+				new SocketTestEvent(eventType, ADDRESS_2, 4000, 4096)};
+		IItemCollection events = new MockEventCollection(testEvents);
+		RunnableFuture<Result> future = rule.evaluate(events, IPreferenceValueProvider.DEFAULT_VALUES);
+		try {
+			future.run();
+			Result res = future.get();
+			String longDesc = res.getLongDescription();
+			Assert.assertEquals(expectedLongDesc, longDesc);
+		} catch (InterruptedException | ExecutionException e) {
+			e.printStackTrace();
+		}
+
+	}
+}

--- a/core/tests/org.openjdk.jmc.flightrecorder.rules.jdk.test/src/test/java/org/openjdk/jmc/flightrecorder/test/rules/jdk/TestSocketReadWriteRule.java
+++ b/core/tests/org.openjdk.jmc.flightrecorder.rules.jdk.test/src/test/java/org/openjdk/jmc/flightrecorder/test/rules/jdk/TestSocketReadWriteRule.java
@@ -53,13 +53,13 @@ public class TestSocketReadWriteRule {
 	@Test
 	public void testReadRule() {
 		testSocketRule(JdkTypeIDs.SOCKET_READ, new SocketReadRule(),
-				"The longest recorded socket read took 5 s to read 4 KiB from the host at 123.45.67.78. Average time of recorded IO: 4.500 s. Total time of recoded IO: 13.500 s. Total time of recoded IO for the host 123.45.67.78: 9.500 s. Note that there are some socket read patterns with high duration reads that we consider to be normal and are therefore excluded. Such patterns include JMX RMI communication and MQ series."); //$NON-NLS-1$
+				"The longest recorded socket read took 5 s to read 4 KiB from the host at 123.45.67.78. Average time of recorded IO: 4.500 s. Total time of recorded IO: 13.500 s. Total time of recorded IO for the host 123.45.67.78: 9.500 s. Note that there are some socket read patterns with high duration reads that we consider to be normal and are therefore excluded. Such patterns include JMX RMI communication and MQ series."); //$NON-NLS-1$
 	}
 
 	@Test
 	public void testWriteRule() {
 		testSocketRule(JdkTypeIDs.SOCKET_WRITE, new SocketWriteRule(),
-				"The longest recorded socket write took 5 s to write 4 KiB to the host at 123.45.67.78. Average time of recroded IO: 4.500 s. Total time of recorded IO: 13.500 s. Total time of recorded IO for the host 123.45.67.78: 9.500 s. Note that there are some socket write patterns with high duration writes that we consider to be normal and are therefore excluded. Such patterns include JMX RMI communication."); //$NON-NLS-1$
+				"The longest recorded socket write took 5 s to write 4 KiB to the host at 123.45.67.78. Average time of recorded IO: 4.500 s. Total time of recorded IO: 13.500 s. Total time of recorded IO for the host 123.45.67.78: 9.500 s. Note that there are some socket write patterns with high duration writes that we consider to be normal and are therefore excluded. Such patterns include JMX RMI communication."); //$NON-NLS-1$
 	}
 
 	private void testSocketRule(String eventType, IRule rule, String expectedLongDesc) {

--- a/core/tests/org.openjdk.jmc.flightrecorder.rules.jdk.test/src/test/java/org/openjdk/jmc/flightrecorder/test/rules/jdk/TestSocketReadWriteRule.java
+++ b/core/tests/org.openjdk.jmc.flightrecorder.rules.jdk.test/src/test/java/org/openjdk/jmc/flightrecorder/test/rules/jdk/TestSocketReadWriteRule.java
@@ -53,13 +53,13 @@ public class TestSocketReadWriteRule {
 	@Test
 	public void testReadRule() {
 		testSocketRule(JdkTypeIDs.SOCKET_READ, new SocketReadRule(),
-				"The longest recorded socket read took 5 s to read 4 KiB from the host at 123.45.67.78. Average time of all IO of the recording: 4.500 s. Total time of all IO of the recording: 13.500 s. Total time of all IO of the host 123.45.67.78: 9.500 s. Note that there are some socket read patterns with high duration reads that we consider to be normal and are therefore excluded. Such patterns include JMX RMI communication and MQ series."); //$NON-NLS-1$
+				"The longest recorded socket read took 5 s to read 4 KiB from the host at 123.45.67.78. Average time of recorded IO: 4.500 s. Total time of recoded IO: 13.500 s. Total time of recoded IO for the host 123.45.67.78: 9.500 s. Note that there are some socket read patterns with high duration reads that we consider to be normal and are therefore excluded. Such patterns include JMX RMI communication and MQ series."); //$NON-NLS-1$
 	}
 
 	@Test
 	public void testWriteRule() {
 		testSocketRule(JdkTypeIDs.SOCKET_WRITE, new SocketWriteRule(),
-				"The longest recorded socket write took 5 s to write 4 KiB to the host at 123.45.67.78. Average time of all IO of the recording: 4.500 s. Total time of all IO of the recording: 13.500 s. Total time of all IO of the host 123.45.67.78: 9.500 s. Note that there are some socket write patterns with high duration writes that we consider to be normal and are therefore excluded. Such patterns include JMX RMI communication."); //$NON-NLS-1$
+				"The longest recorded socket write took 5 s to write 4 KiB to the host at 123.45.67.78. Average time of recroded IO: 4.500 s. Total time of recorded IO: 13.500 s. Total time of recorded IO for the host 123.45.67.78: 9.500 s. Note that there are some socket write patterns with high duration writes that we consider to be normal and are therefore excluded. Such patterns include JMX RMI communication."); //$NON-NLS-1$
 	}
 
 	private void testSocketRule(String eventType, IRule rule, String expectedLongDesc) {

--- a/core/tests/org.openjdk.jmc.flightrecorder.rules.jdk.test/src/test/resources/baseline/JfrRuleBaseline.xml
+++ b/core/tests/org.openjdk.jmc.flightrecorder.rules.jdk.test/src/test/resources/baseline/JfrRuleBaseline.xml
@@ -4525,7 +4525,7 @@
 <severity>Information</severity>
 <score>28.486599569171002</score>
 <shortDescription>There are long socket write pauses in this recording (the longest is 349.745 ms).</shortDescription>
-<longDescription>The longest recorded socket write took 349.745 ms to write 81 B to the host at 10.161.190.213. Average time of all IO of the recording: 37.121 ms. Total time of all IO of the recording: 1.077 s. Total time of all IO of the host 10.161.190.213: 398.835 ms. Note that there are some socket write patterns with high duration writes that we consider to be normal and are therefore excluded. Such patterns include JMX RMI communication.</longDescription>
+<longDescription>The longest recorded socket write took 349.745 ms to write 81 B to the host at 10.161.190.213. Average time of recroded IO: 37.121 ms. Total time of recorded IO: 1.077 s. Total time of recorded IO for the host 10.161.190.213: 398.835 ms. Note that there are some socket write patterns with high duration writes that we consider to be normal and are therefore excluded. Such patterns include JMX RMI communication.</longDescription>
 </rule>
 <rule>
 <id>StackdepthSetting</id>

--- a/core/tests/org.openjdk.jmc.flightrecorder.rules.jdk.test/src/test/resources/baseline/JfrRuleBaseline.xml
+++ b/core/tests/org.openjdk.jmc.flightrecorder.rules.jdk.test/src/test/resources/baseline/JfrRuleBaseline.xml
@@ -4525,7 +4525,7 @@
 <severity>Information</severity>
 <score>28.486599569171002</score>
 <shortDescription>There are long socket write pauses in this recording (the longest is 349.745 ms).</shortDescription>
-<longDescription>The longest recorded socket write took 349.745 ms to write 81 B to the host at 10.161.190.213. Note that there are some socket write patterns with high duration writes that we consider to be normal and are therefore excluded. Such patterns include JMX RMI communication.</longDescription>
+<longDescription>The longest recorded socket write took 349.745 ms to write 81 B to the host at 10.161.190.213. Average time of all IO of the recording: 37.121 ms. Total time of all IO of the recording: 1.077 s. Total time of all IO of the host 10.161.190.213: 398.835 ms. Note that there are some socket write patterns with high duration writes that we consider to be normal and are therefore excluded. Such patterns include JMX RMI communication.</longDescription>
 </rule>
 <rule>
 <id>StackdepthSetting</id>

--- a/core/tests/org.openjdk.jmc.flightrecorder.rules.jdk.test/src/test/resources/baseline/JfrRuleBaseline.xml
+++ b/core/tests/org.openjdk.jmc.flightrecorder.rules.jdk.test/src/test/resources/baseline/JfrRuleBaseline.xml
@@ -4525,7 +4525,7 @@
 <severity>Information</severity>
 <score>28.486599569171002</score>
 <shortDescription>There are long socket write pauses in this recording (the longest is 349.745 ms).</shortDescription>
-<longDescription>The longest recorded socket write took 349.745 ms to write 81 B to the host at 10.161.190.213. Average time of recroded IO: 37.121 ms. Total time of recorded IO: 1.077 s. Total time of recorded IO for the host 10.161.190.213: 398.835 ms. Note that there are some socket write patterns with high duration writes that we consider to be normal and are therefore excluded. Such patterns include JMX RMI communication.</longDescription>
+<longDescription>The longest recorded socket write took 349.745 ms to write 81 B to the host at 10.161.190.213. Average time of recorded IO: 37.121 ms. Total time of recorded IO: 1.077 s. Total time of recorded IO for the host 10.161.190.213: 398.835 ms. Note that there are some socket write patterns with high duration writes that we consider to be normal and are therefore excluded. Such patterns include JMX RMI communication.</longDescription>
 </rule>
 <rule>
 <id>StackdepthSetting</id>


### PR DESCRIPTION
Add new information along with longest event:
 - report the total and average pauses for the entire recording.
 - report the sum of all IO events for that file or host of the longest event
Add also some mock classes for IItemCollection with some mock events

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JMC-5700](https://bugs.openjdk.java.net/browse/JMC-5700): Improve file and socket IO rule result texts


### Reviewers
 * [Marcus Hirt](https://openjdk.java.net/census#hirt) (@thegreystone - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jmc pull/138/head:pull/138`
`$ git checkout pull/138`
