### PR TITLE
7130: JfrThreadsPageTest (UI-test) fails (part 2)

### DIFF
--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/messages/internal/Messages.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/messages/internal/Messages.java
@@ -525,6 +525,7 @@ public class Messages extends NLS {
 	public static String ThreadsPage_NAME;
 	public static String ThreadsPage_NAME_LEGACY;
 	public static String ThreadsPage_RESET_CHART_TO_SELECTION_ACTION;
+	public static String ThreadsPage_SCROLLED_COMPOSITE_NAME;
 	public static String ThreadsPage_SHOW_CHART_TOOLTIP;
 	public static String ThreadsPage_SHOW_TABLE_TOOLTIP;
 	public static String ThreadsPage_TABLE_POPUP_DESCRIPTION;

--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/ThreadsPageLayoutUI.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/ThreadsPageLayoutUI.java
@@ -85,6 +85,7 @@ import org.openjdk.jmc.ui.misc.TimelineCanvas;
 abstract class ThreadsPageLayoutUI extends ChartAndTableUI {
 
 	private static final double Y_SCALE = Display.getCurrent().getDPI().y / Environment.getNormalDPI();
+	private static final String SCROLLED_COMPOSITE_NAME = Messages.ThreadsPage_SCROLLED_COMPOSITE_NAME; //$NON-NLS-1$
 	private static final String TABLE = "table"; //$NON-NLS-1$
 	private static final String CHART = "chart"; //$NON-NLS-1$
 	private static final String CANVAS_SASH = "canvasSash"; //$NON-NLS-1$
@@ -202,6 +203,7 @@ abstract class ThreadsPageLayoutUI extends ChartAndTableUI {
 	private void setupChartContainers(FormToolkit toolkit) {
 		// Scrolled Composite containing all of the chart-related components
 		ScrolledComposite scChartContainer = new ScrolledComposite(sash, SWT.H_SCROLL | SWT.V_SCROLL);
+		scChartContainer.setData("name", SCROLLED_COMPOSITE_NAME ); //$NON-NLS-1$
 		scChartContainer.setAlwaysShowScrollBars(false);
 		scChartContainer.setExpandHorizontal(true);
 		scChartContainer.setExpandVertical(true);

--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/ThreadsPageLayoutUI.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/ThreadsPageLayoutUI.java
@@ -203,7 +203,7 @@ abstract class ThreadsPageLayoutUI extends ChartAndTableUI {
 	private void setupChartContainers(FormToolkit toolkit) {
 		// Scrolled Composite containing all of the chart-related components
 		ScrolledComposite scChartContainer = new ScrolledComposite(sash, SWT.H_SCROLL | SWT.V_SCROLL);
-		scChartContainer.setData("name", SCROLLED_COMPOSITE_NAME ); //$NON-NLS-1$
+		scChartContainer.setData("name", SCROLLED_COMPOSITE_NAME); //$NON-NLS-1$
 		scChartContainer.setAlwaysShowScrollBars(false);
 		scChartContainer.setExpandHorizontal(true);
 		scChartContainer.setExpandVertical(true);

--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/resources/org/openjdk/jmc/flightrecorder/ui/messages/internal/messages.properties
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/resources/org/openjdk/jmc/flightrecorder/ui/messages/internal/messages.properties
@@ -505,6 +505,7 @@ ThreadsPage_LANE_TOOLTIP_TITLE={0} / {1} Lane
 ThreadsPage_NAME=Threads
 ThreadsPage_NAME_LEGACY = (Legacy) Threads
 ThreadsPage_RESET_CHART_TO_SELECTION_ACTION=Reset The Chart To Current Selection
+ThreadsPage_SCROLLED_COMPOSITE_NAME=threadspagelayoutui.scrolledcomposite.name
 ThreadsPage_SHOW_CHART_TOOLTIP=Show Chart
 ThreadsPage_SHOW_TABLE_TOOLTIP=Show Table
 ThreadsPage_VIEW_THREAD_DETAILS=View Thread Details

--- a/application/uitests/org.openjdk.jmc.flightrecorder.uitest/src/test/java/org/openjdk/jmc/flightrecorder/uitest/JfrThreadsPageTest.java
+++ b/application/uitests/org.openjdk.jmc.flightrecorder.uitest/src/test/java/org/openjdk/jmc/flightrecorder/uitest/JfrThreadsPageTest.java
@@ -123,10 +123,10 @@ public class JfrThreadsPageTest extends MCJemmyTestBase {
 	};
 
 	/**
-	 * Some tests require interaction with the chart canvas, and may not work if widgets are obstructed.
-	 *
-	 * If the scrolled composite has a horizontal scrollbar, some widgets may not be visible.
-	 * If the chart canvas is too short, then the tests might not be able to interact with the required lanes.
+	 * Some tests require interaction with the chart canvas, and may not work if widgets are
+	 * obstructed. If the scrolled composite has a horizontal scrollbar, some widgets may not be
+	 * visible. If the chart canvas is too short, then the tests might not be able to interact with
+	 * the required lanes.
 	 *
 	 * @return true if all the controls required are visible
 	 */

--- a/application/uitests/org.openjdk.jmc.test.jemmy/src/test/java/org/openjdk/jmc/test/jemmy/misc/wrappers/MCChartCanvas.java
+++ b/application/uitests/org.openjdk.jmc.test.jemmy/src/test/java/org/openjdk/jmc/test/jemmy/misc/wrappers/MCChartCanvas.java
@@ -148,6 +148,22 @@ public class MCChartCanvas extends MCJemmyBase {
 	}
 
 	/**
+	 * Fetches the height of the Chart Canvas
+	 *
+	 * @return the height of the Chart Canvas
+	 */
+	public int getHeight()  {
+		Fetcher<Integer> fetcher = new Fetcher<Integer>() {
+			@Override
+			public void run() {
+				setOutput(control.getControl().getParent().getSize().y);
+			}
+		};
+		Display.getDefault().syncExec(fetcher);
+		return fetcher.getOutput();
+	}
+
+	/**
 	 * Calculates the click point of the Chart Canvas
 	 *
 	 * @return the Point of the Chart Canvas

--- a/application/uitests/org.openjdk.jmc.test.jemmy/src/test/java/org/openjdk/jmc/test/jemmy/misc/wrappers/MCChartCanvas.java
+++ b/application/uitests/org.openjdk.jmc.test.jemmy/src/test/java/org/openjdk/jmc/test/jemmy/misc/wrappers/MCChartCanvas.java
@@ -152,7 +152,7 @@ public class MCChartCanvas extends MCJemmyBase {
 	 *
 	 * @return the height of the Chart Canvas
 	 */
-	public int getHeight()  {
+	public int getHeight() {
 		Fetcher<Integer> fetcher = new Fetcher<Integer>() {
 			@Override
 			public void run() {

--- a/application/uitests/org.openjdk.jmc.test.jemmy/src/test/java/org/openjdk/jmc/test/jemmy/misc/wrappers/MCScrolledComposite.java
+++ b/application/uitests/org.openjdk.jmc.test.jemmy/src/test/java/org/openjdk/jmc/test/jemmy/misc/wrappers/MCScrolledComposite.java
@@ -78,7 +78,8 @@ public class MCScrolledComposite extends MCJemmyBase {
 	 */
 	@SuppressWarnings("unchecked")
 	public static MCScrolledComposite getByName(Wrap<? extends Shell> shell, String name, StringComparePolicy policy) {
-		return new MCScrolledComposite(shell.as(Parent.class, ScrolledComposite.class).lookup(ScrolledComposite.class, new ByName<>(name, policy)).wrap());
+		return new MCScrolledComposite(shell.as(Parent.class, ScrolledComposite.class)
+				.lookup(ScrolledComposite.class, new ByName<>(name, policy)).wrap());
 	}
 
 	/**

--- a/application/uitests/org.openjdk.jmc.test.jemmy/src/test/java/org/openjdk/jmc/test/jemmy/misc/wrappers/MCScrolledComposite.java
+++ b/application/uitests/org.openjdk.jmc.test.jemmy/src/test/java/org/openjdk/jmc/test/jemmy/misc/wrappers/MCScrolledComposite.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Red Hat Inc. All rights reserved.
+ *
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * The contents of this file are subject to the terms of either the Universal Permissive License
+ * v 1.0 as shown at http://oss.oracle.com/licenses/upl
+ *
+ * or the following license:
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted
+ * provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions
+ * and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other materials provided with
+ * the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to
+ * endorse or promote products derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+ * WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.openjdk.jmc.test.jemmy.misc.wrappers;
+
+import org.eclipse.swt.custom.ScrolledComposite;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.Shell;
+import org.jemmy.control.Wrap;
+import org.jemmy.interfaces.Parent;
+import org.jemmy.resources.StringComparePolicy;
+import org.jemmy.swt.lookup.ByName;
+import org.openjdk.jmc.test.jemmy.misc.base.wrappers.MCJemmyBase;
+import org.openjdk.jmc.test.jemmy.misc.fetchers.Fetcher;
+
+public class MCScrolledComposite extends MCJemmyBase {
+	private static final StringComparePolicy EXACT_POLICY = StringComparePolicy.EXACT;
+
+	private MCScrolledComposite(Wrap<? extends ScrolledComposite> sc) {
+		this.control = sc;
+	}
+
+	/**
+	 * Finds and returns a {@link MCScrolledComposite}
+	 * 
+	 * @param shell
+	 *            the shell from where to start searching for this widget
+	 * @param name
+	 *            the name of the widget (matched by using the default matching policy,
+	 *            {@link StringComparePolicy.EXACT})
+	 * @return a {@link MCScrolledComposite} that matches the name
+	 */
+	public static MCScrolledComposite getByName(String name) {
+		return getByName(getShell(), name, EXACT_POLICY);
+
+	}
+
+	/**
+	 * Finds and returns a {@link MCScrolledComposite}
+	 * 
+	 * @param shell
+	 *            the shell from where to start searching for this widget
+	 * @param name
+	 *            the name of the widget
+	 * @param policy
+	 *            A {@link StringComparePolicy} for matching the name
+	 * @return a {@link MCScrolledComposite} that matches the name
+	 */
+	@SuppressWarnings("unchecked")
+	public static MCScrolledComposite getByName(Wrap<? extends Shell> shell, String name, StringComparePolicy policy) {
+		return new MCScrolledComposite(shell.as(Parent.class, ScrolledComposite.class).lookup(ScrolledComposite.class, new ByName<>(name, policy)).wrap());
+	}
+
+	/**
+	 * Returns the visibility of the horizontal scrollbar
+	 * 
+	 * @return true if the horizontal scrollbar is visible
+	 */
+	public boolean isHorizontalBarVisible() {
+		final ScrolledComposite sc = (ScrolledComposite) control.getControl();
+		Fetcher<Boolean> fetcher = new Fetcher<Boolean>() {
+			@Override
+			public void run() {
+				setOutput(sc.getHorizontalBar().isVisible());
+			}
+		};
+		Display.getDefault().syncExec(fetcher);
+		return fetcher.getOutput();
+	}
+}


### PR DESCRIPTION
This PR is related to JMC-7077, and is a continuation of the fix for JMC-7063 [1].

After updating the `JfrThreadsPageTest` tests to better handle timestamps, Bipin mentioned in JMC-7077 [0] that some tests were still failing due to focusing issues. This PR attempts to address these issues, by adding checks to make sure the ui is a sufficient size to run the tests that require interaction with the canvases. I've chosen to label this fix as 7063 part 2, because JMC-7077 is loaded and isn't only concerned with these changes. Let me know if this works, otherwise I can change the commit message and PR title.

Now there is a new function in the test class to verify that the controls are visible. It does this by first checking the scrolled composite for a horizontal scrollbar (if there is one then some widgets may not be visible), and then checks the height of the ChartCanvas to ensure that the lanes can be interacted with. If the ui is not large enough for this criteria, then the tests are skipped using `Assume.assumeTrue()` in the specific unit tests. I've played around with varying ui dimensions by altering the height/width values in `ApplicationWorkbenchWindowAdvisor.java`, and the tests look to be skipped when appropriate.

For example, I set the width to be 600px, and the resulting test run:
```
Tests run: 10, Failures: 0, Errors: 0, Skipped: 6, Time elapsed: 112.402 s - in org.openjdk.jmc.flightrecorder.uitest.JfrThreadsPageTest
testHideAllThreads(org.openjdk.jmc.flightrecorder.uitest.JfrThreadsPageTest) skipped
testTextCanvasSelection(org.openjdk.jmc.flightrecorder.uitest.JfrThreadsPageTest) skipped
testZoom(org.openjdk.jmc.flightrecorder.uitest.JfrThreadsPageTest) skipped
testFoldingChart(org.openjdk.jmc.flightrecorder.uitest.JfrThreadsPageTest)  Time elapsed: 20.694 s
testFoldingTable(org.openjdk.jmc.flightrecorder.uitest.JfrThreadsPageTest)  Time elapsed: 10.219 s
testMenuItemEnablement(org.openjdk.jmc.flightrecorder.uitest.JfrThreadsPageTest) skipped
testInvalidFoldingActions(org.openjdk.jmc.flightrecorder.uitest.JfrThreadsPageTest)  Time elapsed: 9.268 s
testResetButtons(org.openjdk.jmc.flightrecorder.uitest.JfrThreadsPageTest) skipped
testTimeFilterInvalid(org.openjdk.jmc.flightrecorder.uitest.JfrThreadsPageTest) skipped
testPersistingSashWeights(org.openjdk.jmc.flightrecorder.uitest.JfrThreadsPageTest)  Time elapsed: 15.607 s
```

[0] https://bugs.openjdk.java.net/browse/JMC-7077
[1] https://github.com/openjdk/jmc/commit/8d6fb1b70f96c52f3bd71584ddca287c802e1f6f

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JMC-7130](https://bugs.openjdk.java.net/browse/JMC-7130): JfrThreadsPageTest (UI-test) fails (part 2)


### Reviewers
 * [Marcus Hirt](https://openjdk.java.net/census#hirt) (@thegreystone - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jmc pull/209/head:pull/209`
`$ git checkout pull/209`
