### PR TITLE
7133: Update the build script help to include the installCore option

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,7 @@ Prerequisites for building Mission Control:
 On Linux you can use the build.sh script to build JMC:
 ```
 usage: call ./build.sh with the following options:
+   --installCore to install the core artifacts
    --test        to run the tests
    --testUi      to run the tests including UI tests
    --packageJmc  to package JMC


### PR DESCRIPTION
Noticed this: if you build jmc with build.sh script for the first time, you'll need to run the installCore command first and then all the command listed for testing and packaging it.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JMC-7133](https://bugs.openjdk.java.net/browse/JMC-7133): Update the build script help to include the installCore option


### Reviewers
 * [Marcus Hirt](https://openjdk.java.net/census#hirt) (@thegreystone - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jmc pull/215/head:pull/215`
`$ git checkout pull/215`
