### PR TITLE
5734: Overflow in stacktrace tooltips on Mac

### DIFF
--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/views/stacktrace/StacktraceView.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/views/stacktrace/StacktraceView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -764,12 +764,12 @@ public class StacktraceView extends ViewPart implements ISelectionListener {
 			String frameFraction = UnitLookup.PERCENT_UNITY.quantity(itemCount / (double) totalCount)
 					.displayUsing(IDisplayable.AUTO);
 			StringBuilder sb = new StringBuilder("<form>"); //$NON-NLS-1$
-			sb.append("<li style='image' value='" + COUNT_IMG_KEY + "'>"); //$NON-NLS-1$ //$NON-NLS-2$
+			sb.append("<li style='image' value='" + COUNT_IMG_KEY + "'><span nowrap='true'>"); //$NON-NLS-1$ //$NON-NLS-2$
 			sb.append(Messages.stackTraceMessage(itemCount, totalCount, frameFraction));
-			sb.append("</li>"); //$NON-NLS-1$
-			sb.append("<li style='image' value='" + SIBLINGS_IMG_KEY + "'>"); //$NON-NLS-1$ //$NON-NLS-2$
+			sb.append("</span></li>"); //$NON-NLS-1$
+			sb.append("<li style='image' value='" + SIBLINGS_IMG_KEY + "'><span nowrap='true'>"); //$NON-NLS-1$ //$NON-NLS-2$
 			sb.append(Messages.siblingMessage(itemsInSiblings, parentFork.getBranchCount() - 1));
-			sb.append("</li>"); //$NON-NLS-1$
+			sb.append("</span></li>"); //$NON-NLS-1$
 			sb.append("</form>"); //$NON-NLS-1$
 			return sb.toString();
 		}


### PR DESCRIPTION
[Mac os] stacktrace tooltip view lines used to overflow with second line clipped. 
Solution : Stacktrace contains two list element, by adding span to list element with 'nowarp=true' solves the problem as similarly done in ChartToolTipProvider.

<img width="955" alt="jmc-5734" src="https://user-images.githubusercontent.com/1955702/98459172-30227700-21be-11eb-8fa9-3513feba4614.png">

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | linux | mac | win |
| --- | ----- | ----- | ----- |
| Build / test | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (1/1 passed) |

### Issue
 * [JMC-5734](https://bugs.openjdk.java.net/browse/JMC-5734): Overflow in stacktrace tooltips on Mac


### Reviewers
 * [Marcus Hirt](https://openjdk.java.net/census#hirt) (@thegreystone - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jmc pull/157/head:pull/157`
`$ git checkout pull/157`
