### PR TITLE
7029: In the event configuration the event name should be renamed label

### DIFF
--- a/agent/src/main/java/org/openjdk/jmc/agent/jfr/JFRTransformDescriptor.java
+++ b/agent/src/main/java/org/openjdk/jmc/agent/jfr/JFRTransformDescriptor.java
@@ -52,7 +52,7 @@ import org.openjdk.jmc.agent.TransformDescriptor;
 import org.openjdk.jmc.agent.util.TypeUtils;
 
 public class JFRTransformDescriptor extends TransformDescriptor {
-	private static final String ATTRIBUTE_EVENT_NAME = "name"; //$NON-NLS-1$
+	private static final String ATTRIBUTE_EVENT_LABEL = "label"; //$NON-NLS-1$
 	private static final String ATTRIBUTE_JFR_EVENT_DESCRIPTION = "description"; //$NON-NLS-1$
 	private static final String ATTRIBUTE_JFR_EVENT_PATH = "path"; //$NON-NLS-1$
 	private static final String ATTRIBUTE_STACK_TRACE = "stacktrace"; //$NON-NLS-1$
@@ -61,7 +61,7 @@ public class JFRTransformDescriptor extends TransformDescriptor {
 	private final String classPrefix;
 	private final String eventDescription;
 	private final String eventClassName;
-	private final String eventName;
+	private final String eventLabel;
 	private final String eventPath;
 	private final boolean recordStackTrace;
 	private final boolean useRethrow;
@@ -78,7 +78,7 @@ public class JFRTransformDescriptor extends TransformDescriptor {
 			List<Field> fields) {
 		super(id, className, method, transformationAttributes);
 		classPrefix = initializeClassPrefix();
-		eventName = initializeEventName();
+		eventLabel = initializeEventLabel();
 		eventClassName = initializeEventClassName();
 		eventPath = initializeEventPath();
 		eventDescription = initializeEventDescription();
@@ -124,8 +124,8 @@ public class JFRTransformDescriptor extends TransformDescriptor {
 		return eventClassName;
 	}
 
-	public String getEventName() {
-		return eventName;
+	public String getEventLabel() {
+		return eventLabel;
 	}
 
 	public String getClassPrefix() {
@@ -168,14 +168,14 @@ public class JFRTransformDescriptor extends TransformDescriptor {
 		return DEFAULT_CLASS_PREFIX;
 	}
 
-	private String initializeEventName() {
-		String eventName = getTransformationAttribute(ATTRIBUTE_EVENT_NAME);
-		if (eventName == null || eventName.length() == 0) {
-			eventName = getMethod().getName();
+	private String initializeEventLabel() {
+		String eventLabel = getTransformationAttribute(ATTRIBUTE_EVENT_LABEL);
+		if (eventLabel == null || eventLabel.length() == 0) {
+			eventLabel = getMethod().getName();
 			Logger.getLogger(JFRTransformDescriptor.class.getName()).log(Level.INFO,
-					"Could not find an event name, generated one: " + eventName); //$NON-NLS-1$
+					"Could not find an event name, generated one: " + eventLabel); //$NON-NLS-1$
 		}
-		return eventName;
+		return eventLabel;
 	}
 
 	private String initializeEventDescription() {
@@ -189,7 +189,7 @@ public class JFRTransformDescriptor extends TransformDescriptor {
 
 	private String initializeEventClassName() {
 		return TypeUtils.getPathPart(getClassName()) + getClassPrefix()
-				+ TypeUtils.deriveIdentifierPart(getEventName());
+				+ TypeUtils.deriveIdentifierPart(getEventLabel());
 	}
 
 	private String initializeEventPath() {
@@ -207,7 +207,7 @@ public class JFRTransformDescriptor extends TransformDescriptor {
 		if (strVal == null || strVal.isEmpty()) {
 			Logger.getLogger(JFRTransformDescriptor.class.getName()).log(Level.FINE,
 					"The boolean attribute " + attribute //$NON-NLS-1$
-							+ " was not set for the event " + eventName + ". Assuming " + defaultValue + "."); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+							+ " was not set for the event " + eventLabel + ". Assuming " + defaultValue + "."); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
 			return defaultValue;
 		}
 		return Boolean.parseBoolean(strVal);
@@ -216,7 +216,7 @@ public class JFRTransformDescriptor extends TransformDescriptor {
 	@Override
 	public String toString() {
 		return String.format("JFRTransformDescriptor [method:%s, eventName:%s, #params:%d]", getMethod().toString(), //$NON-NLS-1$
-				eventName, parameters.size());
+				eventLabel, parameters.size());
 	}
 
 	public List<Parameter> getParameters() {

--- a/agent/src/main/java/org/openjdk/jmc/agent/jfr/impl/JFREventClassGenerator.java
+++ b/agent/src/main/java/org/openjdk/jmc/agent/jfr/impl/JFREventClassGenerator.java
@@ -252,7 +252,7 @@ public class JFREventClassGenerator {
 	private static void generateClassAnnotations(ClassWriter cw, JFRTransformDescriptor td) {
 		// Label
 		AnnotationVisitor av = cw.visitAnnotation("Ljdk/jfr/Label;", true);
-		av.visit("value", td.getEventName());
+		av.visit("value", td.getEventLabel());
 		av.visitEnd();
 
 		// Description

--- a/agent/src/main/java/org/openjdk/jmc/agent/jfrlegacy/impl/JFRLegacyEventClassGenerator.java
+++ b/agent/src/main/java/org/openjdk/jmc/agent/jfrlegacy/impl/JFRLegacyEventClassGenerator.java
@@ -201,7 +201,7 @@ public class JFRLegacyEventClassGenerator {
 
 	private static void generateClassAnnotations(ClassWriter cw, JFRTransformDescriptor td) {
 		AnnotationVisitor av0 = cw.visitAnnotation("Lcom/oracle/jrockit/jfr/EventDefinition;", true); //$NON-NLS-1$
-		av0.visit("name", td.getEventName()); //$NON-NLS-1$
+		av0.visit("name", td.getEventLabel()); //$NON-NLS-1$
 		av0.visit("description", td.getEventDescription()); //$NON-NLS-1$
 		av0.visit("path", td.getEventPath()); //$NON-NLS-1$
 		av0.visit("stacktrace", td.isRecordStackTrace()); //$NON-NLS-1$

--- a/agent/src/main/resources/org/openjdk/jmc/agent/impl/jfrprobes_schema.xsd
+++ b/agent/src/main/resources/org/openjdk/jmc/agent/impl/jfrprobes_schema.xsd
@@ -75,7 +75,7 @@
 
 	<xs:complexType name="eventType">
 		<xs:all>
-			<xs:element type="xs:string" name="name" />
+			<xs:element type="xs:string" name="label" />
 			<xs:element type="classType" name="class" />
 			<xs:element type="methodType" name="method" />
 			<xs:element type="xs:string" name="description"

--- a/agent/src/test/java/org/openjdk/jmc/agent/test/TestCompressedFrameTransformation.java
+++ b/agent/src/test/java/org/openjdk/jmc/agent/test/TestCompressedFrameTransformation.java
@@ -17,7 +17,7 @@ public class TestCompressedFrameTransformation implements Opcodes {
 	private static final String XML_EVENT_DESCRIPTION = "<jfragent>" //
 			+ "<events>" // 
 			+ "<event id=\"test.compressed.frame.transformation\">" // 
-			+ "<name>Test Compressed Frame Transformation</name>" //
+			+ "<label>Test Compressed Frame Transformation</label>" //
 			+ "<description>agent instrumentation should be compatible with compressed frame types</description>" //
 			+ "<path>test/frames</path>" //
 			+ "<class>Target</class>" //

--- a/agent/src/test/java/org/openjdk/jmc/agent/test/TestDefaultTransformRegistry.java
+++ b/agent/src/test/java/org/openjdk/jmc/agent/test/TestDefaultTransformRegistry.java
@@ -53,7 +53,7 @@ import org.openjdk.jmc.agent.test.util.TestToolkit;
 public class TestDefaultTransformRegistry {
 
 	private static final String XML_EVENT_DESCRIPTION = "<event id=\"demo.jfr.test1\">"
-			+ "<name>JFR Hello World Event 1 %TEST_NAME% </name>"
+			+ "<label>JFR Hello World Event 1 %TEST_NAME% </label>"
 			+ "<description>Defined in the xml file and added by the agent.</description>"
 			+ "<path>demo/jfrhelloworldevent1</path>" + "<stacktrace>true</stacktrace>"
 			+ "<class>org.openjdk.jmc.agent.test.InstrumentMe</class>" + "<method>" + "<name>printHelloWorldJFR1</name>"

--- a/agent/src/test/java/org/openjdk/jmc/agent/test/TestDefineEventProbes.java
+++ b/agent/src/test/java/org/openjdk/jmc/agent/test/TestDefineEventProbes.java
@@ -68,7 +68,7 @@ public class TestDefineEventProbes {
 
 	private static final String AGENT_OBJECT_NAME = "org.openjdk.jmc.jfr.agent:type=AgentController"; //$NON-NLS-1$
 	private static final String EVENT_ID = "demo.jfr.test6";
-	private static final String EVENT_NAME = "JFR Hello World Event 6 %TEST_NAME%";
+	private static final String EVENT_LABEL = "JFR Hello World Event 6 %TEST_NAME%";
 	private static final String EVENT_DESCRIPTION = "JFR Hello World Event 6 %TEST_NAME%";
 	private static final String EVENT_PATH = "demo/jfrhelloworldevent6";
 	private static final String EVENT_CLASS_NAME = "org.openjdk.jmc.agent.test.InstrumentMe";
@@ -76,7 +76,7 @@ public class TestDefineEventProbes {
 	private static final String METHOD_DESCRIPTOR = "()D";
 
 	private static final String XML_DESCRIPTION = "<jfragent>" + "<events>" + "<event id=\"" + EVENT_ID + "\">"
-			+ "<name>" + EVENT_NAME + "</name>" + "<description>" + EVENT_DESCRIPTION + "</description>" + "<path>"
+			+ "<label>" + EVENT_LABEL + "</label>" + "<description>" + EVENT_DESCRIPTION + "</description>" + "<path>"
 			+ EVENT_PATH + "</path>" + "<stacktrace>true</stacktrace>" + "<class>" + EVENT_CLASS_NAME + "</class>"
 			+ "<method>" + "<name>" + METHOD_NAME + "</name>" + "<descriptor>" + METHOD_DESCRIPTOR + "</descriptor>"
 			+ "</method>" + "<location>WRAP</location>" + "</event>" + "</events>" + "</jfragent>";
@@ -116,7 +116,7 @@ public class TestDefineEventProbes {
 		Method method = new Method(METHOD_NAME, METHOD_DESCRIPTOR);
 		Map<String, String> attributes = new HashMap<>();
 		attributes.put("path", EVENT_PATH);
-		attributes.put("name", EVENT_NAME);
+		attributes.put("label", EVENT_LABEL);
 		attributes.put("description", EVENT_DESCRIPTION);
 		ReturnValue retVal = new ReturnValue(null, "", null, null, null);
 		JFRTransformDescriptor eventTd = new JFRTransformDescriptor(EVENT_ID,

--- a/agent/src/test/java/org/openjdk/jmc/agent/test/TestEmitOnlyOnException.java
+++ b/agent/src/test/java/org/openjdk/jmc/agent/test/TestEmitOnlyOnException.java
@@ -67,11 +67,11 @@ public class TestEmitOnlyOnException {
 			+ "<description>" + EVENT_DESCRIPTION + "</description>" + "<path>" + EVENT_PATH + "</path>"
 			+ "<stacktrace>true</stacktrace>" + "<class>" + EVENT_CLASS_NAME + "</class>" + "<method>" + "<name>"
 			+ METHOD_NAME + "</name>" + "<descriptor>" + METHOD_DESCRIPTOR + "</descriptor>" + "</method>"
-			+ "<location>WRAP</location>" + "</event>" + "<event id=\"" + EVENT_ID + "2" + "\">" + "<label>" + EVENT_LABEL
-			+ "2" + "</label>" + "<description>" + EVENT_DESCRIPTION + "2" + "</description>" + "<path>" + EVENT_PATH
-			+ "</path>" + "<stacktrace>true</stacktrace>" + "<class>" + EVENT_CLASS_NAME + "</class>" + "<method>"
-			+ "<name>" + METHOD_NAME_2 + "</name>" + "<descriptor>" + METHOD_DESCRIPTOR + "</descriptor>" + "</method>"
-			+ "<location>WRAP</location>" + "</event>" + "</events>" + "</jfragent>";
+			+ "<location>WRAP</location>" + "</event>" + "<event id=\"" + EVENT_ID + "2" + "\">" + "<label>"
+			+ EVENT_LABEL + "2" + "</label>" + "<description>" + EVENT_DESCRIPTION + "2" + "</description>" + "<path>"
+			+ EVENT_PATH + "</path>" + "<stacktrace>true</stacktrace>" + "<class>" + EVENT_CLASS_NAME + "</class>"
+			+ "<method>" + "<name>" + METHOD_NAME_2 + "</name>" + "<descriptor>" + METHOD_DESCRIPTOR + "</descriptor>"
+			+ "</method>" + "<location>WRAP</location>" + "</event>" + "</events>" + "</jfragent>";
 
 	@Test
 	public void testEmitOnException() throws Exception {

--- a/agent/src/test/java/org/openjdk/jmc/agent/test/TestEmitOnlyOnException.java
+++ b/agent/src/test/java/org/openjdk/jmc/agent/test/TestEmitOnlyOnException.java
@@ -54,7 +54,7 @@ import org.openjdk.jmc.agent.test.util.TestToolkit;
 public class TestEmitOnlyOnException {
 
 	private static final String EVENT_ID = "demo.jfr.test";
-	private static final String EVENT_NAME = "JFR Emit on Exception Event %TEST_NAME%";
+	private static final String EVENT_LABEL = "JFR Emit on Exception Event %TEST_NAME%";
 	private static final String EVENT_DESCRIPTION = "JFR Emit on Exception Event %TEST_NAME%";
 	private static final String EVENT_PATH = "demo/emitonexceptionevent";
 	private static final String EVENT_CLASS_NAME = "org.openjdk.jmc.agent.test.TestDummy";
@@ -63,12 +63,12 @@ public class TestEmitOnlyOnException {
 	private static final String METHOD_DESCRIPTOR = "()V";
 
 	private static final String XML_DESCRIPTION = "<jfragent>" + "<config>" + "<emitonexception>true</emitonexception>"
-			+ "</config>" + "<events>" + "<event id=\"" + EVENT_ID + "\">" + "<name>" + EVENT_NAME + "</name>"
+			+ "</config>" + "<events>" + "<event id=\"" + EVENT_ID + "\">" + "<label>" + EVENT_LABEL + "</label>"
 			+ "<description>" + EVENT_DESCRIPTION + "</description>" + "<path>" + EVENT_PATH + "</path>"
 			+ "<stacktrace>true</stacktrace>" + "<class>" + EVENT_CLASS_NAME + "</class>" + "<method>" + "<name>"
 			+ METHOD_NAME + "</name>" + "<descriptor>" + METHOD_DESCRIPTOR + "</descriptor>" + "</method>"
-			+ "<location>WRAP</location>" + "</event>" + "<event id=\"" + EVENT_ID + "2" + "\">" + "<name>" + EVENT_NAME
-			+ "2" + "</name>" + "<description>" + EVENT_DESCRIPTION + "2" + "</description>" + "<path>" + EVENT_PATH
+			+ "<location>WRAP</location>" + "</event>" + "<event id=\"" + EVENT_ID + "2" + "\">" + "<label>" + EVENT_LABEL
+			+ "2" + "</label>" + "<description>" + EVENT_DESCRIPTION + "2" + "</description>" + "<path>" + EVENT_PATH
 			+ "</path>" + "<stacktrace>true</stacktrace>" + "<class>" + EVENT_CLASS_NAME + "</class>" + "<method>"
 			+ "<name>" + METHOD_NAME_2 + "</name>" + "<descriptor>" + METHOD_DESCRIPTOR + "</descriptor>" + "</method>"
 			+ "<location>WRAP</location>" + "</event>" + "</events>" + "</jfragent>";

--- a/agent/src/test/java/org/openjdk/jmc/agent/test/TestIncorrectMethodDescriptor.java
+++ b/agent/src/test/java/org/openjdk/jmc/agent/test/TestIncorrectMethodDescriptor.java
@@ -54,8 +54,8 @@ import org.openjdk.jmc.agent.test.util.TestToolkit;
 public class TestIncorrectMethodDescriptor {
 
 	private static final String EVENT_ID = "demo.jfr.test6";
-	private static final String CORRECT_EVENT_NAME = "JFR Hello World Event 6 %TEST_NAME%";
-	private static final String INCORRECT_EVENT_NAME = "JFR Hello World Event 6 Incorrect %TEST_NAME%";
+	private static final String CORRECT_EVENT_LABEL = "JFR Hello World Event 6 %TEST_NAME%";
+	private static final String INCORRECT_EVENT_LABEL = "JFR Hello World Event 6 Incorrect %TEST_NAME%";
 	private static final String EVENT_DESCRIPTION = "JFR Hello World Event 6 %TEST_NAME%";
 	private static final String EVENT_PATH = "demo/jfrhelloworldevent6";
 	private static final String EVENT_CLASS_NAME = "org.openjdk.jmc.agent.test.InstrumentMe";
@@ -64,14 +64,14 @@ public class TestIncorrectMethodDescriptor {
 	private static final String INCORRECT_METHOD_DESCRIPTOR = "()Z";
 
 	private static final String XML_DESCRIPTION = "<jfragent>" + "<events>" + "<event id=\"" + EVENT_ID + "\">"
-			+ "<name>{0}</name>" + "<description>" + EVENT_DESCRIPTION + "</description>" + "<path>" + EVENT_PATH
+			+ "<label>{0}</label>" + "<description>" + EVENT_DESCRIPTION + "</description>" + "<path>" + EVENT_PATH
 			+ "</path>" + "<stacktrace>true</stacktrace>" + "<class>" + EVENT_CLASS_NAME + "</class>" + "<method>"
 			+ "<name>" + METHOD_NAME + "</name>" + "<descriptor>{1}</descriptor>" + "</method>"
 			+ "<location>WRAP</location>" + "</event>" + "</events>" + "</jfragent>";
 
 	@Test
 	public void testCorrectMethodDescriptor() throws Exception {
-		String xmlDescription = MessageFormat.format(XML_DESCRIPTION, CORRECT_EVENT_NAME, CORRECT_METHOD_DESCRIPTOR);
+		String xmlDescription = MessageFormat.format(XML_DESCRIPTION, CORRECT_EVENT_LABEL, CORRECT_METHOD_DESCRIPTOR);
 
 		TransformRegistry registry = DefaultTransformRegistry.from(new ByteArrayInputStream(xmlDescription.getBytes()));
 		assertTrue(registry.hasPendingTransforms(Type.getInternalName(InstrumentMe.class)));
@@ -89,7 +89,7 @@ public class TestIncorrectMethodDescriptor {
 
 	@Test
 	public void testIncorrectMethodDescriptor() throws Exception {
-		String xmlDescription = MessageFormat.format(XML_DESCRIPTION, INCORRECT_EVENT_NAME,
+		String xmlDescription = MessageFormat.format(XML_DESCRIPTION, INCORRECT_EVENT_LABEL,
 				INCORRECT_METHOD_DESCRIPTOR);
 
 		TransformRegistry registry = DefaultTransformRegistry.from(new ByteArrayInputStream(xmlDescription.getBytes()));

--- a/agent/src/test/java/org/openjdk/jmc/agent/test/TestProbeDefinitionValidation.java
+++ b/agent/src/test/java/org/openjdk/jmc/agent/test/TestProbeDefinitionValidation.java
@@ -1,3 +1,36 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, Red Hat Inc. All rights reserved.
+ *
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * The contents of this file are subject to the terms of either the Universal Permissive License
+ * v 1.0 as shown at http://oss.oracle.com/licenses/upl
+ *
+ * or the following license:
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted
+ * provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions
+ * and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other materials provided with
+ * the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to
+ * endorse or promote products derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+ * WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 package org.openjdk.jmc.agent.test;
 
 import org.junit.Test;
@@ -15,7 +48,7 @@ public class TestProbeDefinitionValidation {
 	public void testValidatingProbeDefinition() throws XMLStreamException {
 		// a partially defined event with all optional elements unset
 		String probe = "<event id=\"demo.event2\">\n" // 
-				+ "    <name>Event 2</name>\n" //
+				+ "    <label>Event 2</label>\n" //
 				+ "    <class>org.company.project.MyDemoClass</class>\n" // 
 				+ "    <method>\n" // 
 				+ "        <name>targetFunction</name>\n" //
@@ -29,7 +62,7 @@ public class TestProbeDefinitionValidation {
 	@Test
 	public void testValidatingFullyDefinedProbe() throws XMLStreamException {
 		// a fully defined event with all optional elements set
-		String probe = "<event id=\"demo.event1\">\n" + "            <name>Event 1</name>\n"
+		String probe = "<event id=\"demo.event1\">\n" + "            <label>Event 1</label>\n"
 				+ "            <class>com.company.project.MyDemoClass</class>\n"
 				+ "            <description>demo event #1</description>\n" + "            <path>demo</path>\n"
 				+ "            <stacktrace>true</stacktrace>\n" + "            <method>\n"
@@ -72,7 +105,7 @@ public class TestProbeDefinitionValidation {
 	@Test
 	public void testValidatingCorrectClassNames() throws XMLStreamException {
 		String probe = "<event id=\"demo.event2\">\n" // 
-				+ "    <name>Event 2</name>\n" //
+				+ "    <label>Event 2</label>\n" //
 				+ "    <class>{0}</class>\n" // 
 				+ "    <method>\n" // 
 				+ "        <name>targetFunction</name>\n" //
@@ -90,7 +123,7 @@ public class TestProbeDefinitionValidation {
 	@Test(expected = XMLStreamException.class)
 	public void testValidatingEmptyClassName() throws XMLStreamException {
 		String probe = "<event id=\"demo.event2\">\n" // 
-				+ "    <name>Event 2</name>\n" //
+				+ "    <label>Event 2</label>\n" //
 				+ "    <method>\n" // 
 				+ "        <name>targetFunction</name>\n" //
 				+ "        <descriptor>(Ljava/lang/String;)V</descriptor>\n" // 
@@ -103,7 +136,7 @@ public class TestProbeDefinitionValidation {
 	@Test(expected = XMLStreamException.class)
 	public void testValidatingIncorrectClassPattern() throws XMLStreamException {
 		String probe = "<event id=\"demo.event2\">\n" // 
-				+ "    <name>Event 2</name>\n" //
+				+ "    <label>Event 2</label>\n" //
 				+ "    <class>not a validate full-qualified-class-name</class>\n" //
 				+ "    <method>\n" // 
 				+ "        <name>targetFunction</name>\n" //
@@ -117,7 +150,7 @@ public class TestProbeDefinitionValidation {
 	@Test
 	public void testValidatingMethodDescriptor() throws XMLStreamException {
 		String probe = "<event id=\"demo.event2\">\n" // 
-				+ "    <name>Event 2</name>\n" //
+				+ "    <label>Event 2</label>\n" //
 				+ "    <class>org.company.project.MyDemoClass</class>\n" // 
 				+ "    <method>\n" // 
 				+ "        <name>targetFunction</name>\n" //
@@ -137,7 +170,7 @@ public class TestProbeDefinitionValidation {
 	@Test(expected = XMLStreamException.class)
 	public void testValidatingEmptyDescriptor() throws XMLStreamException {
 		String probe = "<event id=\"demo.event2\">\n" // 
-				+ "    <name>Event 2</name>\n" //
+				+ "    <label>Event 2</label>\n" //
 				+ "    <class>org.company.project.MyDemoClass</class>" //
 				+ "    <method>\n" // 
 				+ "        <name>targetFunction</name>\n" //
@@ -150,7 +183,7 @@ public class TestProbeDefinitionValidation {
 	@Test(expected = XMLStreamException.class)
 	public void testValidatingIncorrectDescriptor() throws XMLStreamException {
 		String probe = "<event id=\"demo.event2\">\n" // 
-				+ "    <name>Event 2</name>\n" //
+				+ "    <label>Event 2</label>\n" //
 				+ "    <class>org.company.project.MyDemoClass</class>" //
 				+ "    <method>\n" // 
 				+ "        <name>targetFunction</name>\n" //
@@ -164,7 +197,7 @@ public class TestProbeDefinitionValidation {
 	@Test
 	public void testValidatingExpressions() throws XMLStreamException {
 		String probe = "<event id=\"demo.event2\">\n" // 
-				+ "    <name>Event 2</name>\n" //
+				+ "    <label>Event 2</label>\n" //
 				+ "    <class>org.company.project.MyDemoClass</class>\n" // 
 				+ "    <method>\n" // 
 				+ "        <name>targetFunction</name>\n" //

--- a/agent/src/test/java/org/openjdk/jmc/agent/test/TestRetrieveEventProbes.java
+++ b/agent/src/test/java/org/openjdk/jmc/agent/test/TestRetrieveEventProbes.java
@@ -47,7 +47,7 @@ public class TestRetrieveEventProbes {
 	private static final String AGENT_OBJECT_NAME = "org.openjdk.jmc.jfr.agent:type=AgentController"; //$NON-NLS-1$
 
 	private static final String XML_TEST_DESCRIPTION = "<jfragent>" + "<events>" + "<event id=\"demo.jfr.test1\">"
-			+ "<name>JFR Hello World Event 1 </name>"
+			+ "<label>JFR Hello World Event 1 </label>"
 			+ "<description>Defined in the xml file and added by the agent.</description>"
 			+ "<path>demo/jfrhelloworldevent1</path>" + "<stacktrace>true</stacktrace>"
 			+ "<class>org.openjdk.jmc.agent.test.InstrumentMe</class>" + "<method>" + "<name>printHelloWorldJFR1</name>"

--- a/agent/src/test/resources/org/openjdk/jmc/agent/converters/test/jfrprobes_template.xml
+++ b/agent/src/test/resources/org/openjdk/jmc/agent/converters/test/jfrprobes_template.xml
@@ -49,7 +49,7 @@
 	<!-- Converter test event probes -->
 	<events>
 		<event id="demo.jfr.convertertest.String">
-			<name>ConverterEventString</name>
+			<label>ConverterEventString</label>
 			<description>Defined in the xml file and added by the agent. Should
 				transform the Gurka parameter to
 				String.
@@ -74,7 +74,7 @@
 			</method>
 		</event>
 		<event id="demo.jfr.convertertest.Int">
-			<name>ConverterEventInt</name>
+			<label>ConverterEventInt</label>
 			<description>Defined in the xml file and added by the agent. Should
 				transform the Gurka parameter to an
 				int.
@@ -100,7 +100,7 @@
 			<location>WRAP</location>
 		</event>
 		<event id="demo.jfr.convertertest.Long">
-			<name>ConverterEventLong</name>
+			<label>ConverterEventLong</label>
 			<description>Defined in the xml file and added by the agent. Should
 				transform the Gurka parameter to a
 				long.
@@ -126,7 +126,7 @@
 			<location>WRAP</location>
 		</event>
 		<event id="demo.jfr.convertertest.Float">
-			<name>ConverterEventFloat</name>
+			<label>ConverterEventFloat</label>
 			<description>Defined in the xml file and added by the agent. Should
 				transform the Gurka parameter to a
 				float.
@@ -151,7 +151,7 @@
 			<location>WRAP</location>
 		</event>
 		<event id="demo.jfr.convertertest.Double">
-			<name>ConverterEventDouble</name>
+			<label>ConverterEventDouble</label>
 			<description>Defined in the xml file and added by the agent. Should
 				transform the Gurka parameter to a
 				double.
@@ -177,7 +177,7 @@
 			<location>WRAP</location>
 		</event>
 		<event id="demo.jfr.convertertest.File">
-			<name>ConverterEventFile</name>
+			<label>ConverterEventFile</label>
 			<description>Defined in the xml file and added by the agent. Should
 				transform the File parameter to a
 				String.
@@ -202,7 +202,7 @@
 			<location>WRAP</location>
 		</event>
 		<event id="demo.jfr.convertertest.URI">
-			<name>ConverterEventUri</name>
+			<label>ConverterEventUri</label>
 			<description>Defined in the xml file and added by the agent. Should
 				transform the URI parameter to a
 				String using the standard toString
@@ -226,7 +226,7 @@
 			<location>WRAP</location>
 		</event>
 		<event id="demo.jfr.convertertest.URI">
-			<name>ConverterEventNumber</name>
+			<label>ConverterEventNumber</label>
 			<description>Defined in the xml file and added by the agent. Should
 				transform the Number parameter to a
 				double.
@@ -253,7 +253,7 @@
 
 		<!-- Multi and custom converters -->
 		<event id="demo.jfr.convertertest.URI">
-			<name>ConverterEventMultiCustomInt</name>
+			<label>ConverterEventMultiCustomInt</label>
 			<description>Testing picking the right method.
 			</description>
 			<path>demo/converterevents</path>
@@ -276,7 +276,7 @@
 			<location>WRAP</location>
 		</event>
 		<event id="demo.jfr.convertertest.URI">
-			<name>ConverterEventMultiCustomDouble</name>
+			<label>ConverterEventMultiCustomDouble</label>
 			<description>Testing picking the right method.
 			</description>
 			<path>demo/converterevents</path>
@@ -299,7 +299,7 @@
 			<location>WRAP</location>
 		</event>
 		<event id="demo.jfr.convertertest.URI">
-			<name>ConverterEventMultiDefaultLong</name>
+			<label>ConverterEventMultiDefaultLong</label>
 			<description>Testing picking the right method.
 			</description>
 			<path>demo/converterevents</path>
@@ -322,7 +322,7 @@
 			<location>WRAP</location>
 		</event>
 		<event id="demo.jfr.convertertest.URI">
-			<name>ConverterEventMultiDefaultDouble</name>
+			<label>ConverterEventMultiDefaultDouble</label>
 			<description>Testing picking the right method.
 			</description>
 			<path>demo/converterevents</path>

--- a/agent/src/test/resources/org/openjdk/jmc/agent/test/jfrprobes_simple.xml
+++ b/agent/src/test/resources/org/openjdk/jmc/agent/test/jfrprobes_simple.xml
@@ -34,7 +34,7 @@
 <jfragent>
 	<events>
 		<event id="demo.jfr.test1">
-			<name>JFR Hello World Event 1 %TEST_NAME%</name>
+			<label>JFR Hello World Event 1 %TEST_NAME%</label>
 			<description>Defined in the xml file and added by the agent.</description>
 			<path>demo/jfrhelloworldevent1</path>
 			<stacktrace>true</stacktrace>

--- a/agent/src/test/resources/org/openjdk/jmc/agent/test/jfrprobes_simple_2.xml
+++ b/agent/src/test/resources/org/openjdk/jmc/agent/test/jfrprobes_simple_2.xml
@@ -35,7 +35,7 @@
 <jfragent>
 	<events>
 		<event id="demo.jfr.test1">
-			<name>JFR Hello World Event 1 %TEST_NAME%</name>
+			<label>JFR Hello World Event 1 %TEST_NAME%</label>
 			<description>Defined in the xml file and added by the agent.</description>
 			<path>demo/jfrhelloworldevent1</path>
 			<stacktrace>true</stacktrace>

--- a/agent/src/test/resources/org/openjdk/jmc/agent/test/jfrprobes_template.xml
+++ b/agent/src/test/resources/org/openjdk/jmc/agent/test/jfrprobes_template.xml
@@ -47,7 +47,7 @@
 	</config>
 	<events>
 		<event id="demo.jfr.test1">
-			<name>JFR Hello World Event 1 %TEST_NAME%</name>
+			<label>JFR Hello World Event 1 %TEST_NAME%</label>
 			<description>Defined in the xml file and added by the agent.
 			</description>
 			<path>demo/jfrhelloworldevent1</path>
@@ -61,7 +61,7 @@
 			<location>WRAP</location>
 		</event>
 		<event id="demo.jfr.test2">
-			<name>JFR Hello World Event 2 %TEST_NAME%</name>
+			<label>JFR Hello World Event 2 %TEST_NAME%</label>
 			<description>Defined in the xml file and added by the agent. Should
 				record the parameters.
 			</description>
@@ -94,7 +94,7 @@
 			<location>WRAP</location>
 		</event>
 		<event id="demo.jfr.test11">
-			<name>JFR Hello World Event 11 %TEST_NAME%</name>
+			<label>JFR Hello World Event 11 %TEST_NAME%</label>
 			<description>Defined in the xml file and added by the agent. Should
 				record the value of static reference
 				'STATIC_STRING_FIELD'
@@ -132,7 +132,7 @@
 			</fields>
 		</event>
 		<event id="demo.jfr.test12">
-			<name>JFR Hello World Event 12 %TEST_NAME%</name>
+			<label>JFR Hello World Event 12 %TEST_NAME%</label>
 			<description>Defined in the xml file and added by the agent. Should
 				record the values of
 				'STATIC_OBJECT_FIELD.STATIC_STRING_FIELD' and
@@ -161,7 +161,7 @@
 			</fields>
 		</event>
 		<event id="demo.jfr.test13">
-			<name>JFR Hello World Event 13 %TEST_NAME%</name>
+			<label>JFR Hello World Event 13 %TEST_NAME%</label>
 			<description>Defined in the xml file and added by the agent. Should
 				record the values of static
 				'STATIC_NULL_FIELD.STATIC_STRING_FIELD'
@@ -190,7 +190,7 @@
 			</fields>
 		</event>
 		<event id="demo.jfr.testI1">
-			<name>JFR Hello World Instance Event 1 %TEST_NAME%</name>
+			<label>JFR Hello World Instance Event 1 %TEST_NAME%</label>
 			<description>Defined in the xml file and added by the agent.
 			</description>
 			<path>demo/jfrhelloworldeventI1</path>
@@ -204,7 +204,7 @@
 			<location>WRAP</location>
 		</event>
 		<event id="demo.jfr.testI2">
-			<name>JFR Hello World Instance Event 2 %TEST_NAME%</name>
+			<label>JFR Hello World Instance Event 2 %TEST_NAME%</label>
 			<description>Defined in the xml file and added by the agent. Should
 				record the parameters.
 			</description>
@@ -233,7 +233,7 @@
 			</method>
 		</event>
 		<event id="demo.jfr.testI3">
-			<name>JFR Hello World Instance Event 3 %TEST_NAME%</name>
+			<label>JFR Hello World Instance Event 3 %TEST_NAME%</label>
 			<description>Defined in the xml file and added by the agent. Should
 				record the parameters.
 			</description>
@@ -254,7 +254,7 @@
 			</method>
 		</event>
 		<event id="demo.jfr.testI4">
-			<name>JFR Hello World Instance Event 4 %TEST_NAME%</name>
+			<label>JFR Hello World Instance Event 4 %TEST_NAME%</label>
 			<description>Defined in the xml file and added by the agent. Should
 				record the parameters.
 			</description>
@@ -275,7 +275,7 @@
 			</method>
 		</event>
 		<event id="demo.jfr.testI5">
-			<name>JFR Hello World Instance Event 5 %TEST_NAME%</name>
+			<label>JFR Hello World Instance Event 5 %TEST_NAME%</label>
 			<description>Defined in the xml file and added by the agent. Should
 				record the parameters.
 			</description>
@@ -296,7 +296,7 @@
 			</method>
 		</event>
 		<event id="demo.jfr.testI6">
-			<name>JFR Hello World Instance Event 6 %TEST_NAME%</name>
+			<label>JFR Hello World Instance Event 6 %TEST_NAME%</label>
 			<description>Defined in the xml file and added by the agent. Should
 				record the return value.
 			</description>
@@ -314,7 +314,7 @@
 			</method>
 		</event>
 		<event id="demo.jfr.testI7">
-			<name>JFR Hello World Instance Event 7 %TEST_NAME%</name>
+			<label>JFR Hello World Instance Event 7 %TEST_NAME%</label>
 			<description>Defined in the xml file and added by the agent. The
 				original method contains a try-catch
 				clause.
@@ -328,7 +328,7 @@
 			</method>
 		</event>
 		<event id="demo.jfr.testI8">
-			<name>JFR Hello World Instance Event 8 %TEST_NAME%</name>
+			<label>JFR Hello World Instance Event 8 %TEST_NAME%</label>
 			<description>Defined in the xml file and added by the agent. Should
 				record even if an exception is raised.
 			</description>
@@ -342,7 +342,7 @@
 			<rethrow>true</rethrow>
 		</event>
 		<event id="demo.jfr.testI9">
-			<name>JFR Hello World Instance Event 9 %TEST_NAME%</name>
+			<label>JFR Hello World Instance Event 9 %TEST_NAME%</label>
 			<description>Defined in the xml file and added by the agent. Should
 				not record if an exception is raised.
 			</description>
@@ -355,7 +355,7 @@
 			</method>
 		</event>
 		<event id="demo.jfr.testI10">
-			<name>JFR Hello World Instance Event 10 %TEST_NAME%</name>
+			<label>JFR Hello World Instance Event 10 %TEST_NAME%</label>
 			<description>Defined in the xml file and added by the agent. Should
 				record even if an exception is raised,
 				but should
@@ -372,7 +372,7 @@
 			<rethrow>true</rethrow>
 		</event>
 		<event id="demo.jfr.testI11">
-			<name>JFR Hello World Instance Event 11 %TEST_NAME%</name>
+			<label>JFR Hello World Instance Event 11 %TEST_NAME%</label>
 			<description>Defined in the xml file and added by the agent. Should
 				record the value of instance reference
 				'instanceStringField'
@@ -408,7 +408,7 @@
 			</fields>
 		</event>
 		<event id="demo.jfr.testI12">
-			<name>JFR Hello World Instance Event 12 %TEST_NAME%</name>
+			<label>JFR Hello World Instance Event 12 %TEST_NAME%</label>
 			<description>Defined in the xml file and added by the agent. Should
 				record the values of various
 				references


### PR DESCRIPTION
...since most people use JFR 2.0 these days.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JMC-7029](https://bugs.openjdk.java.net/browse/JMC-7029): In the event configuration the event name should be renamed label


### Reviewers
 * [Henrik Dafgård](https://openjdk.java.net/census#hdafgard) (@Gunde - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jmc pull/172/head:pull/172`
`$ git checkout pull/172`
