### PR TITLE
7088: Show concurrent option showing lesser number of records.

### DIFF
--- a/core/org.openjdk.jmc.flightrecorder.rules/src/main/java/org/openjdk/jmc/flightrecorder/rules/util/RulesToolkit.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules/src/main/java/org/openjdk/jmc/flightrecorder/rules/util/RulesToolkit.java
@@ -1360,7 +1360,7 @@ public class RulesToolkit {
 	}
 
 	private static final IAggregator<IQuantity, ?> EARLIEST_START_TIME = Aggregators.min(JfrAttributes.START_TIME);
-	
+
 	/**
 	 * Returns the earliest start time in the provided item collection. This method is based on the
 	 * assumption that item collection lanes are sorted by timestamp.
@@ -1396,7 +1396,7 @@ public class RulesToolkit {
 	}
 
 	private static final IAggregator<IQuantity, ?> EARLIEST_END_TIME = Aggregators.min(JfrAttributes.END_TIME);
-	
+
 	/**
 	 * Returns the earliest end time in the provided item collection. This method is based on the
 	 * assumption that item collection lanes are sorted by timestamp and are not overlapping.
@@ -1430,9 +1430,9 @@ public class RulesToolkit {
 			return items.getAggregate(EARLIEST_END_TIME);
 		}
 	}
-	
+
 	private static final IAggregator<IQuantity, ?> LATEST_END_TIME = Aggregators.max(JfrAttributes.END_TIME);
-	
+
 	/**
 	 * Returns the latest end time in the provided item collection. This method is based on the
 	 * assumption that item collection lanes are sorted by timestamp and are not overlapping.

--- a/core/org.openjdk.jmc.flightrecorder.rules/src/main/java/org/openjdk/jmc/flightrecorder/rules/util/RulesToolkit.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules/src/main/java/org/openjdk/jmc/flightrecorder/rules/util/RulesToolkit.java
@@ -1370,6 +1370,7 @@ public class RulesToolkit {
 	 * @return the earliest start time in the provided collection
 	 */
 	public static IQuantity getEarliestStartTime(IItemCollection items) {
+		// JMC-7088: We use this check to disable the optimisation for IItemCollection implementations that don't contain sorted event lanes.
 		if (items.getClass().getName().equals("EventCollection")) { //$NON-NLS-1$
 			IQuantity earliestStartTime = null;
 			for (IItemIterable iItemIterable : items) {
@@ -1406,6 +1407,7 @@ public class RulesToolkit {
 	 * @return the earliest end time in the provided collection
 	 */
 	public static IQuantity getEarliestEndTime(IItemCollection items) {
+		// JMC-7088: We use this check to disable the optimisation for IItemCollection implementations that don't contain sorted event lanes.
 		if (items.getClass().getName().equals("EventCollection")) { //$NON-NLS-1$
 			IQuantity earliestEndTime = null;
 			for (IItemIterable iItemIterable : items) {
@@ -1442,6 +1444,7 @@ public class RulesToolkit {
 	 * @return the latest end time in the provided collection
 	 */
 	public static IQuantity getLatestEndTime(IItemCollection items) {
+		// JMC-7088: We use this check to disable the optimisation for IItemCollection implementations that don't contain sorted event lanes.
 		if (items.getClass().getName().equals("EventCollection")) { //$NON-NLS-1$
 			IQuantity latestEndTime = null;
 			for (IItemIterable iItemIterable : items) {

--- a/core/org.openjdk.jmc.flightrecorder.rules/src/main/java/org/openjdk/jmc/flightrecorder/rules/util/RulesToolkit.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules/src/main/java/org/openjdk/jmc/flightrecorder/rules/util/RulesToolkit.java
@@ -1359,6 +1359,8 @@ public class RulesToolkit {
 		return sortedMap;
 	}
 
+	private static final IAggregator<IQuantity, ?> EARLIEST_START_TIME = Aggregators.min(JfrAttributes.START_TIME);
+	
 	/**
 	 * Returns the earliest start time in the provided item collection. This method is based on the
 	 * assumption that item collection lanes are sorted by timestamp.
@@ -1368,27 +1370,33 @@ public class RulesToolkit {
 	 * @return the earliest start time in the provided collection
 	 */
 	public static IQuantity getEarliestStartTime(IItemCollection items) {
-		IQuantity earliestStartTime = null;
-		for (IItemIterable iItemIterable : items) {
-			IMemberAccessor<IQuantity, IItem> startTimeAccessor = JfrAttributes.START_TIME
-					.getAccessor(iItemIterable.getType());
-			if (iItemIterable.iterator().hasNext()) {
-				IItem next = iItemIterable.iterator().next();
-				if (next != null && startTimeAccessor != null) {
-					IQuantity startTime = startTimeAccessor.getMember(next);
-					if (earliestStartTime == null) {
-						earliestStartTime = startTime;
-					} else {
-						if (earliestStartTime.compareTo(startTime) >= 0) {
+		if (items.getClass().getName().equals("EventCollection")) { //$NON-NLS-1$
+			IQuantity earliestStartTime = null;
+			for (IItemIterable iItemIterable : items) {
+				IMemberAccessor<IQuantity, IItem> startTimeAccessor = JfrAttributes.START_TIME
+						.getAccessor(iItemIterable.getType());
+				if (iItemIterable.iterator().hasNext()) {
+					IItem next = iItemIterable.iterator().next();
+					if (next != null && startTimeAccessor != null) {
+						IQuantity startTime = startTimeAccessor.getMember(next);
+						if (earliestStartTime == null) {
 							earliestStartTime = startTime;
+						} else {
+							if (earliestStartTime.compareTo(startTime) >= 0) {
+								earliestStartTime = startTime;
+							}
 						}
 					}
 				}
 			}
+			return earliestStartTime;
+		} else {
+			return items.getAggregate(EARLIEST_START_TIME);
 		}
-		return earliestStartTime;
 	}
 
+	private static final IAggregator<IQuantity, ?> EARLIEST_END_TIME = Aggregators.min(JfrAttributes.END_TIME);
+	
 	/**
 	 * Returns the earliest end time in the provided item collection. This method is based on the
 	 * assumption that item collection lanes are sorted by timestamp and are not overlapping.
@@ -1398,27 +1406,33 @@ public class RulesToolkit {
 	 * @return the earliest end time in the provided collection
 	 */
 	public static IQuantity getEarliestEndTime(IItemCollection items) {
-		IQuantity earliestEndTime = null;
-		for (IItemIterable iItemIterable : items) {
-			IMemberAccessor<IQuantity, IItem> endTimeAccessor = JfrAttributes.END_TIME
-					.getAccessor(iItemIterable.getType());
-			if (iItemIterable.iterator().hasNext()) {
-				IItem next = iItemIterable.iterator().next();
-				if (next != null && endTimeAccessor != null) {
-					IQuantity endTime = endTimeAccessor.getMember(next);
-					if (earliestEndTime == null) {
-						earliestEndTime = endTime;
-					} else {
-						if (earliestEndTime.compareTo(endTime) >= 0) {
+		if (items.getClass().getName().equals("EventCollection")) { //$NON-NLS-1$
+			IQuantity earliestEndTime = null;
+			for (IItemIterable iItemIterable : items) {
+				IMemberAccessor<IQuantity, IItem> endTimeAccessor = JfrAttributes.END_TIME
+						.getAccessor(iItemIterable.getType());
+				if (iItemIterable.iterator().hasNext()) {
+					IItem next = iItemIterable.iterator().next();
+					if (next != null && endTimeAccessor != null) {
+						IQuantity endTime = endTimeAccessor.getMember(next);
+						if (earliestEndTime == null) {
 							earliestEndTime = endTime;
+						} else {
+							if (earliestEndTime.compareTo(endTime) >= 0) {
+								earliestEndTime = endTime;
+							}
 						}
 					}
 				}
 			}
+			return earliestEndTime;
+		} else {
+			return items.getAggregate(EARLIEST_END_TIME);
 		}
-		return earliestEndTime;
 	}
-
+	
+	private static final IAggregator<IQuantity, ?> LATEST_END_TIME = Aggregators.max(JfrAttributes.END_TIME);
+	
 	/**
 	 * Returns the latest end time in the provided item collection. This method is based on the
 	 * assumption that item collection lanes are sorted by timestamp and are not overlapping.
@@ -1428,26 +1442,31 @@ public class RulesToolkit {
 	 * @return the latest end time in the provided collection
 	 */
 	public static IQuantity getLatestEndTime(IItemCollection items) {
-		IQuantity latestEndTime = null;
-		for (IItemIterable iItemIterable : items) {
-			IMemberAccessor<IQuantity, IItem> endTimeAccessor = JfrAttributes.END_TIME
-					.getAccessor(iItemIterable.getType());
-			Iterator<IItem> iterator = iItemIterable.iterator();
-			IItem next = null;
-			while (iterator.hasNext()) {
-				next = iterator.next();
-			}
-			if (next != null && endTimeAccessor != null) {
-				IQuantity startTime = endTimeAccessor.getMember(next);
-				if (latestEndTime == null) {
-					latestEndTime = startTime;
-				} else {
-					if (latestEndTime.compareTo(startTime) <= 0) {
-						latestEndTime = startTime;
+		if (items.getClass().getName().equals("EventCollection")) { //$NON-NLS-1$
+			IQuantity latestEndTime = null;
+			for (IItemIterable iItemIterable : items) {
+				IMemberAccessor<IQuantity, IItem> endTimeAccessor = JfrAttributes.END_TIME
+						.getAccessor(iItemIterable.getType());
+				Iterator<IItem> iterator = iItemIterable.iterator();
+				IItem next = null;
+				while (iterator.hasNext()) {
+					next = iterator.next();
+				}
+				if (next != null && endTimeAccessor != null) {
+					IQuantity endTime = endTimeAccessor.getMember(next);
+					if (latestEndTime == null) {
+						latestEndTime = endTime;
+					} else {
+						if (latestEndTime.compareTo(endTime) <= 0) {
+							latestEndTime = endTime;
+						}
 					}
 				}
 			}
+			return latestEndTime;
+		} else {
+			return items.getAggregate(LATEST_END_TIME);
 		}
-		return latestEndTime;
+
 	}
 }


### PR DESCRIPTION
Due to how StreamBackedItemCollections differ from EventCollections we can't rely on the assumption made that disjoint events are sorted in each IItemIterable. And since the classes aren't visible from RulesToolkit we have to look at the class name like this.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JMC-7088](https://bugs.openjdk.java.net/browse/JMC-7088): Show concurrent option showing lesser number of records.


### Reviewers
 * [Marcus Hirt](https://openjdk.java.net/census#hirt) (@thegreystone - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jmc pull/208/head:pull/208`
`$ git checkout pull/208`
