### PR TITLE
6948: Add union to QuantityRange

### DIFF
--- a/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/unit/QuantityRange.java
+++ b/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/unit/QuantityRange.java
@@ -243,9 +243,25 @@ public abstract class QuantityRange<U extends TypedUnit<U>> implements IRange<IQ
 	}
 
 	public static IRange<IQuantity> union(IRange<IQuantity> a, IRange<IQuantity> b) {
-		IQuantity minStart = a.getStart().compareTo(b.getStart()) < 0 ? a.getStart() : b.getStart();
-		IQuantity maxEnd = a.getEnd().compareTo(b.getEnd()) < 0 ? b.getEnd() : a.getEnd();
-		if (intersection(a, b) == null) { // if disjoint, no union
+		IQuantity minStart;
+		IQuantity maxStart;
+		if (a.getStart().compareTo(b.getStart()) < 0) {
+			minStart = a.getStart();
+			maxStart = b.getStart();
+		} else {
+			minStart = b.getStart();
+			maxStart = a.getStart();
+		}
+		IQuantity maxEnd;
+		IQuantity minEnd;
+		if (a.getEnd().compareTo(b.getEnd()) < 0) {
+			minEnd = a.getEnd();
+			maxEnd = b.getEnd();
+		} else {
+			minEnd = b.getEnd();
+			maxEnd = a.getEnd();
+		}
+		if (minEnd.compareTo(maxStart) < 0) { // if disjoint, no union
 			return null;
 		}
 		return createWithEnd(minStart, maxEnd);

--- a/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/unit/QuantityRange.java
+++ b/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/unit/QuantityRange.java
@@ -242,6 +242,15 @@ public abstract class QuantityRange<U extends TypedUnit<U>> implements IRange<IQ
 		return minEnd.compareTo(maxStart) >= 0 ? createWithEnd(maxStart, minEnd) : null;
 	}
 
+	public static IRange<IQuantity> union(IRange<IQuantity> a, IRange<IQuantity> b) {
+		IQuantity minStart = a.getStart().compareTo(b.getStart()) < 0 ? a.getStart() : b.getStart();
+		IQuantity maxEnd = a.getEnd().compareTo(b.getEnd()) < 0 ? b.getEnd() : a.getEnd();
+		if (intersection(a, b) == null) { // if disjoint, no union
+			return null;
+		}
+		return createWithEnd(minStart, maxEnd);
+	}
+
 	@Override
 	public ITypedQuantity<U> getStart() {
 		return start;

--- a/core/tests/org.openjdk.jmc.common.test/src/test/java/org/openjdk/jmc/common/test/unit/QuantityRangeTest.java
+++ b/core/tests/org.openjdk.jmc.common.test/src/test/java/org/openjdk/jmc/common/test/unit/QuantityRangeTest.java
@@ -1,0 +1,103 @@
+package org.openjdk.jmc.common.test.unit;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openjdk.jmc.common.unit.IQuantity;
+import org.openjdk.jmc.common.unit.IRange;
+import org.openjdk.jmc.common.unit.QuantityRange;
+import org.openjdk.jmc.common.unit.UnitLookup;
+
+public class QuantityRangeTest {
+
+	@Test
+	public void intersection_overlap() {
+		IRange<IQuantity> r1 = QuantityRange.createWithEnd(UnitLookup.SECOND.quantity(0),
+				UnitLookup.SECOND.quantity(10));
+		IRange<IQuantity> r2 = QuantityRange.createWithEnd(UnitLookup.SECOND.quantity(5),
+				UnitLookup.SECOND.quantity(15));
+		IRange<IQuantity> intersection = QuantityRange.intersection(r1, r2);
+		IRange<IQuantity> expected = QuantityRange.createWithEnd(UnitLookup.SECOND.quantity(5),
+				UnitLookup.SECOND.quantity(10));
+		Assert.assertEquals(expected, intersection);
+	}
+
+	@Test
+	public void intersection_full_overlap() {
+		IRange<IQuantity> r1 = QuantityRange.createWithEnd(UnitLookup.SECOND.quantity(0),
+				UnitLookup.SECOND.quantity(10));
+		IRange<IQuantity> r2 = QuantityRange.createWithEnd(UnitLookup.SECOND.quantity(0),
+				UnitLookup.SECOND.quantity(10));
+		IRange<IQuantity> intersection = QuantityRange.intersection(r1, r2);
+		IRange<IQuantity> expected = QuantityRange.createWithEnd(UnitLookup.SECOND.quantity(0),
+				UnitLookup.SECOND.quantity(10));
+		Assert.assertEquals(expected, intersection);
+	}
+
+	@Test
+	public void intersection_limit() {
+		IRange<IQuantity> r1 = QuantityRange.createWithEnd(UnitLookup.SECOND.quantity(0),
+				UnitLookup.SECOND.quantity(10));
+		IRange<IQuantity> r2 = QuantityRange.createWithEnd(UnitLookup.SECOND.quantity(10),
+				UnitLookup.SECOND.quantity(20));
+		IRange<IQuantity> intersection = QuantityRange.intersection(r1, r2);
+		IRange<IQuantity> expected = QuantityRange.createWithEnd(UnitLookup.SECOND.quantity(10),
+				UnitLookup.SECOND.quantity(10));
+		Assert.assertEquals(expected, intersection);
+	}
+
+	@Test
+	public void intersection_disjoint() {
+		IRange<IQuantity> r1 = QuantityRange.createWithEnd(UnitLookup.SECOND.quantity(0),
+				UnitLookup.SECOND.quantity(5));
+		IRange<IQuantity> r2 = QuantityRange.createWithEnd(UnitLookup.SECOND.quantity(10),
+				UnitLookup.SECOND.quantity(15));
+		IRange<IQuantity> intersection = QuantityRange.intersection(r1, r2);
+		Assert.assertNull(intersection);
+	}
+
+	@Test
+	public void union_overlap() {
+		IRange<IQuantity> r1 = QuantityRange.createWithEnd(UnitLookup.SECOND.quantity(0),
+				UnitLookup.SECOND.quantity(10));
+		IRange<IQuantity> r2 = QuantityRange.createWithEnd(UnitLookup.SECOND.quantity(5),
+				UnitLookup.SECOND.quantity(15));
+		IRange<IQuantity> union = QuantityRange.union(r1, r2);
+		IRange<IQuantity> expected = QuantityRange.createWithEnd(UnitLookup.SECOND.quantity(0),
+				UnitLookup.SECOND.quantity(15));
+		Assert.assertEquals(expected, union);
+	}
+
+	@Test
+	public void union_full_overlap() {
+		IRange<IQuantity> r1 = QuantityRange.createWithEnd(UnitLookup.SECOND.quantity(0),
+				UnitLookup.SECOND.quantity(10));
+		IRange<IQuantity> r2 = QuantityRange.createWithEnd(UnitLookup.SECOND.quantity(0),
+				UnitLookup.SECOND.quantity(10));
+		IRange<IQuantity> union = QuantityRange.union(r1, r2);
+		IRange<IQuantity> expected = QuantityRange.createWithEnd(UnitLookup.SECOND.quantity(0),
+				UnitLookup.SECOND.quantity(10));
+		Assert.assertEquals(expected, union);
+	}
+
+	@Test
+	public void union_limit() {
+		IRange<IQuantity> r1 = QuantityRange.createWithEnd(UnitLookup.SECOND.quantity(0),
+				UnitLookup.SECOND.quantity(10));
+		IRange<IQuantity> r2 = QuantityRange.createWithEnd(UnitLookup.SECOND.quantity(10),
+				UnitLookup.SECOND.quantity(20));
+		IRange<IQuantity> union = QuantityRange.union(r1, r2);
+		IRange<IQuantity> expected = QuantityRange.createWithEnd(UnitLookup.SECOND.quantity(0),
+				UnitLookup.SECOND.quantity(20));
+		Assert.assertEquals(expected, union);
+	}
+
+	@Test
+	public void union_disjoint() {
+		IRange<IQuantity> r1 = QuantityRange.createWithEnd(UnitLookup.SECOND.quantity(0),
+				UnitLookup.SECOND.quantity(5));
+		IRange<IQuantity> r2 = QuantityRange.createWithEnd(UnitLookup.SECOND.quantity(10),
+				UnitLookup.SECOND.quantity(15));
+		IRange<IQuantity> union = QuantityRange.union(r1, r2);
+		Assert.assertNull(union);
+	}
+}

--- a/core/tests/org.openjdk.jmc.common.test/src/test/java/org/openjdk/jmc/common/test/unit/QuantityRangeTest.java
+++ b/core/tests/org.openjdk.jmc.common.test/src/test/java/org/openjdk/jmc/common/test/unit/QuantityRangeTest.java
@@ -1,3 +1,36 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, Datadog, Inc. All rights reserved.
+ *
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * The contents of this file are subject to the terms of either the Universal Permissive License
+ * v 1.0 as shown at http://oss.oracle.com/licenses/upl
+ *
+ * or the following license:
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted
+ * provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions
+ * and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other materials provided with
+ * the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to
+ * endorse or promote products derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+ * WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 package org.openjdk.jmc.common.test.unit;
 
 import org.junit.Assert;


### PR DESCRIPTION
Add tests for intersetion & union

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JMC-6948](https://bugs.openjdk.java.net/browse/JMC-6948): Add union to QuantityRange


### Reviewers
 * [Henrik Dafgård](https://openjdk.java.net/census#hdafgard) (@Gunde - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jmc pull/150/head:pull/150`
`$ git checkout pull/150`
