### PR TITLE
7248: JMC7/8 Automated Analysis taking very long time to produce results for Class Leak Rule.

### DIFF
--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/messages/internal/Messages.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/messages/internal/Messages.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -100,6 +100,8 @@ public class Messages {
 	public static final String BufferLostRuleFactory_RESULT_SOLUTION = "BufferLostRuleFactory_RESULT_SOLUTION"; //$NON-NLS-1$
 	public static final String ClassLeakingRule_CONFIG_WARNING_LIMIT = "ClassLeakingRule_CONFIG_WARNING_LIMIT"; //$NON-NLS-1$
 	public static final String ClassLeakingRule_CONFIG_WARNING_LIMIT_LONG = "ClassLeakingRule_CONFIG_WARNING_LIMIT_LONG"; //$NON-NLS-1$
+	public static final String ClassLeakingRule_CONFIG_CALCULATION_TIMEOUT = "ClassLeakingRule_CONFIG_CALCULATION_TIMEOUT"; //$NON-NLS-1$
+	public static final String ClassLeakingRule_CONFIG_CALCULATION_TIMEOUT_LONG = "ClassLeakingRule_CONFIG_CALCULATION_TIMEOUT_LONG"; //$NON-NLS-1$
 	public static final String ClassLeakingRule_NAME = "ClassLeakingRule_NAME"; //$NON-NLS-1$
 	public static final String ClassLeakingRule_RESULT_SUMMARY = "ClassLeakingRule_RESULT_SUMMARY"; //$NON-NLS-1$
 	public static final String ClassLeakingRule_RESULT_EXPLANATION = "ClassLeakingRule_RESULT_EXPLANATION"; //$NON-NLS-1$

--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/util/DefaultIItemResultSet.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/util/DefaultIItemResultSet.java
@@ -51,6 +51,7 @@ import org.openjdk.jmc.common.item.IItemQuery;
 import org.openjdk.jmc.common.item.IMemberAccessor;
 import org.openjdk.jmc.common.item.IType;
 import org.openjdk.jmc.common.item.ItemFilters;
+import org.openjdk.jmc.flightrecorder.rules.jdk.general.ClassLeakingRule;
 
 /**
  * The default implementation of an {@link IItemResultSet}.
@@ -130,8 +131,8 @@ final class DefaultIItemResultSet implements IItemResultSet {
 				} finally {
 					exec.shutdown();
 				}
-				// Higher timeout value added for worst case
-				exec.awaitTermination(1, TimeUnit.HOURS);
+				// Timeout can be configured in prefrences (default value is set to 5 minutes)
+				exec.awaitTermination(ClassLeakingRule.CONFIGURED_TIMEOUT, TimeUnit.MINUTES);
 			}
 		}
 	}

--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/resources/org/openjdk/jmc/flightrecorder/rules/jdk/messages/internal/messages.properties
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/resources/org/openjdk/jmc/flightrecorder/rules/jdk/messages/internal/messages.properties
@@ -1,5 +1,5 @@
 #
-#  Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+#  Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
 #
 #  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
@@ -104,6 +104,8 @@ BufferLostRuleFactory_RESULT_EXPLANATION={droppedCount} Flight Recorder event bu
 BufferLostRuleFactory_RESULT_SOLUTION=Avoid this by reducing the number of events recorded, especially for event types with high event rates and/or large payloads.
 ClassLeakingRule_CONFIG_WARNING_LIMIT=Warning limit
 ClassLeakingRule_CONFIG_WARNING_LIMIT_LONG=Number of loads of a class to issue a warning.
+ClassLeakingRule_CONFIG_CALCULATION_TIMEOUT=Calculation Timeout (in minutes)
+ClassLeakingRule_CONFIG_CALCULATION_TIMEOUT_LONG=Maximum amount of time to calculate class leak rule (in minutes).
 ClassLeakingRule_NAME=Class Leak
 ClassLeakingRule_TEXT_OK=No classes with identical names have been loaded more times than the limit.
 # {mostLoadedClass} is a java class, {mostLoadedClassTimes} is a number


### PR DESCRIPTION
This PR addresses the optimization of Class Leak Rule.

Please refer the JBS for the sample JFR which was taking ~90 minutes to generate results for Class Leak Rule. After the optimization time is reduced to ~10-15 minutes.

Please review the change and let me the know if there are any comments / suggestions.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Integration blocker
&nbsp;⚠️ Too few reviewers with at least role committer found (have 0, need at least 1) (failed with the updated jcheck configuration)

### Issue
 * [JMC-7248](https://bugs.openjdk.org/browse/JMC-7248): JMC7/8 Automated Analysis taking very long time to produce results for Class Leak Rule. (**Enhancement** - P3) ⚠️ Issue is already resolved. Consider making this a "backport pull request" by setting the PR title to `Backport <hash>` with the hash of the original commit. See [Backports](https://wiki.openjdk.org/display/SKARA/Backports).


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmc.git pull/248/head:pull/248` \
`$ git checkout pull/248`

Update a local copy of the PR: \
`$ git checkout pull/248` \
`$ git pull https://git.openjdk.org/jmc.git pull/248/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 248`

View PR using the GUI difftool: \
`$ git pr show -t 248`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmc/pull/248.diff">https://git.openjdk.org/jmc/pull/248.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jmc/pull/248#issuecomment-839244578)