### PR TITLE
7027: Avoid NPE for callers of TransformRegistry#getTransformData

### DIFF
--- a/agent/src/main/java/org/openjdk/jmc/agent/TransformRegistry.java
+++ b/agent/src/main/java/org/openjdk/jmc/agent/TransformRegistry.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
- * 
+ * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * The contents of this file are subject to the terms of either the Universal Permissive License
@@ -10,17 +10,17 @@
  *
  * Redistribution and use in source and binary forms, with or without modification, are permitted
  * provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice, this list of conditions
  * and the following disclaimer.
- * 
+ *
  * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
  * conditions and the following disclaimer in the documentation and/or other materials provided with
  * the distribution.
- * 
+ *
  * 3. Neither the name of the copyright holder nor the names of its contributors may be used to
  * endorse or promote products derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
  * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
@@ -46,11 +46,12 @@ public interface TransformRegistry {
 	boolean hasPendingTransforms(String className);
 
 	/**
-	 * Returns the list of {@link TransformDescriptor}s for the named class.
+	 * Returns the unmodifiable list of {@link TransformDescriptor}s for the named class.
 	 *
 	 * @param className
 	 *            the class for which to retrieve the transformation metadata.
-	 * @return the list of transformation metadata for the named class.
+	 * @return the list of transformation metadata for the named class; may be empty but never
+	 *         {@code null}.
 	 */
 	List<TransformDescriptor> getTransformData(String className);
 
@@ -94,7 +95,7 @@ public interface TransformRegistry {
 
 	/**
 	 * Signify classes are or are not being reverted to their pre instrumentation versions.
-	 * 
+	 *
 	 * @param shouldRevert
 	 *            true if class instrumentation should be reverted, false otherwise.
 	 */
@@ -102,7 +103,7 @@ public interface TransformRegistry {
 
 	/**
 	 * Determines if classes should be reverted to their pre instrumentation versions.
-	 * 
+	 *
 	 * @return true, if classes should be reverted and false otherwise.
 	 */
 	boolean isRevertIntrumentation();

--- a/agent/src/test/java/org/openjdk/jmc/agent/test/TestDefaultTransformRegistry.java
+++ b/agent/src/test/java/org/openjdk/jmc/agent/test/TestDefaultTransformRegistry.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
- * 
+ * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * The contents of this file are subject to the terms of either the Universal Permissive License
@@ -10,17 +10,17 @@
  *
  * Redistribution and use in source and binary forms, with or without modification, are permitted
  * provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice, this list of conditions
  * and the following disclaimer.
- * 
+ *
  * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
  * conditions and the following disclaimer in the documentation and/or other materials provided with
  * the distribution.
- * 
+ *
  * 3. Neither the name of the copyright holder nor the names of its contributors may be used to
  * endorse or promote products derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
  * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
@@ -135,9 +135,9 @@ public class TestDefaultTransformRegistry {
 				.getProbesXMLFromTemplate(getXMLDescription(XML_EVENT_DESCRIPTION), "clearAllTransformData")); //$NON-NLS-1$
 		assertNotNull(registry);
 		Set<String> classesCleared = registry.clearAllTransformData();
-		assertTrue(classesCleared.size() == 1);
+		assertEquals(1, classesCleared.size());
 		assertEquals(classesCleared.iterator().next(), Type.getInternalName(InstrumentMe.class));
-		assertNull(registry.getTransformData(Type.getInternalName(InstrumentMe.class)));
+		assertEquals(0, registry.getTransformData(Type.getInternalName(InstrumentMe.class)).size());
 	}
 
 	private String getXMLDescription(String eventsDescription) {


### PR DESCRIPTION
…) of no transform data exists

@thegreystone, @Josh-Matsuoka, et al., this fixes an NPE in the `Transformer` class if there is no metadata for the given class (we unconditionally try to iterate over the returned list). I noticed this while debugging something else, it seems this NPE gets swallowed elsewhere, but creating it over and over is costly of course.

I think never returning null from a collection method is a good practice anyways, so I've changed it accordingly. Could someone log an issue for this, so I can reference it? Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JMC-7027](https://bugs.openjdk.java.net/browse/JMC-7027): Avoid NPE for callers of TransformRegistry#getTransformData


### Reviewers
 * [Marcus Hirt](https://openjdk.java.net/census#hirt) (@thegreystone - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jmc pull/169/head:pull/169`
`$ git checkout pull/169`
