### PR TITLE
6936: Parser should track statistics during parsing

### DIFF
--- a/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/IParserStats.java
+++ b/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/IParserStats.java
@@ -1,0 +1,28 @@
+package org.openjdk.jmc.flightrecorder;
+
+import java.util.function.Consumer;
+
+public interface IParserStats {
+
+	public interface IEventStats {
+		String getName();
+
+		long getCount();
+
+		long getTotalSize();
+	}
+
+	void forEachEventType(Consumer<IEventStats> consumer);
+
+	short getMajorVersion();
+
+	short getMinorVersion();
+
+	int getChunkCount();
+
+	long getSkippedEventCount();
+
+	long getEventCountByType(String eventTypeName);
+
+	long getEventTotalSizeByType(String eventTypeName);
+}

--- a/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/IParserStats.java
+++ b/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/IParserStats.java
@@ -1,3 +1,36 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Datadog, Inc. All rights reserved.
+ * 
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * The contents of this file are subject to the terms of either the Universal Permissive License
+ * v 1.0 as shown at http://oss.oracle.com/licenses/upl
+ *
+ * or the following license:
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted
+ * provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions
+ * and the following disclaimer.
+ * 
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other materials provided with
+ * the distribution.
+ * 
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to
+ * endorse or promote products derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+ * WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 package org.openjdk.jmc.flightrecorder;
 
 import java.util.function.Consumer;

--- a/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/RecordingPrinter.java
+++ b/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/RecordingPrinter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/internal/EventArrays.java
+++ b/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/internal/EventArrays.java
@@ -4,15 +4,18 @@ import java.util.Set;
 
 import org.openjdk.jmc.common.unit.IQuantity;
 import org.openjdk.jmc.common.unit.IRange;
+import org.openjdk.jmc.flightrecorder.internal.parser.ParserStats;
 
 public class EventArrays {
 
 	private final EventArray[] arrays;
 	private final Set<IRange<IQuantity>> chunkTimeranges;
+	private final ParserStats parserStats;
 
-	public EventArrays(EventArray[] arrays, Set<IRange<IQuantity>> ranges) {
+	public EventArrays(EventArray[] arrays, Set<IRange<IQuantity>> ranges, ParserStats parserStats) {
 		this.arrays = arrays;
 		this.chunkTimeranges = ranges;
+		this.parserStats = parserStats;
 	}
 
 	public EventArray[] getArrays() {
@@ -21,6 +24,10 @@ public class EventArrays {
 
 	public Set<IRange<IQuantity>> getChunkTimeranges() {
 		return chunkTimeranges;
+	}
+
+	public ParserStats getParserStats() {
+		return parserStats;
 	}
 
 }

--- a/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/internal/EventArrays.java
+++ b/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/internal/EventArrays.java
@@ -1,3 +1,35 @@
+/*
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+ *
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * The contents of this file are subject to the terms of either the Universal Permissive License
+ * v 1.0 as shown at http://oss.oracle.com/licenses/upl
+ *
+ * or the following license:
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted
+ * provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions
+ * and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other materials provided with
+ * the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to
+ * endorse or promote products derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+ * WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 package org.openjdk.jmc.flightrecorder.internal;
 
 import java.util.Set;

--- a/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/internal/FlightRecordingLoader.java
+++ b/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/internal/FlightRecordingLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/internal/FlightRecordingLoader.java
+++ b/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/internal/FlightRecordingLoader.java
@@ -294,6 +294,7 @@ public final class FlightRecordingLoader {
 		try {
 			Chunk chunk = chunkSupplier.getNextChunk(buffer);
 			if (chunk != null) {
+				context.setVersion(chunk.getMajorVersion(), chunk.getMinorVersion());
 				switch (chunk.getMajorVersion()) {
 				case VERSION_0:
 					return ChunkLoaderV0.create(chunk, context);

--- a/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/internal/parser/LoaderContext.java
+++ b/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/internal/parser/LoaderContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/internal/parser/LoaderContext.java
+++ b/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/internal/parser/LoaderContext.java
@@ -37,6 +37,7 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -64,6 +65,7 @@ public class LoaderContext {
 	private final boolean hideExperimentals;
 	private final List<? extends IParserExtension> extensions;
 	private final Set<IRange<IQuantity>> chunkRanges;
+	private final ParserStats parserStats = new ParserStats();
 
 	public LoaderContext(List<? extends IParserExtension> extensions, boolean hideExperimentals) {
 		this.extensions = extensions;
@@ -134,7 +136,26 @@ public class LoaderContext {
 			}
 
 		}
-		return new EventArrays(eventArrays.toArray(new EventArray[eventArrays.size()]), chunkRanges);
+		return new EventArrays(eventArrays.toArray(new EventArray[eventArrays.size()]), chunkRanges, parserStats);
 	}
 
+	public void incChunkCount() {
+		parserStats.incChunkCount();
+	}
+
+	public void updateEventStats(String eventTypeName, long size) {
+		parserStats.updateEventStats(eventTypeName, size);
+	}
+
+	public ParserStats getParserStats() {
+		return parserStats;
+	}
+
+	public void setVersion(short majorVersion, short minorVersion) {
+		parserStats.setVersion(majorVersion, minorVersion);
+	}
+
+	public void setSkippedEventCount(long skippedEventCount) {
+		parserStats.setSkippedEventCount(skippedEventCount);
+	}
 }

--- a/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/internal/parser/ParserStats.java
+++ b/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/internal/parser/ParserStats.java
@@ -1,3 +1,36 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Datadog, Inc. All rights reserved.
+ * 
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * The contents of this file are subject to the terms of either the Universal Permissive License
+ * v 1.0 as shown at http://oss.oracle.com/licenses/upl
+ *
+ * or the following license:
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted
+ * provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions
+ * and the following disclaimer.
+ * 
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other materials provided with
+ * the distribution.
+ * 
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to
+ * endorse or promote products derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+ * WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 package org.openjdk.jmc.flightrecorder.internal.parser;
 
 import java.util.concurrent.ConcurrentHashMap;

--- a/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/internal/parser/ParserStats.java
+++ b/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/internal/parser/ParserStats.java
@@ -1,0 +1,117 @@
+package org.openjdk.jmc.flightrecorder.internal.parser;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Consumer;
+
+import javax.swing.text.html.MinimalHTMLWriter;
+
+import org.openjdk.jmc.flightrecorder.IParserStats.IEventStats;
+
+public class ParserStats {
+	private short majorVersion;
+	private short minorVersion;
+	private final AtomicInteger chunkCount = new AtomicInteger();
+	private final AtomicLong skippedEventCount = new AtomicLong();
+	private final ConcurrentHashMap<String, EventTypeStats> statsByType = new ConcurrentHashMap<>();
+
+	public void setVersion(short majorVersion, short minorVersion) {
+		this.majorVersion = majorVersion;
+		this.minorVersion = minorVersion;
+	}
+
+	public void incChunkCount() {
+		chunkCount.incrementAndGet();
+	}
+
+	public void setSkippedEventCount(long skippedEventCount) {
+		this.skippedEventCount.addAndGet(skippedEventCount);
+	}
+
+	public void updateEventStats(String eventTypeName, long size) {
+		statsByType.compute(eventTypeName, (key, stats) -> {
+			if (stats == null) {
+				return new EventTypeStats(eventTypeName, size);
+			}
+			stats.add(size);
+			return stats;
+		});
+	}
+
+	public void forEachEventType(Consumer<IEventStats> consumer) {
+		for (EventTypeStats eventStats : statsByType.values()) {
+			consumer.accept(eventStats);
+		}
+	}
+
+	public short getMajorVersion() {
+		return majorVersion;
+	}
+
+	public short getMinorVersion() {
+		return minorVersion;
+	}
+
+	public int getChunkCount() {
+		return chunkCount.get();
+	}
+
+	public long getSkippedEventCount() {
+		return skippedEventCount.get();
+	}
+
+	public long getCount(String eventTypeName) {
+		EventTypeStats stats = statsByType.get(eventTypeName);
+		if (stats == null) {
+			return 0;
+		}
+		return stats.count;
+	}
+
+	public long getTotalSize(String eventTypeName) {
+		EventTypeStats stats = statsByType.get(eventTypeName);
+		if (stats == null) {
+			return 0;
+		}
+		return stats.totalSize;
+	}
+
+	private static class EventTypeStats implements IEventStats {
+		private final String eventTypeName;
+		private long count;
+		private long totalSize;
+
+		public EventTypeStats(String eventTypeName, long size) {
+			this.eventTypeName = eventTypeName;
+			this.count = 1;
+			this.totalSize = size;
+		}
+
+		public void add(long size) {
+			count++;
+			totalSize += size;
+		}
+
+		@Override
+		public String getName() {
+			return eventTypeName;
+		}
+
+		@Override
+		public long getCount() {
+			return count;
+		}
+
+		@Override
+		public long getTotalSize() {
+			return totalSize;
+		}
+
+		@Override
+		public String toString() {
+			return "EventTypeStats [eventTypeName=" + eventTypeName + ", count=" + count + ", totalSize=" + totalSize
+					+ "]";
+		}
+	}
+}

--- a/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/internal/parser/v0/ChunkLoaderV0.java
+++ b/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/internal/parser/v0/ChunkLoaderV0.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/internal/parser/v0/ChunkLoaderV0.java
+++ b/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/internal/parser/v0/ChunkLoaderV0.java
@@ -59,6 +59,7 @@ public class ChunkLoaderV0 implements IChunkLoader {
 
 	@Override
 	public byte[] call() throws Exception {
+		context.incChunkCount();
 		// Read constants
 		ReaderFactory readerFactory = new ReaderFactory(metadata, data, context, structure);
 

--- a/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/internal/parser/v0/EventParserManager.java
+++ b/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/internal/parser/v0/EventParserManager.java
@@ -48,10 +48,12 @@ import org.openjdk.jmc.flightrecorder.internal.parser.v0.model.EventTypeDescript
 import org.openjdk.jmc.flightrecorder.internal.parser.v0.model.ProducerDescriptor;
 import org.openjdk.jmc.flightrecorder.internal.parser.v0.model.ValueDescriptor;
 import org.openjdk.jmc.flightrecorder.internal.util.JfrInternalConstants;
+import org.openjdk.jmc.flightrecorder.jdk.JdkTypeIDs;
 import org.openjdk.jmc.flightrecorder.messages.internal.Messages;
 import org.openjdk.jmc.flightrecorder.parser.IEventSink;
 import org.openjdk.jmc.flightrecorder.parser.IEventSinkFactory;
 import org.openjdk.jmc.flightrecorder.parser.ValueField;
+import org.openjdk.jmc.flightrecorder.parser.synthetic.JdkTypeIDsPreJdk11;
 
 class EventParserManager {
 	// Event types
@@ -95,8 +97,9 @@ class EventParserManager {
 				category = Arrays.copyOf(category, category.length - 1);
 				IEventSink sink = context.getSinkFactory().create(id, etd.getLabel(), category, etd.getDescription(),
 						eventSpec.getValueFields());
+				String typeId = JdkTypeIDsPreJdk11.translate(id);
 				eventTypes.put(etd.getIdentifier(),
-						new EventTypeEntry(sink, etd.hasStartTime(), eventSpec.getValueReaders()));
+						new EventTypeEntry(typeId, sink, etd.hasStartTime(), eventSpec.getValueReaders()));
 			}
 		}
 		eventTypes.put(LOST_EVENT_TYPE_INDEX, createBufferLostEntry(context.getSinkFactory()));
@@ -107,6 +110,7 @@ class EventParserManager {
 		if (ep == null) {
 			throw new IllegalArgumentException("Event type " + eventTypeId + " is not described in the file"); //$NON-NLS-1$ //$NON-NLS-2$
 		}
+		long size = offset.getEnd() - offset.get();
 		long endTime = readerFactory.readTicksTimestamp(data, offset);
 		int valueIndex = 0;
 		if (ep.hasStartTime) {
@@ -117,6 +121,7 @@ class EventParserManager {
 			ep.values[valueIndex++] = ep.parsers[n].readValue(data, offset, endTime);
 		}
 		ep.sink.addEvent(ep.values);
+		context.updateEventStats(ep.typeId, size);
 	}
 
 	private EventTypeEntry createBufferLostEntry(IEventSinkFactory esf) throws InvalidJfrFileException {
@@ -127,7 +132,7 @@ class EventParserManager {
 				Messages.getString(Messages.EventParserManager_TYPE_BUFFER_LOST),
 				EventAppearance.getHumanSegmentArray("recordings"), //$NON-NLS-1$
 				Messages.getString(Messages.EventParserManager_TYPE_BUFFER_LOST_DESC), eventReader.getValueFields());
-		return new EventTypeEntry(sink, false, eventReader.getValueReaders());
+		return new EventTypeEntry(JfrInternalConstants.BUFFER_LOST_TYPE_ID, sink, false, eventReader.getValueReaders());
 	}
 
 	private class EventTypeBuilder {
@@ -198,13 +203,14 @@ class EventParserManager {
 	}
 
 	private static class EventTypeEntry {
-
+		private final String typeId;
 		private final Object[] values;
 		private final IValueReader[] parsers;
 		private final IEventSink sink;
 		private final boolean hasStartTime;
 
-		public EventTypeEntry(IEventSink sink, boolean hasStartTime, IValueReader[] valueParsers) {
+		public EventTypeEntry(String typeId, IEventSink sink, boolean hasStartTime, IValueReader[] valueParsers) {
+			this.typeId = typeId;
 			parsers = valueParsers;
 			this.sink = sink;
 			this.hasStartTime = hasStartTime;

--- a/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/internal/parser/v0/EventParserManager.java
+++ b/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/internal/parser/v0/EventParserManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/internal/parser/v0/EventParserManager.java
+++ b/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/internal/parser/v0/EventParserManager.java
@@ -53,7 +53,7 @@ import org.openjdk.jmc.flightrecorder.messages.internal.Messages;
 import org.openjdk.jmc.flightrecorder.parser.IEventSink;
 import org.openjdk.jmc.flightrecorder.parser.IEventSinkFactory;
 import org.openjdk.jmc.flightrecorder.parser.ValueField;
-import org.openjdk.jmc.flightrecorder.parser.synthetic.JdkTypeIDsPreJdk11;
+import org.openjdk.jmc.flightrecorder.parser.synthetic.OracleJdkTypeIDsPre11;
 
 class EventParserManager {
 	// Event types
@@ -97,7 +97,7 @@ class EventParserManager {
 				category = Arrays.copyOf(category, category.length - 1);
 				IEventSink sink = context.getSinkFactory().create(id, etd.getLabel(), category, etd.getDescription(),
 						eventSpec.getValueFields());
-				String typeId = JdkTypeIDsPreJdk11.translate(id);
+				String typeId = OracleJdkTypeIDsPre11.translate(id);
 				eventTypes.put(etd.getIdentifier(),
 						new EventTypeEntry(typeId, sink, etd.hasStartTime(), eventSpec.getValueReaders()));
 			}

--- a/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/internal/parser/v1/ChunkLoaderV1.java
+++ b/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/internal/parser/v1/ChunkLoaderV1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/internal/parser/v1/ChunkLoaderV1.java
+++ b/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/internal/parser/v1/ChunkLoaderV1.java
@@ -62,7 +62,7 @@ public class ChunkLoaderV1 implements IChunkLoader {
 	@Override
 	public byte[] call() throws Exception {
 		SeekableInputStream input = SeekableInputStream.build(data, header.isIntegersCompressed());
-
+		context.incChunkCount();
 		// Read metadata
 		input.seek(header.getMetadataOffset());
 		List<ClassElement> classes = ChunkMetadata.readMetadata(input).metadata.classes;
@@ -89,10 +89,11 @@ public class ChunkLoaderV1 implements IChunkLoader {
 				throw new CouldNotLoadRecordingException("Found event with invalid size (0)"); //$NON-NLS-1$
 			}
 			if (type != CONSTANT_POOL_EVENT_TYPE && type != ChunkMetadata.METADATA_EVENT_TYPE) {
-				manager.readEvent(type, input);
+				manager.readEvent(type, input, size);
 			}
 			index += size;
 		}
+		context.setSkippedEventCount(manager.getSkippedEventCount());
 		return data;
 	}
 

--- a/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/parser/synthetic/JdkTypeIDsPreJdk11.java
+++ b/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/parser/synthetic/JdkTypeIDsPreJdk11.java
@@ -39,7 +39,7 @@ import org.openjdk.jmc.flightrecorder.jdk.JdkTypeIDs;
  * Contains type IDs for events that are produced by JDK 7 and 8.
  */
 @SuppressWarnings({"nls", "unused"})
-final class JdkTypeIDsPreJdk11 {
+public final class JdkTypeIDsPreJdk11 {
 	/**
 	 * The prefix used for JDK 11 and later
 	 */

--- a/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/parser/synthetic/JdkTypeIDsPreJdk11.java
+++ b/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/parser/synthetic/JdkTypeIDsPreJdk11.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/parser/synthetic/OracleJdkTypeIDsPre11.java
+++ b/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/parser/synthetic/OracleJdkTypeIDsPre11.java
@@ -39,7 +39,7 @@ import org.openjdk.jmc.flightrecorder.jdk.JdkTypeIDs;
  * Contains type IDs for events that are produced by JDK 7 and 8.
  */
 @SuppressWarnings({"nls", "unused"})
-public final class JdkTypeIDsPreJdk11 {
+public final class OracleJdkTypeIDsPre11 {
 	/**
 	 * The prefix used for JDK 11 and later
 	 */

--- a/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/parser/synthetic/SettingsTransformer.java
+++ b/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/parser/synthetic/SettingsTransformer.java
@@ -126,42 +126,42 @@ class SettingsTransformer implements IEventSink {
 	private static HashMap<String, Map<String, String>> buildRenameMap() {
 		// NOTE: Replace the last string argument with an identifier reference if a matching one is added to JfrAttributes.
 		HashMap<String, Map<String, String>> map = new HashMap<>();
-		addRenameEntry(map, JdkTypeIDsPreJdk11.THREAD_PARK, "klass", "parkedClass");
-		addRenameEntry(map, JdkTypeIDsPreJdk11.MONITOR_ENTER, "klass", JdkAttributes.MONITOR_CLASS.getIdentifier());
-		addRenameEntry(map, JdkTypeIDsPreJdk11.MONITOR_WAIT, "klass", JdkAttributes.MONITOR_CLASS.getIdentifier());
-		addRenameEntry(map, JdkTypeIDsPreJdk11.INT_FLAG_CHANGED, "old_value", "oldValue");
-		addRenameEntry(map, JdkTypeIDsPreJdk11.INT_FLAG_CHANGED, "new_value", "newValue");
-		addRenameEntry(map, JdkTypeIDsPreJdk11.UINT_FLAG_CHANGED, "old_value", "oldValue");
-		addRenameEntry(map, JdkTypeIDsPreJdk11.UINT_FLAG_CHANGED, "new_value", "newValue");
-		addRenameEntry(map, JdkTypeIDsPreJdk11.LONG_FLAG_CHANGED, "old_value", "oldValue");
-		addRenameEntry(map, JdkTypeIDsPreJdk11.LONG_FLAG_CHANGED, "new_value", "newValue");
-		addRenameEntry(map, JdkTypeIDsPreJdk11.ULONG_FLAG_CHANGED, "old_value", "oldValue");
-		addRenameEntry(map, JdkTypeIDsPreJdk11.ULONG_FLAG_CHANGED, "new_value", "newValue");
-		addRenameEntry(map, JdkTypeIDsPreJdk11.DOUBLE_FLAG_CHANGED, "old_value", "oldValue");
-		addRenameEntry(map, JdkTypeIDsPreJdk11.DOUBLE_FLAG_CHANGED, "new_value", "newValue");
-		addRenameEntry(map, JdkTypeIDsPreJdk11.BOOLEAN_FLAG_CHANGED, "old_value", "oldValue");
-		addRenameEntry(map, JdkTypeIDsPreJdk11.BOOLEAN_FLAG_CHANGED, "new_value", "newValue");
-		addRenameEntry(map, JdkTypeIDsPreJdk11.STRING_FLAG_CHANGED, "old_value", "oldValue");
-		addRenameEntry(map, JdkTypeIDsPreJdk11.STRING_FLAG_CHANGED, "new_value", "newValue");
-		addRenameEntry(map, JdkTypeIDsPreJdk11.GC_DETAILED_EVACUATION_INFO, "allocRegionsUsedBefore",
+		addRenameEntry(map, OracleJdkTypeIDsPre11.THREAD_PARK, "klass", "parkedClass");
+		addRenameEntry(map, OracleJdkTypeIDsPre11.MONITOR_ENTER, "klass", JdkAttributes.MONITOR_CLASS.getIdentifier());
+		addRenameEntry(map, OracleJdkTypeIDsPre11.MONITOR_WAIT, "klass", JdkAttributes.MONITOR_CLASS.getIdentifier());
+		addRenameEntry(map, OracleJdkTypeIDsPre11.INT_FLAG_CHANGED, "old_value", "oldValue");
+		addRenameEntry(map, OracleJdkTypeIDsPre11.INT_FLAG_CHANGED, "new_value", "newValue");
+		addRenameEntry(map, OracleJdkTypeIDsPre11.UINT_FLAG_CHANGED, "old_value", "oldValue");
+		addRenameEntry(map, OracleJdkTypeIDsPre11.UINT_FLAG_CHANGED, "new_value", "newValue");
+		addRenameEntry(map, OracleJdkTypeIDsPre11.LONG_FLAG_CHANGED, "old_value", "oldValue");
+		addRenameEntry(map, OracleJdkTypeIDsPre11.LONG_FLAG_CHANGED, "new_value", "newValue");
+		addRenameEntry(map, OracleJdkTypeIDsPre11.ULONG_FLAG_CHANGED, "old_value", "oldValue");
+		addRenameEntry(map, OracleJdkTypeIDsPre11.ULONG_FLAG_CHANGED, "new_value", "newValue");
+		addRenameEntry(map, OracleJdkTypeIDsPre11.DOUBLE_FLAG_CHANGED, "old_value", "oldValue");
+		addRenameEntry(map, OracleJdkTypeIDsPre11.DOUBLE_FLAG_CHANGED, "new_value", "newValue");
+		addRenameEntry(map, OracleJdkTypeIDsPre11.BOOLEAN_FLAG_CHANGED, "old_value", "oldValue");
+		addRenameEntry(map, OracleJdkTypeIDsPre11.BOOLEAN_FLAG_CHANGED, "new_value", "newValue");
+		addRenameEntry(map, OracleJdkTypeIDsPre11.STRING_FLAG_CHANGED, "old_value", "oldValue");
+		addRenameEntry(map, OracleJdkTypeIDsPre11.STRING_FLAG_CHANGED, "new_value", "newValue");
+		addRenameEntry(map, OracleJdkTypeIDsPre11.GC_DETAILED_EVACUATION_INFO, "allocRegionsUsedBefore",
 				"allocationRegionsUsedBefore");
-		addRenameEntry(map, JdkTypeIDsPreJdk11.GC_DETAILED_EVACUATION_INFO, "allocRegionsUsedAfter",
+		addRenameEntry(map, OracleJdkTypeIDsPre11.GC_DETAILED_EVACUATION_INFO, "allocRegionsUsedAfter",
 				"allocationRegionsUsedAfter");
-		addRenameEntry(map, JdkTypeIDsPreJdk11.SWEEP_CODE_CACHE, "sweepIndex", "sweepId");
-		addRenameEntry(map, JdkTypeIDsPreJdk11.ALLOC_INSIDE_TLAB, "class",
+		addRenameEntry(map, OracleJdkTypeIDsPre11.SWEEP_CODE_CACHE, "sweepIndex", "sweepId");
+		addRenameEntry(map, OracleJdkTypeIDsPre11.ALLOC_INSIDE_TLAB, "class",
 				JdkAttributes.ALLOCATION_CLASS.getIdentifier());
-		addRenameEntry(map, JdkTypeIDsPreJdk11.ALLOC_OUTSIDE_TLAB, "class",
+		addRenameEntry(map, OracleJdkTypeIDsPre11.ALLOC_OUTSIDE_TLAB, "class",
 				JdkAttributes.ALLOCATION_CLASS.getIdentifier());
-		addRenameEntry(map, JdkTypeIDsPreJdk11.OBJECT_COUNT, "class", JdkAttributes.OBJECT_CLASS.getIdentifier());
-		addRenameEntry(map, JdkTypeIDsPreJdk11.COMPILER_PHASE, "compileID",
+		addRenameEntry(map, OracleJdkTypeIDsPre11.OBJECT_COUNT, "class", JdkAttributes.OBJECT_CLASS.getIdentifier());
+		addRenameEntry(map, OracleJdkTypeIDsPre11.COMPILER_PHASE, "compileID",
 				JdkAttributes.COMPILER_COMPILATION_ID.getIdentifier());
-		addRenameEntry(map, JdkTypeIDsPreJdk11.COMPILATION, "compileID",
+		addRenameEntry(map, OracleJdkTypeIDsPre11.COMPILATION, "compileID",
 				JdkAttributes.COMPILER_COMPILATION_ID.getIdentifier());
-		addRenameEntry(map, JdkTypeIDsPreJdk11.COMPILER_FAILURE, "compileID",
+		addRenameEntry(map, OracleJdkTypeIDsPre11.COMPILER_FAILURE, "compileID",
 				JdkAttributes.COMPILER_COMPILATION_ID.getIdentifier());
-		addRenameEntry(map, JdkTypeIDsPreJdk11.COMPILER_FAILURE, "failure",
+		addRenameEntry(map, OracleJdkTypeIDsPre11.COMPILER_FAILURE, "failure",
 				JdkAttributes.COMPILER_FAILED_MESSAGE.getIdentifier());
-		addRenameEntry(map, JdkTypeIDsPreJdk11.GC_DETAILED_OBJECT_COUNT_AFTER_GC, "class",
+		addRenameEntry(map, OracleJdkTypeIDsPre11.GC_DETAILED_OBJECT_COUNT_AFTER_GC, "class",
 				JdkAttributes.OBJECT_CLASS.getIdentifier());
 		return map;
 	}
@@ -214,7 +214,7 @@ class SettingsTransformer implements IEventSink {
 	public void addEvent(Object[] values) {
 		LabeledIdentifier type = (LabeledIdentifier) values[typeIndex];
 		if (type != null) {
-			type = new LabeledIdentifier(JdkTypeIDsPreJdk11.translate(type.getInterfaceId()),
+			type = new LabeledIdentifier(OracleJdkTypeIDsPre11.translate(type.getInterfaceId()),
 					type.getImplementationId(), type.getName(), type.getDeclaredDescription());
 			if (endTimeIndex < 0) {
 				values[typeIndex] = type;
@@ -278,19 +278,19 @@ class SettingsTransformer implements IEventSink {
 			public IEventSink create(
 				String identifier, String label, String[] category, String description,
 				List<ValueField> dataStructure) {
-				if (JdkTypeIDsPreJdk11.RECORDING_SETTING.equals(identifier)
-						|| JdkTypeIDsPreJdk11.JDK9_RECORDING_SETTING.equals(identifier)) {
+				if (OracleJdkTypeIDsPre11.RECORDING_SETTING.equals(identifier)
+						|| OracleJdkTypeIDsPre11.JDK9_RECORDING_SETTING.equals(identifier)) {
 					SettingsTransformer st = new SettingsTransformer(subFactory, label, category, description,
 							dataStructure);
-					if ((JdkTypeIDsPreJdk11.RECORDING_SETTING.equals(identifier) && st.isValid())
-							|| (JdkTypeIDsPreJdk11.JDK9_RECORDING_SETTING.equals(identifier) && st.isValidV1())) {
+					if ((OracleJdkTypeIDsPre11.RECORDING_SETTING.equals(identifier) && st.isValid())
+							|| (OracleJdkTypeIDsPre11.JDK9_RECORDING_SETTING.equals(identifier) && st.isValidV1())) {
 						return st;
 					} else {
 						// FIXME: Avoid System.err.println
 						System.err
 								.println("Cannot create SettingsTransformer from fields: " + dataStructure.toString()); //$NON-NLS-1$
 					}
-				} else if (JdkTypeIDsPreJdk11.RECORDINGS.equals(identifier)) {
+				} else if (OracleJdkTypeIDsPre11.RECORDINGS.equals(identifier)) {
 					/*
 					 * NOTE: Renaming 'duration' and 'startTime' attributes for JDK 8 'Recording'
 					 * events so that they won't conflict with general attributes with the same
@@ -308,15 +308,16 @@ class SettingsTransformer implements IEventSink {
 					}
 					return subFactory.create(JdkTypeIDs.RECORDINGS, label, category, description,
 							Arrays.asList(struct));
-				} else if (JdkTypeIDsPreJdk11.CODE_CACHE_STATISTICS.equals(identifier)) {
+				} else if (OracleJdkTypeIDsPre11.CODE_CACHE_STATISTICS.equals(identifier)) {
 					for (int i = 0; i < dataStructure.size(); i++) {
 						if (UNALLOCATED_CAPACITY_FIELD_ID.equals(dataStructure.get(i).getIdentifier())) {
-							return new FixCodeCacheSink(i, subFactory.create(JdkTypeIDsPreJdk11.translate(identifier),
-									label, category, description, dataStructure));
+							return new FixCodeCacheSink(i,
+									subFactory.create(OracleJdkTypeIDsPre11.translate(identifier), label, category,
+											description, dataStructure));
 						}
 					}
 				}
-				return subFactory.create(JdkTypeIDsPreJdk11.translate(identifier), label, category, description,
+				return subFactory.create(OracleJdkTypeIDsPre11.translate(identifier), label, category, description,
 						translate(identifier, dataStructure));
 			}
 

--- a/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/parser/synthetic/SyntheticAttributeExtension.java
+++ b/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/parser/synthetic/SyntheticAttributeExtension.java
@@ -183,8 +183,8 @@ public class SyntheticAttributeExtension implements IParserExtension {
 	@Override
 	public String getValueInterpretation(String eventTypeId, String fieldId) {
 		if (REC_SETTING_EVENT_ID_ATTRIBUTE.getIdentifier().equals(fieldId)
-				&& (JdkTypeIDsPreJdk11.RECORDING_SETTING.equals(eventTypeId)
-						|| JdkTypeIDsPreJdk11.JDK9_RECORDING_SETTING.equals(eventTypeId)
+				&& (OracleJdkTypeIDsPre11.RECORDING_SETTING.equals(eventTypeId)
+						|| OracleJdkTypeIDsPre11.JDK9_RECORDING_SETTING.equals(eventTypeId)
 						|| JdkTypeIDs.RECORDING_SETTING.equals(eventTypeId))) {
 			return JfrInternalConstants.TYPE_IDENTIFIER_VALUE_INTERPRETATION;
 		}

--- a/core/tests/org.openjdk.jmc.flightrecorder.test/src/test/java/org/openjdk/jmc/flightrecorder/test/RecordingTest.java
+++ b/core/tests/org.openjdk.jmc.flightrecorder.test/src/test/java/org/openjdk/jmc/flightrecorder/test/RecordingTest.java
@@ -32,14 +32,21 @@
  */
 package org.openjdk.jmc.flightrecorder.test;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
 
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.runners.parameterized.TestWithParameters;
 import org.openjdk.jmc.common.item.IItemCollection;
 import org.openjdk.jmc.common.test.io.IOResourceSet;
 import org.openjdk.jmc.flightrecorder.CouldNotLoadRecordingException;
+import org.openjdk.jmc.flightrecorder.IParserStats;
+import org.openjdk.jmc.flightrecorder.JfrLoaderToolkit;
+import org.openjdk.jmc.flightrecorder.IParserStats.IEventStats;
 import org.openjdk.jmc.flightrecorder.test.util.PrintoutsToolkit;
 import org.openjdk.jmc.flightrecorder.test.util.RecordingToolkit;
 
@@ -69,6 +76,32 @@ public class RecordingTest {
 				}
 			} catch (Exception e) {
 				Assert.fail(resourceSet.getResource(0).getName() + ": Could not read baseline file: " + e.getMessage());
+			}
+		}
+	}
+
+	@Test
+	public void testParserStats() throws IOException, CouldNotLoadRecordingException {
+		for (IOResourceSet resourceSet : PrintoutsToolkit.getTestResources()) {
+			IItemCollection items = RecordingToolkit.getFlightRecording(resourceSet);
+			IParserStats parserStats = (IParserStats) items;
+			Set<IEventStats> eventStatsSet = new TreeSet<>((o1, o2) -> Long.compare(o1.getCount(), o2.getCount()));
+			parserStats.forEachEventType((eventStats) -> {
+				eventStatsSet.add(eventStats);
+			});
+			List<String> statsLine = null;
+			try {
+				statsLine = RecordingToolkit.getStats(resourceSet);
+			} catch (IOException ex) {
+				continue;
+			}
+			int i = 0;
+			for (IEventStats eventStats : eventStatsSet) {
+				String[] cols = statsLine.get(i).split(";");
+				Assert.assertEquals(cols[0], eventStats.getName());
+				Assert.assertEquals(Long.parseLong(cols[1]), eventStats.getCount());
+				Assert.assertEquals(Long.parseLong(cols[2]), eventStats.getTotalSize());
+				i++;
 			}
 		}
 	}

--- a/core/tests/org.openjdk.jmc.flightrecorder.test/src/test/java/org/openjdk/jmc/flightrecorder/test/RecordingTest.java
+++ b/core/tests/org.openjdk.jmc.flightrecorder.test/src/test/java/org/openjdk/jmc/flightrecorder/test/RecordingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/core/tests/org.openjdk.jmc.flightrecorder.test/src/test/java/org/openjdk/jmc/flightrecorder/test/util/RecordingToolkit.java
+++ b/core/tests/org.openjdk.jmc.flightrecorder.test/src/test/java/org/openjdk/jmc/flightrecorder/test/util/RecordingToolkit.java
@@ -32,11 +32,15 @@
  */
 package org.openjdk.jmc.flightrecorder.test.util;
 
+import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.io.OutputStream;
+import java.util.List;
+import java.util.stream.Collectors;
 
 import org.openjdk.jmc.common.io.IOToolkit;
 import org.openjdk.jmc.common.item.IItemCollection;
@@ -95,6 +99,16 @@ public class RecordingToolkit {
 		IOToolkit.closeSilently(os);
 		IOToolkit.closeSilently(is);
 		return JfrLoaderToolkit.loadEvents(tmpRecording);
+	}
+
+	public static List<String> getStats(IOResourceSet resourceSet) throws IOException {
+		IOResource resource = resourceSet.getResource(0);
+		String recordingFileName = resource.getName();
+		String statsFileName = recordingFileName.replace(".jfr", ".txt");
+		IOResource statsResource = TestToolkit.getNamedResource(RecordingToolkit.class, "stats", statsFileName);
+		try (BufferedReader reader = new BufferedReader(new InputStreamReader(statsResource.open()))) {
+			return reader.lines().collect(Collectors.toList());
+		}
 	}
 
 	public static File createResultFile(String prefix, String suffix, boolean deleteTempOnExit) throws IOException {

--- a/core/tests/org.openjdk.jmc.flightrecorder.test/src/test/java/org/openjdk/jmc/flightrecorder/test/util/RecordingToolkit.java
+++ b/core/tests/org.openjdk.jmc.flightrecorder.test/src/test/java/org/openjdk/jmc/flightrecorder/test/util/RecordingToolkit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/core/tests/org.openjdk.jmc.flightrecorder.test/src/test/resources/stats/7u40.txt
+++ b/core/tests/org.openjdk.jmc.flightrecorder.test/src/test/resources/stats/7u40.txt
@@ -1,0 +1,8 @@
+jdk.CPUInformation;1;1678
+jdk.PhysicalMemory;2;48
+jdk.ObjectAllocationInNewTLAB;3;132
+jdk.CPULoad;8;160
+jdk.ClassLoadingStatistics;9;216
+jdk.ThreadAllocationStatistics;44;880
+jdk.ActiveSetting;77;9304
+jdk.JavaMonitorWait;108;6156

--- a/core/tests/org.openjdk.jmc.flightrecorder.test/src/test/resources/stats/7u60.txt
+++ b/core/tests/org.openjdk.jmc.flightrecorder.test/src/test/resources/stats/7u60.txt
@@ -1,0 +1,8 @@
+jdk.CPUInformation;1;1782
+jdk.PhysicalMemory;2;48
+jdk.ObjectAllocationInNewTLAB;4;176
+jdk.CPULoad;8;160
+jdk.ClassLoadingStatistics;9;216
+jdk.ThreadAllocationStatistics;45;900
+jdk.ActiveSetting;77;9304
+jdk.JavaMonitorWait;107;6099

--- a/core/tests/org.openjdk.jmc.flightrecorder.test/src/test/resources/stats/7u76.txt
+++ b/core/tests/org.openjdk.jmc.flightrecorder.test/src/test/resources/stats/7u76.txt
@@ -1,0 +1,8 @@
+jdk.CPUInformation;1;1782
+jdk.PhysicalMemory;2;48
+jdk.ObjectAllocationInNewTLAB;3;132
+jdk.SocketRead;9;756
+jdk.ClassLoadingStatistics;10;240
+jdk.ThreadAllocationStatistics;44;880
+jdk.ActiveSetting;77;9304
+jdk.JavaMonitorWait;106;6042

--- a/core/tests/org.openjdk.jmc.flightrecorder.test/src/test/resources/stats/8u0.txt
+++ b/core/tests/org.openjdk.jmc.flightrecorder.test/src/test/resources/stats/8u0.txt
@@ -1,0 +1,7 @@
+jdk.CPUInformation;1;1782
+jdk.PhysicalMemory;2;48
+jdk.ObjectAllocationInNewTLAB;8;352
+jdk.ClassLoadingStatistics;9;216
+jdk.ThreadAllocationStatistics;46;920
+jdk.ActiveSetting;72;8836
+jdk.JavaMonitorWait;106;6042

--- a/core/tests/org.openjdk.jmc.flightrecorder.test/src/test/resources/stats/8u20.txt
+++ b/core/tests/org.openjdk.jmc.flightrecorder.test/src/test/resources/stats/8u20.txt
@@ -1,0 +1,9 @@
+jdk.CPUInformation;1;1782
+jdk.PhysicalMemory;2;48
+jdk.ObjectAllocationInNewTLAB;3;132
+jdk.ExceptionStatistics;9;180
+jdk.ClassLoadingStatistics;10;240
+jdk.SocketRead;19;1596
+jdk.ThreadAllocationStatistics;46;920
+jdk.ActiveSetting;85;10428
+jdk.JavaMonitorWait;108;6156

--- a/core/tests/org.openjdk.jmc.flightrecorder.test/src/test/resources/stats/8u40.txt
+++ b/core/tests/org.openjdk.jmc.flightrecorder.test/src/test/resources/stats/8u40.txt
@@ -1,0 +1,12 @@
+jdk.CPUInformation;1;1782
+jdk.ExecuteVMOperation;2;56
+jdk.ExecutionSampling;6;144
+jdk.SocketRead;9;756
+jdk.CPULoad;10;200
+jdk.ObjectAllocationOutsideTLAB;18;648
+jdk.ExecutionSample;19;418
+jdk.ThreadAllocationStatistics;49;980
+jdk.ObjectAllocationInNewTLAB;51;2244
+jdk.ActiveSetting;85;10428
+jdk.JavaMonitorWait;142;8094
+jdk.ThreadPark;165;8580

--- a/core/tests/org.openjdk.jmc.flightrecorder.test/src/test/resources/stats/8u60.txt
+++ b/core/tests/org.openjdk.jmc.flightrecorder.test/src/test/resources/stats/8u60.txt
@@ -1,0 +1,9 @@
+jdk.CPUInformation;1;1782
+jdk.PhysicalMemory;2;48
+jdk.ObjectAllocationOutsideTLAB;6;216
+jdk.ClassLoadingStatistics;8;192
+jdk.SocketRead;10;840
+jdk.ObjectAllocationInNewTLAB;24;1056
+jdk.ThreadAllocationStatistics;48;960
+jdk.JavaMonitorWait;65;3705
+jdk.ActiveSetting;86;10588

--- a/core/tests/org.openjdk.jmc.flightrecorder.test/src/test/resources/stats/9u0.txt
+++ b/core/tests/org.openjdk.jmc.flightrecorder.test/src/test/resources/stats/9u0.txt
@@ -1,0 +1,10 @@
+com.oracle.jdk.OSInformation;1;139
+com.oracle.jdk.SocketWrite;2;83
+com.oracle.jdk.CPULoad;6;150
+com.oracle.jdk.SocketRead;11;516
+com.oracle.jdk.JavaMonitorWait;27;1004
+com.oracle.jdk.ObjectAllocationOutsideTLAB;58;1160
+com.oracle.jdk.ThreadAllocationStatistics;60;974
+com.oracle.jdk.ActiveSetting;218;7579
+com.oracle.jdk.ObjectAllocationInNewTLAB;270;5739
+com.oracle.jdk.ClassLoaderStatistics;294;8890


### PR DESCRIPTION
Add new `IParserStats` interface implemented by `EventCollection`.
That way, `IItemCollection` is not touched, but you need to cast the
instance to `IParserStats`.
Support of old (v0.x) JFR format.
During parsing, we collect number of events per type, the size, number
of chunks and version of the file.
We also track for version 1.x/2.x the number of skipped events.
`RecordingPrinter` tool class is modified to support a summary verbosity mode
and `-summary` option to print statistics per event type.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JMC-6936](https://bugs.openjdk.java.net/browse/JMC-6936): Parser should track statistics during parsing


### Reviewers
 * [Marcus Hirt](https://openjdk.java.net/census#hirt) (@thegreystone - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/jmc pull/219/head:pull/219`
`$ git checkout pull/219`
