### PR TITLE
4167: "Copy Column Headers" in stack trace view has no effect

### DIFF
--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/views/stacktrace/StacktraceView.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/views/stacktrace/StacktraceView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020, 2021, Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -88,7 +88,6 @@ import org.eclipse.ui.PartInitException;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.forms.widgets.FormText;
 import org.eclipse.ui.part.ViewPart;
-
 import org.openjdk.jmc.common.IDisplayable;
 import org.openjdk.jmc.common.IMCFrame;
 import org.openjdk.jmc.common.IState;
@@ -505,8 +504,10 @@ public class StacktraceView extends ViewPart implements ISelectionListener {
 		}
 		new StacktraceViewToolTipSupport(viewer);
 		MCContextMenuManager mm = MCContextMenuManager.create(viewer.getControl());
-		CopySelectionAction copyAction = new CopySelectionAction(viewer,
-				FormatToolkit.selectionFormatter(stackTraceLabelProvider, countLabelProvider, percentageLabelProvider));
+		List<String> headers = Arrays.asList(Messages.STACKTRACE_VIEW_STACK_TRACE,
+				Messages.STACKTRACE_VIEW_COUNT_COLUMN_NAME, Messages.STACKTRACE_VIEW_PERCENTAGE_COLUMN_NAME);
+		CopySelectionAction copyAction = new CopySelectionAction(viewer, FormatToolkit.selectionFormatter(headers,
+				stackTraceLabelProvider, countLabelProvider, percentageLabelProvider));
 		InFocusHandlerActivator.install(viewer.getControl(), copyAction);
 		mm.appendToGroup(MCContextMenuManager.GROUP_EDIT, copyAction);
 		mm.appendToGroup(MCContextMenuManager.GROUP_EDIT, CopySettings.getInstance().createContributionItem());

--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/views/stacktrace/StacktraceView.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/views/stacktrace/StacktraceView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/misc/FormatToolkit.java
+++ b/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/misc/FormatToolkit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -81,6 +81,20 @@ public class FormatToolkit {
 			Function<Stream<String>, String> rowFormatter = getPreferredRowFormatter();
 			Function<Object, String> objectFormatter = o -> rowFormatter.apply(Stream.of(lps).map(lp -> lp.getText(o)));
 			return FormatToolkit.formatSelection(selection, objectFormatter);
+		};
+	}
+
+	public static Function<IStructuredSelection, Stream<String>> selectionFormatter(
+		List<String> headers, ILabelProvider ... lps) {
+		return selection -> {
+			Function<Stream<String>, String> rowFormatter = getPreferredRowFormatter();
+			Function<Object, String> objectFormatter = o -> rowFormatter.apply(Stream.of(lps).map(lp -> lp.getText(o)));
+			Stream<String> strings = FormatToolkit.formatSelection(selection, objectFormatter);
+			if (CopySettings.getInstance().shouldCopyColumnHeaders()) {
+				return Stream.concat(Stream.of(rowFormatter.apply(headers.stream())), strings);
+			} else {
+				return strings;
+			}
 		};
 	}
 


### PR DESCRIPTION
Add explicitly header column names as ILabelProvider does not provide this information

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JMC-4167](https://bugs.openjdk.java.net/browse/JMC-4167): "Copy Column Headers" in stack trace view has no effect


### Reviewers
 * [Marcus Hirt](https://openjdk.java.net/census#hirt) (@thegreystone - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jmc pull/198/head:pull/198`
`$ git checkout pull/198`
