### PR TITLE
7162: Stop using the chromium library based browser component

### DIFF
--- a/application/org.openjdk.jmc.feature.core/feature.xml
+++ b/application/org.openjdk.jmc.feature.core/feature.xml
@@ -63,17 +63,6 @@
    </requires>
 
    <plugin
-         id="com.make.chromium.cef.win32.win32.x86_64"
-         os="win32"
-         ws="win32"
-         arch="x86_64"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         fragment="true"
-         unpack="false"/>
-
-   <plugin
          id="org.openjdk.jmc.attach"
          download-size="0"
          install-size="0"

--- a/application/org.openjdk.jmc.rcp.product/jmc.product
+++ b/application/org.openjdk.jmc.rcp.product/jmc.product
@@ -57,7 +57,7 @@
       </vmArgsLin>
       <vmArgsMac>--add-exports=java.desktop/sun.lwawt.macosx=ALL-UNNAMED -XstartOnFirstThread -Dorg.eclipse.swt.internal.carbon.smallFonts
       </vmArgsMac>
-      <vmArgsWin>-Dorg.eclipse.swt.browser.DefaultType=chromium --add-exports=java.desktop/sun.awt.windows=ALL-UNNAMED
+      <vmArgsWin>--add-exports=java.desktop/sun.awt.windows=ALL-UNNAMED
       </vmArgsWin>
    </launcherArgs>
 

--- a/releng/platform-definitions/platform-definition-2019-12/platform-definition-2019-12.target
+++ b/releng/platform-definitions/platform-definition-2019-12/platform-definition-2019-12.target
@@ -59,10 +59,6 @@
             <unit id="org.eclipse.babel.nls_eclipse_zh.feature.group" version="4.14.0.v20200113020001"/>
             <repository location="https://archive.eclipse.org/technology/babel/update-site/R0.17.1/2019-12/"/>
         </location>
-        <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-           <unit id="com.make.chromium.cef.feature.feature.group" version="0.4.0.202005172227"/>
-           <repository location="https://equo-chromium-cef.ams3.digitaloceanspaces.com/rls/repository"/>
-        </location>
     </locations>
     <targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 </target>

--- a/releng/platform-definitions/platform-definition-2020-03/platform-definition-2020-03.target
+++ b/releng/platform-definitions/platform-definition-2020-03/platform-definition-2020-03.target
@@ -59,10 +59,6 @@
             <unit id="org.eclipse.babel.nls_eclipse_zh.feature.group" version="4.14.0.v20200113020001"/>
             <repository location="https://archive.eclipse.org/technology/babel/update-site/R0.17.1/2019-12/"/>
         </location>
-        <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-            <unit id="com.make.chromium.cef.feature.feature.group" version="0.4.0.202005172227"/>
-            <repository location="https://equo-chromium-cef.ams3.digitaloceanspaces.com/rls/repository"/>
-        </location>
     </locations>
     <targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 </target>

--- a/releng/platform-definitions/platform-definition-2020-06/platform-definition-2020-06.target
+++ b/releng/platform-definitions/platform-definition-2020-06/platform-definition-2020-06.target
@@ -59,10 +59,6 @@
             <unit id="org.eclipse.babel.nls_eclipse_zh.feature.group" version="4.16.0.v20201226013120"/>
             <repository location="https://archive.eclipse.org/technology/babel/update-site/R0.18.2/2020-06/"/>
         </location>
-        <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-            <unit id="com.make.chromium.cef.feature.feature.group" version="0.4.0.202005172227"/>
-            <repository location="https://equo-chromium-cef.ams3.digitaloceanspaces.com/rls/repository"/>
-        </location>
     </locations>
     <targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 </target>

--- a/releng/platform-definitions/platform-definition-2020-09/platform-definition-2020-09.target
+++ b/releng/platform-definitions/platform-definition-2020-09/platform-definition-2020-09.target
@@ -59,10 +59,6 @@
             <unit id="org.eclipse.babel.nls_eclipse_zh.feature.group" version="4.17.0.v20201010020001"/>
             <repository location="https://archive.eclipse.org/technology/babel/update-site/R0.18.1/2020-09/"/>
         </location>
-        <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-            <unit id="com.make.chromium.cef.feature.feature.group" version="0.4.0.202005172227"/>
-            <repository location="https://equo-chromium-cef.ams3.digitaloceanspaces.com/rls/repository"/>
-        </location>
     </locations>
     <targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
 </target>

--- a/releng/platform-definitions/platform-definition-2020-12/platform-definition-2020-12.target
+++ b/releng/platform-definitions/platform-definition-2020-12/platform-definition-2020-12.target
@@ -59,10 +59,6 @@
             <unit id="org.eclipse.babel.nls_eclipse_zh.feature.group" version="4.17.0.v20201010020001"/>
             <repository location="https://archive.eclipse.org/technology/babel/update-site/R0.18.1/2020-09/"/>
         </location>
-        <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-            <unit id="com.make.chromium.cef.feature.feature.group" version="0.4.0.202005172227"/>
-            <repository location="https://equo-chromium-cef.ams3.digitaloceanspaces.com/rls/repository"/>
-        </location>
     </locations>
     <targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
 </target>


### PR DESCRIPTION
Removed Chromium library usage on Windows

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JMC-7162](https://bugs.openjdk.java.net/browse/JMC-7162): Stop using the chromium library based browser component


### Reviewers
 * [Marcus Hirt](https://openjdk.java.net/census#hirt) (@thegreystone - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jmc pull/234/head:pull/234` \
`$ git checkout pull/234`

Update a local copy of the PR: \
`$ git checkout pull/234` \
`$ git pull https://git.openjdk.java.net/jmc pull/234/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 234`

View PR using the GUI difftool: \
`$ git pr show -t 234`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jmc/pull/234.diff">https://git.openjdk.java.net/jmc/pull/234.diff</a>

</details>
