### PR TITLE
7060: [WLS] Rule result formatting update w.r.t Rule 2.0

### DIFF
--- a/core/org.openjdk.jmc.flightrecorder.rules/src/main/java/org/openjdk/jmc/flightrecorder/rules/tree/ItemTreeToolkit.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules/src/main/java/org/openjdk/jmc/flightrecorder/rules/tree/ItemTreeToolkit.java
@@ -55,6 +55,9 @@ import org.openjdk.jmc.flightrecorder.rules.util.RulesToolkit;
  */
 public final class ItemTreeToolkit {
 
+	private static final String NEW_LINE_SEPARATOR = "\n";
+	private static final String BULLET_CHARACTER = "\\u2022 ";
+
 	/**
 	 * @return A String representation of the tree. Useful for debugging.
 	 */
@@ -99,7 +102,7 @@ public final class ItemTreeToolkit {
 			reports.add(String.format("&nbsp;&nbsp;%s, %s (%s)", next.getType().getName(), toString(duration), //$NON-NLS-1$
 					RulesToolkit.toRatioPercentString(duration, topLevelDuration)));
 		}
-		report.append(StringToolkit.join(reports, " =><br>")); //$NON-NLS-1$
+		report.append(StringToolkit.join(reports, NEW_LINE_SEPARATOR)); //$NON-NLS-1$
 	}
 
 	/**
@@ -128,7 +131,7 @@ public final class ItemTreeToolkit {
 
 		IQuantity firstLayerDuration = null;
 		report.append(Messages.getString(Messages.ItemTreeToolkit_BREAKDOWN_HEADER_LAYERS));
-		report.append("<ul>"); //$NON-NLS-1$
+		report.append(NEW_LINE_SEPARATOR); //$NON-NLS-1$
 
 		for (int i = 0; i < layers.size() && i <= maxDepth; i++) {
 			LayerBreakdown breakdown = layers.get(i);
@@ -138,14 +141,13 @@ public final class ItemTreeToolkit {
 			} else if (firstLayerDuration == null) {
 				firstLayerDuration = layerDuration;
 			}
-			report.append("<li>"); //$NON-NLS-1$
+			report.append(NEW_LINE_SEPARATOR + BULLET_CHARACTER); //$NON-NLS-1$
 			report.append(MessageFormat.format(Messages.getString(Messages.ItemTreeToolkit_BREAKDOWN_LAYER_CAPTION),
 					breakdown.getLayer()));
 			appendLayerBreakdown(report, firstLayerDuration, breakdown);
-			report.append("</li>"); //$NON-NLS-1$
-			report.append("<br>"); //$NON-NLS-1$
+			report.append(NEW_LINE_SEPARATOR); //$NON-NLS-1$
 		}
-		report.append("</ul>"); //$NON-NLS-1$
+		report.append(NEW_LINE_SEPARATOR + NEW_LINE_SEPARATOR); //$NON-NLS-1$
 	}
 
 	private static void appendLayerBreakdown(
@@ -156,7 +158,7 @@ public final class ItemTreeToolkit {
 					RulesToolkit.toRatioPercentString(entry.getDuration(), firstLayerDuration),
 					entry.getType().getName(), toString(entry.getDuration())));
 		}
-		report.append(StringToolkit.join(reportEntries, "<br>")); //$NON-NLS-1$
+		report.append(StringToolkit.join(reportEntries, NEW_LINE_SEPARATOR)); //$NON-NLS-1$
 	}
 
 	private static Object toString(IQuantity duration) {

--- a/core/org.openjdk.jmc.flightrecorder.rules/src/main/resources/org/openjdk/jmc/flightrecorder/rules/messages/internal/messages.properties
+++ b/core/org.openjdk.jmc.flightrecorder.rules/src/main/resources/org/openjdk/jmc/flightrecorder/rules/messages/internal/messages.properties
@@ -64,9 +64,9 @@ Severity_NOT_APPLICABLE=Not Applicable
 Severity_OK=OK
 Severity_WARNING=Warning
 
-ItemTreeToolkit_BREAKDOWN_HEADER_LAYERS=<b>Breakdown (layers):</b><br>
-ItemTreeToolkit_BREAKDOWN_HEADER_MAX_DURATION_EVENT_CHAIN=<b>Breakdown (max duration event chain):</b><br>
-ItemTreeToolkit_BREAKDOWN_LAYER_CAPTION=Layer {0}:<br>
+ItemTreeToolkit_BREAKDOWN_HEADER_LAYERS=\n\u2023\u2023 Breakdown (layers):\n
+ItemTreeToolkit_BREAKDOWN_HEADER_MAX_DURATION_EVENT_CHAIN=\u2043\u2043 Breakdown (max duration event chain):\n
+ItemTreeToolkit_BREAKDOWN_LAYER_CAPTION=Layer {0}:\n
 
 TypedResult_SCORE_NAME=Score
 TypedResult_SCORE_DESCRIPTION=Rule Score


### PR DESCRIPTION
This PR addresses the replacement of HTML tags which are not supported after Rules 2.0.

This change is mainly addressing the regression caused due to Rules 2.0 in WLS plugin rule Long Lasting Servlet Rule Request. After Rules 2.0 the report on automated analysis screen became unreadable as HTML tags like ``<ul> <li>`` were directly shown on UI. As part of this change I have replaced these tags with some appropriate characters to make the report readable.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JMC-7060](https://bugs.openjdk.java.net/browse/JMC-7060): [WLS] Rule result formatting update w.r.t Rule 2.0


### Reviewers
 * [Henrik Dafgård](https://openjdk.java.net/census#hdafgard) (@Gunde - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jmc pull/258/head:pull/258` \
`$ git checkout pull/258`

Update a local copy of the PR: \
`$ git checkout pull/258` \
`$ git pull https://git.openjdk.java.net/jmc pull/258/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 258`

View PR using the GUI difftool: \
`$ git pr show -t 258`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jmc/pull/258.diff">https://git.openjdk.java.net/jmc/pull/258.diff</a>

</details>
