### PR TITLE
7016: JAWS only read “link” on letter small A and big A for welcome page

### DIFF
--- a/application/org.openjdk.jmc.rcp.intro/content/root.xhtml
+++ b/application/org.openjdk.jmc.rcp.intro/content/root.xhtml
@@ -14,10 +14,10 @@
 <body> 
 <include path="pageparts/banner" />
 <div class="fontsize">
-	<a href="http://org.eclipse.ui.intro/showPage?id=root" class="normal">
+	<a href="http://org.eclipse.ui.intro/showPage?id=root" class="normal" aria-label="Normal Font">
 		A		
 	</a>	
-	<a href="http://org.eclipse.ui.intro/showPage?id=root_l" class="large">
+	<a href="http://org.eclipse.ui.intro/showPage?id=root_l" class="large" aria-label="Large Font">
 		A		
 	</a>	
 </div>	

--- a/application/org.openjdk.jmc.rcp.intro/content/root_l.xhtml
+++ b/application/org.openjdk.jmc.rcp.intro/content/root_l.xhtml
@@ -14,10 +14,10 @@
 <body> 
 <include path="pageparts/banner" />
 <div class="fontsize">
-	<a href="http://org.eclipse.ui.intro/showPage?id=root" class="normal">
+	<a href="http://org.eclipse.ui.intro/showPage?id=root" class="normal" aria-label="Normal Font">
 		A		
 	</a>	
-	<a href="http://org.eclipse.ui.intro/showPage?id=root_l" class="large">
+	<a href="http://org.eclipse.ui.intro/showPage?id=root_l" class="large" aria-label="Large Font">
 		A		
 	</a>	
 </div>	


### PR DESCRIPTION
In order to make the links readable by JAWS, added label for the links for font - normal and large. 

Please review the change.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JMC-7016](https://bugs.openjdk.java.net/browse/JMC-7016): JAWS only read “link” on letter small A and big A for welcome page


### Reviewers
 * [Marcus Hirt](https://openjdk.java.net/census#hirt) (@thegreystone - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jmc pull/176/head:pull/176`
`$ git checkout pull/176`
