### PR TITLE
7259: README.md should mention that the build script works for Mac OS

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ Prerequisites for building Mission Control:
 
 2. Install Maven (version 3.3.x. or above)
 
-On Linux you can use the build.sh script to build JMC:
+On Linux or macOS you can use the build.sh script to build JMC:
 ```
 usage: call ./build.sh with the following options:
    --installCore to install the core artifacts


### PR DESCRIPTION
Found that the build.sh script works on macOS, too.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JMC-7259](https://bugs.openjdk.java.net/browse/JMC-7259): README.md should mention that the build script works for Mac OS


### Reviewers
 * [Marcus Hirt](https://openjdk.java.net/census#hirt) (@thegreystone - **Reviewer**)
 * @bric3 (no known github.com user name / role)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jmc pull/251/head:pull/251` \
`$ git checkout pull/251`

Update a local copy of the PR: \
`$ git checkout pull/251` \
`$ git pull https://git.openjdk.java.net/jmc pull/251/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 251`

View PR using the GUI difftool: \
`$ git pr show -t 251`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jmc/pull/251.diff">https://git.openjdk.java.net/jmc/pull/251.diff</a>

</details>
