### PR TITLE
7048: No matter how funny java.rmi.server.hostname resolves, you should alway be able to connect to yourself

### DIFF
--- a/application/org.openjdk.jmc.browser.attach/src/main/java/org/openjdk/jmc/browser/attach/LocalConnectionDescriptor.java
+++ b/application/org.openjdk.jmc.browser.attach/src/main/java/org/openjdk/jmc/browser/attach/LocalConnectionDescriptor.java
@@ -148,14 +148,7 @@ public class LocalConnectionDescriptor implements IConnectionDescriptor {
 	}
 
 	private void setAddress(String address) {
-		if (address != null) {
-			try {
-				url = new JMXServiceURL(address);
-			} catch (MalformedURLException e) {
-				BrowserAttachPlugin.getPluginLogger().log(Level.SEVERE,
-						"Could not get create service URL from a local address!", e); //$NON-NLS-1$
-			}
-		} else if (isSelfMonitoring()) {
+		if (isSelfMonitoring() || address == null) {
 			// If we're attempting to monitor ourselves, use the local
 			// JVM (since the poor agent currently may go into infinite
 			// recursion otherwise).
@@ -164,6 +157,13 @@ public class LocalConnectionDescriptor implements IConnectionDescriptor {
 			} catch (MalformedURLException e) {
 				// Not going to happen...
 				e.printStackTrace();
+			}
+		} else {
+			try {
+				url = new JMXServiceURL(address);
+			} catch (MalformedURLException e) {
+				BrowserAttachPlugin.getPluginLogger().log(Level.SEVERE,
+						"Could not get create service URL from a local address!", e); //$NON-NLS-1$
 			}
 		}
 	}


### PR DESCRIPTION
So, simply set up the address properly always if connecting to ourselves, even if we could resolve a stub address.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JMC-7048](https://bugs.openjdk.java.net/browse/JMC-7048): No matter how funny java.rmi.server.hostname resolves, you should alway be able to connect to yourself


### Reviewers
 * [Guru Hb](https://openjdk.java.net/census#ghb) (@guruhb - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jmc pull/178/head:pull/178`
`$ git checkout pull/178`
