### PR TITLE
7242: Adding new JDK Events to core API

### DIFF
--- a/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/jdk/JdkAttributes.java
+++ b/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/jdk/JdkAttributes.java
@@ -769,6 +769,14 @@ public final class JdkAttributes {
 	public static final IAttribute<String> DUMP_REASON_RECORDING_ID = attr("recordingId", //$NON-NLS-1$
 			Messages.getString(Messages.ATTR_DUMP_REASON_RECORDING_ID),
 			Messages.getString(Messages.ATTR_DUMP_REASON_RECORDING_ID_DESC), PLAIN_TEXT);
+			
+	public static final IAttribute<IQuantity> THREAD_SYSTEM_CPU_LOAD = Attribute.attr("system", //$NON-NLS-1$
+			Messages.getString(Messages.ATTR_SYSTEM_LOAD), Messages.getString(Messages.ATTR_SYSTEM_LOAD_DESC),PERCENTAGE);
+	public static final IAttribute<IQuantity> THREAD_USER_CPU_LOAD = Attribute.attr("user", //$NON-NLS-1$
+			Messages.getString(Messages.ATTR_USER_LOAD), Messages.getString(Messages.ATTR_USER_LOAD_DESC),PERCENTAGE);
+	public static final IAttribute<IMCThread> JAVA_THREAD = Attribute.attr("thread",
+			Messages.getString(Messages.ATTR_JAVA_THREAD), Messages.getString(Messages.ATTR_JAVA_THREAD_DESC), UnitLookup.THREAD);			   
+		
 
 	public static final IAttribute<String> SHUTDOWN_REASON = attr("reason", //$NON-NLS-1$
 			Messages.getString(Messages.ATTR_SHUTDOWN_REASON), Messages.getString(Messages.ATTR_SHUTDOWN_REASON_DESC),

--- a/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/jdk/JdkFilters.java
+++ b/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/jdk/JdkFilters.java
@@ -144,6 +144,10 @@ public final class JdkFilters {
 	public static final IItemFilter BIASED_LOCKING_REVOCATIONS = ItemFilters.type(
 			JdkTypeIDs.BIASED_LOCK_CLASS_REVOCATION, JdkTypeIDs.BIASED_LOCK_REVOCATION,
 			JdkTypeIDs.BIASED_LOCK_SELF_REVOCATION);
+	public static final IItemFilter THREAD_CPU_LOAD = ItemFilters.type(JdkTypeIDs.THREAD_CPU_LOAD);
+	public static final IItemFilter NATIVE_METHOD_SAMPLE = ItemFilters.type(JdkTypeIDs.NATIVE_METHOD_SAMPLE);
+	public static final IItemFilter THREAD_START = ItemFilters.type(JdkTypeIDs.JAVA_THREAD_START);
+	public static final IItemFilter THREAD_END = ItemFilters.type(JdkTypeIDs.JAVA_THREAD_END);		
 
 	public static class MethodFilter implements IItemFilter {
 

--- a/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/jdk/JdkTypeIDs.java
+++ b/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/jdk/JdkTypeIDs.java
@@ -50,6 +50,7 @@ public final class JdkTypeIDs {
 	private final static String PREFIX = "jdk.";
 
 	public static final String CPU_LOAD = PREFIX + "CPULoad";
+	public static final String THREAD_CPU_LOAD = PREFIX + "ThreadCPULoad";
 	public static final String EXECUTION_SAMPLE = PREFIX + "ExecutionSample";
 	public static final String EXECUTION_SAMPLING_INFO_EVENT_ID = PREFIX + "ExecutionSampling";
 	public static final String NATIVE_METHOD_SAMPLE = PREFIX + "NativeMethodSample";

--- a/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/jdk/messages/internal/Messages.java
+++ b/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/jdk/messages/internal/Messages.java
@@ -464,7 +464,13 @@ public class Messages {
 	public static final String ATTR_YOUNG_GENERATION_MIN_SIZE = "ATTR_YOUNG_GENERATION_MIN_SIZE"; //$NON-NLS-1$
 	public static final String ATTR_SHUTDOWN_REASON = "ATTR_SHUTDOWN_REASON"; //$NON-NLS-1$
 	public static final String ATTR_SHUTDOWN_REASON_DESC = "ATTR_SHUTDOWN_REASON_DESC"; //$NON-NLS-1$
-	public static final String ATTR_SHUTDOWN_TIME = "ATTR_SHUTDOWN_TIME"; //$NON-NLS-1$	
+	public static final String ATTR_SHUTDOWN_TIME = "ATTR_SHUTDOWN_TIME"; //$NON-NLS-1$
+	public static final String ATTR_SYSTEM_LOAD = "ATTR_SYSTEM_LOAD"; //$NON-NLS-1$
+	public static final String ATTR_SYSTEM_LOAD_DESC = "ATTR_SYSTEM_LOAD_DESC"; //$NON-NLS-1$
+	public static final String ATTR_USER_LOAD = "ATTR_USER_LOAD"; //$NON-NLS-1$
+	public static final String ATTR_USER_LOAD_DESC = "ATTR_USER_LOAD_DESC"; //$NON-NLS-1$
+	public static final String ATTR_JAVA_THREAD = "ATTR_JAVA_THREAD"; //$NON-NLS-1$
+	public static final String ATTR_JAVA_THREAD_DESC = "ATTR_JAVA_THREAD_DESC"; //$NON-NLS-1$
 
 	private Messages() {
 	}

--- a/core/org.openjdk.jmc.flightrecorder/src/main/resources/org/openjdk/jmc/flightrecorder/jdk/messages/internal/messages.properties
+++ b/core/org.openjdk.jmc.flightrecorder/src/main/resources/org/openjdk/jmc/flightrecorder/jdk/messages/internal/messages.properties
@@ -446,4 +446,7 @@ AGGR_VM_OPERATION_DURATION=VM Operation Duration
 AGGR_VM_OPERATION_DURATION_DESC=The sum of the durations for the selected VM operation events.
 AGGR_COMPILATIONS_COUNT=Compilations
 AGGR_COMPILATIONS_COUNT_DESC=The number of compilations
-
+ATTR_SYSTEM_LOAD=System Mode CPU Load
+ATTR_SYSTEM_LOAD_DESC=CPU used by Thread in System mode
+ATTR_USER_LOAD=User Mode CPU Load
+ATTR_USER_LOAD_DESC=CPU used by Thread in User mode


### PR DESCRIPTION
This PR will address these missing events and add them to core API.

jdk.ThreadCPULoad

jdk.NativeMethodSample

jdk.ThreadStart

jdk.ThreadEnd

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JMC-7242](https://bugs.openjdk.java.net/browse/JMC-7242): Adding new JDK Events to core API


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jmc pull/242/head:pull/242` \
`$ git checkout pull/242`

Update a local copy of the PR: \
`$ git checkout pull/242` \
`$ git pull https://git.openjdk.java.net/jmc pull/242/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 242`

View PR using the GUI difftool: \
`$ git pr show -t 242`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jmc/pull/242.diff">https://git.openjdk.java.net/jmc/pull/242.diff</a>

</details>
