### PR TITLE
7039: Timestamp granularity too coarse

### DIFF
--- a/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/unit/TimestampKind.java
+++ b/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/unit/TimestampKind.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -140,8 +140,8 @@ class TimestampKind extends KindOfQuantity<TimestampUnit> {
 	}
 
 	static {
-		DateFormat df = new SimpleDateFormat("MM/dd/yyyy h:mm:ss:SSS a");
-		DATE_TIME_FORMATTER_HOLDER = new FormatThreadLocal<>(patchYear(df));
+		DateFormat df = patchYear(DateFormat.getDateTimeInstance(DateFormat.SHORT, DateFormat.MEDIUM));
+		DATE_TIME_FORMATTER_HOLDER = new FormatThreadLocal<>(df);
 	}
 
 	private static DateFormat patchYear(DateFormat df) {
@@ -183,9 +183,8 @@ class TimestampKind extends KindOfQuantity<TimestampUnit> {
 		YEAR_TO_MILLIS_FORMATTER = new LegacyAndFractionFormatter(DATE_TIME_FORMATTER_HOLDER, MILLIS_UNIT);
 		YEAR_TO_MICROS_FORMATTER = new LegacyAndFractionFormatter(DATE_TIME_FORMATTER_HOLDER, MICROS_UNIT);
 		YEAR_TO_NANOS_FORMATTER = new LegacyAndFractionFormatter(DATE_TIME_FORMATTER_HOLDER, NANOS_UNIT);
-		
-		DateFormat dateFormat = new SimpleDateFormat("h:mm:ss:SSS a");
-		FormatThreadLocal<DateFormat> timeHolder = new FormatThreadLocal<>(dateFormat);
+		FormatThreadLocal<DateFormat> timeHolder = new FormatThreadLocal<>(
+				DateFormat.getTimeInstance(DateFormat.MEDIUM));
 		HOUR_TO_SECONDS_FORMATTER = new LegacyFormatter(timeHolder);
 		HOUR_TO_MILLIS_FORMATTER = new LegacyAndFractionFormatter(timeHolder, MILLIS_UNIT);
 		HOUR_TO_MICROS_FORMATTER = new LegacyAndFractionFormatter(timeHolder, MICROS_UNIT);

--- a/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/unit/TimestampKind.java
+++ b/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/unit/TimestampKind.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -140,8 +140,8 @@ class TimestampKind extends KindOfQuantity<TimestampUnit> {
 	}
 
 	static {
-		DateFormat df = patchYear(DateFormat.getDateTimeInstance(DateFormat.SHORT, DateFormat.MEDIUM));
-		DATE_TIME_FORMATTER_HOLDER = new FormatThreadLocal<>(df);
+		DateFormat df = new SimpleDateFormat("MM/dd/yyyy h:mm:ss:SSS a");
+		DATE_TIME_FORMATTER_HOLDER = new FormatThreadLocal<>(patchYear(df));
 	}
 
 	private static DateFormat patchYear(DateFormat df) {
@@ -183,8 +183,9 @@ class TimestampKind extends KindOfQuantity<TimestampUnit> {
 		YEAR_TO_MILLIS_FORMATTER = new LegacyAndFractionFormatter(DATE_TIME_FORMATTER_HOLDER, MILLIS_UNIT);
 		YEAR_TO_MICROS_FORMATTER = new LegacyAndFractionFormatter(DATE_TIME_FORMATTER_HOLDER, MICROS_UNIT);
 		YEAR_TO_NANOS_FORMATTER = new LegacyAndFractionFormatter(DATE_TIME_FORMATTER_HOLDER, NANOS_UNIT);
-		FormatThreadLocal<DateFormat> timeHolder = new FormatThreadLocal<>(
-				DateFormat.getTimeInstance(DateFormat.MEDIUM));
+		
+		DateFormat dateFormat = new SimpleDateFormat("h:mm:ss:SSS a");
+		FormatThreadLocal<DateFormat> timeHolder = new FormatThreadLocal<>(dateFormat);
 		HOUR_TO_SECONDS_FORMATTER = new LegacyFormatter(timeHolder);
 		HOUR_TO_MILLIS_FORMATTER = new LegacyAndFractionFormatter(timeHolder, MILLIS_UNIT);
 		HOUR_TO_MICROS_FORMATTER = new LegacyAndFractionFormatter(timeHolder, MICROS_UNIT);

--- a/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/unit/UnitLookup.java
+++ b/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/unit/UnitLookup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -47,6 +47,7 @@ import static org.openjdk.jmc.common.unit.DecimalPrefix.YOCTO;
 import static org.openjdk.jmc.common.unit.DecimalPrefix.YOTTA;
 
 import java.text.DateFormat;
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -521,7 +522,8 @@ final public class UnitLookup {
 						try {
 							// NOTE: This used to return the floor value.
 							Date date = new Date(quantity.longValueIn(TimestampKind.MILLIS_UNIT));
-							return DateFormat.getDateTimeInstance(DateFormat.SHORT, DateFormat.MEDIUM).format(date);
+							DateFormat df = new SimpleDateFormat("MM/dd/yyyy h:mm:ss:SSS a");
+							return df.format(date);
 						} catch (QuantityConversionException e) {
 							return Messages.getString(Messages.UnitLookup_TIMESTAMP_OUT_OF_RANGE);
 						}

--- a/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/unit/UnitLookup.java
+++ b/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/unit/UnitLookup.java
@@ -517,7 +517,7 @@ final public class UnitLookup {
 		if (df instanceof SimpleDateFormat) {
 			SimpleDateFormat sdf = (SimpleDateFormat) df;
 			String pattern = sdf.toPattern();
-			String newPattern = pattern.replaceFirst("s{2,4}", "ss:SSS"); //$NON-NLS-1$ //$NON-NLS-2$
+			String newPattern = pattern.replaceFirst("s{2,4}", "ss.SSS"); //$NON-NLS-1$ //$NON-NLS-2$
 			sdf.applyPattern(newPattern);
 		}
 		return df;

--- a/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/unit/UnitLookup.java
+++ b/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/unit/UnitLookup.java
@@ -512,6 +512,16 @@ final public class UnitLookup {
 
 		return timeSpan;
 	}
+	
+	private static DateFormat patchTimestamp(DateFormat df) {
+		if (df instanceof SimpleDateFormat) {
+			SimpleDateFormat sdf = (SimpleDateFormat) df;
+			String pattern = sdf.toPattern();
+			String newPattern = pattern.replaceFirst("s{2,4}", "ss:SSS"); //$NON-NLS-1$ //$NON-NLS-2$
+			sdf.applyPattern(newPattern);
+		}
+		return df;
+	}
 
 	private static TimestampKind createTimestamp(LinearKindOfQuantity timespan) {
 		TimestampKind timestampContentType = TimestampKind.buildContentType(timespan);
@@ -522,7 +532,7 @@ final public class UnitLookup {
 						try {
 							// NOTE: This used to return the floor value.
 							Date date = new Date(quantity.longValueIn(TimestampKind.MILLIS_UNIT));
-							DateFormat df = new SimpleDateFormat("MM/dd/yyyy h:mm:ss:SSS a");
+							DateFormat df = patchTimestamp(DateFormat.getDateTimeInstance(DateFormat.SHORT, DateFormat.MEDIUM));
 							return df.format(date);
 						} catch (QuantityConversionException e) {
 							return Messages.getString(Messages.UnitLookup_TIMESTAMP_OUT_OF_RANGE);

--- a/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/unit/UnitLookup.java
+++ b/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/unit/UnitLookup.java
@@ -512,7 +512,7 @@ final public class UnitLookup {
 
 		return timeSpan;
 	}
-	
+
 	private static DateFormat patchTimestamp(DateFormat df) {
 		if (df instanceof SimpleDateFormat) {
 			SimpleDateFormat sdf = (SimpleDateFormat) df;
@@ -532,7 +532,8 @@ final public class UnitLookup {
 						try {
 							// NOTE: This used to return the floor value.
 							Date date = new Date(quantity.longValueIn(TimestampKind.MILLIS_UNIT));
-							DateFormat df = patchTimestamp(DateFormat.getDateTimeInstance(DateFormat.SHORT, DateFormat.MEDIUM));
+							DateFormat df = patchTimestamp(
+									DateFormat.getDateTimeInstance(DateFormat.SHORT, DateFormat.MEDIUM));
 							return df.format(date);
 						} catch (QuantityConversionException e) {
 							return Messages.getString(Messages.UnitLookup_TIMESTAMP_OUT_OF_RANGE);

--- a/core/tests/org.openjdk.jmc.flightrecorder.rules.jdk.test/src/test/resources/baseline/JfrRuleBaseline.xml
+++ b/core/tests/org.openjdk.jmc.flightrecorder.rules.jdk.test/src/test/resources/baseline/JfrRuleBaseline.xml
@@ -2037,7 +2037,7 @@ Enabling the following event types would improve the accuracy of this rule: jdk.
 <id>ManyRunningProcesses</id>
 <severity>OK</severity>
 <summary>137 processes were running while this Flight Recording was made.</summary>
-<explanation>At 4/4/14 11:17:10 AM, a total of 137 other processes were running on the host machine that this Flight Recording was made on.</explanation>
+<explanation>At 4/4/14 11:17:10:326 AM, a total of 137 other processes were running on the host machine that this Flight Recording was made on.</explanation>
 <solution>If this is a server environment, it may be good to only run other critical processes on that machine.</solution>
 </rule>
 <rule>
@@ -2322,7 +2322,7 @@ Enabling the following event types would improve the accuracy of this rule: jdk.
 <id>ManyRunningProcesses</id>
 <severity>OK</severity>
 <summary>137 processes were running while this Flight Recording was made.</summary>
-<explanation>At 4/4/14 8:54:38 AM, a total of 137 other processes were running on the host machine that this Flight Recording was made on.</explanation>
+<explanation>At 4/4/14 8:54:38:623 AM, a total of 137 other processes were running on the host machine that this Flight Recording was made on.</explanation>
 <solution>If this is a server environment, it may be good to only run other critical processes on that machine.</solution>
 </rule>
 <rule>

--- a/core/tests/org.openjdk.jmc.flightrecorder.rules.jdk.test/src/test/resources/baseline/JfrRuleBaseline.xml
+++ b/core/tests/org.openjdk.jmc.flightrecorder.rules.jdk.test/src/test/resources/baseline/JfrRuleBaseline.xml
@@ -2037,7 +2037,7 @@ Enabling the following event types would improve the accuracy of this rule: jdk.
 <id>ManyRunningProcesses</id>
 <severity>OK</severity>
 <summary>137 processes were running while this Flight Recording was made.</summary>
-<explanation>At 4/4/14 11:17:10:326 AM, a total of 137 other processes were running on the host machine that this Flight Recording was made on.</explanation>
+<explanation>At 4/4/14 11:17:10.326 AM, a total of 137 other processes were running on the host machine that this Flight Recording was made on.</explanation>
 <solution>If this is a server environment, it may be good to only run other critical processes on that machine.</solution>
 </rule>
 <rule>
@@ -2322,7 +2322,7 @@ Enabling the following event types would improve the accuracy of this rule: jdk.
 <id>ManyRunningProcesses</id>
 <severity>OK</severity>
 <summary>137 processes were running while this Flight Recording was made.</summary>
-<explanation>At 4/4/14 8:54:38:623 AM, a total of 137 other processes were running on the host machine that this Flight Recording was made on.</explanation>
+<explanation>At 4/4/14 8:54:38.623 AM, a total of 137 other processes were running on the host machine that this Flight Recording was made on.</explanation>
 <solution>If this is a server environment, it may be good to only run other critical processes on that machine.</solution>
 </rule>
 <rule>


### PR DESCRIPTION
As part of this enhancement request, user can see the timestamps down to fraction of a second.
This will solve the problem for all views, including Event Browser, Properties where most of the records are differentiated by fraction of seconds but since the timestamp shown is only till second, the difference is not visible on UI.

For ex: If the End Time of Event is listed as below, the difference is clearly visible
![image](https://user-images.githubusercontent.com/11155712/105097851-465a8680-5acf-11eb-8a5c-f01ecb3390ce.png)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JMC-7039](https://bugs.openjdk.java.net/browse/JMC-7039): Timestamp granularity too coarse


### Reviewers
 * [Marcus Hirt](https://openjdk.java.net/census#hirt) (@thegreystone - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jmc pull/201/head:pull/201`
`$ git checkout pull/201`
