### PR TITLE
7256: Use .jcheck/conf property to control version

### DIFF
--- a/.jcheck/conf
+++ b/.jcheck/conf
@@ -1,6 +1,6 @@
 ;
-;  Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
-;  Copyright (c) 2019, Datadog, Inc. All rights reserved.
+;  Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
+;  Copyright (c) 2019, 2021, Datadog, Inc. All rights reserved.
 ;
 ;  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 ;
@@ -36,6 +36,7 @@
 [general]
 project=jmc
 jbs=jmc
+version=8.1.0
 
 [checks]
 error=author,reviewers,merge,message,issues


### PR DESCRIPTION
See Erik Joelsson's comment in https://bugs.openjdk.java.net/browse/SKARA-1033.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JMC-7256](https://bugs.openjdk.java.net/browse/JMC-7256): Use .jcheck/conf property to control version


### Reviewers
 * [Guru Hb](https://openjdk.java.net/census#ghb) (@guruhb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jmc pull/249/head:pull/249` \
`$ git checkout pull/249`

Update a local copy of the PR: \
`$ git checkout pull/249` \
`$ git pull https://git.openjdk.java.net/jmc pull/249/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 249`

View PR using the GUI difftool: \
`$ git pr show -t 249`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jmc/pull/249.diff">https://git.openjdk.java.net/jmc/pull/249.diff</a>

</details>
