### PR TITLE
6974: Try to use the chromium SWT browser by default on windows

### DIFF
--- a/application/org.openjdk.jmc.feature.core/feature.xml
+++ b/application/org.openjdk.jmc.feature.core/feature.xml
@@ -63,6 +63,17 @@
    </requires>
 
    <plugin
+         id="com.make.chromium.cef.win32.win32.x86_64"
+         os="win32"
+         ws="win32"
+         arch="x86_64"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         fragment="true"
+         unpack="false"/>
+
+   <plugin
          id="org.openjdk.jmc.attach"
          download-size="0"
          install-size="0"

--- a/application/org.openjdk.jmc.rcp.product/jmc.product
+++ b/application/org.openjdk.jmc.rcp.product/jmc.product
@@ -56,7 +56,7 @@
       </programArgsMac>
       <programArgsWin>
       </programArgsWin>
-      <vmArgs>-XX:+IgnoreUnrecognizedVMOptions -XX:+UnlockDiagnosticVMOptions -XX:+DebugNonSafepoints -XX:FlightRecorderOptions=stackdepth=128 -XX:+FlightRecorder -XX:StartFlightRecording=name=JMC_Default,maxsize=100m -Djava.net.preferIPv4Stack=true -Djdk.attach.allowAttachSelf=true --add-exports=java.xml/com.sun.org.apache.xerces.internal.parsers=ALL-UNNAMED --add-exports=jdk.internal.jvmstat/sun.jvmstat.monitor=ALL-UNNAMED --add-exports=java.management/sun.management=ALL-UNNAMED --add-exports=java.management/sun.management.counter.perf=ALL-UNNAMED --add-exports=jdk.management.agent/jdk.internal.agent=ALL-UNNAMED --add-exports=jdk.attach/sun.tools.attach=ALL-UNNAMED --add-opens=java.base/java.net=ALL-UNNAMED --add-opens=jdk.attach/sun.tools.attach=ALL-UNNAMED 
+      <vmArgs>-XX:+IgnoreUnrecognizedVMOptions -XX:+UnlockDiagnosticVMOptions -XX:+DebugNonSafepoints -XX:FlightRecorderOptions=stackdepth=128 -XX:+FlightRecorder -XX:StartFlightRecording=name=JMC_Default,maxsize=100m -Djava.net.preferIPv4Stack=true -Djdk.attach.allowAttachSelf=true -Dorg.eclipse.swt.browser.DefaultType=chromium --add-exports=java.xml/com.sun.org.apache.xerces.internal.parsers=ALL-UNNAMED --add-exports=jdk.internal.jvmstat/sun.jvmstat.monitor=ALL-UNNAMED --add-exports=java.management/sun.management=ALL-UNNAMED --add-exports=java.management/sun.management.counter.perf=ALL-UNNAMED --add-exports=jdk.management.agent/jdk.internal.agent=ALL-UNNAMED --add-exports=jdk.attach/sun.tools.attach=ALL-UNNAMED --add-opens=java.base/java.net=ALL-UNNAMED --add-opens=jdk.attach/sun.tools.attach=ALL-UNNAMED
       -Dsun.java.command=JMC
       </vmArgs>
       <vmArgsLin>--add-exports=java.desktop/sun.awt.X11=ALL-UNNAMED

--- a/releng/platform-definitions/platform-definition-2019-12/platform-definition-2019-12.target
+++ b/releng/platform-definitions/platform-definition-2019-12/platform-definition-2019-12.target
@@ -59,6 +59,10 @@
             <unit id="org.eclipse.babel.nls_eclipse_zh.feature.group" version="4.14.0.v20200113020001"/>
             <repository location="https://archive.eclipse.org/technology/babel/update-site/R0.17.1/2019-12/"/>
         </location>
+        <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+           <unit id="com.make.chromium.cef.feature.feature.group" version="0.4.0.202005172227"/>
+           <repository location="https://equo-chromium-cef.ams3.digitaloceanspaces.com/rls/repository"/>
+        </location>
     </locations>
     <targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 </target>

--- a/releng/platform-definitions/platform-definition-2020-03/platform-definition-2020-03.target
+++ b/releng/platform-definitions/platform-definition-2020-03/platform-definition-2020-03.target
@@ -59,6 +59,10 @@
             <unit id="org.eclipse.babel.nls_eclipse_zh.feature.group" version="4.14.0.v20200113020001"/>
             <repository location="https://archive.eclipse.org/technology/babel/update-site/R0.17.1/2019-12/"/>
         </location>
+        <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+            <unit id="com.make.chromium.cef.feature.feature.group" version="0.4.0.202005172227"/>
+            <repository location="https://equo-chromium-cef.ams3.digitaloceanspaces.com/rls/repository"/>
+        </location>
     </locations>
     <targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 </target>

--- a/releng/platform-definitions/platform-definition-2020-06/platform-definition-2020-06.target
+++ b/releng/platform-definitions/platform-definition-2020-06/platform-definition-2020-06.target
@@ -59,6 +59,10 @@
             <unit id="org.eclipse.babel.nls_eclipse_zh.feature.group" version="4.16.0.v20200711020001"/>
             <repository location="https://archive.eclipse.org/technology/babel/update-site/R0.18.0/2020-06/"/>
         </location>
+        <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+            <unit id="com.make.chromium.cef.feature.feature.group" version="0.4.0.202005172227"/>
+            <repository location="https://equo-chromium-cef.ams3.digitaloceanspaces.com/rls/repository"/>
+        </location>
     </locations>
     <targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 </target>

--- a/releng/platform-definitions/platform-definition-2020-09/platform-definition-2020-09.target
+++ b/releng/platform-definitions/platform-definition-2020-09/platform-definition-2020-09.target
@@ -59,6 +59,10 @@
             <unit id="org.eclipse.babel.nls_eclipse_zh.feature.group" version="4.16.0.v20200711020001"/>
             <repository location="https://archive.eclipse.org/technology/babel/update-site/R0.18.0/2020-06/"/>
         </location>
+        <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+            <unit id="com.make.chromium.cef.feature.feature.group" version="0.4.0.202005172227"/>
+            <repository location="https://equo-chromium-cef.ams3.digitaloceanspaces.com/rls/repository"/>
+        </location>
     </locations>
     <targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
 </target>


### PR DESCRIPTION
Using SWT Chromium browser for windows .
Followed steps provided in https://www.eclipse.org/swt/faq.php#howusechromium 

With the plugin "com.make.chromium.cef.win32.win32.x86_64" inclusion in the core feature.xml makes other platform and its product definition to contain the chromium p2 site, which makes other build to have extra 56 MB of swt chromium jar which doesn't work on Eclipse 2020-06 and below. 


Note: Eclipse IDE (on Windows) add "-Dorg.eclipse.swt.browser.DefaultType=chromium" to override default browser to Chromium, Were as standalone rcp application and its jmc.ini contains this flag.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | linux | mac | win |
| --- | ----- | ----- | ----- |
| Build / test | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (1/1 passed) |

### Issue
 * [JMC-6974](https://bugs.openjdk.java.net/browse/JMC-6974): Try to use the chromium SWT browser by default on windows


### Reviewers
 * [Marcus Hirt](https://openjdk.java.net/census#hirt) (@thegreystone - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jmc pull/160/head:pull/160`
`$ git checkout pull/160`
