### PR TITLE
7079: Numeric values in automated analysis summary is not resolved

### DIFF
--- a/application/org.openjdk.jmc.flightrecorder.ext.jfx/src/main/java/org/openjdk/jmc/flightrecorder/ext/jfx/JfxPulseDurationRule.java
+++ b/application/org.openjdk.jmc.flightrecorder.ext.jfx/src/main/java/org/openjdk/jmc/flightrecorder/ext/jfx/JfxPulseDurationRule.java
@@ -87,7 +87,7 @@ public class JfxPulseDurationRule implements IRule {
 			"The target rendering frequency.", UnitLookup.FREQUENCY, IQuantity.class);
 
 	private static final Collection<TypedResult<?>> RESULT_ATTRIBUTES = Arrays
-			.<TypedResult<?>> asList(TypedResult.SCORE);
+			.<TypedResult<?>> asList(TypedResult.SCORE, SLOW_PHASES, TARGET_TIME, RENDER_TARGET);
 
 	private IResult getResult(
 		IItemCollection items, IPreferenceValueProvider valueProvider, IResultValueProvider resultProvider) {

--- a/application/org.openjdk.jmc.flightrecorder.ext.jfx/src/main/java/org/openjdk/jmc/flightrecorder/ext/jfx/JfxPulseDurationRule.java
+++ b/application/org.openjdk.jmc.flightrecorder.ext.jfx/src/main/java/org/openjdk/jmc/flightrecorder/ext/jfx/JfxPulseDurationRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *


### PR DESCRIPTION
JFX Pulse Duration rule does not register result attributes properly, this causes templating to fail.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JMC-7079](https://bugs.openjdk.java.net/browse/JMC-7079): Numeric values in automated analysis summary is not resolved 


### Reviewers
 * [Marcus Hirt](https://openjdk.java.net/census#hirt) (@thegreystone - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jmc pull/191/head:pull/191`
`$ git checkout pull/191`
