### PR TITLE
7195: GC confguration with GC Flags

### DIFF
--- a/application/org.openjdk.jmc.flightrecorder.ui/defaultPages.xml
+++ b/application/org.openjdk.jmc.flightrecorder.ui/defaultPages.xml
@@ -776,6 +776,15 @@
 		</page>
 		<page factory="org.openjdk.jmc.flightrecorder.ui.gcconfiguration"
 			id="org.openjdk.jmc.flightrecorder.ui.gcconfiguration">
+			<state>
+				<jvmFlags sortColumn="name:text">
+					<column id="name:text" width="200" />
+					<column id="value" width="110" />
+					<column id="origin:text" width="110" />
+				</jvmFlags>
+				<jvmFlagsFilter showFilter="false" showSearch="true" />
+			</state>
+			
 		</page>
 		<page factory="org.openjdk.jmc.flightrecorder.ui.compilations" id="org.openjdk.jmc.flightrecorder.ui.compilations">
 			<state>

--- a/application/org.openjdk.jmc.flightrecorder.ui/defaultPages.xml
+++ b/application/org.openjdk.jmc.flightrecorder.ui/defaultPages.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--   
-   Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+   Copyright (c) 2018, 2021 Oracle and/or its affiliates. All rights reserved.
    
    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
    

--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/messages/internal/Messages.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/messages/internal/Messages.java
@@ -184,6 +184,8 @@ public class Messages extends NLS {
 	public static String GCConfigurationPage_SECTION_GC_CONFIG;
 	public static String GCConfigurationPage_SECTION_HEAP_CONFIG;
 	public static String GCConfigurationPage_SECTION_YOUNG_CONFIG;
+	public static String GCConfigurationPage_SECTION_JVM_GC_FLAGS;
+	public static String GCConfigurationPage_COLUMN_VALUE;
 	public static String GarbageCollectionsPage_COMMITTED_HEAP_DELTA;
 	public static String GarbageCollectionsPage_COMMITTED_METASPACE_DELTA;
 	public static String GarbageCollectionsPage_DISABLED_TOOLTIP;

--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/messages/internal/Messages.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/messages/internal/Messages.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021 Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/GCConfigurationPage.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/GCConfigurationPage.java
@@ -44,7 +44,6 @@ import org.eclipse.swt.widgets.Composite;
 import org.eclipse.ui.forms.widgets.Form;
 import org.eclipse.ui.forms.widgets.FormToolkit;
 import org.eclipse.ui.forms.widgets.Section;
-
 import org.openjdk.jmc.common.IState;
 import org.openjdk.jmc.common.item.IAccessorFactory;
 import org.openjdk.jmc.common.item.IItemFilter;
@@ -72,9 +71,9 @@ import org.openjdk.jmc.flightrecorder.ui.common.ItemHistogram;
 import org.openjdk.jmc.flightrecorder.ui.common.ItemHistogram.CompositeKeyHistogramBuilder;
 import org.openjdk.jmc.flightrecorder.ui.messages.internal.Messages;
 import org.openjdk.jmc.ui.accessibility.SimpleTraverseListener;
+import org.openjdk.jmc.ui.column.ColumnManager.SelectionState;
 import org.openjdk.jmc.ui.column.ColumnMenusFactory;
 import org.openjdk.jmc.ui.column.TableSettings;
-import org.openjdk.jmc.ui.column.ColumnManager.SelectionState;
 import org.openjdk.jmc.ui.handlers.MCContextMenuManager;
 import org.openjdk.jmc.ui.misc.CompositeToolkit;
 
@@ -249,10 +248,20 @@ public class GCConfigurationPage extends AbstractDataPage {
 		if(oldCollector == null) {
 			return ItemFilters.all();
 		}
+
 		
 		// Flags like ParallelGCThreads, ConcGCThreads, Xmx, NewRatio are left as this information is contained in the gc configuration event
+		// from https://github.com/openjdk/jdk11u/blob/master/src/hotspot/share/gc/shared/gc_globals.hpp
 		switch (oldCollector) {
+		// https://github.com/openjdk/jdk11u/blob/6c31ac2acdc2b2efa63fe92de8368ab964d847e9/src/hotspot/share/gc/epsilon/epsilon_globals.hpp
+		// TODO
+//		case "Epsilon":
+//			// from https://github.com/openjdk/jdk11u/blob/6c31ac2acdc2b2efa63fe92de8368ab964d847e9/src/hotspot/share/gc/serial/serial_globals.hpp
+//			return ItemFilters.or(ItemFilters.equals(JdkAttributes.FLAG_NAME, "UseEpsilonGC"), //$NON-NLS-1$
+//					ItemFilters.matches(JdkAttributes.FLAG_NAME, "^Epsilon.+")); //$NON-NLS-1$
+
 		case "G1Old":
+			// https://github.com/openjdk/jdk11u/blob/6c31ac2acdc2b2efa63fe92de8368ab964d847e9/src/hotspot/share/gc/g1/g1_globals.hpp
 			return ItemFilters.or(
 					ItemFilters.equals(JdkAttributes.FLAG_NAME, "UseG1GC"), //$NON-NLS-1$
 					ItemFilters.equals(JdkAttributes.FLAG_NAME, "InitiatingHeapOccupancyPercent"), //$NON-NLS-1$
@@ -264,9 +273,10 @@ public class GCConfigurationPage extends AbstractDataPage {
 					ItemFilters.equals(JdkAttributes.FLAG_NAME, "UseTransparentHugePages"), //$NON-NLS-1$
 					ItemFilters.equals(JdkAttributes.FLAG_NAME, "UseNUMA"), //$NON-NLS-1$
 					ItemFilters.equals(JdkAttributes.FLAG_NAME, "AlwaysPreTouch"), //$NON-NLS-1$
-					ItemFilters.matches(JdkAttributes.FLAG_NAME, "^G1.+")) ; //$NON-NLS-1$
+					ItemFilters.matches(JdkAttributes.FLAG_NAME, "^G1.+")); //$NON-NLS-1$
 
 		case "Z":
+			// from https://github.com/openjdk/jdk11u/blob/6c31ac2acdc2b2efa63fe92de8368ab964d847e9/src/hotspot/share/gc/z/z_globals.hpp
 			return ItemFilters.or(
 					ItemFilters.equals(JdkAttributes.FLAG_NAME, "UseZGC"), //$NON-NLS-1$
 					ItemFilters.equals(JdkAttributes.FLAG_NAME, "SoftMaxHeapSize"), //$NON-NLS-1$
@@ -276,9 +286,10 @@ public class GCConfigurationPage extends AbstractDataPage {
 					ItemFilters.equals(JdkAttributes.FLAG_NAME, "UseStringDeduplication"), //$NON-NLS-1$
 					ItemFilters.equals(JdkAttributes.FLAG_NAME, "SoftRefLRUPolicyMSPerMB"), //$NON-NLS-1$
 					ItemFilters.equals(JdkAttributes.FLAG_NAME, "AlwaysPreTouch"), //$NON-NLS-1$
-					ItemFilters.matches(JdkAttributes.FLAG_NAME, "^Z[A-Z].+")) ; //$NON-NLS-1$
+					ItemFilters.matches(JdkAttributes.FLAG_NAME, "^Z[A-Z].+")); //$NON-NLS-1$
 			
 		case "Shenandoah":
+			// from https://github.com/openjdk/jdk11u/blob/6c31ac2acdc2b2efa63fe92de8368ab964d847e9/src/hotspot/share/gc/shenandoah/shenandoah_globals.hpp
 			return ItemFilters.or(
 					ItemFilters.equals(JdkAttributes.FLAG_NAME, "UseShenandoahGC"), //$NON-NLS-1$
 					ItemFilters.equals(JdkAttributes.FLAG_NAME, "SoftMaxHeapSize"), //$NON-NLS-1$
@@ -288,7 +299,38 @@ public class GCConfigurationPage extends AbstractDataPage {
 					ItemFilters.equals(JdkAttributes.FLAG_NAME, "UseNUMA"), //$NON-NLS-1$
 					ItemFilters.equals(JdkAttributes.FLAG_NAME, "SoftRefLRUPolicyMSPerMB"), //$NON-NLS-1$
 					ItemFilters.equals(JdkAttributes.FLAG_NAME, "AlwaysPreTouch"), //$NON-NLS-1$
-					ItemFilters.matches(JdkAttributes.FLAG_NAME, "^Z[A-Z].+")) ; //$NON-NLS-1$
+					ItemFilters.matches(JdkAttributes.FLAG_NAME, "^Z[A-Z].+")); //$NON-NLS-1$
+			
+		case "SerialOld":
+			// from https://github.com/openjdk/jdk11u/blob/6c31ac2acdc2b2efa63fe92de8368ab964d847e9/src/hotspot/share/gc/serial/serial_globals.hpp
+			return ItemFilters.or(ItemFilters.equals(JdkAttributes.FLAG_NAME, "UseSerialGC")); //$NON-NLS-1$
+
+		case "ParallelOld":
+			// from https://github.com/openjdk/jdk11u/blob/6c31ac2acdc2b2efa63fe92de8368ab964d847e9/src/hotspot/share/gc/parallel/parallel_globals.hpp
+			return ItemFilters.or(ItemFilters.equals(JdkAttributes.FLAG_NAME, "UseParallelGC"), //$NON-NLS-1$
+					ItemFilters.equals(JdkAttributes.FLAG_NAME, "HeapMaximumCompactionInterval"), //$NON-NLS-1$
+					ItemFilters.equals(JdkAttributes.FLAG_NAME, "HeapFirstMaximumCompactionCount"), //$NON-NLS-1$
+					ItemFilters.equals(JdkAttributes.FLAG_NAME, "UseMaximumCompactionOnSystemGC"), //$NON-NLS-1$
+					ItemFilters.equals(JdkAttributes.FLAG_NAME, "ParallelOldDeadWoodLimiterMean"), //$NON-NLS-1$
+					ItemFilters.equals(JdkAttributes.FLAG_NAME, "ParallelOldDeadWoodLimiterStdDev"), //$NON-NLS-1$
+					ItemFilters.equals(JdkAttributes.FLAG_NAME, "GCWorkerDelayMillis"), //$NON-NLS-1$
+					ItemFilters.equals(JdkAttributes.FLAG_NAME, "PSChunkLargeArrays"), //$NON-NLS-1$
+					ItemFilters.equals(JdkAttributes.FLAG_NAME, "HeapMaximumCompactionInterval"), //$NON-NLS-1$
+					ItemFilters.equals(JdkAttributes.FLAG_NAME, "UseNUMA"), //$NON-NLS-1$
+					ItemFilters.equals(JdkAttributes.FLAG_NAME, "AlwaysPreTouch"), //$NON-NLS-1$
+					ItemFilters.matches(JdkAttributes.FLAG_NAME, "^CMS[A-Z].+")); //$NON-NLS-1$
+
+		case "ConcurrentMarkSweep":
+			// from https://github.com/openjdk/jdk11u/blob/6c31ac2acdc2b2efa63fe92de8368ab964d847e9/src/hotspot/share/gc/cms/cms_globals.hpp
+			return ItemFilters.or(
+					ItemFilters.equals(JdkAttributes.FLAG_NAME, "UseConcMarkSweepGC"), //$NON-NLS-1$
+					ItemFilters.equals(JdkAttributes.FLAG_NAME, "UseCMSInitiatingOccupancyOnly"), //$NON-NLS-1$
+					ItemFilters.equals(JdkAttributes.FLAG_NAME, "BindCMSThreadToCPU"), //$NON-NLS-1$
+					ItemFilters.equals(JdkAttributes.FLAG_NAME, "CPUForCMSThread"), //$NON-NLS-1$
+					ItemFilters.equals(JdkAttributes.FLAG_NAME, "ParallelRefProcEnabled"), //$NON-NLS-1$
+					ItemFilters.equals(JdkAttributes.FLAG_NAME, "ScavengeBeforeFullGC"), //$NON-NLS-1$
+					ItemFilters.equals(JdkAttributes.FLAG_NAME, "AlwaysPreTouch"), //$NON-NLS-1$
+					ItemFilters.matches(JdkAttributes.FLAG_NAME, "^(CMS|FLS|ParGC)[A-Z_].+")); //$NON-NLS-1$
 		}
 
 		return ItemFilters.contains(JdkAttributes.FLAG_NAME, oldCollector);

--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/GCConfigurationPage.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/GCConfigurationPage.java
@@ -32,7 +32,12 @@
  */
 package org.openjdk.jmc.flightrecorder.ui.pages;
 
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
 import org.eclipse.jface.resource.ImageDescriptor;
+import org.eclipse.jface.viewers.ColumnViewer;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.SashForm;
 import org.eclipse.swt.widgets.Composite;
@@ -41,9 +46,17 @@ import org.eclipse.ui.forms.widgets.FormToolkit;
 import org.eclipse.ui.forms.widgets.Section;
 
 import org.openjdk.jmc.common.IState;
+import org.openjdk.jmc.common.IWritableState;
+import org.openjdk.jmc.common.item.IAccessorFactory;
 import org.openjdk.jmc.common.item.IItemFilter;
+import org.openjdk.jmc.common.item.IMemberAccessor;
+import org.openjdk.jmc.common.item.IType;
+import org.openjdk.jmc.common.item.ItemFilters;
+import org.openjdk.jmc.flightrecorder.JfrAttributes;
 import org.openjdk.jmc.flightrecorder.jdk.JdkAggregators;
+import org.openjdk.jmc.flightrecorder.jdk.JdkAttributes;
 import org.openjdk.jmc.flightrecorder.jdk.JdkFilters;
+import org.openjdk.jmc.flightrecorder.jdk.JdkTypeIDs;
 import org.openjdk.jmc.flightrecorder.rules.util.JfrRuleTopics;
 import org.openjdk.jmc.flightrecorder.ui.FlightRecorderUI;
 import org.openjdk.jmc.flightrecorder.ui.IDataPageFactory;
@@ -54,11 +67,18 @@ import org.openjdk.jmc.flightrecorder.ui.IPageUI;
 import org.openjdk.jmc.flightrecorder.ui.StreamModel;
 import org.openjdk.jmc.flightrecorder.ui.common.AbstractDataPage;
 import org.openjdk.jmc.flightrecorder.ui.common.DataPageToolkit;
+import org.openjdk.jmc.flightrecorder.ui.common.FilterComponent;
 import org.openjdk.jmc.flightrecorder.ui.common.ImageConstants;
 import org.openjdk.jmc.flightrecorder.ui.common.ItemAggregateViewer;
+import org.openjdk.jmc.flightrecorder.ui.common.ItemHistogram;
+import org.openjdk.jmc.flightrecorder.ui.common.ItemHistogram.CompositeKeyHistogramBuilder;
 import org.openjdk.jmc.flightrecorder.ui.messages.internal.Messages;
 import org.openjdk.jmc.ui.accessibility.SimpleTraverseListener;
+import org.openjdk.jmc.ui.column.ColumnMenusFactory;
+import org.openjdk.jmc.ui.column.TableSettings;
+import org.openjdk.jmc.ui.handlers.MCContextMenuManager;
 import org.openjdk.jmc.ui.misc.CompositeToolkit;
+import org.openjdk.jmc.ui.misc.PersistableSashForm;
 
 public class GCConfigurationPage extends AbstractDataPage {
 	public static class GCConfigurationPageFactory implements IDataPageFactory {
@@ -84,15 +104,69 @@ public class GCConfigurationPage extends AbstractDataPage {
 		}
 
 	}
+	
+	
+	
+	private static final String JVM_FLAGS = "jvmFlags"; //$NON-NLS-1$
+	private static final Set<String> FLAGS;
+
+	static {
+		Set<String> types = new HashSet<>();
+		types.add(JdkTypeIDs.LONG_FLAG);
+		types.add(JdkTypeIDs.ULONG_FLAG);
+		types.add(JdkTypeIDs.DOUBLE_FLAG);
+		types.add(JdkTypeIDs.BOOLEAN_FLAG);
+		types.add(JdkTypeIDs.STRING_FLAG);
+		types.add(JdkTypeIDs.INT_FLAG);
+		types.add(JdkTypeIDs.UINT_FLAG);
+		FLAGS = Collections.unmodifiableSet(types);
+	}
+	private static final IItemFilter FLAGS_FILTER = ItemFilters.type(FLAGS);
+	private static final IAccessorFactory<?> FLAG_VALUE_FIELD = new IAccessorFactory<Object>() {
+
+		@Override
+		public <T> IMemberAccessor<?, T> getAccessor(IType<T> type) {
+			switch (type.getIdentifier()) {
+			case JdkTypeIDs.LONG_FLAG:
+			case JdkTypeIDs.ULONG_FLAG:
+			case JdkTypeIDs.DOUBLE_FLAG:
+			case JdkTypeIDs.INT_FLAG:
+			case JdkTypeIDs.UINT_FLAG:
+				return JdkAttributes.FLAG_VALUE_NUMBER.getAccessor(type);
+			case JdkTypeIDs.BOOLEAN_FLAG:
+				return JdkAttributes.FLAG_VALUE_BOOLEAN.getAccessor(type);
+			case JdkTypeIDs.STRING_FLAG:
+				return JdkAttributes.FLAG_VALUE_TEXT.getAccessor(type);
+			default:
+				// FIXME: Return fallback function instead?
+				return null;
+			}
+		}
+
+	};
+    private static final String FLAG_VALUE_COL_ID = "value"; //$NON-NLS-1$
+	private static final CompositeKeyHistogramBuilder FLAG_HISTOGRAM = new CompositeKeyHistogramBuilder();
+	static {
+		FLAG_HISTOGRAM.addKeyColumn(JdkAttributes.FLAG_NAME);
+		FLAG_HISTOGRAM.addKeyColumn(JdkAttributes.FLAG_ORIGIN);
+		FLAG_HISTOGRAM.addKeyColumn(FLAG_VALUE_COL_ID, Messages.JVMInformationPage_COLUMN_VALUE, FLAG_VALUE_FIELD);
+	}
+	private SashForm flagSash;
+	private ItemHistogram allFlagsTable;
+	private IItemFilter flagsFilter;
+	private FilterComponent allFlagsFilter;
+
 
 	@Override
 	public IPageUI display(Composite parent, FormToolkit toolkit, IPageContainer pageContainer, IState state) {
 		Form form = DataPageToolkit.createForm(parent, toolkit, getName(), getIcon());
-		SashForm container = new SashForm(form.getBody(), SWT.HORIZONTAL);
-		container.setSashWidth(5);
-		container.addTraverseListener(new SimpleTraverseListener());
+		SashForm container = new SashForm(form.getBody(), SWT.VERTICAL);
+		
+		SashForm gcConfigSash = new SashForm(container, SWT.HORIZONTAL);
+		gcConfigSash.setSashWidth(5);
+		gcConfigSash.addTraverseListener(new SimpleTraverseListener());
 
-		Section gcConfigSection = CompositeToolkit.createSection(container, toolkit,
+		Section gcConfigSection = CompositeToolkit.createSection(gcConfigSash, toolkit,
 				Messages.GCConfigurationPage_SECTION_GC_CONFIG);
 		ItemAggregateViewer gcConfig = new ItemAggregateViewer(gcConfigSection, toolkit);
 		gcConfig.addAggregate(JdkAggregators.YOUNG_COLLECTOR);
@@ -105,7 +179,7 @@ public class GCConfigurationPage extends AbstractDataPage {
 		gcConfig.addAggregate(JdkAggregators.GC_TIME_RATIO_MIN);
 		gcConfigSection.setClient(gcConfig.getControl());
 
-		Section heapConfigSection = CompositeToolkit.createSection(container, toolkit,
+		Section heapConfigSection = CompositeToolkit.createSection(gcConfigSash, toolkit,
 				Messages.GCConfigurationPage_SECTION_HEAP_CONFIG);
 		ItemAggregateViewer heapConfig = new ItemAggregateViewer(heapConfigSection, toolkit);
 		heapConfig.addAggregate(JdkAggregators.HEAP_CONF_INITIAL_SIZE_MIN);
@@ -117,7 +191,7 @@ public class GCConfigurationPage extends AbstractDataPage {
 		heapConfig.addAggregate(JdkAggregators.HEAP_OBJECT_ALIGNMENT_MIN);
 		heapConfigSection.setClient(heapConfig.getControl());
 
-		Section ycConfigSection = CompositeToolkit.createSection(container, toolkit,
+		Section ycConfigSection = CompositeToolkit.createSection(gcConfigSash, toolkit,
 				Messages.GCConfigurationPage_SECTION_YOUNG_CONFIG);
 		ItemAggregateViewer ycConfig = new ItemAggregateViewer(ycConfigSection, toolkit);
 		ycConfig.addAggregate(JdkAggregators.YOUNG_GENERATION_MIN_SIZE);
@@ -133,11 +207,47 @@ public class GCConfigurationPage extends AbstractDataPage {
 		gcConfig.setValues(getDataSource().getItems());
 		heapConfig.setValues(getDataSource().getItems());
 		ycConfig.setValues(getDataSource().getItems());
+		
+		
+		flagSash = new SashForm(container, SWT.VERTICAL);
+		toolkit.adapt(flagSash);
 
+		// put below (sashform)
+		Section allFlagsSection = CompositeToolkit.createSection(flagSash, toolkit,
+				Messages.JVMInformationPage_SECTION_JVM_FLAGS);
+		allFlagsTable = FLAG_HISTOGRAM.buildWithoutBorder(allFlagsSection,
+				null);
+//				new TableSettings(state.getChild(JVM_FLAGS)));
+		allFlagsFilter = FilterComponent.createFilterComponent(allFlagsTable, flagsFilter,
+				getDataSource().getItems().apply(FLAGS_FILTER), pageContainer.getSelectionStore()::getSelections,
+				this::onFlagsFilterChange);
+		MCContextMenuManager flagsMm = MCContextMenuManager
+				.create(allFlagsTable.getManager().getViewer().getControl());
+		ColumnMenusFactory.addDefaultMenus(allFlagsTable.getManager(), flagsMm);
+		flagsMm.add(allFlagsFilter.getShowFilterAction());
+		flagsMm.add(allFlagsFilter.getShowSearchAction());
+		allFlagsSection.setClient(allFlagsFilter.getComponent());
+
+		ColumnViewer flagViewer = allFlagsTable.getManager().getViewer();
+		flagViewer.addSelectionChangedListener(
+				e -> pageContainer.showSelection(allFlagsTable.getSelection().getItems()));
+		
+		
+		
+		allFlagsTable.show(getDataSource().getItems().apply(FLAGS_FILTER));
+		onFlagsFilterChange(flagsFilter);
+		// allFlagsTable.getManager().setSelectionState(flagsSelection);
+		
 		addResultActions(form);
 
 		return null;
 	}
+	
+	private void onFlagsFilterChange(IItemFilter filter) {
+		allFlagsFilter.filterChangeHelper(filter, allFlagsTable, getDataSource().getItems().apply(FLAGS_FILTER));
+		flagsFilter = filter;
+	}
+
 
 	public GCConfigurationPage(IPageDefinition dpd, StreamModel items, IPageContainer editor) {
 		super(dpd, items, editor);
@@ -145,6 +255,6 @@ public class GCConfigurationPage extends AbstractDataPage {
 
 	@Override
 	public IItemFilter getDefaultSelectionFilter() {
-		return JdkFilters.GC_CONFIG;
+		return ItemFilters.or(FLAGS_FILTER, JdkFilters.GC_CONFIG);
 	}
 }

--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/GCConfigurationPage.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/GCConfigurationPage.java
@@ -249,6 +249,9 @@ public class GCConfigurationPage extends AbstractDataPage {
 	// Straw man flag filter, need to support CMS, Serial, ParallelGC, Epsilon
 	// Looking at the old collector name in order to inspect/load a single event.
 	private IItemFilter collectorFlags(String oldCollector) {
+		if(oldCollector == null) {
+			return ItemFilters.all();
+		}
 		switch (oldCollector) {
 		case "G1Old":
 			return ItemFilters.matches(JdkAttributes.FLAG_NAME, "UseG1GC|^G1.+"); //$NON-NLS-1$

--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/GCConfigurationPage.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/GCConfigurationPage.java
@@ -268,11 +268,10 @@ public class GCConfigurationPage extends AbstractDataPage {
 	// Looking at the old collector name in order to inspect/load a single event.
 	private IItemFilter collectorFlags(String oldCollector) {
 		// THis may happen for JFR files without GC configuration events, like those of async-profiler
-		if(oldCollector == null) {
+		if (oldCollector == null) {
 			return ItemFilters.all();
 		}
 
-		
 		// Flags like ParallelGCThreads, ConcGCThreads, Xmx, NewRatio are left as this information is contained in the gc configuration event
 		// Most flags from https://github.com/openjdk/jdk11u/blob/master/src/hotspot/share/gc/shared/gc_globals.hpp
 		// are not added at this time.
@@ -285,8 +284,7 @@ public class GCConfigurationPage extends AbstractDataPage {
 
 		case "G1Old":
 			// https://github.com/openjdk/jdk11u/blob/6c31ac2acdc2b2efa63fe92de8368ab964d847e9/src/hotspot/share/gc/g1/g1_globals.hpp
-			return ItemFilters.or(
-					ItemFilters.equals(JdkAttributes.FLAG_NAME, "UseG1GC"), //$NON-NLS-1$
+			return ItemFilters.or(ItemFilters.equals(JdkAttributes.FLAG_NAME, "UseG1GC"), //$NON-NLS-1$
 					ItemFilters.equals(JdkAttributes.FLAG_NAME, "InitiatingHeapOccupancyPercent"), //$NON-NLS-1$
 					ItemFilters.equals(JdkAttributes.FLAG_NAME, "UseStringDeduplication"), //$NON-NLS-1$
 					ItemFilters.equals(JdkAttributes.FLAG_NAME, "ParallelRefProcEnabled"), //$NON-NLS-1$
@@ -300,8 +298,7 @@ public class GCConfigurationPage extends AbstractDataPage {
 
 		case "Z":
 			// from https://github.com/openjdk/jdk11u/blob/6c31ac2acdc2b2efa63fe92de8368ab964d847e9/src/hotspot/share/gc/z/z_globals.hpp
-			return ItemFilters.or(
-					ItemFilters.equals(JdkAttributes.FLAG_NAME, "UseZGC"), //$NON-NLS-1$
+			return ItemFilters.or(ItemFilters.equals(JdkAttributes.FLAG_NAME, "UseZGC"), //$NON-NLS-1$
 					ItemFilters.equals(JdkAttributes.FLAG_NAME, "SoftMaxHeapSize"), //$NON-NLS-1$
 					ItemFilters.equals(JdkAttributes.FLAG_NAME, "UseLargePages"), //$NON-NLS-1$
 					ItemFilters.equals(JdkAttributes.FLAG_NAME, "UseTransparentHugePages"), //$NON-NLS-1$
@@ -310,11 +307,10 @@ public class GCConfigurationPage extends AbstractDataPage {
 					ItemFilters.equals(JdkAttributes.FLAG_NAME, "SoftRefLRUPolicyMSPerMB"), //$NON-NLS-1$
 					ItemFilters.equals(JdkAttributes.FLAG_NAME, "AlwaysPreTouch"), //$NON-NLS-1$
 					ItemFilters.matches(JdkAttributes.FLAG_NAME, "^Z[A-Z].+")); //$NON-NLS-1$
-			
+
 		case "Shenandoah":
 			// from https://github.com/openjdk/jdk11u/blob/6c31ac2acdc2b2efa63fe92de8368ab964d847e9/src/hotspot/share/gc/shenandoah/shenandoah_globals.hpp
-			return ItemFilters.or(
-					ItemFilters.equals(JdkAttributes.FLAG_NAME, "UseShenandoahGC"), //$NON-NLS-1$
+			return ItemFilters.or(ItemFilters.equals(JdkAttributes.FLAG_NAME, "UseShenandoahGC"), //$NON-NLS-1$
 					ItemFilters.equals(JdkAttributes.FLAG_NAME, "SoftMaxHeapSize"), //$NON-NLS-1$
 					ItemFilters.equals(JdkAttributes.FLAG_NAME, "UseStringDeduplication"), //$NON-NLS-1$
 					ItemFilters.equals(JdkAttributes.FLAG_NAME, "UseLargePages"), //$NON-NLS-1$
@@ -323,7 +319,7 @@ public class GCConfigurationPage extends AbstractDataPage {
 					ItemFilters.equals(JdkAttributes.FLAG_NAME, "SoftRefLRUPolicyMSPerMB"), //$NON-NLS-1$
 					ItemFilters.equals(JdkAttributes.FLAG_NAME, "AlwaysPreTouch"), //$NON-NLS-1$
 					ItemFilters.matches(JdkAttributes.FLAG_NAME, "^Z[A-Z].+")); //$NON-NLS-1$
-			
+
 		case "SerialOld":
 			// from https://github.com/openjdk/jdk11u/blob/6c31ac2acdc2b2efa63fe92de8368ab964d847e9/src/hotspot/share/gc/serial/serial_globals.hpp
 			return ItemFilters.or(ItemFilters.equals(JdkAttributes.FLAG_NAME, "UseSerialGC")); //$NON-NLS-1$
@@ -345,8 +341,7 @@ public class GCConfigurationPage extends AbstractDataPage {
 
 		case "ConcurrentMarkSweep":
 			// from https://github.com/openjdk/jdk11u/blob/6c31ac2acdc2b2efa63fe92de8368ab964d847e9/src/hotspot/share/gc/cms/cms_globals.hpp
-			return ItemFilters.or(
-					ItemFilters.equals(JdkAttributes.FLAG_NAME, "UseConcMarkSweepGC"), //$NON-NLS-1$
+			return ItemFilters.or(ItemFilters.equals(JdkAttributes.FLAG_NAME, "UseConcMarkSweepGC"), //$NON-NLS-1$
 					ItemFilters.equals(JdkAttributes.FLAG_NAME, "UseCMSInitiatingOccupancyOnly"), //$NON-NLS-1$
 					ItemFilters.equals(JdkAttributes.FLAG_NAME, "BindCMSThreadToCPU"), //$NON-NLS-1$
 					ItemFilters.equals(JdkAttributes.FLAG_NAME, "CPUForCMSThread"), //$NON-NLS-1$

--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/GCConfigurationPage.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/GCConfigurationPage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021 Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/resources/org/openjdk/jmc/flightrecorder/ui/messages/internal/messages.properties
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/resources/org/openjdk/jmc/flightrecorder/ui/messages/internal/messages.properties
@@ -307,6 +307,8 @@ GCConfigurationPage_PAGE_NAME=GC Configuration
 GCConfigurationPage_SECTION_GC_CONFIG=GC Configuration
 GCConfigurationPage_SECTION_HEAP_CONFIG=Heap Configuration
 GCConfigurationPage_SECTION_YOUNG_CONFIG=Young Generation Configuration
+GCConfigurationPage_SECTION_JVM_GC_FLAGS=JVM GC Related Flags
+GCConfigurationPage_COLUMN_VALUE=Value
 # {0} is a size in bytes
 HeapPage_LIVE_SIZE_OF_CLASS=Live Size of {0}
 HeapPage_OVERLAY_GC=Garbage Collection

--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/resources/org/openjdk/jmc/flightrecorder/ui/messages/internal/messages.properties
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/resources/org/openjdk/jmc/flightrecorder/ui/messages/internal/messages.properties
@@ -1,5 +1,5 @@
 #
-#  Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+#  Copyright (c) 2018, 2021 Oracle and/or its affiliates. All rights reserved.
 #
 #  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #


### PR DESCRIPTION
This pull request proposes to display related garbage collector flags.

**Motivation**

When turning the GC flag knobs, it is useful to be able to quickly see
the GC configuration, however the _GC configuration_ page only show 3 
events, if one wants to have a look at flags he has to either check
the command line or inspect the _JVM internal_ page to find relevant
GC flags. Therefore having these flags right there is useful to get
a quick picture of the current configuration.

**Current limitations**

1. At this time the selected flags depends on the GC algorithm which is 
   derived from the name of the old collector name. This is simple, 
   however it prevents to identify EpsilonGC because whose old 
   collector name is `SerialOld`, which is the same as SerialGC.

2. There are some global flags in `gc/shared/gc_globals.hpp` that 
   I didn't include as I didn't use most of them. I'm not sure these 
   flags are seen much in the wild.


**Remarks**

As mentionned above the use of the OldCollector name may not be the 
best choice, I would like to refactor this part to use the `Use*GC`
flags instead. I am a bit unsure at this time how to use the 
existing API.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JMC-7195](https://bugs.openjdk.java.net/browse/JMC-7195): GC confguration with GC Flags


### Reviewers
 * [Marcus Hirt](https://openjdk.java.net/census#hirt) (@thegreystone - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jmc pull/230/head:pull/230` \
`$ git checkout pull/230`

Update a local copy of the PR: \
`$ git checkout pull/230` \
`$ git pull https://git.openjdk.java.net/jmc pull/230/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 230`

View PR using the GUI difftool: \
`$ git pr show -t 230`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jmc/pull/230.diff">https://git.openjdk.java.net/jmc/pull/230.diff</a>

</details>
