### PR TITLE
7266: Context Switch event handling breaks if JMC has old and new types parsed simultaneously

### DIFF
--- a/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/jdk/JdkAttributes.java
+++ b/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/jdk/JdkAttributes.java
@@ -1160,7 +1160,7 @@ public final class JdkAttributes {
 	private static final IAttribute<IQuantity> OS_SWITCH_RATE_NUMBER = attr("switchRate", //$NON-NLS-1$
 			Messages.getString(Messages.ATTR_OS_SWITCH_RATE), NUMBER);
 	public static final IAttribute<IQuantity> OS_SWITCH_RATE = Attribute.canonicalize(new Attribute<IQuantity>(
-			"oldObjectClass", Messages.getString(Messages.ATTR_OS_SWITCH_RATE), "", FREQUENCY) { //$NON-NLS-1$ //$NON-NLS-2$
+			"(switchRate)", Messages.getString(Messages.ATTR_OS_SWITCH_RATE), "", FREQUENCY) { //$NON-NLS-1$ //$NON-NLS-2$
 		@Override
 		public <U> IMemberAccessor<IQuantity, U> customAccessor(IType<U> type) {
 			final IMemberAccessor<IQuantity, U> rateNumberAccessor = OS_SWITCH_RATE_NUMBER.getAccessor(type);

--- a/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/jdk/JdkAttributes.java
+++ b/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/jdk/JdkAttributes.java
@@ -1159,15 +1159,16 @@ public final class JdkAttributes {
 			Messages.getString(Messages.ATTR_OS_SWITCH_RATE), FREQUENCY);
 	private static final IAttribute<IQuantity> OS_SWITCH_RATE_NUMBER = attr("switchRate", //$NON-NLS-1$
 			Messages.getString(Messages.ATTR_OS_SWITCH_RATE), NUMBER);
-	public static final IAttribute<IQuantity> OS_SWITCH_RATE = Attribute.canonicalize(new Attribute<IQuantity>(
-			"(switchRate)", Messages.getString(Messages.ATTR_OS_SWITCH_RATE), "", FREQUENCY) { //$NON-NLS-1$ //$NON-NLS-2$
-		@Override
-		public <U> IMemberAccessor<IQuantity, U> customAccessor(IType<U> type) {
-			final IMemberAccessor<IQuantity, U> rateNumberAccessor = OS_SWITCH_RATE_NUMBER.getAccessor(type);
-			final IMemberAccessor<IQuantity, U> rateFrequencyAccessor = OS_SWITCH_RATE_FREQUENCY.getAccessor(type);
-			return rateNumberAccessor == null ? rateFrequencyAccessor : rateNumberAccessor;
-		}
-	});
+	public static final IAttribute<IQuantity> OS_SWITCH_RATE = Attribute.canonicalize(
+			new Attribute<IQuantity>("(switchRate)", Messages.getString(Messages.ATTR_OS_SWITCH_RATE), "", FREQUENCY) { //$NON-NLS-1$ //$NON-NLS-2$
+				@Override
+				public <U> IMemberAccessor<IQuantity, U> customAccessor(IType<U> type) {
+					final IMemberAccessor<IQuantity, U> rateNumberAccessor = OS_SWITCH_RATE_NUMBER.getAccessor(type);
+					final IMemberAccessor<IQuantity, U> rateFrequencyAccessor = OS_SWITCH_RATE_FREQUENCY
+							.getAccessor(type);
+					return rateNumberAccessor == null ? rateFrequencyAccessor : rateNumberAccessor;
+				}
+			});
 	public static final IAttribute<String> REFERENCE_STATISTICS_TYPE = attr("type", //$NON-NLS-1$
 			Messages.getString(Messages.ATTR_REFERENCE_STATISTICS_TYPE), PLAIN_TEXT);
 	public static final IAttribute<IQuantity> REFERENCE_STATISTICS_COUNT = attr("count", //$NON-NLS-1$


### PR DESCRIPTION
Follow up PR to fix incorrect synthetic attribute ID.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JMC-7266](https://bugs.openjdk.java.net/browse/JMC-7266): Context Switch event handling breaks if JMC has old and new types parsed simultaneously ⚠️ Issue is not open.


### Reviewers
 * [Guru Hb](https://openjdk.java.net/census#ghb) (@guruhb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jmc pull/263/head:pull/263` \
`$ git checkout pull/263`

Update a local copy of the PR: \
`$ git checkout pull/263` \
`$ git pull https://git.openjdk.java.net/jmc pull/263/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 263`

View PR using the GUI difftool: \
`$ git pr show -t 263`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jmc/pull/263.diff">https://git.openjdk.java.net/jmc/pull/263.diff</a>

</details>
