### PR TITLE
6964: [Agent] Automatically open base module for accessing Unsafe on JDK 11+

### DIFF
--- a/agent/pom.xml
+++ b/agent/pom.xml
@@ -130,7 +130,7 @@
 						<goal>verify</goal>
 					</goals>
 						<configuration>
-							<argLine> -Djava.security.manager -Djava.security.policy=target/test-classes/org/openjdk/jmc/agent/test/failing_control_permission.policy --add-opens java.base/jdk.internal.misc=ALL-UNNAMED
+							<argLine> -Djava.security.manager -Djava.security.policy=target/test-classes/org/openjdk/jmc/agent/test/failing_control_permission.policy
 								-XX:+FlightRecorder -javaagent:target/org.openjdk.jmc.agent-1.0.0-SNAPSHOT.jar=target/test-classes/org/openjdk/jmc/agent/test/jfrprobes_template.xml
 								 -cp target/org.openjdk.jmc.agent-1.0.0-SNAPSHOT.jar:target/test-classes/ </argLine>
 							<includes>TestPermissionChecks.java</includes>
@@ -143,7 +143,7 @@
               				<goal>verify</goal>
             			</goals>
 						<configuration>
-							<argLine> --add-opens java.base/jdk.internal.misc=ALL-UNNAMED
+							<argLine>
 								-XX:+FlightRecorder -javaagent:target/org.openjdk.jmc.agent-1.0.0-SNAPSHOT.jar=target/test-classes/org/openjdk/jmc/agent/test/jfrprobes_template.xml
 								 -cp target/org.openjdk.jmc.agent-1.0.0-SNAPSHOT.jar:target/test-classes/ </argLine>
 							<includes>TestDefineEventProbes.java</includes>
@@ -156,7 +156,7 @@
 							<goal>verify</goal>
 						</goals>
 						<configuration>
-							<argLine> --add-opens java.base/jdk.internal.misc=ALL-UNNAMED
+							<argLine>
 								-XX:+FlightRecorder -javaagent:target/org.openjdk.jmc.agent-1.0.0-SNAPSHOT.jar=target/test-classes/org/openjdk/jmc/agent/test/jfrprobes_simple_2.xml
 								 -cp target/org.openjdk.jmc.agent-1.0.0-SNAPSHOT.jar:target/test-classes/ </argLine>
 							<includes>TestCustomClassloader.java</includes>
@@ -169,7 +169,7 @@
 							<goal>verify</goal>
 						</goals>
 						<configuration>
-							<argLine> --add-opens java.base/jdk.internal.misc=ALL-UNNAMED
+							<argLine>
 								-XX:+FlightRecorder -javaagent:target/org.openjdk.jmc.agent-1.0.0-SNAPSHOT.jar
 								 -cp target/org.openjdk.jmc.agent-1.0.0-SNAPSHOT.jar:target/test-classes/ </argLine>
 							<includes>TestRetrieveEventProbes.java</includes>
@@ -182,7 +182,7 @@
 							<goal>verify</goal>
 						</goals>
 						<configuration>
-							<argLine> --add-opens java.base/jdk.internal.misc=ALL-UNNAMED
+							<argLine>
 								-XX:+FlightRecorder -javaagent:target/org.openjdk.jmc.agent-1.0.0-SNAPSHOT.jar=target/test-classes/org/openjdk/jmc/agent/test/jfrprobes_simple.xml
 								 -cp target/org.openjdk.jmc.agent-1.0.0-SNAPSHOT.jar:target/test-classes/ </argLine>
 							<includes>TestRetrieveCurrentTransforms.java</includes>

--- a/agent/src/main/java/org/openjdk/jmc/agent/Agent.java
+++ b/agent/src/main/java/org/openjdk/jmc/agent/Agent.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
- * 
+ *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * The contents of this file are subject to the terms of either the Universal Permissive License
@@ -10,17 +10,17 @@
  *
  * Redistribution and use in source and binary forms, with or without modification, are permitted
  * provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice, this list of conditions
  * and the following disclaimer.
- * 
+ *
  * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
  * conditions and the following disclaimer in the documentation and/or other materials provided with
  * the distribution.
- * 
+ *
  * 3. Neither the name of the copyright holder nor the names of its contributors may be used to
  * endorse or promote products derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
  * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
@@ -48,6 +48,7 @@ import javax.xml.stream.XMLStreamException;
 
 import org.openjdk.jmc.agent.impl.DefaultTransformRegistry;
 import org.openjdk.jmc.agent.jmx.AgentManagementFactory;
+import org.openjdk.jmc.agent.util.ModuleUtils;
 
 /**
  * Small ASM based byte code instrumentation agent for declaratively adding logging and JFR events.
@@ -71,6 +72,7 @@ public class Agent {
 	public static void premain(String agentArguments, Instrumentation instrumentation) {
 		printVersion();
 		getLogger().fine("Starting from premain"); //$NON-NLS-1$
+		ModuleUtils.openUnsafePackage(instrumentation);
 		initializeAgent(agentArguments, instrumentation);
 	}
 

--- a/agent/src/main/java/org/openjdk/jmc/agent/Transformer.java
+++ b/agent/src/main/java/org/openjdk/jmc/agent/Transformer.java
@@ -43,11 +43,11 @@ import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.ClassWriter;
 import org.openjdk.jmc.agent.jfr.JFRTransformDescriptor;
-import org.openjdk.jmc.agent.jfr.VersionResolver;
-import org.openjdk.jmc.agent.jfr.VersionResolver.JFRVersion;
 import org.openjdk.jmc.agent.jfr.impl.JFRClassVisitor;
 import org.openjdk.jmc.agent.jfrnext.impl.JFRNextClassVisitor;
 import org.openjdk.jmc.agent.util.InspectionClassLoader;
+import org.openjdk.jmc.agent.util.VersionUtils;
+import org.openjdk.jmc.agent.util.VersionUtils.JFRVersion;
 
 public class Transformer implements ClassFileTransformer {
 	private TransformRegistry registry;
@@ -89,14 +89,14 @@ public class Transformer implements ClassFileTransformer {
 	private byte[] doJFRLogging(
 		JFRTransformDescriptor td, byte[] classfileBuffer, ClassLoader definingClassLoader,
 		Class<?> classBeingRedefined, ProtectionDomain protectionDomain, InspectionClassLoader inspectionClassLoader) {
-		if (VersionResolver.getAvailableJFRVersion() == JFRVersion.NONE) {
+		if (VersionUtils.getAvailableJFRVersion() == JFRVersion.NONE) {
 			Logger.getLogger(getClass().getName()).log(Level.SEVERE,
 					"Could not find JFR classes. Failed to instrument " + td.getMethod().toString()); //$NON-NLS-1$
 			return classfileBuffer;
 		}
 		try {
 			ClassWriter classWriter = new ClassWriter(ClassWriter.COMPUTE_MAXS);
-			ClassVisitor visitor = VersionResolver.getAvailableJFRVersion() == JFRVersion.JFRNEXT
+			ClassVisitor visitor = VersionUtils.getAvailableJFRVersion() == JFRVersion.JFRNEXT
 					? new JFRNextClassVisitor(classWriter, td, definingClassLoader, classBeingRedefined,
 							protectionDomain, inspectionClassLoader)
 					: new JFRClassVisitor(classWriter, td, definingClassLoader, classBeingRedefined, protectionDomain,

--- a/agent/src/main/java/org/openjdk/jmc/agent/jfr/VersionResolver.java
+++ b/agent/src/main/java/org/openjdk/jmc/agent/jfr/VersionResolver.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
- * 
+ *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * The contents of this file are subject to the terms of either the Universal Permissive License
@@ -10,17 +10,17 @@
  *
  * Redistribution and use in source and binary forms, with or without modification, are permitted
  * provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice, this list of conditions
  * and the following disclaimer.
- * 
+ *
  * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
  * conditions and the following disclaimer in the documentation and/or other materials provided with
  * the distribution.
- * 
+ *
  * 3. Neither the name of the copyright holder nor the names of its contributors may be used to
  * endorse or promote products derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
  * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
@@ -32,8 +32,13 @@
  */
 package org.openjdk.jmc.agent.jfr;
 
+import java.lang.reflect.Method;
+import java.util.OptionalInt;
+
 public final class VersionResolver {
+
 	private final static JFRVersion availableJFRVersion;
+	private static final int FEATURE_VERSION = determineFeatureVersion();
 
 	public enum JFRVersion {
 		JFR, JFRNEXT, NONE
@@ -60,5 +65,48 @@ public final class VersionResolver {
 
 	public static JFRVersion getAvailableJFRVersion() {
 		return availableJFRVersion;
+	}
+
+	/**
+	 * Returns the current JVM' feature (major) version, e.g. 8, 11, or 15.
+	 */
+	public static OptionalInt getFeatureVersion() {
+		return FEATURE_VERSION == 0 ? OptionalInt.empty() : OptionalInt.of(FEATURE_VERSION);
+	}
+
+	private static int determineFeatureVersion() {
+		try {
+			Method versionMethod = getMethod(Runtime.class, "version");
+
+			// pre Java 9
+			if (versionMethod == null) {
+				String version = System.getProperty("java.version");
+				return Integer.valueOf(version.substring(2, 3));
+			}
+
+			Object version = versionMethod.invoke(null);
+
+			Method featureMethod = getMethod(version.getClass(), "feature");
+
+			// Java 10+
+			if (featureMethod != null) {
+				return (int) featureMethod.invoke(version);
+			} else {
+				// Java 9
+				Method majorMethod = getMethod(version.getClass(), "major");
+				return (int) majorMethod.invoke(version);
+			}
+
+		} catch (Exception e) {
+			return 0;
+		}
+	}
+
+	private static Method getMethod(Class<?> clazz, String methodName) throws Exception {
+		try {
+			return clazz.getDeclaredMethod(methodName);
+		} catch (NoSuchMethodException e) {
+			return null;
+		}
 	}
 }

--- a/agent/src/main/java/org/openjdk/jmc/agent/util/AccessUtils.java
+++ b/agent/src/main/java/org/openjdk/jmc/agent/util/AccessUtils.java
@@ -40,6 +40,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.OptionalInt;
 import java.util.Queue;
 
 /**
@@ -203,7 +204,8 @@ public final class AccessUtils {
 	 * @return whether the class is accessible
 	 */
 	public static boolean verifyModuleAccess(Class<?> targetClass, Class<?> callerClass) {
-		if (isPreJava9()) {
+		OptionalInt featureVersion = VersionUtils.getFeatureVersion();
+		if (featureVersion.isPresent() && featureVersion.getAsInt() < 9) {
 			return true; // There is no module for pre-java 9
 		}
 
@@ -231,15 +233,6 @@ public final class AccessUtils {
 				| IllegalAccessException
 				| InvocationTargetException e) {
 			throw new RuntimeException(e); // this should not happen
-		}
-	}
-
-	private static boolean isPreJava9() {
-		try {
-			Class.forName("java.lang.Module");
-			return false;
-		} catch (ClassNotFoundException e) {
-			return true;
 		}
 	}
 

--- a/agent/src/main/java/org/openjdk/jmc/agent/util/ModuleUtils.java
+++ b/agent/src/main/java/org/openjdk/jmc/agent/util/ModuleUtils.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2020 Red Hat Inc. All rights reserved.
+ * Copyright (c) 2020, Red Hat Inc. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -40,7 +40,6 @@ import java.util.Collections;
 import java.util.logging.Level;
 
 import org.openjdk.jmc.agent.Agent;
-import org.openjdk.jmc.agent.jfr.VersionResolver;
 
 /**
  * Utility for dealing with module system specifics.
@@ -51,7 +50,7 @@ public class ModuleUtils {
 	 * Allows the agent's module to access the Unsafe class when running on JDK 11 or newer.
 	 */
 	public static void openUnsafePackage(Instrumentation instrumentation) {
-		VersionResolver.getFeatureVersion().ifPresent(featureVersion -> {
+		VersionUtils.getFeatureVersion().ifPresent(featureVersion -> {
 			if (featureVersion >= 11) {
 
 				Method redefineModule = getRedefineModuleMethod();

--- a/agent/src/main/java/org/openjdk/jmc/agent/util/ModuleUtils.java
+++ b/agent/src/main/java/org/openjdk/jmc/agent/util/ModuleUtils.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020 Red Hat Inc. All rights reserved.
+ *
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * The contents of this file are subject to the terms of either the Universal Permissive License
+ * v 1.0 as shown at http://oss.oracle.com/licenses/upl
+ *
+ * or the following license:
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted
+ * provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions
+ * and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other materials provided with
+ * the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to
+ * endorse or promote products derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+ * WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.openjdk.jmc.agent.util;
+
+import java.lang.instrument.Instrumentation;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Collections;
+import java.util.logging.Level;
+
+import org.openjdk.jmc.agent.Agent;
+import org.openjdk.jmc.agent.jfr.VersionResolver;
+
+/**
+ * Utility for dealing with module system specifics.
+ */
+public class ModuleUtils {
+
+	/**
+	 * Allows the agent's module to access the Unsafe class when running on JDK 11 or newer.
+	 */
+	public static void openUnsafePackage(Instrumentation instrumentation) {
+		VersionResolver.getFeatureVersion().ifPresent(featureVersion -> {
+			if (featureVersion >= 11) {
+
+				Method redefineModule = getRedefineModuleMethod();
+
+				try {
+					redefineModule.invoke(instrumentation, Object.class.getModule(), Collections.emptySet(), // extraReads
+							Collections.emptyMap(), // extraExports
+							Collections.singletonMap("jdk.internal.misc",
+									Collections.singleton(Agent.class.getModule())), // extraOpens
+							Collections.emptySet(), // extraUses
+							Collections.emptyMap() // extraProvides
+					);
+				} catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
+					Agent.getLogger().log(Level.WARNING, "Failed to open module", e); //$NON-NLS-1$
+				}
+			}
+		});
+	}
+
+	private static Method getRedefineModuleMethod() {
+		for (java.lang.reflect.Method method : Instrumentation.class.getDeclaredMethods()) {
+			if (method.getName().equals("redefineModule")) {
+				return method;
+			}
+		}
+
+		return null;
+	}
+}

--- a/agent/src/main/java/org/openjdk/jmc/agent/util/VersionUtils.java
+++ b/agent/src/main/java/org/openjdk/jmc/agent/util/VersionUtils.java
@@ -30,21 +30,24 @@
  * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
  * WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.openjdk.jmc.agent.jfr;
+package org.openjdk.jmc.agent.util;
 
 import java.lang.reflect.Method;
 import java.util.OptionalInt;
 
-public final class VersionResolver {
+public final class VersionUtils {
 
-	private final static JFRVersion availableJFRVersion;
+	private static final JFRVersion AVAILABLE_JFR_VERSION = determineJFRVersion();
 	private static final int FEATURE_VERSION = determineFeatureVersion();
 
 	public enum JFRVersion {
 		JFR, JFRNEXT, NONE
 	}
 
-	static {
+	private VersionUtils() {
+	}
+
+	private static JFRVersion determineJFRVersion() {
 		JFRVersion type = null;
 		try {
 			Class.forName("com.oracle.jrockit.jfr.InstantEvent"); //$NON-NLS-1$
@@ -57,18 +60,18 @@ public final class VersionResolver {
 				type = JFRVersion.NONE;
 			}
 		}
-		availableJFRVersion = type;
-	}
-
-	private VersionResolver() {
-	}
-
-	public static JFRVersion getAvailableJFRVersion() {
-		return availableJFRVersion;
+		return type;
 	}
 
 	/**
-	 * Returns the current JVM' feature (major) version, e.g. 8, 11, or 15.
+	 * Returns the current JVM's JFR version.
+	 */
+	public static JFRVersion getAvailableJFRVersion() {
+		return AVAILABLE_JFR_VERSION;
+	}
+
+	/**
+	 * Returns the current JVM's feature (major) version, e.g. 8, 11, or 15.
 	 */
 	public static OptionalInt getFeatureVersion() {
 		return FEATURE_VERSION == 0 ? OptionalInt.empty() : OptionalInt.of(FEATURE_VERSION);

--- a/agent/src/test/java/org/openjdk/jmc/agent/test/TestRetrieveCurrentTransforms.java
+++ b/agent/src/test/java/org/openjdk/jmc/agent/test/TestRetrieveCurrentTransforms.java
@@ -51,7 +51,7 @@ public class TestRetrieveCurrentTransforms {
 	private static final String FIELD_NAME = "'InstrumentMe.STATIC_STRING_FIELD'"; //$NON-NLS-1$
 
 	@Test
-	public void testRetreiveCurrentTransforms() throws Exception {
+	public void testRetrieveCurrentTransforms() throws Exception {
 		JFRTransformDescriptor[] jfrTds = doRetrieveCurrentTransforms();
 		Assert.assertTrue(jfrTds.length == 1);
 		for (JFRTransformDescriptor jfrTd : jfrTds) {


### PR DESCRIPTION
So here's a fresh take on the `Unsafe` / `add-opens` issue for JMC Agent. This still is using `Unsafe`, but I'm using the instrumentation API for opening up the base module within the agent itself, instead of requiring the user to do so. Ideally, we'd still get away from `Unsafe`, but this make the agent easier to use. This is still a draft, would do some more polishing if you all think it's the right approach. Feedback welcome!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | linux | mac | win |
| --- | ----- | ----- | ----- |
| Build / test | ❌ (1/1 failed) | ✔️ (1/1 passed) | ✔️ (1/1 passed) |

**Failed test task**
- [linux](https://github.com/gunnarmorling/jmc/runs/1470660959)

### Issue
 * [JMC-6964](https://bugs.openjdk.java.net/browse/JMC-6964): [Agent] Automatically open base module for accessing Unsafe on JDK 11+


### Reviewers
 * [Marcus Hirt](https://openjdk.java.net/census#hirt) (@thegreystone - **Reviewer**) ⚠️ Review applies to 5d4792ff4c6efebcf60775264e7874bc185a2ddf


### Download
`$ git fetch https://git.openjdk.java.net/jmc pull/152/head:pull/152`
`$ git checkout pull/152`
