### PR TITLE
6890: defineEventProbes should throw exception on malformed probe definitions

### DIFF
--- a/agent/src/main/java/org/openjdk/jmc/agent/Agent.java
+++ b/agent/src/main/java/org/openjdk/jmc/agent/Agent.java
@@ -102,7 +102,7 @@ public class Agent {
 	 *             if the configuration could not be read.
 	 */
 	public static void initializeAgent(InputStream configuration, Instrumentation instrumentation)
-			throws XMLStreamException {
+			throws XMLStreamException, XMLValidationException {
 		TransformRegistry registry = configuration != null ? DefaultTransformRegistry.from(configuration)
 				: DefaultTransformRegistry.empty();
 		instrumentation.addTransformer(new Transformer(registry), true);
@@ -132,7 +132,7 @@ public class Agent {
 		if (agentArguments == null || agentArguments.trim().length() == 0) {
 			try {
 				initializeAgent((InputStream) null, instrumentation);
-			} catch (XMLStreamException e) {
+			} catch (XMLStreamException | XMLValidationException e) {
 				// noop: null as InputStream causes defaults to be used - the stream will not be used
 			}
 			return;
@@ -141,7 +141,7 @@ public class Agent {
 		File file = new File(agentArguments);
 		try (InputStream stream = new FileInputStream(file)) {
 			initializeAgent(stream, instrumentation);
-		} catch (XMLStreamException | IOException e) {
+		} catch (XMLStreamException | IOException | XMLValidationException e) {
 			getLogger().log(Level.SEVERE, "Failed to read jfr probe definitions from " + file.getPath(), e); //$NON-NLS-1$
 		}
 	}

--- a/agent/src/main/java/org/openjdk/jmc/agent/TransformRegistry.java
+++ b/agent/src/main/java/org/openjdk/jmc/agent/TransformRegistry.java
@@ -35,6 +35,8 @@ package org.openjdk.jmc.agent;
 import java.util.List;
 import java.util.Set;
 
+import javax.xml.stream.XMLStreamException;
+
 public interface TransformRegistry {
 	/**
 	 * The named class has transforms that have not been executed yet.
@@ -83,8 +85,10 @@ public interface TransformRegistry {
 	 * @param xmlDescription
 	 *            an XML snippet describing the wanted modifications.
 	 * @return a set of class names associated with modified {@link TransformDescriptor}s.
+	 * @throws XMLStreamException
+	 *             if the supplied XML fails to validate.
 	 */
-	Set<String> modify(String xmlDescription);
+	Set<String> modify(String xmlDescription) throws XMLStreamException;
 
 	/**
 	 * Clears all classes and their corresponding transforms in the registry.

--- a/agent/src/main/java/org/openjdk/jmc/agent/TransformRegistry.java
+++ b/agent/src/main/java/org/openjdk/jmc/agent/TransformRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -34,8 +34,6 @@ package org.openjdk.jmc.agent;
 
 import java.util.List;
 import java.util.Set;
-
-import javax.xml.stream.XMLStreamException;
 
 public interface TransformRegistry {
 	/**
@@ -85,10 +83,10 @@ public interface TransformRegistry {
 	 * @param xmlDescription
 	 *            an XML snippet describing the wanted modifications.
 	 * @return a set of class names associated with modified {@link TransformDescriptor}s.
-	 * @throws XMLStreamException
+	 * @throws XMLValidationException
 	 *             if the supplied XML fails to validate.
 	 */
-	Set<String> modify(String xmlDescription) throws XMLStreamException;
+	Set<String> modify(String xmlDescription) throws XMLValidationException;
 
 	/**
 	 * Clears all classes and their corresponding transforms in the registry.

--- a/agent/src/main/java/org/openjdk/jmc/agent/XMLValidationException.java
+++ b/agent/src/main/java/org/openjdk/jmc/agent/XMLValidationException.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Red Hat Inc. All rights reserved.
+ * 
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * The contents of this file are subject to the terms of either the Universal Permissive License
+ * v 1.0 as shown at http://oss.oracle.com/licenses/upl
+ *
+ * or the following license:
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted
+ * provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions
+ * and the following disclaimer.
+ * 
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other materials provided with
+ * the distribution.
+ * 
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to
+ * endorse or promote products derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+ * WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.openjdk.jmc.agent;
+
+/**
+ * Exception to throw when validating the agent probe definitino xml fails
+ */
+public class XMLValidationException extends Exception {
+
+	/**
+	 */
+	private static final long serialVersionUID = -9001765953540356861L;
+
+	/**
+	 * @param message
+	 */
+	public XMLValidationException(String message) {
+		super(message);
+	}
+
+	/**
+	 * @param message
+	 * @param cause
+	 */
+	public XMLValidationException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+}

--- a/agent/src/main/java/org/openjdk/jmc/agent/impl/DefaultTransformRegistry.java
+++ b/agent/src/main/java/org/openjdk/jmc/agent/impl/DefaultTransformRegistry.java
@@ -484,7 +484,7 @@ public class DefaultTransformRegistry implements TransformRegistry {
 	}
 
 	@Override
-	public Set<String> modify(String xmlDescription) {
+	public Set<String> modify(String xmlDescription) throws XMLStreamException {
 		try {
 			validateProbeDefinition(xmlDescription);
 
@@ -517,7 +517,7 @@ public class DefaultTransformRegistry implements TransformRegistry {
 			return modifiedClasses;
 		} catch (XMLStreamException xse) {
 			logger.log(Level.SEVERE, "Failed to create XML Stream Reader", xse);
-			return null;
+			throw xse;
 		}
 	}
 

--- a/agent/src/main/java/org/openjdk/jmc/agent/impl/DefaultTransformRegistry.java
+++ b/agent/src/main/java/org/openjdk/jmc/agent/impl/DefaultTransformRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -68,6 +68,7 @@ import org.openjdk.jmc.agent.Parameter;
 import org.openjdk.jmc.agent.ReturnValue;
 import org.openjdk.jmc.agent.TransformDescriptor;
 import org.openjdk.jmc.agent.TransformRegistry;
+import org.openjdk.jmc.agent.XMLValidationException;
 import org.openjdk.jmc.agent.jfr.JFRTransformDescriptor;
 import org.openjdk.jmc.agent.util.IOToolkit;
 import org.openjdk.jmc.agent.util.TypeUtils;
@@ -121,20 +122,20 @@ public class DefaultTransformRegistry implements TransformRegistry {
 		return new DefaultTransformRegistry();
 	}
 
-	public static void validateProbeDefinition(InputStream in) throws XMLStreamException {
+	public static void validateProbeDefinition(InputStream in) throws XMLValidationException {
 		try {
 			Validator validator = PROBE_SCHEMA.newValidator();
 			validator.validate(new StreamSource(in));
 		} catch (IOException | SAXException e) {
-			throw new XMLStreamException(e);
+			throw new XMLValidationException(e.getMessage(), e);
 		}
 	}
 
-	public static void validateProbeDefinition(String configuration) throws XMLStreamException {
+	public static void validateProbeDefinition(String configuration) throws XMLValidationException {
 		validateProbeDefinition(new ByteArrayInputStream(configuration.getBytes()));
 	}
 
-	public static TransformRegistry from(InputStream in) throws XMLStreamException {
+	public static TransformRegistry from(InputStream in) throws XMLStreamException, XMLValidationException {
 		byte[] buf;
 		InputStream configuration;
 		try {
@@ -145,6 +146,8 @@ public class DefaultTransformRegistry implements TransformRegistry {
 			configuration.reset();
 		} catch (IOException e) {
 			throw new XMLStreamException(e);
+		} catch (XMLValidationException xve) {
+			throw xve;
 		}
 
 		HashMap<String, String> globalDefaults = new HashMap<>();
@@ -484,7 +487,7 @@ public class DefaultTransformRegistry implements TransformRegistry {
 	}
 
 	@Override
-	public Set<String> modify(String xmlDescription) throws XMLStreamException {
+	public Set<String> modify(String xmlDescription) throws XMLValidationException {
 		try {
 			validateProbeDefinition(xmlDescription);
 
@@ -517,7 +520,7 @@ public class DefaultTransformRegistry implements TransformRegistry {
 			return modifiedClasses;
 		} catch (XMLStreamException xse) {
 			logger.log(Level.SEVERE, "Failed to create XML Stream Reader", xse);
-			throw xse;
+			throw new XMLValidationException(xse.getMessage(), xse);
 		}
 	}
 

--- a/agent/src/main/java/org/openjdk/jmc/agent/jmx/AgentController.java
+++ b/agent/src/main/java/org/openjdk/jmc/agent/jmx/AgentController.java
@@ -66,14 +66,15 @@ public class AgentController implements AgentControllerMXBean {
 			registry.setCurrentConfiguration("");
 		} else {
 			Set<String> initialClasses = new HashSet<>(registry.getClassNames());
-			Set<String> modifiedClasses = registry.modify(xmlDescription);
-			if (modifiedClasses == null) {
-				logger.log(Level.SEVERE, "Failed to identify transformations: " + xmlDescription);
-				return;
-			} else {
-				modifiedClasses.addAll(initialClasses);
-				classesToRetransformArray = retransformClasses(modifiedClasses);
+			Set<String> modifiedClasses;
+			try {
+				modifiedClasses = registry.modify(xmlDescription);
+			} catch (Exception e) {
+				logger.severe("Failed to identify transformations: " + xmlDescription);
+				throw e;
 			}
+			modifiedClasses.addAll(initialClasses);
+			classesToRetransformArray = retransformClasses(modifiedClasses);
 		}
 		registry.setRevertInstrumentation(true);
 		instrumentation.retransformClasses(classesToRetransformArray);

--- a/agent/src/main/java/org/openjdk/jmc/agent/jmx/AgentController.java
+++ b/agent/src/main/java/org/openjdk/jmc/agent/jmx/AgentController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021 Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/agent/src/test/java/org/openjdk/jmc/agent/converters/test/TestConverterTransforms.java
+++ b/agent/src/test/java/org/openjdk/jmc/agent/converters/test/TestConverterTransforms.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021 Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -52,6 +52,7 @@ import org.objectweb.asm.util.CheckClassAdapter;
 import org.objectweb.asm.util.TraceClassVisitor;
 import org.openjdk.jmc.agent.TransformRegistry;
 import org.openjdk.jmc.agent.Transformer;
+import org.openjdk.jmc.agent.XMLValidationException;
 import org.openjdk.jmc.agent.impl.DefaultTransformRegistry;
 import org.openjdk.jmc.agent.test.util.TestToolkit;
 
@@ -63,7 +64,8 @@ public class TestConverterTransforms {
 	}
 
 	@Test
-	public void testRunConverterTransforms() throws XMLStreamException, IllegalClassFormatException, IOException {
+	public void testRunConverterTransforms()
+			throws XMLStreamException, IllegalClassFormatException, IOException, XMLValidationException {
 		TransformRegistry registry = DefaultTransformRegistry.from(TestToolkit.getProbesXMLFromTemplate(getTemplate(),
 				"testRunConverterTransforms" + runCount.getAndIncrement())); //$NON-NLS-1$
 
@@ -84,7 +86,8 @@ public class TestConverterTransforms {
 		reader.accept(checkAdapter, 0);
 	}
 
-	public static void main(String[] args) throws XMLStreamException, IOException, IllegalClassFormatException {
+	public static void main(String[] args)
+			throws XMLStreamException, IOException, IllegalClassFormatException, XMLValidationException {
 		TransformRegistry registry = DefaultTransformRegistry.from(TestToolkit.getProbesXMLFromTemplate(getTemplate(),
 				"testRunConverterTransforms" + runCount.getAndIncrement())); //$NON-NLS-1$
 

--- a/agent/src/test/java/org/openjdk/jmc/agent/test/TestDefaultTransformRegistry.java
+++ b/agent/src/test/java/org/openjdk/jmc/agent/test/TestDefaultTransformRegistry.java
@@ -124,8 +124,14 @@ public class TestDefaultTransformRegistry {
 		assertNotNull(registry);
 		final String initialConfiguration = registry.getCurrentConfiguration();
 		final String invalidSnippet = XML_EVENT_DESCRIPTION;
-		Set<String> modifiedClassNames = registry.modify(invalidSnippet);
-		assertNull(modifiedClassNames);
+		boolean exceptionThrown = false;
+		try {
+			Set<String> modifiedClassNames = registry.modify(invalidSnippet);
+		} catch (Exception e) {
+			e.printStackTrace(System.err);
+			exceptionThrown = true;
+		}
+		assertTrue(exceptionThrown);
 		assertEquals(registry.getCurrentConfiguration(), initialConfiguration);
 	}
 

--- a/agent/src/test/java/org/openjdk/jmc/agent/test/TestDefaultTransformRegistry.java
+++ b/agent/src/test/java/org/openjdk/jmc/agent/test/TestDefaultTransformRegistry.java
@@ -47,6 +47,7 @@ import org.junit.Test;
 import org.objectweb.asm.Type;
 import org.openjdk.jmc.agent.TransformDescriptor;
 import org.openjdk.jmc.agent.TransformRegistry;
+import org.openjdk.jmc.agent.XMLValidationException;
 import org.openjdk.jmc.agent.impl.DefaultTransformRegistry;
 import org.openjdk.jmc.agent.test.util.TestToolkit;
 
@@ -64,7 +65,7 @@ public class TestDefaultTransformRegistry {
 	}
 
 	@Test
-	public void testHasPendingTransforms() throws XMLStreamException, IOException {
+	public void testHasPendingTransforms() throws XMLStreamException, IOException, XMLValidationException {
 		TransformRegistry registry = DefaultTransformRegistry
 				.from(TestToolkit.getProbesXMLFromTemplate(getTemplate(), "HasPendingTransforms")); //$NON-NLS-1$
 		assertNotNull(registry);
@@ -78,14 +79,14 @@ public class TestDefaultTransformRegistry {
 	}
 
 	@Test
-	public void testFrom() throws XMLStreamException, IOException {
+	public void testFrom() throws XMLStreamException, IOException, XMLValidationException {
 		TransformRegistry registry = DefaultTransformRegistry
 				.from(TestToolkit.getProbesXMLFromTemplate(getTemplate(), "From")); //$NON-NLS-1$
 		assertNotNull(registry);
 	}
 
 	@Test
-	public void testGetTransformData() throws XMLStreamException, IOException {
+	public void testGetTransformData() throws XMLStreamException, IOException, XMLValidationException {
 		TransformRegistry registry = DefaultTransformRegistry
 				.from(TestToolkit.getProbesXMLFromTemplate(getTemplate(), "GetTransformData")); //$NON-NLS-1$
 		assertNotNull(registry);
@@ -95,7 +96,7 @@ public class TestDefaultTransformRegistry {
 	}
 
 	@Test
-	public void testModify() throws XMLStreamException, IOException {
+	public void testModify() throws XMLValidationException, IOException, XMLStreamException {
 		TransformRegistry registry = DefaultTransformRegistry
 				.from(TestToolkit.getProbesXMLFromTemplate(getTemplate(), "Modify")); //$NON-NLS-1$
 		assertNotNull(registry);
@@ -107,7 +108,7 @@ public class TestDefaultTransformRegistry {
 	}
 
 	@Test
-	public void testModifyNameCollision() throws XMLStreamException, IOException {
+	public void testModifyNameCollision() throws XMLValidationException, IOException, XMLStreamException {
 		TransformRegistry registry = DefaultTransformRegistry
 				.from(TestToolkit.getProbesXMLFromTemplate(getTemplate(), "Modify")); //$NON-NLS-1$
 		assertNotNull(registry);
@@ -118,7 +119,7 @@ public class TestDefaultTransformRegistry {
 	}
 
 	@Test
-	public void testModifyInvalidXml() throws XMLStreamException, IOException {
+	public void testModifyInvalidXml() throws XMLStreamException, IOException, XMLValidationException {
 		TransformRegistry registry = DefaultTransformRegistry
 				.from(TestToolkit.getProbesXMLFromTemplate(getTemplate(), "Modify")); //$NON-NLS-1$
 		assertNotNull(registry);
@@ -136,7 +137,7 @@ public class TestDefaultTransformRegistry {
 	}
 
 	@Test
-	public void testClearAllTransformData() throws XMLStreamException, IOException {
+	public void testClearAllTransformData() throws XMLStreamException, IOException, XMLValidationException {
 		TransformRegistry registry = DefaultTransformRegistry.from(TestToolkit
 				.getProbesXMLFromTemplate(getXMLDescription(XML_EVENT_DESCRIPTION), "clearAllTransformData")); //$NON-NLS-1$
 		assertNotNull(registry);

--- a/agent/src/test/java/org/openjdk/jmc/agent/test/TestDefineEventProbes.java
+++ b/agent/src/test/java/org/openjdk/jmc/agent/test/TestDefineEventProbes.java
@@ -80,6 +80,8 @@ public class TestDefineEventProbes {
 			+ EVENT_PATH + "</path>" + "<stacktrace>true</stacktrace>" + "<class>" + EVENT_CLASS_NAME + "</class>"
 			+ "<method>" + "<name>" + METHOD_NAME + "</name>" + "<descriptor>" + METHOD_DESCRIPTOR + "</descriptor>"
 			+ "</method>" + "<location>WRAP</location>" + "</event>" + "</events>" + "</jfragent>";
+	private static final String MALFORMED_XML = "<this>" + "<is>" + "<not>" + "<a>" + "<valid>" + "<probe>"
+			+ "<definition>" + "</definition>" + "</probe>" + "</valid>" + "</a>" + "</not>" + "</is>" + "</this>";
 
 	@Test
 	public void testDefineEventProbes() throws Exception {
@@ -110,6 +112,18 @@ public class TestDefineEventProbes {
 			e.printStackTrace(System.err);
 		}
 		assertFalse(exceptionThrown);
+	}
+
+	@Test
+	public void testMalformedProbeDefinition() throws Exception {
+		boolean exceptionThrown = false;
+		try {
+			doDefineEventProbes(MALFORMED_XML);
+		} catch (Exception e) {
+			exceptionThrown = true;
+			e.printStackTrace(System.err);
+		}
+		assertTrue(exceptionThrown);
 	}
 
 	private void injectFailingEvent() throws Exception {

--- a/agent/src/test/java/org/openjdk/jmc/agent/test/TestDefineEventProbes.java
+++ b/agent/src/test/java/org/openjdk/jmc/agent/test/TestDefineEventProbes.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2019, 2020, Red Hat Inc. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2021, Red Hat Inc. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/agent/src/test/java/org/openjdk/jmc/agent/test/TestJFRTransformer.java
+++ b/agent/src/test/java/org/openjdk/jmc/agent/test/TestJFRTransformer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021 Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -52,6 +52,7 @@ import org.objectweb.asm.util.TraceClassVisitor;
 import org.openjdk.jmc.agent.Agent;
 import org.openjdk.jmc.agent.TransformRegistry;
 import org.openjdk.jmc.agent.Transformer;
+import org.openjdk.jmc.agent.XMLValidationException;
 import org.openjdk.jmc.agent.impl.DefaultTransformRegistry;
 import org.openjdk.jmc.agent.test.util.TestToolkit;
 
@@ -59,7 +60,8 @@ public class TestJFRTransformer {
 	private static AtomicInteger runCount = new AtomicInteger(0);
 
 	@Test
-	public void testRunTransforms() throws XMLStreamException, IllegalClassFormatException, IOException {
+	public void testRunTransforms()
+			throws XMLStreamException, XMLValidationException, IllegalClassFormatException, IOException {
 		TransformRegistry registry = DefaultTransformRegistry.from(TestToolkit.getProbesXMLFromTemplate(
 				TestDefaultTransformRegistry.getTemplate(), "RunTransforms" + runCount.getAndIncrement())); //$NON-NLS-1$
 

--- a/agent/src/test/java/org/openjdk/jmc/agent/test/TestProbeDefinitionValidation.java
+++ b/agent/src/test/java/org/openjdk/jmc/agent/test/TestProbeDefinitionValidation.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2020, Red Hat Inc. All rights reserved.
+ * Copyright (c) 2020, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2021 Red Hat Inc. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -34,9 +34,9 @@
 package org.openjdk.jmc.agent.test;
 
 import org.junit.Test;
+import org.openjdk.jmc.agent.XMLValidationException;
 import org.openjdk.jmc.agent.impl.DefaultTransformRegistry;
 
-import javax.xml.stream.XMLStreamException;
 import java.text.MessageFormat;
 import java.util.Arrays;
 
@@ -45,7 +45,7 @@ public class TestProbeDefinitionValidation {
 	private final String GLOBAL_POSTFIX = "</events></jfragent>";
 
 	@Test
-	public void testValidatingProbeDefinition() throws XMLStreamException {
+	public void testValidatingProbeDefinition() throws XMLValidationException {
 		// a partially defined event with all optional elements unset
 		String probe = "<event id=\"demo.event2\">\n" // 
 				+ "    <label>Event 2</label>\n" //
@@ -60,7 +60,7 @@ public class TestProbeDefinitionValidation {
 	}
 
 	@Test
-	public void testValidatingFullyDefinedProbe() throws XMLStreamException {
+	public void testValidatingFullyDefinedProbe() throws XMLValidationException {
 		// a fully defined event with all optional elements set
 		String probe = "<event id=\"demo.event1\">\n" + "            <label>Event 1</label>\n"
 				+ "            <class>com.company.project.MyDemoClass</class>\n"
@@ -92,18 +92,18 @@ public class TestProbeDefinitionValidation {
 		DefaultTransformRegistry.validateProbeDefinition(GLOBAL_PREFIX + probe + GLOBAL_POSTFIX);
 	}
 
-	@Test(expected = XMLStreamException.class)
-	public void testValidatingEmptyString() throws XMLStreamException {
+	@Test(expected = XMLValidationException.class)
+	public void testValidatingEmptyString() throws XMLValidationException {
 		DefaultTransformRegistry.validateProbeDefinition("");
 	}
 
-	@Test(expected = XMLStreamException.class)
-	public void testValidatingNonXmlInput() throws XMLStreamException {
+	@Test(expected = XMLValidationException.class)
+	public void testValidatingNonXmlInput() throws XMLValidationException {
 		DefaultTransformRegistry.validateProbeDefinition("This is not an XML string");
 	}
 
 	@Test
-	public void testValidatingCorrectClassNames() throws XMLStreamException {
+	public void testValidatingCorrectClassNames() throws XMLValidationException {
 		String probe = "<event id=\"demo.event2\">\n" // 
 				+ "    <label>Event 2</label>\n" //
 				+ "    <class>{0}</class>\n" // 
@@ -120,8 +120,8 @@ public class TestProbeDefinitionValidation {
 		}
 	}
 
-	@Test(expected = XMLStreamException.class)
-	public void testValidatingEmptyClassName() throws XMLStreamException {
+	@Test(expected = XMLValidationException.class)
+	public void testValidatingEmptyClassName() throws XMLValidationException {
 		String probe = "<event id=\"demo.event2\">\n" // 
 				+ "    <label>Event 2</label>\n" //
 				+ "    <method>\n" // 
@@ -133,8 +133,8 @@ public class TestProbeDefinitionValidation {
 		DefaultTransformRegistry.validateProbeDefinition(GLOBAL_PREFIX + probe + GLOBAL_POSTFIX);
 	}
 
-	@Test(expected = XMLStreamException.class)
-	public void testValidatingIncorrectClassPattern() throws XMLStreamException {
+	@Test(expected = XMLValidationException.class)
+	public void testValidatingIncorrectClassPattern() throws XMLValidationException {
 		String probe = "<event id=\"demo.event2\">\n" // 
 				+ "    <label>Event 2</label>\n" //
 				+ "    <class>not a validate full-qualified-class-name</class>\n" //
@@ -148,7 +148,7 @@ public class TestProbeDefinitionValidation {
 	}
 
 	@Test
-	public void testValidatingMethodDescriptor() throws XMLStreamException {
+	public void testValidatingMethodDescriptor() throws XMLValidationException {
 		String probe = "<event id=\"demo.event2\">\n" // 
 				+ "    <label>Event 2</label>\n" //
 				+ "    <class>org.company.project.MyDemoClass</class>\n" // 
@@ -167,8 +167,8 @@ public class TestProbeDefinitionValidation {
 		}
 	}
 
-	@Test(expected = XMLStreamException.class)
-	public void testValidatingEmptyDescriptor() throws XMLStreamException {
+	@Test(expected = XMLValidationException.class)
+	public void testValidatingEmptyDescriptor() throws XMLValidationException {
 		String probe = "<event id=\"demo.event2\">\n" // 
 				+ "    <label>Event 2</label>\n" //
 				+ "    <class>org.company.project.MyDemoClass</class>" //
@@ -180,8 +180,8 @@ public class TestProbeDefinitionValidation {
 		DefaultTransformRegistry.validateProbeDefinition(GLOBAL_PREFIX + probe + GLOBAL_POSTFIX);
 	}
 
-	@Test(expected = XMLStreamException.class)
-	public void testValidatingIncorrectDescriptor() throws XMLStreamException {
+	@Test(expected = XMLValidationException.class)
+	public void testValidatingIncorrectDescriptor() throws XMLValidationException {
 		String probe = "<event id=\"demo.event2\">\n" // 
 				+ "    <label>Event 2</label>\n" //
 				+ "    <class>org.company.project.MyDemoClass</class>" //
@@ -195,7 +195,7 @@ public class TestProbeDefinitionValidation {
 	}
 
 	@Test
-	public void testValidatingExpressions() throws XMLStreamException {
+	public void testValidatingExpressions() throws XMLValidationException {
 		String probe = "<event id=\"demo.event2\">\n" // 
 				+ "    <label>Event 2</label>\n" //
 				+ "    <class>org.company.project.MyDemoClass</class>\n" // 


### PR DESCRIPTION
This PR addresses JMC-6890 (defineEventProbes should throw exception on malformed probe definitions) [1]. Previously the exception would be swallowed by DefaultTransformRegistry when the XML failed validation, and would simply return null. With this change the exception is rethrown and can be handled accordingly by the AgentController, which rethrows it, and the user. I've added a test for the AgentController and updated the test for DefaultTransformRegistry accordingly.

[1] https://bugs.openjdk.java.net/browse/JMC-6890

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JMC-6890](https://bugs.openjdk.java.net/browse/JMC-6890): defineEventProbes should throw exception on malformed probe definitions


### Reviewers
 * [Marcus Hirt](https://openjdk.java.net/census#hirt) (@thegreystone - **Reviewer**)


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jmc pull/227/head:pull/227`
`$ git checkout pull/227`

To update a local copy of the PR:
`$ git checkout pull/227`
`$ git pull https://git.openjdk.java.net/jmc pull/227/head`
