### PR TITLE
7194 : No local JVMs found message could be more helpful

### DIFF
--- a/application/org.openjdk.jmc.browser/src/main/resources/org/openjdk/jmc/browser/views/messages.properties
+++ b/application/org.openjdk.jmc.browser/src/main/resources/org/openjdk/jmc/browser/views/messages.properties
@@ -57,7 +57,7 @@ JVMBrowserView_NO_LOCAL_JVMS_TITLE=No local JVMs detected
 JVMBrowserView_NO_LOCAL_JVMS_MESSAGE=No local (attachable) JVMs were detected, not even the JVM running this instance of JDK Mission Control.
 # JVMBrowserView_NO_LOCAL_JVMS_WARN_CAUSE has newlines placed so that the rows doesn't get too long. It would be
 # great if the translation also contains newlines so the rows get about the same length.
-JVMBrowserView_NO_LOCAL_JVMS_WARN_CAUSE=Local JVMs will not be detected if the JDK Mission Control Client is run with a JRE instead of a JDK, or if the hsperfdata_<user> folder in TMP is not writable. See the FAQ help section for more information.
+JVMBrowserView_NO_LOCAL_JVMS_WARN_CAUSE=Local JVMs will not be detected if the JDK Mission Control Client is run with a JRE instead of a JDK, if the JDK is <11, or if the hsperfdata_<user> folder in TMP is not writable. See the FAQ help section for more information.
 JVMBrowserView_NO_LOCAL_JVMS_WARN_PREFERENCE=Warn when no local JVMs are detected
 JVMBrowserView_COMMAND_LINE=Command Line
 JVMBrowserView_TOOLTIP_PID=Process ID


### PR DESCRIPTION
The message refers to this question in FAQ https://community.oracle.com/tech/developers/discussion/2579717/jmc-frequently-asked-questions (FAQ seems to be not in this repo).

Q: I cannot see any locally running JVMs in the JVM browser!

Answer A3 should become A4 and the new A3 could be:
"You have to run the JMC with a JDK >=11. The JDK is obtained from PATH or can be specified with parameter "-vm" in jmc.ini. Must be placed before the -vmargs parameter." 

Is this path JAVA_HOME/lib/missioncontrol/jmc.ini in the current A3 outdated?

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Issue
 * [JMC-7194](https://bugs.openjdk.java.net/browse/JMC-7194): No local JVMs found message could be more helpful


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jmc pull/231/head:pull/231`
`$ git checkout pull/231`

To update a local copy of the PR:
`$ git checkout pull/231`
`$ git pull https://git.openjdk.java.net/jmc pull/231/head`
