### PR TITLE
Unsafe migration

### DIFF
--- a/agent/pom.xml
+++ b/agent/pom.xml
@@ -130,7 +130,7 @@
 						<goal>verify</goal>
 					</goals>
 						<configuration>
-							<argLine> -Djava.security.manager -Djava.security.policy=target/test-classes/org/openjdk/jmc/agent/test/failing_control_permission.policy --add-opens java.base/jdk.internal.misc=ALL-UNNAMED
+							<argLine> -Djava.security.manager -Djava.security.policy=target/test-classes/org/openjdk/jmc/agent/test/failing_control_permission.policy
 								-XX:+FlightRecorder -javaagent:target/org.openjdk.jmc.agent-1.0.0-SNAPSHOT.jar=target/test-classes/org/openjdk/jmc/agent/test/jfrprobes_template.xml
 								 -cp target/org.openjdk.jmc.agent-1.0.0-SNAPSHOT.jar:target/test-classes/ </argLine>
 							<includes>TestPermissionChecks.java</includes>
@@ -143,7 +143,7 @@
               				<goal>verify</goal>
             			</goals>
 						<configuration>
-							<argLine> --add-opens java.base/jdk.internal.misc=ALL-UNNAMED
+							<argLine>
 								-XX:+FlightRecorder -javaagent:target/org.openjdk.jmc.agent-1.0.0-SNAPSHOT.jar=target/test-classes/org/openjdk/jmc/agent/test/jfrprobes_template.xml
 								 -cp target/org.openjdk.jmc.agent-1.0.0-SNAPSHOT.jar:target/test-classes/ </argLine>
 							<includes>TestDefineEventProbes.java</includes>
@@ -156,7 +156,7 @@
 							<goal>verify</goal>
 						</goals>
 						<configuration>
-							<argLine> --add-opens java.base/jdk.internal.misc=ALL-UNNAMED
+							<argLine>
 								-XX:+FlightRecorder -javaagent:target/org.openjdk.jmc.agent-1.0.0-SNAPSHOT.jar=target/test-classes/org/openjdk/jmc/agent/test/jfrprobes_simple_2.xml
 								 -cp target/org.openjdk.jmc.agent-1.0.0-SNAPSHOT.jar:target/test-classes/ </argLine>
 							<includes>TestCustomClassloader.java</includes>
@@ -169,7 +169,7 @@
 							<goal>verify</goal>
 						</goals>
 						<configuration>
-							<argLine> --add-opens java.base/jdk.internal.misc=ALL-UNNAMED
+							<argLine>
 								-XX:+FlightRecorder -javaagent:target/org.openjdk.jmc.agent-1.0.0-SNAPSHOT.jar
 								 -cp target/org.openjdk.jmc.agent-1.0.0-SNAPSHOT.jar:target/test-classes/ </argLine>
 							<includes>TestRetrieveEventProbes.java</includes>
@@ -182,7 +182,7 @@
 							<goal>verify</goal>
 						</goals>
 						<configuration>
-							<argLine> --add-opens java.base/jdk.internal.misc=ALL-UNNAMED
+							<argLine>
 								-XX:+FlightRecorder -javaagent:target/org.openjdk.jmc.agent-1.0.0-SNAPSHOT.jar=target/test-classes/org/openjdk/jmc/agent/test/jfrprobes_simple.xml
 								 -cp target/org.openjdk.jmc.agent-1.0.0-SNAPSHOT.jar:target/test-classes/ </argLine>
 							<includes>TestRetrieveCurrentTransforms.java</includes>

--- a/agent/src/main/java/org/openjdk/jmc/agent/jfr/impl/JFRClassVisitor.java
+++ b/agent/src/main/java/org/openjdk/jmc/agent/jfr/impl/JFRClassVisitor.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
- * 
+ *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * The contents of this file are subject to the terms of either the Universal Permissive License
@@ -10,17 +10,17 @@
  *
  * Redistribution and use in source and binary forms, with or without modification, are permitted
  * provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice, this list of conditions
  * and the following disclaimer.
- * 
+ *
  * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
  * conditions and the following disclaimer in the documentation and/or other materials provided with
  * the distribution.
- * 
+ *
  * 3. Neither the name of the copyright holder nor the names of its contributors may be used to
  * endorse or promote products derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
  * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
@@ -96,8 +96,8 @@ public class JFRClassVisitor extends ClassVisitor implements Opcodes {
 
 	private Class<?> generateEventClass() throws Exception {
 		byte[] eventClass = JFREventClassGenerator.generateEventClass(transformDescriptor, inspectionClass);
-		return TypeUtils.defineClass(transformDescriptor.getEventClassName(), eventClass, 0, eventClass.length,
-				definingClassLoader, protectionDomain);
+		return TypeUtils.defineClass(inspectionClass, transformDescriptor.getEventClassName(), eventClass, 0,
+				eventClass.length, definingClassLoader, protectionDomain);
 	}
 
 }

--- a/agent/src/main/java/org/openjdk/jmc/agent/jfrnext/impl/JFRNextClassVisitor.java
+++ b/agent/src/main/java/org/openjdk/jmc/agent/jfrnext/impl/JFRNextClassVisitor.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
- * 
+ *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * The contents of this file are subject to the terms of either the Universal Permissive License
@@ -10,17 +10,17 @@
  *
  * Redistribution and use in source and binary forms, with or without modification, are permitted
  * provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice, this list of conditions
  * and the following disclaimer.
- * 
+ *
  * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
  * conditions and the following disclaimer in the documentation and/or other materials provided with
  * the distribution.
- * 
+ *
  * 3. Neither the name of the copyright holder nor the names of its contributors may be used to
  * endorse or promote products derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
  * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
@@ -60,7 +60,7 @@ public class JFRNextClassVisitor extends ClassVisitor {
 		this.protectionDomain = protectionDomain;
 
 		try {
-			this.inspectionClass = classBeingRedefined != null || descriptor.getFields().isEmpty() ? classBeingRedefined
+			this.inspectionClass = classBeingRedefined != null ? classBeingRedefined
 					: inspectionClassLoader.loadClass(TypeUtils.getCanonicalName(transformDescriptor.getClassName()));
 		} catch (ClassNotFoundException e) {
 			throw new IllegalStateException(e); // This should not happen
@@ -102,7 +102,7 @@ public class JFRNextClassVisitor extends ClassVisitor {
 
 	private Class<?> generateEventClass() throws Exception {
 		byte[] eventClass = JFRNextEventClassGenerator.generateEventClass(transformDescriptor, inspectionClass);
-		return TypeUtils.defineClass(transformDescriptor.getEventClassName(), eventClass, 0, eventClass.length,
-				definingClassLoader, protectionDomain);
+		return TypeUtils.defineClass(inspectionClass, transformDescriptor.getEventClassName(), eventClass, 0,
+				eventClass.length, definingClassLoader, protectionDomain);
 	}
 }

--- a/agent/src/main/java/org/openjdk/jmc/agent/util/VersionUtils.java
+++ b/agent/src/main/java/org/openjdk/jmc/agent/util/VersionUtils.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, Red Hat Inc. All rights reserved.
+ *
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * The contents of this file are subject to the terms of either the Universal Permissive License
+ * v 1.0 as shown at http://oss.oracle.com/licenses/upl
+ *
+ * or the following license:
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted
+ * provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions
+ * and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other materials provided with
+ * the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to
+ * endorse or promote products derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+ * WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.openjdk.jmc.agent.util;
+
+import java.lang.reflect.Method;
+
+public class VersionUtils {
+
+	private static final int FEATURE_VERSION = determineFeatureVersion();
+
+	public static int getFeatureVersion() {
+		return FEATURE_VERSION;
+	}
+
+	private static int determineFeatureVersion() {
+		try {
+			Method versionMethod = getMethod(Runtime.class, "version");
+
+			if (versionMethod == null) {
+				String version = System.getProperty("java.version");
+				return Integer.valueOf(version.substring(2, 3));
+			}
+
+			Object version = versionMethod.invoke(null);
+
+			Method featureMethod = getMethod(version.getClass(), "feature");
+			if (featureMethod != null) {
+				return (int) featureMethod.invoke(version);
+			} else {
+				Method majorMethod = getMethod(version.getClass(), "major");
+				return (int) majorMethod.invoke(version);
+			}
+
+		} catch (Exception e) {
+			System.out.println(
+					"Could not identify Java version. The agent will not work. If on JDK 11, try adding  --add-exports java.base/jdk.internal.misc=ALL-UNNAMED"); //$NON-NLS-1$
+			e.printStackTrace();
+			System.out.flush();
+			System.exit(3);
+
+			return 0;
+		}
+	}
+
+	private static Method getMethod(Class<?> clazz, String methodName) throws Exception {
+		try {
+			return clazz.getDeclaredMethod(methodName);
+		} catch (NoSuchMethodException e) {
+			return null;
+		}
+	}
+}

--- a/agent/src/test/java/org/openjdk/jmc/agent/test/TestCompressedFrameTransformation.java
+++ b/agent/src/test/java/org/openjdk/jmc/agent/test/TestCompressedFrameTransformation.java
@@ -1,5 +1,9 @@
 package org.openjdk.jmc.agent.test;
 
+import java.text.MessageFormat;
+import java.util.HashMap;
+import java.util.Map;
+
 import org.junit.Test;
 import org.objectweb.asm.ClassWriter;
 import org.objectweb.asm.Label;
@@ -9,21 +13,18 @@ import org.openjdk.jmc.agent.TransformRegistry;
 import org.openjdk.jmc.agent.Transformer;
 import org.openjdk.jmc.agent.impl.DefaultTransformRegistry;
 
-import java.util.HashMap;
-import java.util.Map;
-
 public class TestCompressedFrameTransformation implements Opcodes {
 
 	private static final String XML_EVENT_DESCRIPTION = "<jfragent>" //
-			+ "<events>" // 
-			+ "<event id=\"test.compressed.frame.transformation\">" // 
-			+ "<name>Test Compressed Frame Transformation</name>" //
+			+ "<events>" //
+			+ "<event id=\"test.compressed.frame.transformation\">" //
+			+ "<name>Test Compressed Frame Transformation {0}</name>" //
 			+ "<description>agent instrumentation should be compatible with compressed frame types</description>" //
 			+ "<path>test/frames</path>" //
 			+ "<class>Target</class>" //
 			+ "<method>" //
 			+ "<name>echo</name>" //
-			+ "<descriptor>(I)I</descriptor>" // 
+			+ "<descriptor>(I)I</descriptor>" //
 			+ "</method>" //
 			+ "</event>" //
 			+ "</events>" //
@@ -85,13 +86,15 @@ public class TestCompressedFrameTransformation implements Opcodes {
 	private void testCompressedFrameNoVerificationError(int frameType) throws Exception {
 		TestClassLoader tcl = new TestClassLoader(TestCompressedFrameTransformation.class.getClassLoader());
 		byte[] classBuffer = generateClassBuffer(frameType);
+		tcl.putClassBuffer("Target", classBuffer);
 
 		TransformRegistry registry = DefaultTransformRegistry.empty();
 		Transformer transformer = new Transformer(registry);
 
-		registry.modify(XML_EVENT_DESCRIPTION);
+		registry.modify(MessageFormat.format(XML_EVENT_DESCRIPTION, frameType));
 		classBuffer = transformer.transform(tcl, "Target", null, null, classBuffer);
 
+		tcl = new TestClassLoader(TestCompressedFrameTransformation.class.getClassLoader());
 		tcl.putClassBuffer("Target", classBuffer);
 		tcl.loadClass("Target");
 

--- a/agent/src/test/java/org/openjdk/jmc/agent/test/TestCustomClassloader.java
+++ b/agent/src/test/java/org/openjdk/jmc/agent/test/TestCustomClassloader.java
@@ -34,28 +34,15 @@
 
 package org.openjdk.jmc.agent.test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.lang.management.ManagementFactory;
-import java.util.List;
 import java.util.logging.Logger;
 
 import javax.management.JMX;
 import javax.management.ObjectName;
 
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Test;
-import org.objectweb.asm.Type;
-import org.openjdk.jmc.agent.TransformDescriptor;
-import org.openjdk.jmc.agent.TransformRegistry;
-import org.openjdk.jmc.agent.Transformer;
-import org.openjdk.jmc.agent.impl.DefaultTransformRegistry;
-import org.openjdk.jmc.agent.jfr.JFRTransformDescriptor;
 import org.openjdk.jmc.agent.jmx.AgentControllerMXBean;
 import org.openjdk.jmc.agent.test.util.TestToolkit;
 
@@ -138,11 +125,11 @@ public class TestCustomClassloader {
 		@Override
 		protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
 			try {
-				ClassLoader.getPlatformClassLoader().loadClass(name);
+				ClassLoader.getSystemClassLoader().loadClass(name);
 			} catch (Exception e) {
 				logger.severe("Exception thrown: " + e.toString());
 			}
-			return ClassLoader.getPlatformClassLoader().loadClass(name);
+			return ClassLoader.getSystemClassLoader().loadClass(name);
 		}
 	}
 }

--- a/agent/src/test/java/org/openjdk/jmc/agent/test/TestDefineEventProbes.java
+++ b/agent/src/test/java/org/openjdk/jmc/agent/test/TestDefineEventProbes.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2019, 2020, Red Hat Inc. All rights reserved.
- * 
+ *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * The contents of this file are subject to the terms of either the Universal Permissive License
@@ -11,17 +11,17 @@
  *
  * Redistribution and use in source and binary forms, with or without modification, are permitted
  * provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice, this list of conditions
  * and the following disclaimer.
- * 
+ *
  * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
  * conditions and the following disclaimer in the documentation and/or other materials provided with
  * the distribution.
- * 
+ *
  * 3. Neither the name of the copyright holder nor the names of its contributors may be used to
  * endorse or promote products derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
  * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
@@ -152,7 +152,7 @@ public class TestDefineEventProbes {
 		reader.accept(classVisitor, 0);
 		byte[] modifiedEvent = classWriter.toByteArray();
 
-		TypeUtils.defineClass(eventTd.getEventClassName(), modifiedEvent, 0, modifiedEvent.length,
+		TypeUtils.defineClass(InstrumentMe.class, eventTd.getEventClassName(), modifiedEvent, 0, modifiedEvent.length,
 				ClassLoader.getSystemClassLoader(), null);
 	}
 


### PR DESCRIPTION
@thegreystone, I took a quick stab at getting rid of the usage of `Unsafe` in JMC Agent on JDK 11+, so to avoid the need for `--add-opens java.base/jdk.internal.misc=ALL-UNNAMED`.

I'm using `MethodHandles.Lookup` as replacement, and overall it _seems_ to work. ~~There's one failing test, though: `TestDefineEventProbes#testDefineEventProbes`; specifically, the `RuntimeException` by the injected event isn't raised any more, causing the assertion on line 103 to fail. I don't quite understand how this test is working to begin with: how does this "injection" work, so that the agent picks up the event class defined in the test?~~

~~Update: all tests pass now. I had to cater for the (implicit) assumption in some tests that trying to define the same event class a second time is silently ignored.~~

~~So the key difference to the earlier behavior is this: event types are generated in the package of JMC Agent's `TypeUtils` class now, using the agent's classloader (i.e. the app classloader). As per @thegreystone, this may pose an issue in cases where an instrumented class get unloaded in a dynamic environment, which also should make all associated event classes subject to GC. What I'm wondering: does this happen actually with the current code on master, as we never _unregister_ event types with JFR; i.e. isn't a strong reference to these classes kept to begin with? In which case not generating the event types using the instrumented classes' loader actually would be an improvement? Or does JFR only keep weak references to event classes?~~

~~One alternative option I could pursue is to use JDK 15 hidden classes for the event types ([JEP 371](https://openjdk.java.net/jeps/371)), which would make them independent from any classloader and GC-able as soon as there's no strong reference to them (still might require to unregister them, not totally sure). In that case, the reference to `Unsafe` would be avoided on JDK 15+ only.~~

Ok, time for another update: I've reworked this now to use a _private lookup_, which allows to avoid `Unsafe` on JDK 11+, while still generating the event types into the instrumented classes' packages. This works without further configuration for classes in the unnamed module, I suppose to make this 100% correct also for classes in other modules, I should have the agent open the classes package towards the agent's module (which the agent can do itself).

Overall, this works, there's one failing test (`TestCustomClassloader`) which I'm not sure atm. how to address.

@thegreystone, @jpbempel, @Josh-Matsuoka, @jiekang, @jessyec-s, any feedback welcome. Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Testing

|     | linux | mac | win |
| --- | ----- | ----- | ----- |
| Build / test | ❌ (1/1 failed) | ❌ (1/1 failed) | ✔️ (1/1 passed) |

**Failed test tasks**
- [linux](https://github.com/gunnarmorling/jmc/runs/1339313654)
- [mac](https://github.com/gunnarmorling/jmc/runs/1339313622)

### Download
`$ git fetch https://git.openjdk.java.net/jmc pull/148/head:pull/148`
`$ git checkout pull/148`
