### PR TITLE
6939: Time range indicator isn't updated when setting the time range

### DIFF
--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/common/FlavorSelector.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/common/FlavorSelector.java
@@ -528,7 +528,7 @@ public class FlavorSelector implements SelectionStoreListener {
 			painter.current = range.orElse(null);
 			canvas.setVisible(painter.current != null);
 			canvas.setToolTipText(range.map(FlavorSelector::formatRange).orElse(null));
-			container.layout();
+			container.redraw();
 
 			// FIXME: Always use concurrent if (all?) items can't be displayed on page?
 			IItemCollection itemsToUse = null;

--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/ChartAndTableUI.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/ChartAndTableUI.java
@@ -206,14 +206,13 @@ abstract class ChartAndTableUI implements IPageUI {
 		this.timeRange = timeRange;
 		table.show(getItems());
 
-		if (selectionItems != null) {
-			Object[] tableInput = ((Object[]) table.getManager().getViewer().getInput());
-			if (tableInput != null) {
-				table.getManager().getViewer().setSelection(new StructuredSelection(tableInput));
-			} else {
-				table.getManager().getViewer().setSelection(null);
-			}
+		Object[] tableInput = ((Object[]) table.getManager().getViewer().getInput());
+		if (selectionItems != null && tableInput != null) {
+			table.getManager().getViewer().setSelection(new StructuredSelection(tableInput));
+		} else {
+			table.getManager().getViewer().setSelection(null);
 		}
+		chart.setVisibleRange(timeRange.getStart(), timeRange.getEnd());
 	}
 
 	protected void buildChart() {

--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/ThreadsPageLayoutUI.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/ThreadsPageLayoutUI.java
@@ -322,14 +322,13 @@ abstract class ThreadsPageLayoutUI extends ChartAndTableUI {
 		this.timeRange = timeRange;
 		table.show(getItems());
 
-		if (selectionItems != null) {
-			Object[] tableInput = (Object[]) table.getManager().getViewer().getInput();
-			if (tableInput != null) {
-				table.getManager().getViewer().setSelection(new StructuredSelection(tableInput));
-			} else {
-				table.getManager().getViewer().setSelection(null);
-			}
+		Object[] tableInput = ((Object[]) table.getManager().getViewer().getInput());
+		if (selectionItems != null && tableInput != null) {
+			table.getManager().getViewer().setSelection(new StructuredSelection(tableInput));
+		} else {
+			table.getManager().getViewer().setSelection(null);
 		}
+		chart.setVisibleRange(timeRange.getStart(), timeRange.getEnd());
 	}
 
 	protected void buildChart(boolean resetLaneHeightControls) {


### PR DESCRIPTION
This PR addresses JMC-6939 [[0]](https://bugs.openjdk.java.net/browse/JMC-6939), in which the time range indicator does not update when setting a time range.

The issue here is that visible range of the chart is not updated when a new range is selected. In `onFlavorSelected()`, the table is updated with the new selection, but the chart is not. Here I've added a line to set the visible range with the new selection values. Additionally, I've tweaked the if-statement so that when "No Selection" is selected in the flavor selector the table & chart display the default selection. Previously if the "No Selection" option was selected after viewing a different selection, because `selectionItems` is null there would be no update to the table or chart; now it is really showing "No Selection".

There was also a problem with the time range indicator in the flavor selector not updating properly when a selection is chosen. The issue seems to be the `layout()` call not resulting in a redraw of the canvas, so it has been changed to `redraw()` instead.

[0] https://bugs.openjdk.java.net/browse/JMC-6939

### Gif examples:

**Before**
The table updates correctly, but the chart doesn't.
The flavor selector time range indicator doesn't redraw as expected.
![6939-before](https://user-images.githubusercontent.com/10425301/114095984-2051b080-988c-11eb-97a7-64f90465049d.gif)

**After**
The chart updates to the selected time range, and the flavor selector redraws as expected.
![6939-after](https://user-images.githubusercontent.com/10425301/114096008-2a73af00-988c-11eb-9a77-196bd47f9ef7.gif)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JMC-6939](https://bugs.openjdk.java.net/browse/JMC-6939): Time range indicator isn't updated when setting the time range


### Reviewers
 * [Marcus Hirt](https://openjdk.java.net/census#hirt) (@thegreystone - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jmc pull/238/head:pull/238` \
`$ git checkout pull/238`

Update a local copy of the PR: \
`$ git checkout pull/238` \
`$ git pull https://git.openjdk.java.net/jmc pull/238/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 238`

View PR using the GUI difftool: \
`$ git pr show -t 238`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jmc/pull/238.diff">https://git.openjdk.java.net/jmc/pull/238.diff</a>

</details>
