### PR TITLE
7205: Correct URL for Oracle's JMC production binaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Binary distributions of JDK Mission Control are provided by different downstream
 * Integrated (in-app) update site
 * Eclipse update site
 
-[https://www.oracle.com/java/technologies/javase/products-jmc7-downloads.html](https://www.oracle.com/java/technologies/javase/products-jmc7-downloads.html)
+[https://www.oracle.com/java/technologies/jdk-mission-control.html](https://www.oracle.com/java/technologies/jdk-mission-control.html)
 
 ### Red Hat
 * Released version

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Binary distributions of JDK Mission Control are provided by different downstream
 * Integrated (in-app) update site
 * Eclipse update site
 
-[http://jdk.java.net/jmc](http://jdk.java.net/jmc)
+[https://www.oracle.com/java/technologies/javase/products-jmc7-downloads.html](https://www.oracle.com/java/technologies/javase/products-jmc7-downloads.html)
 
 ### Red Hat
 * Released version


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JMC-7205](https://bugs.openjdk.java.net/browse/JMC-7205): Correct URL for Oracle's JMC production binaries


### Reviewers
 * [Marcus Hirt](https://openjdk.java.net/census#hirt) (@thegreystone - **Reviewer**)


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jmc pull/216/head:pull/216`
`$ git checkout pull/216`

To update a local copy of the PR:
`$ git checkout pull/216`
`$ git pull https://git.openjdk.java.net/jmc pull/216/head`
