### PR TITLE
6923: Retain treeview stack trace while switching between JFRs

### DIFF
--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/views/stacktrace/StacktraceView.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/views/stacktrace/StacktraceView.java
@@ -210,7 +210,7 @@ public class StacktraceView extends ViewPart implements ISelectionListener {
 	private IAction[] layoutActions;
 	private ViewerAction[] viewerActions;
 	private int[] columnWidths;
-	private Map<IItemCollection, Object[]> itemsExpanded = new WeakHashMap<>();
+	private Map<IItemCollection, Object[]> treeViewerExpandedItems = new WeakHashMap<>();
 
 	private static class StacktraceViewToolTipSupport extends ColumnViewerToolTipSupport {
 
@@ -710,7 +710,7 @@ public class StacktraceView extends ViewPart implements ISelectionListener {
 			// persist the older items expandedElements
 			Object[] expandedElements = ((TreeViewer) viewer).getExpandedElements();
 			if (expandedElements.length > 0) {
-				itemsExpanded.put(itemsToShow, expandedElements);
+				treeViewerExpandedItems.put(itemsToShow, expandedElements);
 			}
 		}
 		itemsToShow = items;
@@ -757,8 +757,8 @@ public class StacktraceView extends ViewPart implements ISelectionListener {
 
 	private void setViewerInput(Fork rootFork) {
 		// NOTE: will be slow for TreeViewer if number of roots or children of a node are more than ~1000
-		if (rootFork != null && viewer instanceof TreeViewer && itemsExpanded.containsKey(itemsToShow)) {
-			Object[] expandedElements = itemsExpanded.get(itemsToShow);
+		if (rootFork != null && viewer instanceof TreeViewer && treeViewerExpandedItems.containsKey(itemsToShow)) {
+			Object[] expandedElements = treeViewerExpandedItems.get(itemsToShow);
 			viewer.setInput(rootFork);
 			((TreeViewer) viewer).setExpandedElements(expandedElements);
 		} else {

--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/views/stacktrace/StacktraceView.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/views/stacktrace/StacktraceView.java
@@ -34,7 +34,9 @@ package org.openjdk.jmc.flightrecorder.ui.views.stacktrace;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.WeakHashMap;
 import java.util.concurrent.CompletableFuture;
 import java.util.logging.Level;
 import java.util.stream.Collectors;
@@ -208,6 +210,7 @@ public class StacktraceView extends ViewPart implements ISelectionListener {
 	private IAction[] layoutActions;
 	private ViewerAction[] viewerActions;
 	private int[] columnWidths;
+	private Map<IItemCollection, Object[]> itemsExpanded = new WeakHashMap<>();
 
 	private static class StacktraceViewToolTipSupport extends ColumnViewerToolTipSupport {
 
@@ -703,6 +706,13 @@ public class StacktraceView extends ViewPart implements ISelectionListener {
 	}
 
 	private void setItems(IItemCollection items) {
+		if (viewer.getInput() != null && viewer instanceof TreeViewer && itemsToShow.hasItems()) {
+			// persist the older items expandedElements
+			Object[] expandedElements = ((TreeViewer) viewer).getExpandedElements();
+			if (expandedElements.length > 0) {
+				itemsExpanded.put(itemsToShow, expandedElements);
+			}
+		}
 		itemsToShow = items;
 		rebuildModel();
 	}
@@ -747,7 +757,13 @@ public class StacktraceView extends ViewPart implements ISelectionListener {
 
 	private void setViewerInput(Fork rootFork) {
 		// NOTE: will be slow for TreeViewer if number of roots or children of a node are more than ~1000
-		viewer.setInput(rootFork);
+		if (rootFork != null && viewer instanceof TreeViewer && itemsExpanded.containsKey(itemsToShow)) {
+			Object[] expandedElements = itemsExpanded.get(itemsToShow);
+			viewer.setInput(rootFork);
+			((TreeViewer) viewer).setExpandedElements(expandedElements);
+		} else {
+			viewer.setInput(rootFork);
+		}
 	}
 
 	private ITreeContentProvider createTreeContentProvider() {

--- a/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/stacktrace/StacktraceFrame.java
+++ b/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/stacktrace/StacktraceFrame.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -98,6 +98,44 @@ public class StacktraceFrame {
 	 */
 	public int getItemCount() {
 		return items.size();
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((frame == null) ? 0 : frame.hashCode());
+		result = prime * result + indexInBranch;
+		result = prime * result + ((items == null) ? 0 : items.size());
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		StacktraceFrame other = (StacktraceFrame) obj;
+
+		if (branch == null) {
+			if (other.branch != null)
+				return false;
+		}
+		if (frame == null) {
+			if (other.frame != null) {
+				return false;
+			}
+		}
+		if (indexInBranch != other.indexInBranch)
+			return false;
+		if (items == null || other.items == null) {
+			return false;
+		} else if (items.size() != other.items.size())
+			return false;
+		return true;
 	}
 
 }


### PR DESCRIPTION
Persist Treeviewer expanded items during main view (JfrEditor) switch. This behavior will help comparing two jfr recording.

Solution : 
1. StackTraceView is a Viewpart which lists the stacktraces of JfrEditor (EditorPart). Switching between JfrEditor or selecting other context (Event Browser, Filtered events, etc..) makes an update in stacktraceview by providing "Items" to list.  This Lists are then presented to StackTraceModel with reducedTree (i.e only the Top frame is expanded) and rest of them are listed with its root. 
With this fix, Persisting the ExpandedElements based on Items and then setting back during Editor Switch. 
2. StackTraceFrame requires hashCode and equals in order to Distinguish between old and new frames. Or persisting the StackTraceModel will be bit more expensive then set and restoring the Expanded elements.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JMC-6923](https://bugs.openjdk.java.net/browse/JMC-6923): Retain treeview stack trace while switching between JFRs


### Reviewers
 * @bric3 (no known github.com user name / role)
 * [Alex Macdonald](https://openjdk.java.net/census#aptmac) (@aptmac - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jmc pull/259/head:pull/259` \
`$ git checkout pull/259`

Update a local copy of the PR: \
`$ git checkout pull/259` \
`$ git pull https://git.openjdk.java.net/jmc pull/259/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 259`

View PR using the GUI difftool: \
`$ git pr show -t 259`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jmc/pull/259.diff">https://git.openjdk.java.net/jmc/pull/259.diff</a>

</details>
