### PR TITLE
7001: Missing chromium binary message on MacOS X

### DIFF
--- a/application/org.openjdk.jmc.rcp.product/jmc.product
+++ b/application/org.openjdk.jmc.rcp.product/jmc.product
@@ -56,14 +56,14 @@
       </programArgsMac>
       <programArgsWin>
       </programArgsWin>
-      <vmArgs>-XX:+IgnoreUnrecognizedVMOptions -XX:+UnlockDiagnosticVMOptions -XX:+DebugNonSafepoints -XX:FlightRecorderOptions=stackdepth=128 -XX:+FlightRecorder -XX:StartFlightRecording=name=JMC_Default,maxsize=100m -Djava.net.preferIPv4Stack=true -Djdk.attach.allowAttachSelf=true -Dorg.eclipse.swt.browser.DefaultType=chromium --add-exports=java.xml/com.sun.org.apache.xerces.internal.parsers=ALL-UNNAMED --add-exports=jdk.internal.jvmstat/sun.jvmstat.monitor=ALL-UNNAMED --add-exports=java.management/sun.management=ALL-UNNAMED --add-exports=java.management/sun.management.counter.perf=ALL-UNNAMED --add-exports=jdk.management.agent/jdk.internal.agent=ALL-UNNAMED --add-exports=jdk.attach/sun.tools.attach=ALL-UNNAMED --add-opens=java.base/java.net=ALL-UNNAMED --add-opens=jdk.attach/sun.tools.attach=ALL-UNNAMED
+      <vmArgs>-XX:+IgnoreUnrecognizedVMOptions -XX:+UnlockDiagnosticVMOptions -XX:+DebugNonSafepoints -XX:FlightRecorderOptions=stackdepth=128 -XX:+FlightRecorder -XX:StartFlightRecording=name=JMC_Default,maxsize=100m -Djava.net.preferIPv4Stack=true -Djdk.attach.allowAttachSelf=true --add-exports=java.xml/com.sun.org.apache.xerces.internal.parsers=ALL-UNNAMED --add-exports=jdk.internal.jvmstat/sun.jvmstat.monitor=ALL-UNNAMED --add-exports=java.management/sun.management=ALL-UNNAMED --add-exports=java.management/sun.management.counter.perf=ALL-UNNAMED --add-exports=jdk.management.agent/jdk.internal.agent=ALL-UNNAMED --add-exports=jdk.attach/sun.tools.attach=ALL-UNNAMED --add-opens=java.base/java.net=ALL-UNNAMED --add-opens=jdk.attach/sun.tools.attach=ALL-UNNAMED
       -Dsun.java.command=JMC
       </vmArgs>
       <vmArgsLin>--add-exports=java.desktop/sun.awt.X11=ALL-UNNAMED
       </vmArgsLin>
       <vmArgsMac>--add-exports=java.desktop/sun.lwawt.macosx=ALL-UNNAMED -XstartOnFirstThread -Dorg.eclipse.swt.internal.carbon.smallFonts
       </vmArgsMac>
-      <vmArgsWin>--add-exports=java.desktop/sun.awt.windows=ALL-UNNAMED
+      <vmArgsWin>-Dorg.eclipse.swt.browser.DefaultType=chromium --add-exports=java.desktop/sun.awt.windows=ALL-UNNAMED
       </vmArgsWin>
    </launcherArgs>
 


### PR DESCRIPTION
RC : property "-Dorg.eclipse.swt.browser.DefaultType=chromium" was added to all three platform configuration file (jmc.ini) as it as supposed to be only for windows platform.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | linux | mac | win |
| --- | ----- | ----- | ----- |
| Build / test | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (1/1 passed) |

### Issue
 * [JMC-7001](https://bugs.openjdk.java.net/browse/JMC-7001): Missing chromium binary message on MacOS X


### Reviewers
 * [Marcus Hirt](https://openjdk.java.net/census#hirt) (@thegreystone - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jmc pull/166/head:pull/166`
`$ git checkout pull/166`
