### PR TITLE
7070: Allow JMC to open compressed recordings with the extension .lz4

### DIFF
--- a/application/org.openjdk.jmc.flightrecorder.ui/plugin.xml
+++ b/application/org.openjdk.jmc.flightrecorder.ui/plugin.xml
@@ -60,7 +60,7 @@
        point="org.eclipse.ui.editors">
       <editor
             class="org.openjdk.jmc.flightrecorder.ui.JfrEditor"
-            extensions="jfr"
+            extensions="jfr,lz4"
             icon="icons/jfr.png"
             id="org.openjdk.jmc.flightrecorder.ui.JfrEditor"
             name="Flight Recording">


### PR DESCRIPTION
This one-worder addresses JMC-7070 [[0]](https://bugs.openjdk.java.net/browse/JMC-7070), in which LZ4 compressed files cannot be opened while having the file extension ".lz4"

JMC-6701 added support for opening jfr files that were compressed using lz4 [[0]](https://github.com/openjdk/jmc/commit/b6e5bde2f45e7e44f252f42488332fc81b58506b). The functionality works, however the file association was not updated to include files ending in ".lz4" for flight recording files, so these compressed recordings must still be supplied with the file ending of ".jfr". This isn't ideal, because the default behaviour of `lz4` is to append ".lz4" to the end of the supplied file; in my example I have a file called `lol.jfr`, which when compressed becomes `lol.jfr.lz4` and cannot be opened by JMC without manually renaming it.

This one-word fix adds the file extension "lz4" to the extension list in `flightrecorder.ui`'s `plugin.xml` for `JfrEditor`, so that supplying a `*.lz4` file will result in trying to open a JfrEditor page.

[0] https://bugs.openjdk.java.net/browse/JMC-7070
[1] https://github.com/openjdk/jmc/commit/b6e5bde2f45e7e44f252f42488332fc81b58506b

### Before:
- LZ4 does not exist as a valid file extension in the open file dialog
![0-before-opening](https://user-images.githubusercontent.com/10425301/119050175-7c314e00-b98f-11eb-91e6-540b8303d61b.png)
- LZ4 does not have a valid file association in the preferences
![1-before-file-associations](https://user-images.githubusercontent.com/10425301/119050200-82272f00-b98f-11eb-99cd-c102729cae8a.png)
- Dialog pops up complaining that no editor is associated with the file ending "lz4"
![2-before-opening](https://user-images.githubusercontent.com/10425301/119050186-7fc4d500-b98f-11eb-9cc3-cb37de6add2d.png)

### After:
- LZ4 is listed as a valid extension in the open file dialog
![2021-05-20-171807_192x239_scrot](https://user-images.githubusercontent.com/10425301/119050233-8fdcb480-b98f-11eb-873a-251e09d6a8ad.png)
- LZ4 appears as a valid file extension in the preferences
![3-after-file-associations](https://user-images.githubusercontent.com/10425301/119050237-91a67800-b98f-11eb-9d86-3645bf5ff752.png)
- Opening a LZ4 compressed recording works
![4-after-opened](https://user-images.githubusercontent.com/10425301/119050244-9539ff00-b98f-11eb-83fa-262fe47b2af7.png)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JMC-7070](https://bugs.openjdk.java.net/browse/JMC-7070): Allow JMC to open compressed recordings with the extension .lz4


### Reviewers
 * @bric3 (no known github.com user name / role)
 * [Marcus Hirt](https://openjdk.java.net/census#hirt) (@thegreystone - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jmc pull/250/head:pull/250` \
`$ git checkout pull/250`

Update a local copy of the PR: \
`$ git checkout pull/250` \
`$ git pull https://git.openjdk.java.net/jmc pull/250/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 250`

View PR using the GUI difftool: \
`$ git pr show -t 250`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jmc/pull/250.diff">https://git.openjdk.java.net/jmc/pull/250.diff</a>

</details>
