### PR TITLE
6967: Add Percentage Column w.r.t 'Profiling Samples' in Thread table

### DIFF
--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/messages/internal/Messages.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/messages/internal/Messages.java
@@ -299,6 +299,8 @@ public class Messages extends NLS {
 	public static String JavaApplicationPage_COLUMN_THREAD_DURATION_DESC;
 	public static String JavaApplicationPage_COLUMN_THREAD_END;
 	public static String JavaApplicationPage_COLUMN_THREAD_END_DESC;
+	public static String JavaApplicationPage_COLUMN_THREAD_PERCENTAGE;
+	public static String JavaApplicationPage_COLUMN_THREAD_PERCENTAGE_DESC;
 	public static String JavaApplicationPage_COLUMN_THREAD_START;
 	public static String JavaApplicationPage_COLUMN_THREAD_START_DESC;
 	public static String JavaApplicationPage_EDIT_THREAD_LANES_ACTION;

--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/JavaApplicationPage.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/JavaApplicationPage.java
@@ -206,8 +206,8 @@ public class JavaApplicationPage extends AbstractDataPage {
 			return null;
 		}, Messages.JavaApplicationPage_COLUMN_THREAD_DURATION,
 				Messages.JavaApplicationPage_COLUMN_THREAD_DURATION_DESC);
-		HISTOGRAM.addPercentageColumn(PROFILING_PERCENTAGE_COL, JdkAggregators.EXECUTION_SAMPLE_COUNT, "Percentage",
-				"Percentage over total Profiling samples");
+		HISTOGRAM.addPercentageColumn(PROFILING_PERCENTAGE_COL, JdkAggregators.EXECUTION_SAMPLE_COUNT, Messages.JavaApplicationPage_COLUMN_THREAD_PERCENTAGE,
+				Messages.JavaApplicationPage_COLUMN_THREAD_PERCENTAGE_DESC);
 	}
 
 	private class JavaApplicationUi extends ChartAndTableUI {

--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/JavaApplicationPage.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/JavaApplicationPage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021 Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -159,6 +159,7 @@ public class JavaApplicationPage extends AbstractDataPage {
 	private static final String CLASSLOAD_TIME_COL = "classloadingTime"; //$NON-NLS-1$
 	private static final String APPLICATION_PAUSE_ID = "applicationPause"; //$NON-NLS-1$
 	private static final String ACTIVITY_LANES_ID = "threadActivityLanes"; //$NON-NLS-1$
+	private static final String PROFILING_PERCENTAGE_COL = "profilingCount.Percentage"; //$NON-NLS-1$
 
 	private static final ItemHistogramBuilder HISTOGRAM = new ItemHistogramBuilder();
 
@@ -205,6 +206,8 @@ public class JavaApplicationPage extends AbstractDataPage {
 			return null;
 		}, Messages.JavaApplicationPage_COLUMN_THREAD_DURATION,
 				Messages.JavaApplicationPage_COLUMN_THREAD_DURATION_DESC);
+		HISTOGRAM.addPercentageColumn(PROFILING_PERCENTAGE_COL, JdkAggregators.EXECUTION_SAMPLE_COUNT, "Percentage",
+				"Percentage over total Profiling samples");
 	}
 
 	private class JavaApplicationUi extends ChartAndTableUI {

--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/JavaApplicationPage.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/JavaApplicationPage.java
@@ -206,7 +206,8 @@ public class JavaApplicationPage extends AbstractDataPage {
 			return null;
 		}, Messages.JavaApplicationPage_COLUMN_THREAD_DURATION,
 				Messages.JavaApplicationPage_COLUMN_THREAD_DURATION_DESC);
-		HISTOGRAM.addPercentageColumn(PROFILING_PERCENTAGE_COL, JdkAggregators.EXECUTION_SAMPLE_COUNT, Messages.JavaApplicationPage_COLUMN_THREAD_PERCENTAGE,
+		HISTOGRAM.addPercentageColumn(PROFILING_PERCENTAGE_COL, JdkAggregators.EXECUTION_SAMPLE_COUNT,
+				Messages.JavaApplicationPage_COLUMN_THREAD_PERCENTAGE,
 				Messages.JavaApplicationPage_COLUMN_THREAD_PERCENTAGE_DESC);
 	}
 

--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/resources/org/openjdk/jmc/flightrecorder/ui/messages/internal/messages.properties
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/resources/org/openjdk/jmc/flightrecorder/ui/messages/internal/messages.properties
@@ -146,6 +146,8 @@ ExceptionsPage_THROWABLES_LOG_SELECTION=Throwables Log Selection
 ExceptionsPage_THROWABLES_TIMELINE_SELECTION=Throwables Timeline Selection
 SEARCH_TREE_TEXT=Search the tree
 
+JavaApplicationPage_COLUMN_THREAD_PERCENTAGE=Percentage
+JavaApplicationPage_COLUMN_THREAD_PERCENTAGE_DESC=Percentage over total Profiling samples
 JavaApplicationPage_COLUMN_THREAD_START=Thread Start
 JavaApplicationPage_COLUMN_THREAD_START_DESC=Thread start time if available
 JavaApplicationPage_COLUMN_THREAD_END=Thread End


### PR DESCRIPTION
Adding "Percentage" column in Thread table (JavaApplication View). which is helpful in knowing the ratio w.r.t "Profiling Samples"
JMC 5.x had the Percentage Column in "Hot threads" tab.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JMC-6967](https://bugs.openjdk.java.net/browse/JMC-6967): Add Percentage Column w.r.t 'Profiling Samples' in Thread table


### Reviewers
 * [Alex Macdonald](https://openjdk.java.net/census#aptmac) (@aptmac - Committer)
 * @bric3 (no known github.com user name / role) ⚠️ Review applies to 183e87a29a595131e5d0fb089ba17f11f7c9e146


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jmc pull/260/head:pull/260` \
`$ git checkout pull/260`

Update a local copy of the PR: \
`$ git checkout pull/260` \
`$ git pull https://git.openjdk.java.net/jmc pull/260/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 260`

View PR using the GUI difftool: \
`$ git pr show -t 260`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jmc/pull/260.diff">https://git.openjdk.java.net/jmc/pull/260.diff</a>

</details>
