### PR TITLE
6986: "Flight Recorder" is not working as expected for localhost Connection

### DIFF
--- a/application/org.openjdk.jmc.rjmx/src/main/java/org/openjdk/jmc/rjmx/services/internal/CommercialFeaturesServiceFactory.java
+++ b/application/org.openjdk.jmc.rjmx/src/main/java/org/openjdk/jmc/rjmx/services/internal/CommercialFeaturesServiceFactory.java
@@ -32,10 +32,19 @@
  */
 package org.openjdk.jmc.rjmx.services.internal;
 
+import java.io.IOException;
+import java.lang.management.OperatingSystemMXBean;
+import java.lang.management.RuntimeMXBean;
+import java.util.Map;
+
+import javax.management.MBeanServerConnection;
+
 import org.openjdk.jmc.common.version.JavaVersion;
+import org.openjdk.jmc.common.version.JavaVersionSupport;
 import org.openjdk.jmc.rjmx.ConnectionException;
 import org.openjdk.jmc.rjmx.ConnectionToolkit;
 import org.openjdk.jmc.rjmx.IConnectionHandle;
+import org.openjdk.jmc.rjmx.IServerDescriptor;
 import org.openjdk.jmc.rjmx.ServiceNotAvailableException;
 import org.openjdk.jmc.rjmx.services.ICommercialFeaturesService;
 import org.openjdk.jmc.rjmx.services.IServiceFactory;
@@ -53,6 +62,10 @@ public class CommercialFeaturesServiceFactory implements IServiceFactory<ICommer
 		if (descriptor != null) {
 			JavaVersion version = new JavaVersion(descriptor.getJavaVersion());
 			if (version.getMajorVersion() >= 11) {
+				return new NoCommercialFeaturesService();
+			}
+		} else if (handle.isConnected() && ConnectionToolkit.isOracle(handle)) {
+			if (ConnectionToolkit.isJavaVersionAboveOrEqual(handle, JavaVersionSupport.JDK_11)) {
 				return new NoCommercialFeaturesService();
 			}
 		}

--- a/application/org.openjdk.jmc.rjmx/src/main/java/org/openjdk/jmc/rjmx/services/internal/CommercialFeaturesServiceFactory.java
+++ b/application/org.openjdk.jmc.rjmx/src/main/java/org/openjdk/jmc/rjmx/services/internal/CommercialFeaturesServiceFactory.java
@@ -32,19 +32,11 @@
  */
 package org.openjdk.jmc.rjmx.services.internal;
 
-import java.io.IOException;
-import java.lang.management.OperatingSystemMXBean;
-import java.lang.management.RuntimeMXBean;
-import java.util.Map;
-
-import javax.management.MBeanServerConnection;
-
 import org.openjdk.jmc.common.version.JavaVersion;
 import org.openjdk.jmc.common.version.JavaVersionSupport;
 import org.openjdk.jmc.rjmx.ConnectionException;
 import org.openjdk.jmc.rjmx.ConnectionToolkit;
 import org.openjdk.jmc.rjmx.IConnectionHandle;
-import org.openjdk.jmc.rjmx.IServerDescriptor;
 import org.openjdk.jmc.rjmx.ServiceNotAvailableException;
 import org.openjdk.jmc.rjmx.services.ICommercialFeaturesService;
 import org.openjdk.jmc.rjmx.services.IServiceFactory;


### PR DESCRIPTION
RC : "Unlock Commercial Feature " Dialog was promoted while Using : Oracle JDK 11.0.x + Local rmi connection (Not for OpenJDK 11 or above). 
Solution : Check if the target JVM is Oracle JDK and its version is greater than or equal to 11.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JMC-6986](https://bugs.openjdk.java.net/browse/JMC-6986): "Flight Recorder" is not working as expected for localhost Connection


### Reviewers
 * [Marcus Hirt](https://openjdk.java.net/census#hirt) (@thegreystone - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jmc pull/181/head:pull/181`
`$ git checkout pull/181`
