### PR TITLE
7063: JfrThreadsPageTest (UI-test) fails

### DIFF
--- a/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/misc/TimeFilter.java
+++ b/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/misc/TimeFilter.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2020, Red Hat Inc. All rights reserved.
+ * Copyright (c) 2020, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2021 Red Hat Inc. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -62,8 +62,10 @@ public class TimeFilter extends Composite {
 		START, END
 	};
 
-	private static final String dateFormat = "yyyy-MM-dd ";
-	private static final String timeFormat = "HH:mm:ss:SSS";
+	public static final String START_TIME_NAME = "timefilter.startTime.text.name"; //$NON-NLS-1$
+	public static final String END_TIME_NAME = "timefilter.endTime.text.name"; //$NON-NLS-1$
+	public static final String dateFormat = "yyyy-MM-dd ";
+	public static final String timeFormat = "HH:mm:ss:SSS";
 	private boolean isMultiDayRecording = false;
 	public Calendar calendar;
 	private ChartCanvas chartCanvas;
@@ -156,6 +158,8 @@ public class TimeFilter extends Composite {
 			this.defaultTime = defaultTime;
 			this.setLayout(new GridLayout());
 			timeText = new Text(this, SWT.SEARCH | SWT.SINGLE);
+			timeText.setData("name", type == FilterType.START ? START_TIME_NAME : END_TIME_NAME); //$NON-NLS-1$
+
 			// if the recording spans multiple days, include the date in the time display
 			if (!isMultiDayRecording) {
 				timeText.setTextLimit(12);


### PR DESCRIPTION
Hi! This PR addresses JMC-7063 [[0]](https://bugs.openjdk.java.net/browse/JMC-7063), in which there are test failures when running uitests on the threads page. This test failure has also been brought up in JMC-7077 [[1]](https://bugs.openjdk.java.net/browse/JMC-7077), which encompasses the larger problem of uitest failures in JMC 8.

The problem here was the hardcoded time strings (do'h!). I had originally thought the problem was Jemmy being unable to find the time filter text boxes due to screen size limitations, but in reality Jemmy couldn't find the text boxes because we had hardcoded the time strings in the test class for verification purposes. A big thanks to Bipin for posting a video clip of the test failure to the JMC-7077 [[1]](https://bugs.openjdk.java.net/browse/JMC-7077) issue report, I was able to see that Jemmy was struggling to find the text box with "08:06:19:489" because it was not the right time in his timezone!

To address this, Jemmy will now lookup the text boxes using a "name" that is assigned to them when they are created. The unit tests will now use a simple date formatter to apply a time offset to the start and end times to verify behaviour in the UI instead of checking against a (probably) incorrect hardcoded time string.

For quicker testing and reviewing, I've attached a patch diff (in txt format) that can be applied on top of this commit if you wish to only test the JfrThreadsPageTest. It simply prevents the non-flightrecorder.ui uitest modules from running, and gets rid of all other test classes: [only-jfrthreadspagetest.txt](https://github.com/openjdk/jmc/files/5797935/only-jfrthreadspagetest.txt)

[0] https://bugs.openjdk.java.net/browse/JMC-7063
[1] https://bugs.openjdk.java.net/browse/JMC-7077

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JMC-7063](https://bugs.openjdk.java.net/browse/JMC-7063): JfrThreadsPageTest (UI-test) fails


### Reviewers
 * [Marcus Hirt](https://openjdk.java.net/census#hirt) (@thegreystone - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jmc pull/195/head:pull/195`
`$ git checkout pull/195`
