### PR TITLE
7241: Adjust main pom.xml to more align for 3th party builds

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -101,6 +101,10 @@
 		<module>coverage</module>
 	</modules>
 	<distributionManagement>
+		<repository>
+			<id>jmc-publish</id>
+			<url>${release.repo}</url>
+		</repository>
 		<snapshotRepository>
 			<id>jmc-publish-snapshot</id>
 			<url>${snapshot.repo}</url>
@@ -239,16 +243,6 @@
 					<excludePackageNames>*.internal</excludePackageNames>
 					<quiet>true</quiet>
 					<failOnError>false</failOnError>
-				</configuration>
-			</plugin>
-			<plugin>
-				<groupId>org.sonatype.plugins</groupId>
-				<artifactId>nexus-staging-maven-plugin</artifactId>
-				<version>${nexus.staging.version}</version>
-				<extensions>true</extensions>
-				<configuration>
-					<serverId>jmc-publish-snapshot</serverId>
-					<autoReleaseAfterClose>true</autoReleaseAfterClose>
 				</configuration>
 			</plugin>
 			<plugin>


### PR DESCRIPTION
Signed-off-by: Patrick Reinhart <patrick@reini.net>

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JMC-7241](https://bugs.openjdk.java.net/browse/JMC-7241): Adjust main pom.xml to more align for 3th party builds


### Reviewers
 * [Guru Hb](https://openjdk.java.net/census#ghb) (@guruhb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jmc pull/241/head:pull/241` \
`$ git checkout pull/241`

Update a local copy of the PR: \
`$ git checkout pull/241` \
`$ git pull https://git.openjdk.java.net/jmc pull/241/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 241`

View PR using the GUI difftool: \
`$ git pr show -t 241`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jmc/pull/241.diff">https://git.openjdk.java.net/jmc/pull/241.diff</a>

</details>
