### PR TITLE
7299: Accessibility Issue - Too low contrast on rule result values

### DIFF
--- a/core/org.openjdk.jmc.flightrecorder.rules/src/main/resources/org/openjdk/jmc/flightrecorder/rules/report/html/internal/rules_overview.html
+++ b/core/org.openjdk.jmc.flightrecorder.rules/src/main/resources/org/openjdk/jmc/flightrecorder/rules/report/html/internal/rules_overview.html
@@ -109,11 +109,10 @@ section {
 .rule_score {
 	border: 0.1em solid darkgrey;
 	float: left;
-	color: #F0F0F0;
+	color: #171616;
 	text-align: center;
 	width: 5em;
-	min-width: 5em;
-	text-shadow: -0.1em 0 grey, 0 0.1em grey, 0.1em 0 grey, 0 -0.1em grey;
+	min-width: 5em;	
 }
 
 .progress_score {
@@ -147,7 +146,7 @@ section {
 }
 
 .rule_bar.warning {
-	background-color: #D40D12;
+	background-color: #f2383d;
 }
 
 .rule_bar.info {


### PR DESCRIPTION
This PR addresses an accessibility issue where the contrast of the rules score on Automated Analysis screen is too low.

Please review the change and let me know if any changes are required.

The UI looks like this now:

![image](https://user-images.githubusercontent.com/11155712/122291146-1c887d00-cf12-11eb-957f-03f662f2805f.png)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JMC-7299](https://bugs.openjdk.java.net/browse/JMC-7299): Accessibility Issue - Too low contrast on rule result values


### Reviewers
 * [Marcus Hirt](https://openjdk.java.net/census#hirt) (@thegreystone - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jmc pull/268/head:pull/268` \
`$ git checkout pull/268`

Update a local copy of the PR: \
`$ git checkout pull/268` \
`$ git pull https://git.openjdk.java.net/jmc pull/268/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 268`

View PR using the GUI difftool: \
`$ git pr show -t 268`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jmc/pull/268.diff">https://git.openjdk.java.net/jmc/pull/268.diff</a>

</details>
