### PR TITLE
7055: Flameview manifest is exporting non-existent package

### DIFF
--- a/application/org.openjdk.jmc.flightrecorder.flameview/META-INF/MANIFEST.MF
+++ b/application/org.openjdk.jmc.flightrecorder.flameview/META-INF/MANIFEST.MF
@@ -12,5 +12,4 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-Vendor: Oracle Corporation
 Automatic-Module-Name: org.openjdk.jmc.flightrecorder.ext.flameview
 Export-Package: org.openjdk.jmc.flightrecorder.flameview,
- org.openjdk.jmc.flightrecorder.flameview.tree,
  org.openjdk.jmc.flightrecorder.flameview.views


### PR DESCRIPTION
Should be removed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JMC-7055](https://bugs.openjdk.java.net/browse/JMC-7055): Flameview manifest is exporting non-existent package


### Reviewers
 * [Guru Hb](https://openjdk.java.net/census#ghb) (@guruhb - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jmc pull/180/head:pull/180`
`$ git checkout pull/180`
