### PR TITLE
7062: Update to the Eclipse 2020-12 platform

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -112,9 +112,6 @@
 	<profiles>
 		<profile>
 			<id>2020-12</id>
-			<activation>
-				<activeByDefault>true</activeByDefault>
-			</activation>
 			<build>
 				<plugins>
 					<plugin>
@@ -136,6 +133,9 @@
 		</profile>
 		<profile>
 			<id>2020-09</id>
+			<activation>
+				<activeByDefault>true</activeByDefault>
+			</activation>
 			<build>
 				<plugins>
 					<plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -111,10 +111,31 @@
 	</distributionManagement>
 	<profiles>
 		<profile>
-			<id>2020-09</id>
+			<id>2020-12</id>
 			<activation>
 				<activeByDefault>true</activeByDefault>
 			</activation>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.eclipse.tycho</groupId>
+						<artifactId>target-platform-configuration</artifactId>
+						<version>${tycho.version}</version>
+						<configuration>
+							<target>
+								<artifact>
+									<groupId>org.openjdk.jmc</groupId>
+									<artifactId>platform-definition-2020-12</artifactId>
+									<version>8.0.0-SNAPSHOT</version>
+								</artifact>
+							</target>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+		<profile>
+			<id>2020-09</id>
 			<build>
 				<plugins>
 					<plugin>

--- a/releng/platform-definitions/platform-definition-2020-09/.project
+++ b/releng/platform-definitions/platform-definition-2020-09/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>platform-definition-2020-09</name>
+	<name>platform-definition-2020-12</name>
 	<comment></comment>
 	<projects>
 	</projects>

--- a/releng/platform-definitions/platform-definition-2020-09/.project
+++ b/releng/platform-definitions/platform-definition-2020-09/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>platform-definition-2020-12</name>
+	<name>platform-definition-2020-09</name>
 	<comment></comment>
 	<projects>
 	</projects>

--- a/releng/platform-definitions/platform-definition-2020-12/.project
+++ b/releng/platform-definitions/platform-definition-2020-12/.project
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>platform-definition-2020-12</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+	</natures>
+</projectDescription>

--- a/releng/platform-definitions/platform-definition-2020-12/platform-definition-2020-12.target
+++ b/releng/platform-definitions/platform-definition-2020-12/platform-definition-2020-12.target
@@ -33,7 +33,7 @@
    WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 -->
 <?pde version="3.8"?>
-<target name="jmc-target-2020-09" sequenceNumber="47">
+<target name="jmc-target-2020-12" sequenceNumber="47">
     <locations>
         <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
             <unit id="com.sun.mail.jakarta.mail" version="1.6.5"/>
@@ -49,10 +49,10 @@
             <repository location="http://localhost:8080/site"/>
         </location>
         <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-            <unit id="org.eclipse.equinox.executable.feature.group" version="3.8.900.v20200819-0940"/>
-            <unit id="org.eclipse.pde.feature.group" version="3.14.500.v20200902-1800"/>
-            <unit id="org.eclipse.platform.sdk" version="4.17.0.I20200902-1800"/>
-            <repository location="http://download.eclipse.org/releases/2020-09/"/>
+            <unit id="org.eclipse.equinox.executable.feature.group" version="3.8.1000.v20200915-1508"/>
+            <unit id="org.eclipse.pde.feature.group" version="3.14.600.v20201202-1800"/>
+            <unit id="org.eclipse.platform.sdk" version="4.18.0.I20201202-1800"/>
+            <repository location="http://download.eclipse.org/releases/2020-12/"/>
         </location>
         <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
             <unit id="org.eclipse.babel.nls_eclipse_ja.feature.group" version="4.17.0.v20201010020001"/>

--- a/releng/platform-definitions/platform-definition-2020-12/pom.xml
+++ b/releng/platform-definitions/platform-definition-2020-12/pom.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-   Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+   Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+   Copyright (c) 2020, Datadog, Inc. All rights reserved.
 
    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
@@ -35,20 +36,13 @@
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.openjdk.jmc</groupId>
-		<artifactId>missioncontrol.releng</artifactId>
+		<artifactId>platform-definitions</artifactId>
 		<version>8.0.0-SNAPSHOT</version>
 	</parent>
-	<artifactId>platform-definitions</artifactId>
-	<packaging>pom</packaging>
+	<artifactId>platform-definition-2020-12</artifactId>
+	<packaging>eclipse-target-definition</packaging>
 
 	<properties>
-		<spotless.config.path>${basedir}/../../configuration/ide/eclipse/formatting/formatting.xml</spotless.config.path>
+		<spotless.config.path>${basedir}/../../../configuration/ide/eclipse/formatting/formatting.xml</spotless.config.path>
 	</properties>
-
-	<modules>
-		<module>platform-definition-2020-12</module>
-		<module>platform-definition-2020-09</module>
-		<module>platform-definition-2020-06</module>
-		<module>platform-definition-2020-03</module>
-	</modules>
 </project>


### PR DESCRIPTION
Also updating the babel bundles for the 2020-09 platform.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JMC-7062](https://bugs.openjdk.java.net/browse/JMC-7062): Update to the Eclipse 2020-12 platform


### Reviewers
 * [Jie Kang](https://openjdk.java.net/census#jkang) (@jiekang - Author)
 * [Guru Hb](https://openjdk.java.net/census#ghb) (@guruhb - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jmc pull/185/head:pull/185`
`$ git checkout pull/185`
