### PR TITLE
7040: Event list is not updated and Stack trace stale upon Set as Focused Selection

### DIFF
--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/EventBrowserPage.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/EventBrowserPage.java
@@ -248,8 +248,6 @@ public class EventBrowserPage extends AbstractDataPage {
 		}
 
 		private void refreshTree() {
-			boolean noTypesWereSelected = selectedTypes.isEmpty();
-
 			typeFilterTree.getViewer().getControl().setRedraw(false);
 			TreePath[] expansion = typeFilterTree.getViewer().getExpandedTreePaths();
 			ISelection selection = typeFilterTree.getViewer().getSelection();
@@ -259,11 +257,7 @@ public class EventBrowserPage extends AbstractDataPage {
 			typeFilterTree.getViewer().setSelection(selection);
 			typeFilterTree.getViewer().getControl().setRedraw(true);
 			typeFilterTree.getViewer().getControl().redraw();
-
-			if (noTypesWereSelected) {
-				// force re-interpretation of empty type selection
-				rebuildItemList();
-			}
+			rebuildItemList();
 		}
 
 		private IItemCollection getFilteredItems() {


### PR DESCRIPTION
This PR fixes the issue of the event table not refreshing on change of focused selection.

Please review the change.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JMC-7040](https://bugs.openjdk.java.net/browse/JMC-7040): Event list is not updated and Stack trace stale upon Set as Focused Selection


### Reviewers
 * @oscerd (no known github.com user name / role)
 * [Marcus Hirt](https://openjdk.java.net/census#hirt) (@thegreystone - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jmc pull/213/head:pull/213`
`$ git checkout pull/213`
