### PR TITLE
7002: Too large graphs will freeze JMC

### DIFF
--- a/application/org.openjdk.jmc.flightrecorder.graphview/src/main/java/org/openjdk/jmc/flightrecorder/ext/graphview/graph/DotGenerator.java
+++ b/application/org.openjdk.jmc.flightrecorder.graphview/src/main/java/org/openjdk/jmc/flightrecorder/ext/graphview/graph/DotGenerator.java
@@ -261,15 +261,19 @@ public final class DotGenerator {
 	/**
 	 * Renders a {@link StacktraceGraphModel} in DOT format.
 	 */
-	public static String toDot(StacktraceGraphModel model, Map<ConfigurationKey, String> configuration) {
+	public static String toDot(
+		StacktraceGraphModel model, int maxNodesRendered, Map<ConfigurationKey, String> configuration) {
 		StringBuilder builder = new StringBuilder(2048);
 		String graphName = getConf(configuration, ConfigurationKey.Name, DEFAULT_NAME);
 		builder.append(String.format("digraph \"%s\" {%n", graphName));
-		if (model.getNodes().size() > 100) {
-			emitMessage(builder, "Too many nodes in current selection", configuration);
+		int nodeCount = model.getNodes().size();
+		if (nodeCount > maxNodesRendered) {
+			String message = String.format("Too many nodes in current selection\n(max: %d, actual: %d)",
+					maxNodesRendered, nodeCount);
+			emitMessage(builder, message, configuration);
 			builder.append("}");
 			return builder.toString();
-		} else if (model.getNodes().size() == 0) {
+		} else if (nodeCount == 0) {
 			emitMessage(builder, "No graph data in current selection", configuration);
 			builder.append("}");
 			return builder.toString();
@@ -445,6 +449,6 @@ public final class DotGenerator {
 		StacktraceGraphModel model = new StacktraceGraphModel(frameSeparator, filteredItems, null);
 		Map<ConfigurationKey, String> configuration = getDefaultConfiguration();
 		configuration.put(ConfigurationKey.Name, jfrFile.getName());
-		System.out.println(toDot(model, configuration));
+		System.out.println(toDot(model, 1000, configuration));
 	}
 }

--- a/application/org.openjdk.jmc.flightrecorder.graphview/src/main/java/org/openjdk/jmc/flightrecorder/ext/graphview/graph/DotGenerator.java
+++ b/application/org.openjdk.jmc.flightrecorder.graphview/src/main/java/org/openjdk/jmc/flightrecorder/ext/graphview/graph/DotGenerator.java
@@ -274,7 +274,7 @@ public final class DotGenerator {
 			builder.append("}");
 			return builder.toString();
 		} else if (nodeCount == 0) {
-			emitMessage(builder, "No graph data in current selection", configuration);
+			emitEmptyMessage(builder, "No graph data in current selection", configuration);
 			builder.append("}");
 			return builder.toString();
 		}
@@ -381,6 +381,13 @@ public final class DotGenerator {
 		builder.append("\" fillcolor=\"");
 		builder.append(fillColor);
 		builder.append("\"]\n");
+	}
+
+	private static void emitEmptyMessage(
+		StringBuilder builder, String message, Map<ConfigurationKey, String> configuration) {
+		builder.append("label= <<font color='gray' point-size='1'>");
+		builder.append(message);
+		builder.append("</font>>");
 	}
 
 	private static void createSubgraphNode(

--- a/application/org.openjdk.jmc.flightrecorder.graphview/src/main/java/org/openjdk/jmc/flightrecorder/ext/graphview/graph/DotGenerator.java
+++ b/application/org.openjdk.jmc.flightrecorder.graphview/src/main/java/org/openjdk/jmc/flightrecorder/ext/graphview/graph/DotGenerator.java
@@ -265,7 +265,15 @@ public final class DotGenerator {
 		StringBuilder builder = new StringBuilder(2048);
 		String graphName = getConf(configuration, ConfigurationKey.Name, DEFAULT_NAME);
 		builder.append(String.format("digraph \"%s\" {%n", graphName));
-
+		if (model.getNodes().size() > 100) {
+			emitMessage(builder, "Too many nodes in current selection", configuration);
+			builder.append("}");
+			return builder.toString();
+		} else if (model.getNodes().size() == 0) {
+			emitMessage(builder, "No graph data in current selection", configuration);
+			builder.append("}");
+			return builder.toString();
+		}
 		createDefaultNodeSettingsEntry(builder, configuration);
 		if (Boolean.valueOf(getConf(configuration, ConfigurationKey.TitleArea, "false"))) {
 			createSubgraphNode(builder, graphName, configuration, model);
@@ -350,6 +358,24 @@ public final class DotGenerator {
 		builder.append(configurator.color);
 		builder.append("\" fillcolor=\"");
 		builder.append(configurator.fillColor);
+		builder.append("\"]\n");
+	}
+
+	private static void emitMessage(
+		StringBuilder builder, String message, Map<ConfigurationKey, String> configuration) {
+		String shape = getConf(configuration, ConfigurationKey.NodeShape, DEFAULT_SHAPE);
+		String color = getConf(configuration, ConfigurationKey.NodeColor, "#b22b00");
+		String fillColor = getConf(configuration, ConfigurationKey.NodeFillColor, "#eddbd5");
+		builder.append("message [label=\"");
+		builder.append(message);
+		builder.append("\" id=\"message\"");
+		builder.append(" shape=");
+		builder.append(shape);
+		builder.append(" fontsize=5");
+		builder.append(" color=\"");
+		builder.append(color);
+		builder.append("\" fillcolor=\"");
+		builder.append(fillColor);
 		builder.append("\"]\n");
 	}
 

--- a/application/org.openjdk.jmc.flightrecorder.graphview/src/main/java/org/openjdk/jmc/flightrecorder/ext/graphview/graph/DotGenerator.java
+++ b/application/org.openjdk.jmc.flightrecorder.graphview/src/main/java/org/openjdk/jmc/flightrecorder/ext/graphview/graph/DotGenerator.java
@@ -268,7 +268,7 @@ public final class DotGenerator {
 		builder.append(String.format("digraph \"%s\" {%n", graphName));
 		int nodeCount = model.getNodes().size();
 		if (nodeCount > maxNodesRendered) {
-			String message = String.format("Too many nodes in current selection\n(max: %d, actual: %d)",
+			String message = String.format("Too many nodes in current selection%n(max: %d, actual: %d)",
 					maxNodesRendered, nodeCount);
 			emitMessage(builder, message, configuration);
 			builder.append("}");

--- a/application/org.openjdk.jmc.flightrecorder.graphview/src/main/java/org/openjdk/jmc/flightrecorder/graphview/views/GraphView.java
+++ b/application/org.openjdk.jmc.flightrecorder.graphview/src/main/java/org/openjdk/jmc/flightrecorder/graphview/views/GraphView.java
@@ -39,6 +39,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.text.MessageFormat;
 import java.util.Base64;
+import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
@@ -70,6 +71,7 @@ import org.eclipse.ui.IWorkbenchPart;
 import org.eclipse.ui.PartInitException;
 import org.eclipse.ui.part.ViewPart;
 import org.openjdk.jmc.common.item.IItemCollection;
+import org.openjdk.jmc.common.util.Pair;
 import org.openjdk.jmc.common.util.StringToolkit;
 import org.openjdk.jmc.flightrecorder.ext.graphview.graph.DotGenerator;
 import org.openjdk.jmc.flightrecorder.stacktrace.FrameSeparator;
@@ -181,6 +183,8 @@ public class GraphView extends ViewPart implements ISelectionListener {
 
 	private class NodeThresholdSelection extends Action implements IMenuCreator {
 		private Menu menu;
+		private final List<Pair<String, Integer>> items = List.of(new Pair<>("100", 100), new Pair<>("500", 500),
+				new Pair<>("1000", 1000));
 
 		NodeThresholdSelection() {
 			super("Max Nodes", IAction.AS_DROP_DOWN_MENU);
@@ -189,7 +193,7 @@ public class GraphView extends ViewPart implements ISelectionListener {
 
 		@Override
 		public void dispose() {
-			// TODO: understand when this needs to be called
+			// do nothing
 		}
 
 		@Override
@@ -211,10 +215,9 @@ public class GraphView extends ViewPart implements ISelectionListener {
 		}
 
 		private void populate(Menu menu) {
-			int[] values = new int[] {1, 50, 100, 500, 1000};
-			for (int i : values) {
+			for (Pair<String, Integer> item : items) {
 				ActionContributionItem actionItem = new ActionContributionItem(
-						new SetNodeThreshold(i, i == maxNodesRendered));
+						new SetNodeThreshold(item, item.right == maxNodesRendered));
 				actionItem.fill(menu, -1);
 			}
 		}
@@ -223,9 +226,9 @@ public class GraphView extends ViewPart implements ISelectionListener {
 	private class SetNodeThreshold extends Action {
 		private int value;
 
-		SetNodeThreshold(int value, boolean isSelected) {
-			super(String.valueOf(value), IAction.AS_RADIO_BUTTON);
-			this.value = value;
+		SetNodeThreshold(Pair<String, Integer> item, boolean isSelected) {
+			super(item.left, IAction.AS_RADIO_BUTTON);
+			this.value = item.right;
 			setChecked(isSelected);
 		}
 

--- a/application/org.openjdk.jmc.flightrecorder.graphview/src/main/java/org/openjdk/jmc/flightrecorder/graphview/views/GraphView.java
+++ b/application/org.openjdk.jmc.flightrecorder.graphview/src/main/java/org/openjdk/jmc/flightrecorder/graphview/views/GraphView.java
@@ -183,7 +183,7 @@ public class GraphView extends ViewPart implements ISelectionListener {
 		private Menu menu;
 
 		NodeThresholdSelection() {
-			super("Max nodes rendered", IAction.AS_DROP_DOWN_MENU);
+			super("Max Nodes", IAction.AS_DROP_DOWN_MENU);
 			setMenuCreator(this);
 		}
 

--- a/application/org.openjdk.jmc.flightrecorder.graphview/src/main/java/org/openjdk/jmc/flightrecorder/graphview/views/GraphView.java
+++ b/application/org.openjdk.jmc.flightrecorder.graphview/src/main/java/org/openjdk/jmc/flightrecorder/graphview/views/GraphView.java
@@ -46,6 +46,11 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Level;
 import java.util.stream.Stream;
 
+import org.eclipse.jface.action.Action;
+import org.eclipse.jface.action.ActionContributionItem;
+import org.eclipse.jface.action.IAction;
+import org.eclipse.jface.action.IMenuCreator;
+import org.eclipse.jface.action.IToolBarManager;
 import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.swt.SWT;
@@ -56,6 +61,8 @@ import org.eclipse.swt.custom.SashForm;
 import org.eclipse.swt.events.MenuDetectEvent;
 import org.eclipse.swt.events.MenuDetectListener;
 import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Control;
+import org.eclipse.swt.widgets.Menu;
 import org.eclipse.ui.IMemento;
 import org.eclipse.ui.ISelectionListener;
 import org.eclipse.ui.IViewSite;
@@ -99,11 +106,14 @@ public class GraphView extends ViewPart implements ISelectionListener {
 		private final FrameSeparator separator;
 		private IItemCollection items;
 		private volatile boolean isInvalid;
+		private final int maxNodesRendered;
 
-		private ModelRebuildRunnable(GraphView view, FrameSeparator separator, IItemCollection items) {
+		private ModelRebuildRunnable(GraphView view, FrameSeparator separator, IItemCollection items,
+				int maxNodesRendered) {
 			this.view = view;
 			this.items = items;
 			this.separator = separator;
+			this.maxNodesRendered = maxNodesRendered;
 		}
 
 		private void setInvalid() {
@@ -121,12 +131,12 @@ public class GraphView extends ViewPart implements ISelectionListener {
 			if (isInvalid) {
 				return;
 			}
-			String json = GraphView.toDot(model);
+			String dotString = GraphView.toDot(model, maxNodesRendered);
 			if (isInvalid) {
 				return;
 			} else {
 				view.modelState = ModelState.FINISHED;
-				DisplayToolkit.inDisplayThread().execute(() -> view.setModel(items, json));
+				DisplayToolkit.inDisplayThread().execute(() -> view.setModel(items, dotString));
 			}
 		}
 	}
@@ -150,11 +160,16 @@ public class GraphView extends ViewPart implements ISelectionListener {
 	private IItemCollection currentItems;
 	private volatile ModelState modelState = ModelState.NONE;
 	private ModelRebuildRunnable modelRebuildRunnable;
+	private int maxNodesRendered = 100;
 
 	@Override
 	public void init(IViewSite site, IMemento memento) throws PartInitException {
 		super.init(site, memento);
 		frameSeparator = new FrameSeparator(FrameCategorization.METHOD, false);
+
+		IToolBarManager toolBar = site.getActionBars().getToolBarManager();
+		toolBar.add(new NodeThresholdSelection());
+
 		getSite().getPage().addSelectionListener(this);
 	}
 
@@ -162,6 +177,65 @@ public class GraphView extends ViewPart implements ISelectionListener {
 	public void dispose() {
 		getSite().getPage().removeSelectionListener(this);
 		super.dispose();
+	}
+
+	private class NodeThresholdSelection extends Action implements IMenuCreator {
+		private Menu menu;
+
+		NodeThresholdSelection() {
+			super("Max nodes rendered", IAction.AS_DROP_DOWN_MENU);
+			setMenuCreator(this);
+		}
+
+		@Override
+		public void dispose() {
+			// TODO: understand when this needs to be called
+		}
+
+		@Override
+		public Menu getMenu(Control parent) {
+			if (menu == null) {
+				menu = new Menu(parent);
+				populate(menu);
+			}
+			return menu;
+		}
+
+		@Override
+		public Menu getMenu(Menu parent) {
+			if (menu == null) {
+				menu = new Menu(parent);
+				populate(menu);
+			}
+			return menu;
+		}
+
+		private void populate(Menu menu) {
+			int[] values = new int[] {1, 50, 100, 500, 1000};
+			for (int i : values) {
+				ActionContributionItem actionItem = new ActionContributionItem(
+						new SetNodeThreshold(i, i == maxNodesRendered));
+				actionItem.fill(menu, -1);
+			}
+		}
+	}
+
+	private class SetNodeThreshold extends Action {
+		private int value;
+
+		SetNodeThreshold(int value, boolean isSelected) {
+			super(String.valueOf(value), IAction.AS_RADIO_BUTTON);
+			this.value = value;
+			setChecked(isSelected);
+		}
+
+		@Override
+		public void run() {
+			if (maxNodesRendered != value) {
+				maxNodesRendered = value;
+				triggerRebuildTask(currentItems);
+			}
+		}
 	}
 
 	@Override
@@ -207,7 +281,7 @@ public class GraphView extends ViewPart implements ISelectionListener {
 
 		currentItems = items;
 		modelState = ModelState.NOT_STARTED;
-		modelRebuildRunnable = new ModelRebuildRunnable(this, frameSeparator, items);
+		modelRebuildRunnable = new ModelRebuildRunnable(this, frameSeparator, items, maxNodesRendered);
 		if (!modelRebuildRunnable.isInvalid) {
 			MODEL_EXECUTOR.execute(modelRebuildRunnable);
 		}
@@ -241,15 +315,15 @@ public class GraphView extends ViewPart implements ISelectionListener {
 		});
 	}
 
-	private static String toDot(StacktraceGraphModel model) {
+	private static String toDot(StacktraceGraphModel model, int maxNodesRendered) {
 		if (model == null) {
 			return "\"\"";
 		}
-		return render(model);
+		return render(model, maxNodesRendered);
 	}
 
-	private static String render(StacktraceGraphModel model) {
-		return DotGenerator.toDot(model, DotGenerator.getDefaultConfiguration());
+	private static String render(StacktraceGraphModel model, int maxNodesRendered) {
+		return DotGenerator.toDot(model, maxNodesRendered, DotGenerator.getDefaultConfiguration());
 	}
 
 	private static String loadLibraries(String ... libs) {


### PR DESCRIPTION
This PR adds a control to limit the maximum number of nodes that can be rendered in the JMC graph view.

At the moment, rendering very large graphs makes the application unresponsive so we want to guard against this by setting a limit on the maximum number of nodes that will be rendered. When this limit is exceeded, we don't try to render our `StacktraceGraphModel` into a graphiz dot string and instead we generate a simple dot string with one node and a message informing the user that they are trying to render too many nodes.

I spent a couple of hours fighting with SWT to get the basic dropdown functionality working in the component toolbar. I took some inspiration from the FlameView component's toolbar actions and I found some (not great) examples with Google. I'm happy to use other components - this seemed to be the simplest from what I found. Please let me know if there's anything better. 😃

---

![Screenshot 2021-01-10 at 18 14 39](https://user-images.githubusercontent.com/348973/104131749-4987a100-5370-11eb-8ae1-b9ee8064921f.png)

![Screenshot 2021-01-10 at 18 15 00](https://user-images.githubusercontent.com/348973/104131756-5c01da80-5370-11eb-9fe3-67e357d0fa00.png)

We will also display a similar message when the graph model has no information (no nodes):

![Screenshot 2021-01-10 at 18 14 20](https://user-images.githubusercontent.com/348973/104131741-3c6ab200-5370-11eb-8d6f-1901371ab21f.png)

---

Other things we've considered:

- ~add an icon instead of the text in the toolbar~ - we'll leave the text label for now
- ~create text labels instead of the hardcoded strings I'm using now~ - we decided not to do localisation while this view is experimental
- I was on the fence about adding a 'no limit' option in the dropdown and decided against it. I guess it's useful in development when trying out pruning strategies, but it might surprise people unfamiliar with how it works and freeze their apps. In development, we can just remove the limit when we want to try things out.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JMC-7002](https://bugs.openjdk.java.net/browse/JMC-7002): Too large graphs will freeze JMC


### Reviewers
 * [Marcus Hirt](https://openjdk.java.net/census#hirt) (@thegreystone - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jmc pull/193/head:pull/193`
`$ git checkout pull/193`
