### PR TITLE
7105: Unable to open graph-view if JMC is booted with JDK 8

### DIFF
--- a/application/org.openjdk.jmc.flightrecorder.graphview/src/main/java/org/openjdk/jmc/flightrecorder/graphview/views/GraphView.java
+++ b/application/org.openjdk.jmc.flightrecorder.graphview/src/main/java/org/openjdk/jmc/flightrecorder/graphview/views/GraphView.java
@@ -38,6 +38,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.text.MessageFormat;
+import java.util.Arrays;
 import java.util.Base64;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
@@ -183,7 +184,7 @@ public class GraphView extends ViewPart implements ISelectionListener {
 
 	private class NodeThresholdSelection extends Action implements IMenuCreator {
 		private Menu menu;
-		private final List<Pair<String, Integer>> items = List.of(new Pair<>("100", 100), new Pair<>("500", 500),
+		private final List<Pair<String, Integer>> items = Arrays.asList(new Pair<>("100", 100), new Pair<>("500", 500),
 				new Pair<>("1000", 1000));
 
 		NodeThresholdSelection() {


### PR DESCRIPTION
This one-liner PR addresses JMC-7105 [[0]](https://bugs.openjdk.java.net/browse/JMC-7105), in which the GraphView is unable to open when JMC is launched with JDK 8.

The problem here is the usage of `List.of()` [[1]](https://github.com/openjdk/jmc/blob/master/application/org.openjdk.jmc.flightrecorder.graphview/src/main/java/org/openjdk/jmc/flightrecorder/graphview/views/GraphView.java#L186), which is supported in JDK 9+ [[2]](https://docs.oracle.com/javase/9/docs/api/java/util/List.html#of--), but not available in JDK 8 [[3]](https://docs.oracle.com/javase/8/docs/api/java/util/List.html).

This PR simply changes `List.of()` to `Arrays.asList()` to make it JDK 8 compliant.

[0] https://bugs.openjdk.java.net/browse/JMC-7105
[1] https://github.com/openjdk/jmc/blob/master/application/org.openjdk.jmc.flightrecorder.graphview/src/main/java/org/openjdk/jmc/flightrecorder/graphview/views/GraphView.java#L186
[2] https://docs.oracle.com/javase/9/docs/api/java/util/List.html#of--
[3] https://docs.oracle.com/javase/8/docs/api/java/util/List.html

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JMC-7105](https://bugs.openjdk.java.net/browse/JMC-7105): Unable to open graph-view if JMC is booted with JDK 8


### Reviewers
 * [Marcus Hirt](https://openjdk.java.net/census#hirt) (@thegreystone - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jmc pull/239/head:pull/239` \
`$ git checkout pull/239`

Update a local copy of the PR: \
`$ git checkout pull/239` \
`$ git pull https://git.openjdk.java.net/jmc pull/239/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 239`

View PR using the GUI difftool: \
`$ git pr show -t 239`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jmc/pull/239.diff">https://git.openjdk.java.net/jmc/pull/239.diff</a>

</details>
