### PR TITLE
7120: Charts in custom pages are not auto refreshed

### DIFF
--- a/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/misc/ChartCanvas.java
+++ b/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/misc/ChartCanvas.java
@@ -714,6 +714,7 @@ public class ChartCanvas extends Canvas {
 	public void setChart(XYChart awtChart) {
 		this.awtChart = awtChart;
 		notifyListener();
+		redrawChart();
 	}
 
 	public void setTextCanvas(ChartTextCanvas textCanvas) {


### PR DESCRIPTION
This PR addresses JMC-7120 [0], in which charts in the custom pages are not auto refreshed. This issue is a regression from the changes to the `ChartCanvas` in the threads page enhancement, sorry about that.

The culprit here was the wrongful removal of a `redrawChart()` call in `ChartCanvas.setChart`. Looking back through the old commits I have for the Threads Page work I couldn't find where it was removed, but it must have been pretty early into the work. I noticed that the `redrawChart()` is present in JMC 7 [1] and in the commit prior to the threads page pr going in [2], but not afterwards [3]. This PR simply adds back the redraw call.

gif:
![7120](https://user-images.githubusercontent.com/10425301/106956199-462fcd00-6704-11eb-9dad-f60ff55590a5.gif)

[0] https://bugs.openjdk.java.net/browse/JMC-7120
[1] https://hg.openjdk.java.net/jmc/jmc7/file/63ec7d0ee8d9/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/misc/ChartCanvas.java#l533
[2] https://github.com/openjdk/jmc/blob/c3f49204ce36139ac83ccfa88b2ada26a0b2cd04/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/misc/ChartCanvas.java#L533
[3] https://github.com/openjdk/jmc/blob/5feaf25fa2a4a61236a733053dc60134c89efccf/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/misc/ChartCanvas.java#L716

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JMC-7120](https://bugs.openjdk.java.net/browse/JMC-7120): Charts in custom pages are not auto refreshed 


### Reviewers
 * [Marcus Hirt](https://openjdk.java.net/census#hirt) (@thegreystone - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jmc pull/211/head:pull/211`
`$ git checkout pull/211`
