### PR TITLE
5709: Improve Biased lock revocation result text

### DIFF
--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/resources/org/openjdk/jmc/flightrecorder/rules/jdk/messages/internal/messages.properties
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/resources/org/openjdk/jmc/flightrecorder/rules/jdk/messages/internal/messages.properties
@@ -84,9 +84,9 @@ BiasedLockingRevocationRule_TEXT_EPILOGUE=<p>Biased locking is a technique used 
 BiasedLockingRevocationPauseRule_CONFIG_WARNING_LIMIT=Biased locking warning limit time
 BiasedLockingRevocationPauseRule_CONFIG_WARNING_LIMIT_LONG=The total time spent on revoking biased locks needed to trigger a warning
 BiasedLockingRevocationPauseRule_RULE_NAME=Biased Locking Revocation Pauses
-BiasedLockingRevocationPauseRule_TEXT_INFO_LONG=To avoid this, either turn off biased Locking ('-XX:-UseBiasedLocking') or, if this occurs during startup, delay the use of biased Locking ('-XX:BiasedLockingStartupDelay').
+BiasedLockingRevocationPauseRule_TEXT_INFO_LONG=Biased locks are an optimization for uncontended locks. When locks have contentions, optimization need to be revoked when application halts. To avoid this, either turn off biased Locking ('-XX:-UseBiasedLocking') or, if this occurs during startup, delay the use of biased Locking ('-XX:BiasedLockingStartupDelay').
 # {0} is a time period
-BiasedLockingRevocationPauseRule_TEXT_MESSAGE=The total time spent revoking biased locks was {0}.
+BiasedLockingRevocationPauseRule_TEXT_MESSAGE=Application halts for a total time of {0} revoking biased locks.
 BiasedLockingRevocationPauseRule_TEXT_OK=No revocation of biased locks found.
 BufferLostRuleFactory_CONFIG_WARN_LIMIT=Buffer lost limit
 BufferLostRuleFactory_CONFIG_WARN_LIMIT_LONG=The number of lost buffer events needed to trigger a warning

--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/resources/org/openjdk/jmc/flightrecorder/rules/jdk/messages/internal/messages.properties
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/resources/org/openjdk/jmc/flightrecorder/rules/jdk/messages/internal/messages.properties
@@ -84,9 +84,9 @@ BiasedLockingRevocationRule_TEXT_EPILOGUE=<p>Biased locking is a technique used 
 BiasedLockingRevocationPauseRule_CONFIG_WARNING_LIMIT=Biased locking warning limit time
 BiasedLockingRevocationPauseRule_CONFIG_WARNING_LIMIT_LONG=The total time spent on revoking biased locks needed to trigger a warning
 BiasedLockingRevocationPauseRule_RULE_NAME=Biased Locking Revocation Pauses
-BiasedLockingRevocationPauseRule_TEXT_INFO_LONG=Biased locks are an optimization for uncontended locks. When locks have contentions, optimization need to be revoked when application halts. To avoid this, either turn off biased Locking ('-XX:-UseBiasedLocking') or, if this occurs during startup, delay the use of biased Locking ('-XX:BiasedLockingStartupDelay').
+BiasedLockingRevocationPauseRule_TEXT_INFO_LONG=Biased locking is an optimization for uncontended locks. If the locks become contended, this optimization must be revoked, which in turn cause application halts. To avoid this, either turn off biased Locking ('-XX:-UseBiasedLocking') or, if this occurs during startup, delay the use of biased Locking ('-XX:BiasedLockingStartupDelay').
 # {0} is a time period
-BiasedLockingRevocationPauseRule_TEXT_MESSAGE=Application halts for a total time of {0} revoking biased locks.
+BiasedLockingRevocationPauseRule_TEXT_MESSAGE=The application was halted for a total time of {0} revoking biased locks.
 BiasedLockingRevocationPauseRule_TEXT_OK=No revocation of biased locks found.
 BufferLostRuleFactory_CONFIG_WARN_LIMIT=Buffer lost limit
 BufferLostRuleFactory_CONFIG_WARN_LIMIT_LONG=The number of lost buffer events needed to trigger a warning


### PR DESCRIPTION
Improved explanation, stressing that the application is halted during revocation and explaining what are biased locking and revocation

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JMC-5709](https://bugs.openjdk.java.net/browse/JMC-5709): Improve Biased lock revocation result text


### Reviewers
 * [Marcus Hirt](https://openjdk.java.net/census#hirt) (@thegreystone - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jmc pull/144/head:pull/144`
`$ git checkout pull/144`
