### PR TITLE
7121: Unhandled exception while working with Thread Graphs

### DIFF
--- a/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/misc/ChartCanvas.java
+++ b/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/misc/ChartCanvas.java
@@ -287,8 +287,9 @@ public class ChartCanvas extends Canvas {
 	}
 
 	protected int initMinLaneHeight() {
+		// if there are no items, or
 		// if the min readable lane height * the number of items exceeds the screen, then use min readable height
-		if (minReadableLaneHeight * getNumItems() > getParent().getSize().y) {
+		if (getNumItems() == 0 || minReadableLaneHeight * getNumItems() > getParent().getSize().y) {
 			return minReadableLaneHeight;
 		} else { // if the minimum readable lane height * the number of items leaves extra space, then the min height is the height / number of items
 			return getParent().getSize().y / getNumItems();


### PR DESCRIPTION
This short PR addresses JMC-7121 [0], in which a  division by 0 error can occur when viewing the threads page with a focused selection that has no relevant thread information. A big thanks to Bipin for catching this, but for also providing easy steps to reproduce the issue.

The fix here adds a check when initializing the minimum lane height, ensuring that the default value gets set if there are no items.

[0] https://bugs.openjdk.java.net/browse/JMC-7121

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JMC-7121](https://bugs.openjdk.java.net/browse/JMC-7121): Unhandled exception while working with Thread Graphs


### Reviewers
 * [Marcus Hirt](https://openjdk.java.net/census#hirt) (@thegreystone - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jmc pull/210/head:pull/210`
`$ git checkout pull/210`
