### PR TITLE
7028: The ids are wrong in the agent tests

### DIFF
--- a/agent/src/test/resources/org/openjdk/jmc/agent/converters/test/jfrprobes_template.xml
+++ b/agent/src/test/resources/org/openjdk/jmc/agent/converters/test/jfrprobes_template.xml
@@ -225,7 +225,7 @@
 			</method>
 			<location>WRAP</location>
 		</event>
-		<event id="demo.jfr.convertertest.URI">
+		<event id="demo.jfr.convertertest.ConverterEventNumber">
 			<name>ConverterEventNumber</name>
 			<description>Defined in the xml file and added by the agent. Should
 				transform the Number parameter to a
@@ -252,7 +252,7 @@
 		</event>
 
 		<!-- Multi and custom converters -->
-		<event id="demo.jfr.convertertest.URI">
+		<event id="demo.jfr.convertertest.ConverterEventMultiCustomInt">
 			<name>ConverterEventMultiCustomInt</name>
 			<description>Testing picking the right method.
 			</description>
@@ -275,7 +275,7 @@
 			</method>
 			<location>WRAP</location>
 		</event>
-		<event id="demo.jfr.convertertest.URI">
+		<event id="demo.jfr.convertertest.ConverterEventMultiCustomDouble">
 			<name>ConverterEventMultiCustomDouble</name>
 			<description>Testing picking the right method.
 			</description>
@@ -298,7 +298,7 @@
 			</method>
 			<location>WRAP</location>
 		</event>
-		<event id="demo.jfr.convertertest.URI">
+		<event id="demo.jfr.convertertest.ConverterEventMultiDefaultLong">
 			<name>ConverterEventMultiDefaultLong</name>
 			<description>Testing picking the right method.
 			</description>
@@ -321,7 +321,7 @@
 			</method>
 			<location>WRAP</location>
 		</event>
-		<event id="demo.jfr.convertertest.URI">
+		<event id="demo.jfr.convertertest.ConverterEventMultiDefaultDouble">
 			<name>ConverterEventMultiDefaultDouble</name>
 			<description>Testing picking the right method.
 			</description>


### PR DESCRIPTION
Even more important, since we may want to use them as the event name.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JMC-7028](https://bugs.openjdk.java.net/browse/JMC-7028): The ids are wrong in the agent tests


### Reviewers
 * [Henrik Dafgård](https://openjdk.java.net/census#hdafgard) (@Gunde - **Reviewer**) ⚠️ Review applies to 4ab7a81404d6dc2a73e874091f8f1ca8be7e1c03


### Download
`$ git fetch https://git.openjdk.java.net/jmc pull/171/head:pull/171`
`$ git checkout pull/171`
