### PR TITLE
7033: Allow overriding the id (name) of the event type

### DIFF
--- a/agent/src/main/java/org/openjdk/jmc/agent/Field.java
+++ b/agent/src/main/java/org/openjdk/jmc/agent/Field.java
@@ -32,14 +32,13 @@
  */
 package org.openjdk.jmc.agent;
 
-import org.openjdk.jmc.agent.util.expression.ExpressionResolver;
-import org.openjdk.jmc.agent.util.expression.IllegalSyntaxException;
-import org.openjdk.jmc.agent.util.expression.ReferenceChain;
-
 import javax.management.openmbean.CompositeData;
 
 import org.openjdk.jmc.agent.impl.AbstractConvertable;
 import org.openjdk.jmc.agent.util.TypeUtils;
+import org.openjdk.jmc.agent.util.expression.ExpressionResolver;
+import org.openjdk.jmc.agent.util.expression.IllegalSyntaxException;
+import org.openjdk.jmc.agent.util.expression.ReferenceChain;
 
 public class Field extends AbstractConvertable implements Attribute {
 
@@ -61,7 +60,7 @@ public class Field extends AbstractConvertable implements Attribute {
 		this.description = description;
 		this.contentType = contentType;
 		this.relationKey = relationKey;
-		this.fieldName = "field" + TypeUtils.deriveIdentifierPart(name);
+		this.fieldName = TypeUtils.deriveIdentifierPart(name);
 	}
 
 	public static Field from(CompositeData cd) {

--- a/agent/src/main/java/org/openjdk/jmc/agent/jfr/impl/JFREventClassGenerator.java
+++ b/agent/src/main/java/org/openjdk/jmc/agent/jfr/impl/JFREventClassGenerator.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
- * 
+ *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * The contents of this file are subject to the terms of either the Universal Permissive License
@@ -10,17 +10,17 @@
  *
  * Redistribution and use in source and binary forms, with or without modification, are permitted
  * provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice, this list of conditions
  * and the following disclaimer.
- * 
+ *
  * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
  * conditions and the following disclaimer in the documentation and/or other materials provided with
  * the distribution.
- * 
+ *
  * 3. Neither the name of the copyright holder nor the names of its contributors may be used to
  * endorse or promote products derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
  * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
@@ -44,8 +44,8 @@ import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;
 import org.openjdk.jmc.agent.Agent;
 import org.openjdk.jmc.agent.Attribute;
-import org.openjdk.jmc.agent.Parameter;
 import org.openjdk.jmc.agent.Field;
+import org.openjdk.jmc.agent.Parameter;
 import org.openjdk.jmc.agent.ReturnValue;
 import org.openjdk.jmc.agent.impl.MalformedConverterException;
 import org.openjdk.jmc.agent.impl.ResolvedConvertable;
@@ -250,8 +250,17 @@ public class JFREventClassGenerator {
 	}
 
 	private static void generateClassAnnotations(ClassWriter cw, JFRTransformDescriptor td) {
+		AnnotationVisitor av;
+
+		// Name
+		if (td.getId() != null) {
+			av = cw.visitAnnotation("Ljdk/jfr/Name;", true);
+			av.visit("value", td.getId());
+			av.visitEnd();
+		}
+
 		// Label
-		AnnotationVisitor av = cw.visitAnnotation("Ljdk/jfr/Label;", true);
+		av = cw.visitAnnotation("Ljdk/jfr/Label;", true);
 		av.visit("value", td.getEventLabel());
 		av.visitEnd();
 


### PR DESCRIPTION
@thegreystone et al., this PR proposes two changes to the names of generated event types and their fields:

* An explicit event type name is derived from the name given in the configuration, instead of using the class name; this is nicer to work with e.g. when enabling/disabling event types for recordings
* the "field" prefix is removed from event type field names; when examining e.g. `RecordedEvent` instances, names are nicer to look at that way IMO

Could you log an issue for this change if you agree it's desirable? Thanks! I ran into these issues while using JMC Agent for [tracking SQL statements](https://twitter.com/gunnarmorling/status/1333152245463064579); note the odd "fieldSQLQuery" name marked on the left; the event type name is already adjusted in this screenshot as per this PR here.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JMC-7033](https://bugs.openjdk.java.net/browse/JMC-7033): Allow overriding the id (name) of the event type


### Reviewers
 * [Marcus Hirt](https://openjdk.java.net/census#hirt) (@thegreystone - **Reviewer**) ⚠️ Review applies to 7ccc108a9557e801d2f7e01342c590c198e49330


### Download
`$ git fetch https://git.openjdk.java.net/jmc pull/170/head:pull/170`
`$ git checkout pull/170`
