### PR TITLE
7264: Improve the performance of the JFR parser

### DIFF
--- a/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/internal/parser/v1/SpecificReaders.java
+++ b/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/internal/parser/v1/SpecificReaders.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Datadog, Inc. All rights reserved.
+ *
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * The contents of this file are subject to the terms of either the Universal Permissive License
+ * v 1.0 as shown at http://oss.oracle.com/licenses/upl
+ *
+ * or the following license:
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted
+ * provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions
+ * and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other materials provided with
+ * the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to
+ * endorse or promote products derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+ * WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.openjdk.jmc.flightrecorder.internal.parser.v1;
+
+import org.openjdk.jmc.common.unit.ContentType;
+import org.openjdk.jmc.flightrecorder.internal.InvalidJfrFileException;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+
+public class SpecificReaders {
+	static class StackFrame2Reader extends ValueReaders.ReflectiveReader {
+		<T> StackFrame2Reader(Class<T> klass, int fieldCount, ContentType<? super T> ct) {
+			super(klass, fieldCount, ct);
+		}
+
+		@Override
+		public Object read(IDataInput in, boolean allowUnresolvedReference)
+				throws IOException, InvalidJfrFileException {
+			StructTypes.JfrFrame jfrFrame = new StructTypes.JfrFrame();
+			jfrFrame.method = valueReaders.get(0).read(in, allowUnresolvedReference);
+			jfrFrame.lineNumber = valueReaders.get(1).read(in, allowUnresolvedReference);
+			jfrFrame.bytecodeIndex = valueReaders.get(2).read(in, allowUnresolvedReference);
+			jfrFrame.type = valueReaders.get(3).read(in, allowUnresolvedReference);
+			return jfrFrame;
+		}
+
+		@Override
+		public Object resolve(Object value) throws InvalidJfrFileException {
+			if (!(value instanceof StructTypes.JfrFrame))
+				throw new RuntimeException("Invalid object type, expected JfrFrame");
+			StructTypes.JfrFrame jfrFrame = (StructTypes.JfrFrame) value;
+			jfrFrame.method = valueReaders.get(0).resolve(jfrFrame.method);
+			jfrFrame.lineNumber = valueReaders.get(1).resolve(jfrFrame.lineNumber);
+			jfrFrame.bytecodeIndex = valueReaders.get(2).resolve(jfrFrame.bytecodeIndex);
+			jfrFrame.type = valueReaders.get(3).resolve(jfrFrame.type);
+			return value;
+		}
+	}
+}

--- a/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/internal/parser/v1/TypeManager.java
+++ b/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/internal/parser/v1/TypeManager.java
@@ -214,7 +214,7 @@ class TypeManager {
 			case STRUCT_TYPE_METHOD_2:
 				return new ReflectiveReader(JfrMethod.class, fieldCount, UnitLookup.METHOD);
 			case STRUCT_TYPE_STACK_FRAME_2:
-				return new ReflectiveReader(JfrFrame.class, fieldCount, UnitLookup.STACKTRACE_FRAME);
+				return new SpecificReaders.StackFrame2Reader(JfrFrame.class, fieldCount, UnitLookup.STACKTRACE_FRAME);
 			case STRUCT_TYPE_STACK_TRACE_2:
 				return new ReflectiveReader(JfrStackTrace.class, fieldCount, UnitLookup.STACKTRACE);
 			case STRUCT_TYPE_MODULE_2:


### PR DESCRIPTION
When parsing a JFR file, StackFrames are the objects that are the most
deserialized using Readers.
By default, JMC core parser used a generic ReflectiveReaders
which use reflection to parser the structure. However, we have known
objects like stack frames where we could directly map to the typed
object instead on relying on reflection, which speed up significantly
the parsing.

Here the results for c5.2xlarge instance single threaded parsing with 24MB jfr recording with 100 iterations:

| runs | baseline | specific readers optim | improvement |
| --- | --- | --- | --- |
| run 1 | 54,317ms | 39,623ms | -27% |
| run 2 | 54,988ms | 39,520ms | -28% |
| run 3 | 54,209ms | 39,904ms | -26% |

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JMC-7264](https://bugs.openjdk.java.net/browse/JMC-7264): Improve the performance of the JFR parser


### Reviewers
 * [Erik Gahlin](https://openjdk.java.net/census#egahlin) (@egahlin - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jmc pull/266/head:pull/266` \
`$ git checkout pull/266`

Update a local copy of the PR: \
`$ git checkout pull/266` \
`$ git pull https://git.openjdk.java.net/jmc pull/266/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 266`

View PR using the GUI difftool: \
`$ git pr show -t 266`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jmc/pull/266.diff">https://git.openjdk.java.net/jmc/pull/266.diff</a>

</details>
