### PR TITLE
7246: ClassCastException when opening heap dump

### DIFF
--- a/application/org.openjdk.jmc.joverflow/src/main/java/org/openjdk/jmc/joverflow/heap/model/Snapshot.java
+++ b/application/org.openjdk.jmc.joverflow/src/main/java/org/openjdk/jmc/joverflow/heap/model/Snapshot.java
@@ -771,7 +771,7 @@ public class Snapshot {
 			}
 
 			// Create fake instance class
-			return new JavaClass(name, 0, 0, 0, 0, fields, JavaClass.NO_FIELDS, JavaClass.NO_VALUES, instSize,
+			return new JavaClass(classID, name, 0, 0, 0, 0, fields, JavaClass.NO_FIELDS, JavaClass.NO_VALUES, instSize,
 					getInMemoryInstanceSize(instSize));
 		}
 


### PR DESCRIPTION
Signed-off-by: Tobias Stadler <ts.stadler@gmx.de>

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JMC-7246](https://bugs.openjdk.java.net/browse/JMC-7246): ClassCastException when opening heap dump


### Reviewers
 * [Marcus Hirt](https://openjdk.java.net/census#hirt) (@thegreystone - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jmc pull/243/head:pull/243` \
`$ git checkout pull/243`

Update a local copy of the PR: \
`$ git checkout pull/243` \
`$ git pull https://git.openjdk.java.net/jmc pull/243/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 243`

View PR using the GUI difftool: \
`$ git pr show -t 243`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jmc/pull/243.diff">https://git.openjdk.java.net/jmc/pull/243.diff</a>

</details>
