### PR TITLE
6982: CoreLibs: Add license and TPL info to sources and javadocs

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -83,6 +83,7 @@
 		<maven.javadoc.version>3.2.0</maven.javadoc.version>
 		<nexus.staging.version>1.6.8</nexus.staging.version>
 		<maven.gpg.version>1.6</maven.gpg.version>
+		<build.helper.maven.version>3.2.0</build.helper.maven.version>
 		<spotless.config.path>${basedir}/../configuration/ide/eclipse/formatting/formatting.xml</spotless.config.path>
 	</properties>
 
@@ -148,14 +149,15 @@
 							<goal>copy-resources</goal>
 						</goals>
 						<configuration>
-							<outputDirectory>${project.build.directory}/classes</outputDirectory>
+							<outputDirectory>${project.build.directory}</outputDirectory>
 							<resources>
 								<resource>
+									<targetPath>${basedir}/target/classes</targetPath>
 									<directory>${rootDir}/license</directory>
-									<includes>
-										<include>LICENSE.txt</include>
-										<include>THIRD_PARTY_LICENSES.txt</include>
-									</includes>
+								</resource>
+								<resource>
+									<targetPath>${basedir}/target/apidocs</targetPath>
+									<directory>${rootDir}/license</directory>
 								</resource>
 							</resources>
 						</configuration>
@@ -178,6 +180,24 @@
 						<phase>initialize</phase>
 						<configuration>
 							<property>rootDir</property>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>build-helper-maven-plugin</artifactId>
+				<version>${build.helper.maven.version}</version>
+				<executions>
+					<execution>
+						<phase>package</phase>
+						<goals>
+							<goal>add-source</goal>
+						</goals>
+						<configuration>
+							<sources>
+								<source>${rootDir}/license</source>
+							</sources>
 						</configuration>
 					</execution>
 				</executions>


### PR DESCRIPTION
Adding "LICENSE.txt" and "THIRD_PARTY_LICENSES.txt" for "*-{source, javadoc}.jar" in core libraries.

Note: "maven-source-plugin" doesn't have capability to add resource outside the project directory. Added "org.codehaus.mojo:build-helper-maven-plugin" for copying license for the *-source.jar.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | linux | mac | win |
| --- | ----- | ----- | ----- |
| Build / test | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (1/1 passed) |

### Issue
 * [JMC-6982](https://bugs.openjdk.java.net/browse/JMC-6982): CoreLibs: Add license and TPL info to sources and javadocs


### Reviewers
 * [Marcus Hirt](https://openjdk.java.net/census#hirt) (@thegreystone - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jmc pull/164/head:pull/164`
`$ git checkout pull/164`
