### PR TITLE
6690: Find a home for the Flame View in the JMC perspective

### DIFF
--- a/application/org.openjdk.jmc.flightrecorder.flameview/plugin.xml
+++ b/application/org.openjdk.jmc.flightrecorder.flameview/plugin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-   Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
-   Copyright (c) 2019, Datadog, Inc. All rights reserved.
+   Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+   Copyright (c) 2019, 2020, Datadog, Inc. All rights reserved.
 
    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
@@ -40,9 +40,17 @@
 			category="org.openjdk.jmc.ui.main"
 			class="org.openjdk.jmc.flightrecorder.flameview.views.FlameGraphView"
 			icon="icons/flame.png"
-			id="org.openjdk.jmc.flightrecorder.flameview"
-			name="%FLAME_VIEW_NAME"
-			restorable="true">
-		</view>
+			id="org.openjdk.jmc.flightrecorder.FlameView"
+			name="%FLAME_VIEW_NAME"/>
+	</extension>
+	<extension point="org.eclipse.ui.perspectiveExtensions">
+		<perspectiveExtension targetID="org.openjdk.jmc.ui.idesupport.StandardPerspective">
+			<view
+				id="org.openjdk.jmc.flightrecorder.FlameView"
+				relationship="stack"
+				relative="org.openjdk.jmc.flightrecorder.ui.StacktraceView"
+				showTitle="true"
+				visible="true"/>
+		</perspectiveExtension>
 	</extension>
 </plugin>

--- a/application/org.openjdk.jmc.flightrecorder.ui/META-INF/MANIFEST.MF
+++ b/application/org.openjdk.jmc.flightrecorder.ui/META-INF/MANIFEST.MF
@@ -13,6 +13,7 @@ Require-Bundle: org.openjdk.jmc.rjmx,
  org.openjdk.jmc.flightrecorder.rules.jdk,
  org.openjdk.jmc.flightrecorder.configuration,
  org.openjdk.jmc.commands,
+ org.openjdk.jmc.browser,
  org.hdrhistogram.HdrHistogram
 Bundle-ActivationPolicy: lazy
 Bundle-Activator: org.openjdk.jmc.flightrecorder.ui.FlightRecorderUI


### PR DESCRIPTION
Adding another plug-in to the default perspective can cause the JVM browser to be loaded _after_ the Flight Recorder UI, making views end up in the wrong place. To avoid this, I added a dependency on the JVM Browser bundle. This is sad, since it was previously easy to, for example, build a JFR-only-file viewer, without even including the JVM browser, JMX Console etc, by simply editing the features. A better long term solution would probably be to include the flame graph in the JFR UI bundle. I suggest using the dependency approach for 8.0.0, since I don't know anyone shipping a partial release of the JMC app, for now.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | linux | mac | win |
| --- | ----- | ----- | ----- |
| Build / test | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (1/1 passed) |

### Issue
 * [JMC-6690](https://bugs.openjdk.java.net/browse/JMC-6690): Find a home for the Flame View in the JMC perspective


### Reviewers
 * [Henrik Dafgård](https://openjdk.java.net/census#hdafgard) (@Gunde - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jmc pull/167/head:pull/167`
`$ git checkout pull/167`
