### PR TITLE
6965: Thirdparty licenses missing in core, Maven plugins version update

### DIFF
--- a/agent/pom.xml
+++ b/agent/pom.xml
@@ -43,7 +43,7 @@
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>
 		<asm.version>8.0.1</asm.version>
-		<junit.version>4.12</junit.version>
+		<junit.version>4.13.1</junit.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<spotless.version>1.26.0</spotless.version>
 		<spotless.config.path>${basedir}/../configuration/ide/eclipse/formatting/formatting.xml</spotless.config.path>

--- a/core/license/LICENSE.txt
+++ b/core/license/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
 
 The Universal Permissive License (UPL), Version 1.0
 

--- a/core/license/THIRD_PARTY_LICENSES.txt
+++ b/core/license/THIRD_PARTY_LICENSES.txt
@@ -1,0 +1,252 @@
+Third Party Attributions
+
+The following software (or certain identified files distributed with the
+software) may be included in this product. Unless otherwise specified,
+the software identified in this file is licensed under the licenses
+described below. The disclaimers and copyright notices provided are
+based on information made available to Oracle by the third party
+licensors listed.
+
+%% The following notice is provided with respect to OWASP Java
+Encoder Project 1.2.2 which may be included with this product.
+
+Copyright (c) 2015 Jeff Ichnowski
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+    * Redistributions of source code must retain the above
+      copyright notice, this list of conditions and the following
+      disclaimer.
+
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials
+      provided with the distribution.
+
+    * Neither the name of the OWASP nor the names of its
+      contributors may be used to endorse or promote products
+      derived from this software without specific prior written
+      permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+%% The following notice is provided with respect to lz4-java,
+which may be included with this product.
+
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/internal/parser/v0/factories/IPoolFactory.java
+++ b/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/internal/parser/v0/factories/IPoolFactory.java
@@ -43,8 +43,6 @@ public interface IPoolFactory<T> {
 	 *
 	 * @param identifier
 	 *            the identifier that is used to look up the object
-	 * @param the
-	 *            object that would normally be returned from the pool
 	 * @return the replacement object that will be used instead
 	 */
 	T createObject(long identifier, Object o);

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -37,15 +37,52 @@
 	<artifactId>missioncontrol.core</artifactId>
 	<version>8.0.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
-
+	<description>JDK Mission Control is an advanced set of tools that enables
+		efficient and detailed analysis of the extensive of data collected by
+		JDK Flight Recorder. The tool chain enables developers and
+		administrators to collect and analyze data from Java applications
+		running locally or deployed in production environments.
+	</description>
+	<url>http://jdk.java.net/jmc</url>
+	<licenses>
+		<license>
+			<name>Universal Permissive License Version 1.0</name>
+			<url>http://oss.oracle.com/licenses/upl</url>
+			<distribution>repo</distribution>
+			<comments>Copyright (c) 2018, 2020, Oracle and/or its affiliates. Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.</comments>
+		</license>
+	</licenses>
+	<organization>
+		<name>Oracle</name>
+		<url>https://www.oracle.com</url>
+	</organization>
+	<issueManagement>
+		<system>JIRA</system>
+		<url>https://bugs.openjdk.java.net/projects/JMC/issues</url>
+	</issueManagement>
+	<mailingLists>
+		<mailingList>
+			<name>jmc dev</name>
+			<subscribe>http://mail.openjdk.java.net/mailman/listinfo/jmc-dev</subscribe>
+			<unsubscribe>http://mail.openjdk.java.net/mailman/listinfo/jmc-dev</unsubscribe>
+			<archive>http://mail.openjdk.java.net/pipermail/jmc-dev/</archive>
+		</mailingList>
+	</mailingLists>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>
 		<manifest-location>META-INF</manifest-location>
-		<maven.bundle.plugin.version>3.5.1</maven.bundle.plugin.version>
-		<spotless.version>1.26.0</spotless.version>
+		<maven.jar.version>3.2.0</maven.jar.version>
+		<maven.bundle.version>5.1.1</maven.bundle.version>
+		<spotless.version>2.5.0</spotless.version>
+		<maven.directory.version>0.3.1</maven.directory.version>
+		<maven.resources.version>3.2.0</maven.resources.version>
+		<maven.source.version>3.2.1</maven.source.version>
+		<maven.javadoc.version>3.2.0</maven.javadoc.version>
+		<nexus.staging.version>1.6.8</nexus.staging.version>
+		<maven.gpg.version>1.6</maven.gpg.version>
 		<spotless.config.path>${basedir}/../configuration/ide/eclipse/formatting/formatting.xml</spotless.config.path>
 	</properties>
 
@@ -58,7 +95,6 @@
 		<module>tests</module>
 		<module>coverage</module>
 	</modules>
-
 	<distributionManagement>
 		<snapshotRepository>
 			<id>jmc-publish-snapshot</id>
@@ -70,8 +106,9 @@
 		<pluginManagement>
 			<plugins>
 				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-jar-plugin</artifactId>
-					<version>3.1.0</version>
+					<version>${maven.jar.version}</version>
 					<configuration>
 						<archive>
 							<manifestFile>${manifest-location}/MANIFEST.MF</manifestFile>
@@ -81,7 +118,7 @@
 				<plugin>
 					<groupId>org.apache.felix</groupId>
 					<artifactId>maven-bundle-plugin</artifactId>
-					<version>${maven.bundle.plugin.version}</version>
+					<version>${maven.bundle.version}</version>
 					<configuration>
 						<manifestLocation>${manifest-location}</manifestLocation>
 					</configuration>
@@ -102,7 +139,7 @@
 				<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-resources-plugin</artifactId>
-				<version>3.0.2</version>
+				<version>${maven.resources.version}</version>
 				<executions>
 					<execution>
 						<id>copy-resources</id>
@@ -111,12 +148,13 @@
 							<goal>copy-resources</goal>
 						</goals>
 						<configuration>
-							<outputDirectory>${project.build.directory}/classes/license</outputDirectory>
+							<outputDirectory>${project.build.directory}/classes</outputDirectory>
 							<resources>
 								<resource>
-									<directory>${project.basedir}/../license</directory>
+									<directory>${rootDir}/license</directory>
 									<includes>
 										<include>LICENSE.txt</include>
+										<include>THIRD_PARTY_LICENSES.txt</include>
 									</includes>
 								</resource>
 							</resources>
@@ -128,9 +166,26 @@
 		</pluginManagement>
 		<plugins>
 			<plugin>
+				<groupId>org.commonjava.maven.plugins</groupId>
+				<artifactId>directory-maven-plugin</artifactId>
+				<version>${maven.directory.version}</version>
+				<executions>
+					<execution>
+						<id>directories</id>
+						<goals>
+							<goal>highest-basedir</goal>
+						</goals>
+						<phase>initialize</phase>
+						<configuration>
+							<property>rootDir</property>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-source-plugin</artifactId>
-				<version>3.0.1</version>
+				<version>${maven.source.version}</version>
 				<executions>
 					<execution>
 						<id>attach-sources</id>
@@ -143,7 +198,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>3.0.1</version>
+				<version>${maven.javadoc.version}</version>
 				<executions>
 					<execution>
 						<id>attach-javadocs</id>
@@ -165,7 +220,7 @@
 			<plugin>
 				<groupId>org.sonatype.plugins</groupId>
 				<artifactId>nexus-staging-maven-plugin</artifactId>
-				<version>1.6.8</version>
+				<version>${nexus.staging.version}</version>
 				<extensions>true</extensions>
 				<configuration>
 					<serverId>jmc-publish-snapshot</serverId>
@@ -175,7 +230,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-gpg-plugin</artifactId>
-				<version>1.6</version>
+				<version>${maven.gpg.version}</version>
 				<executions>
 					<execution>
 						<id>gpg-sign</id>

--- a/core/tests/org.openjdk.jmc.common.test/pom.xml
+++ b/core/tests/org.openjdk.jmc.common.test/pom.xml
@@ -52,6 +52,7 @@
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
+			<version>${junit.version}</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
@@ -61,6 +62,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-jar-plugin</artifactId>
+				<version>${maven.jar.version}</version>
 				<executions>
 					<execution>
 						<goals>

--- a/core/tests/org.openjdk.jmc.flightrecorder.rules.jdk.test/pom.xml
+++ b/core/tests/org.openjdk.jmc.flightrecorder.rules.jdk.test/pom.xml
@@ -87,6 +87,7 @@
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
+			<version>${junit.version}</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
@@ -96,6 +97,7 @@
          <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-jar-plugin</artifactId>
+            <version>${maven.jar.version}</version>
             <executions>
                <execution>
                   <goals>

--- a/core/tests/org.openjdk.jmc.flightrecorder.rules.test/pom.xml
+++ b/core/tests/org.openjdk.jmc.flightrecorder.rules.test/pom.xml
@@ -75,6 +75,7 @@
            <dependency>
                    <groupId>junit</groupId>
                    <artifactId>junit</artifactId>
+                   <version>${junit.version}</version>
                    <scope>test</scope>
            </dependency>
    </dependencies>
@@ -84,6 +85,7 @@
          <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-jar-plugin</artifactId>
+            <version>${maven.jar.version}</version>
             <executions>
                <execution>
                   <goals>

--- a/core/tests/org.openjdk.jmc.flightrecorder.test/pom.xml
+++ b/core/tests/org.openjdk.jmc.flightrecorder.test/pom.xml
@@ -68,6 +68,7 @@
            <dependency>
                    <groupId>junit</groupId>
                    <artifactId>junit</artifactId>
+                   <version>${junit.version}</version>
                    <scope>test</scope>
            </dependency>
    </dependencies>
@@ -77,6 +78,7 @@
          <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-jar-plugin</artifactId>
+            <version>${maven.jar.version}</version>
             <executions>
                <execution>
                   <goals>

--- a/core/tests/org.openjdk.jmc.jdp.test/pom.xml
+++ b/core/tests/org.openjdk.jmc.jdp.test/pom.xml
@@ -53,6 +53,7 @@
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
+			<version>${junit.version}</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/core/tests/pom.xml
+++ b/core/tests/pom.xml
@@ -54,6 +54,7 @@
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>
 		<spotless.config.path>${basedir}/../../configuration/ide/eclipse/formatting/formatting.xml</spotless.config.path>
+		<junit.version>4.13.1</junit.version>
 	</properties>
 	<profiles>
 		<profile>
@@ -106,7 +107,7 @@
 			<dependency>
 				<groupId>junit</groupId>
 				<artifactId>junit</artifactId>
-				<version>4.12</version>
+				<version>${junit.version}</version>
 				<scope>test</scope>
 			</dependency>
 		</dependencies>

--- a/license/LICENSE.txt
+++ b/license/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
 
 The Universal Permissive License (UPL), Version 1.0
 

--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,7 @@
 			<name>Universal Permissive License Version 1.0</name>
 			<url>http://oss.oracle.com/licenses/upl</url>
 			<distribution>repo</distribution>
+			<comments>Copyright (c) 2018, 2020, Oracle and/or its affiliates. Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.</comments>
 		</license>
 	</licenses>
 	<organization>
@@ -79,10 +80,10 @@
 		<tycho.version>2.0.0</tycho.version>
 		<maven.buildnumber.version>1.4</maven.buildnumber.version>
 		<maven.deploy.version>2.8.2</maven.deploy.version>
-		<maven.directory.version>0.2</maven.directory.version>
+		<maven.directory.version>0.3.1</maven.directory.version>
 		<maven.enforcer.version>3.0.0-M1</maven.enforcer.version>
-		<maven.resources.version>3.0.2</maven.resources.version>
-		<spotless.version>1.26.0</spotless.version>
+		<maven.resources.version>3.2.0</maven.resources.version>
+		<spotless.version>2.5.0</spotless.version>
 		<spotless.config.path>${basedir}/configuration/ide/eclipse/formatting/formatting.xml</spotless.config.path>
 		<spotbugs.version>4.0.4</spotbugs.version>
 		<buildId>${user.name}</buildId>

--- a/releng/third-party/pom.xml
+++ b/releng/third-party/pom.xml
@@ -106,7 +106,7 @@
 			<plugin>
 				<groupId>org.eclipse.jetty</groupId>
 				<artifactId>jetty-maven-plugin</artifactId>
-				<version>9.4.14.v20181114</version>
+				<version>9.4.33.v20201020</version>
 				<configuration>
 					<scanIntervalSeconds>60</scanIntervalSeconds>
 					<webAppSourceDirectory>${basedir}/target/repository/</webAppSourceDirectory>
@@ -121,7 +121,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-enforcer-plugin</artifactId>
-				<version>3.0.0-M1</version>
+				<version>3.0.0-M3</version>
 				<executions>
 					<execution>
 						<id>enforce-java</id>


### PR DESCRIPTION
Fix contails : 
1 "THIRD_PARTY_LICENSES.txt" (new file) contain license attributes of owasp java encoder and lz4-java.
2. "LICENSE.TXT" should be contained in the root directory (inside jar) instead of "rootdir/license/Licenses.txt" (which was earlier fixed in JMC-6951" 
3. Maven build time plugins version update for : 
 [core] update maven dependent plugin with latest version : 
   org.apache.maven.plugins:maven-jar-plugin:3.2.0 (old : 3.1.0)
   org.apache.maven.plugins:maven-resources-plugin:3.2.0 (old : 3.0.2) 
   org.apache.maven.plugins:maven-source-plugin:3.2.1 (old: 3.0.2) 
   org.apache.maven.plugins:maven-javadoc-plugin: 3.2.0 (old : 3.0.2) 
 [jmc] 
   org.commonjava.maven.plugins:directory-maven-plugin:0.3.1 (old : 0.2)
   org.apache.maven.plugins:maven-resource-plugin:3.2.0 (old : 3.0.2)
junit:junit:4.13.1 (old : 4.12)

4. Fixed javadoc error (Invalid parameter 'the"  in IPoolFactory.java) after upgrading javadoc-plugin with 3.2.0
5. [Core] Fixed Warning "'build.plugins.plugin.version' for org.apache.maven.plugins:maven-jar-plugin is missing" in test modules : missing <version> value in the test pom.xml

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | linux | mac | win |
| --- | ----- | ----- | ----- |
| Build / test | ❌ (1/1 failed) | ✔️ (1/1 passed) | ✔️ (1/1 passed) |

**Failed test task**
- [linux](https://github.com/guruhb/jmc/runs/1346277275)

### Issue
 * [JMC-6965](https://bugs.openjdk.java.net/browse/JMC-6965): Thirdparty licenses missing in core, Maven plugins version update 


### Reviewers
 * [Marcus Hirt](https://openjdk.java.net/census#hirt) (@thegreystone - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jmc pull/154/head:pull/154`
`$ git checkout pull/154`
