### PR TITLE
4454: Other JMC launched after this JMC is listed as "-XX:+UseG1GC" in JVM Browser

### DIFF
--- a/application/org.openjdk.jmc.browser.attach/src/main/java/org/openjdk/jmc/browser/attach/LocalJVMToolkit.java
+++ b/application/org.openjdk.jmc.browser.attach/src/main/java/org/openjdk/jmc/browser/attach/LocalJVMToolkit.java
@@ -373,6 +373,13 @@ public class LocalJVMToolkit {
 						// This leaks one thread handle due to Sun bug in j2se/src/windows/native/sun/tools/attach/WindowsVirtualMachine.c
 						Properties props = null;
 						try {
+							try {
+								// try to force finish init the attached JVM
+								// to ensure properties are correctly populated 
+								((HotSpotVirtualMachine) vm).startLocalManagementAgent();
+							} catch (Exception ex) {
+								// swallow exceptions
+							}
 							props = vm.getSystemProperties();
 						} catch (IOException e) {
 							BrowserAttachPlugin.getPluginLogger().log(Level.FINER,

--- a/application/org.openjdk.jmc.browser.attach/src/main/java/org/openjdk/jmc/browser/attach/LocalJVMToolkit.java
+++ b/application/org.openjdk.jmc.browser.attach/src/main/java/org/openjdk/jmc/browser/attach/LocalJVMToolkit.java
@@ -375,7 +375,8 @@ public class LocalJVMToolkit {
 						try {
 							try {
 								// try to force finish init the attached JVM
-								// to ensure properties are correctly populated 
+								// to ensure properties are correctly populated
+								// see JMC-4454 for details
 								((HotSpotVirtualMachine) vm).startLocalManagementAgent();
 							} catch (Exception ex) {
 								// swallow exceptions


### PR DESCRIPTION
Add startLocalManagement to force finishing th init of the attached JVM

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JMC-4454](https://bugs.openjdk.java.net/browse/JMC-4454): Other JMC launched after this JMC is listed as "-XX:+UseG1GC" in JVM Browser


### Reviewers
 * [Marcus Hirt](https://openjdk.java.net/census#hirt) (@thegreystone - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jmc pull/143/head:pull/143`
`$ git checkout pull/143`
