### PR TITLE
7117: JMC with Eclipse 2020-06 fails to launch in simplified Chinese language

### DIFF
--- a/releng/platform-definitions/platform-definition-2020-06/platform-definition-2020-06.target
+++ b/releng/platform-definitions/platform-definition-2020-06/platform-definition-2020-06.target
@@ -55,9 +55,9 @@
             <repository location="http://download.eclipse.org/releases/2020-06/"/>
         </location>
         <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-            <unit id="org.eclipse.babel.nls_eclipse_ja.feature.group" version="4.16.0.v20200711020001"/>
-            <unit id="org.eclipse.babel.nls_eclipse_zh.feature.group" version="4.16.0.v20200711020001"/>
-            <repository location="https://archive.eclipse.org/technology/babel/update-site/R0.18.0/2020-06/"/>
+            <unit id="org.eclipse.babel.nls_eclipse_ja.feature.group" version="4.16.0.v20201226013120"/>
+            <unit id="org.eclipse.babel.nls_eclipse_zh.feature.group" version="4.16.0.v20201226013120"/>
+            <repository location="https://archive.eclipse.org/technology/babel/update-site/R0.18.2/2020-06/"/>
         </location>
         <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
             <unit id="com.make.chromium.cef.feature.feature.group" version="0.4.0.202005172227"/>


### PR DESCRIPTION
Jmc fails to launch with Eclipse 2020-06 SDK in "zh_CN" (simplified Chinese Language). 
Note: This defect is only for Eclipse 2020-06 and not with Eclipse 2020-09 or later . 

Solution : Using the latest version of babel which has the fix as part of https://bugs.eclipse.org/bugs/show_bug.cgi?id=565976 (Fixed in https://bugs.eclipse.org/bugs/show_bug.cgi?id=565380 )

 

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JMC-7117](https://bugs.openjdk.java.net/browse/JMC-7117): JMC with Eclipse 2020-06 fails to launch in simplified Chinese language 


### Reviewers
 * [Marcus Hirt](https://openjdk.java.net/census#hirt) (@thegreystone - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jmc pull/207/head:pull/207`
`$ git checkout pull/207`
