### PR TITLE
7136: Restrict local management agent for own process

### DIFF
--- a/application/org.openjdk.jmc.browser.attach/src/main/java/org/openjdk/jmc/browser/attach/LocalJVMToolkit.java
+++ b/application/org.openjdk.jmc.browser.attach/src/main/java/org/openjdk/jmc/browser/attach/LocalJVMToolkit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -68,6 +68,7 @@ import org.openjdk.jmc.ui.common.jvm.Connectable;
 import org.openjdk.jmc.ui.common.jvm.JVMArch;
 import org.openjdk.jmc.ui.common.jvm.JVMDescriptor;
 import org.openjdk.jmc.ui.common.jvm.JVMType;
+import org.openjdk.jmc.ui.common.util.Environment;
 
 import com.sun.tools.attach.AgentLoadException;
 import com.sun.tools.attach.AttachNotSupportedException;
@@ -373,13 +374,15 @@ public class LocalJVMToolkit {
 						// This leaks one thread handle due to Sun bug in j2se/src/windows/native/sun/tools/attach/WindowsVirtualMachine.c
 						Properties props = null;
 						try {
-							try {
-								// try to force finish init the attached JVM
-								// to ensure properties are correctly populated
-								// see JMC-4454 for details
-								((HotSpotVirtualMachine) vm).startLocalManagementAgent();
-							} catch (Exception ex) {
-								// swallow exceptions
+							if (Integer.parseInt(vmd.id()) != Environment.getThisPID()) {
+								try {
+									// try to force finish init the attached JVM
+									// to ensure properties are correctly populated
+									// see JMC-4454 for details
+									((HotSpotVirtualMachine) vm).startLocalManagementAgent();
+								} catch (Exception ex) {
+									// swallow exceptions
+								}
 							}
 							props = vm.getSystemProperties();
 						} catch (IOException e) {


### PR DESCRIPTION
RC : Starting Local management agent for JMC's own process is not required.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JMC-7136](https://bugs.openjdk.java.net/browse/JMC-7136): Restrict local management agent for own process


### Reviewers
 * [Marcus Hirt](https://openjdk.java.net/census#hirt) (@thegreystone - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jmc pull/217/head:pull/217`
`$ git checkout pull/217`
