### PR TITLE
6840: [Accessibility, JAWS] 'Start Using JMC' link in Welcome Page is not traversable using Keyboard

### DIFF
--- a/application/org.openjdk.jmc.rcp.intro/content/root.xhtml
+++ b/application/org.openjdk.jmc.rcp.intro/content/root.xhtml
@@ -115,8 +115,8 @@
 
 </td></tr></table>
 
-<table><tr><td>
-        <a href="http://org.eclipse.ui.intro/runAction?class=org.openjdk.jmc.rcp.intro.CloseIntroAction&amp;pluginId=org.openjdk.jmc.rcp.intro">
+<table tabindex="0"><tr><td>
+        <a href="http://org.eclipse.ui.intro/runAction?class=org.openjdk.jmc.rcp.intro.CloseIntroAction&amp;pluginId=org.openjdk.jmc.rcp.intro" aria-label="Click here to start using JDK Mission Control">
             <h2> <img src="images/mission_control_64.png"/><include path="strings/gettowork_title" /></h2>
         </a>
 </td></tr></table>  

--- a/application/org.openjdk.jmc.rcp.intro/content/root_l.xhtml
+++ b/application/org.openjdk.jmc.rcp.intro/content/root_l.xhtml
@@ -118,8 +118,8 @@
 </td>
 </tr></table>
 
-<table><tr><td>
-        <a href="http://org.eclipse.ui.intro/runAction?class=org.openjdk.jmc.rcp.intro.CloseIntroAction&amp;pluginId=org.openjdk.jmc.rcp.intro">
+<table tabindex="0"><tr><td>
+        <a href="http://org.eclipse.ui.intro/runAction?class=org.openjdk.jmc.rcp.intro.CloseIntroAction&amp;pluginId=org.openjdk.jmc.rcp.intro" aria-label="Click here to start using JDK Mission Control">
             <h2> <img src="images/mission_control_64.png"/><include path="strings/gettowork_title" /></h2>   
         </a>
 </td></tr></table>  


### PR DESCRIPTION
Fixed the issue of making the link accessible using Keyboard and reading out the content.

Please review the change.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JMC-6840](https://bugs.openjdk.java.net/browse/JMC-6840): [Accessibility, JAWS] 'Start Using JMC' link in Welcome Page is not traversable using Keyboard


### Reviewers
 * [Marcus Hirt](https://openjdk.java.net/census#hirt) (@thegreystone - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jmc pull/177/head:pull/177`
`$ git checkout pull/177`
