### PR TITLE
JMC-6141: JMC logs warnings when creating recordings

### DIFF
--- a/application/org.openjdk.jmc.flightrecorder.configuration/src/main/java/org/openjdk/jmc/flightrecorder/configuration/internal/CommonConstraints.java
+++ b/application/org.openjdk.jmc.flightrecorder.configuration/src/main/java/org/openjdk/jmc/flightrecorder/configuration/internal/CommonConstraints.java
@@ -40,6 +40,7 @@ import static org.openjdk.jmc.common.unit.DecimalPrefix.NONE;
 import static org.openjdk.jmc.common.unit.UnitLookup.BYTE;
 import static org.openjdk.jmc.common.unit.UnitLookup.DAY;
 import static org.openjdk.jmc.common.unit.UnitLookup.EPOCH_MS;
+import static org.openjdk.jmc.common.unit.UnitLookup.EPOCH_NS;
 import static org.openjdk.jmc.common.unit.UnitLookup.HOUR;
 import static org.openjdk.jmc.common.unit.UnitLookup.MEMORY;
 import static org.openjdk.jmc.common.unit.UnitLookup.MINUTE;
@@ -270,7 +271,7 @@ public class CommonConstraints {
 	}
 
 	public final static IConstraint<IQuantity> POSITIVE_TIMESPAN = new ComparableConstraint<>(
-			new TimePersisterBrokenSI(), SECOND.quantity(0), YEAR.quantity(200));
+			new TimePersisterBrokenSI(), SECOND.quantity(0), EPOCH_NS.quantity(Long.MAX_VALUE));
 	public final static IConstraint<IQuantity> PERIOD_V1 = new ComparableConstraint<>(new PeriodPersister(),
 			NANOSECOND.quantity(1), YEAR.quantity(1));
 	public final static IConstraint<IQuantity> PERIOD_V2 = new ComparableConstraint<>(new PeriodPersisterV2(),

--- a/application/org.openjdk.jmc.rjmx.services.jfr/src/main/java/org/openjdk/jmc/rjmx/services/jfr/internal/EventTypeMetadataV2.java
+++ b/application/org.openjdk.jmc.rjmx.services.jfr/src/main/java/org/openjdk/jmc/rjmx/services/jfr/internal/EventTypeMetadataV2.java
@@ -52,7 +52,7 @@ import org.openjdk.jmc.rjmx.services.jfr.IEventTypeInfo;
  * Provides information about an event type for JFR 2.0.
  */
 public final class EventTypeMetadataV2 implements IEventTypeInfo {
-	private static final String JFR_SETTINGS_PERIOD = "com.oracle.jfr.settings.Period"; //$NON-NLS-1$
+	private static final String JFR_SETTINGS_PERIOD = "jdk.settings.Period"; //$NON-NLS-1$
 	private final Long id;
 	private final EventTypeIDV2 eventTypeID;
 	private final String label;

--- a/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/unit/LinearKindOfQuantity.java
+++ b/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/unit/LinearKindOfQuantity.java
@@ -84,6 +84,7 @@ public class LinearKindOfQuantity extends KindOfQuantity<LinearUnit> {
 	private static final FormatThreadLocal<NumberFormat> NUMBER_FORMAT_INTERACTIVE_HOLDER;
 	// Holder of display number formatter/parser, which may contain non-breaking spaces.
 	private static final FormatThreadLocal<NumberFormat> NUMBER_FORMAT_DISPLAY_HOLDER;
+	private static final String INFINITY = "infinity"; //$NON-NLS-1$
 
 	protected final LinearUnit atomUnit;
 	// Since units no longer have an explicit name, only a description, use this to generate prefixed names.
@@ -612,6 +613,9 @@ public class LinearKindOfQuantity extends KindOfQuantity<LinearUnit> {
 			} else {
 				throw QuantityConversionException.unknownUnit(persistedQuantity, getDefaultUnit().quantity(1234.0));
 			}
+		}
+		if (INFINITY.equals(persistedQuantity)) {
+			return UnitLookup.NANOSECOND.quantity(Long.MAX_VALUE);
 		}
 		throw QuantityConversionException.unparsable(persistedQuantity, getDefaultUnit().quantity(1234.0));
 	}

--- a/core/tests/org.openjdk.jmc.common.test/src/test/java/org/openjdk/jmc/common/test/unit/ContentTypeTest.java
+++ b/core/tests/org.openjdk.jmc.common.test/src/test/java/org/openjdk/jmc/common/test/unit/ContentTypeTest.java
@@ -250,4 +250,10 @@ public class ContentTypeTest extends MCTestCase {
 		AdHocQuantityTest.assertNearlySame(quantity, wellKnown);
 	}
 
+	@Test
+	public void testPersistedQuantityInfinity() throws Exception {
+		ITypedQuantity<LinearUnit> quantity = TIMESPAN.parsePersisted("infinity");
+		assertEquals(quantity.longValue(), Long.MAX_VALUE);
+	}
+
 }


### PR DESCRIPTION
This PR addresses JMC-6141 [[0]](https://bugs.openjdk.java.net/browse/JMC-6141), in which JMC logs warnings when creating recordings. This is particularly annoying when running unit tests because the terminal gets flooded with warnings.

There are two problems here.

The first problem is that the `JFR_SETTINGS_PERIOD` constant in EventTypeMetadataV2 is outdated. It is currently hardcoded as `com.oracle.jfr.settings.Period` which looks to have been the name prior to open-sourcing [[1]](https://github.com/alibaba/dragonwell8_jdk/blob/423386885af50cf6f956d1b1ba159a994045a8ae/src/share/classes/jdk/jfr/internal/settings/PeriodSetting.java/#L43), but has since become `jdk.settings.Period` [[2]](https://github.com/openjdk/jdk/blob/master/src/jdk.jfr/share/classes/jdk/jfr/internal/settings/PeriodSetting.java#L42)[[3]](https://github.com/openjdk/jdk/blob/master/src/jdk.jfr/share/classes/jdk/jfr/internal/Type.java#L53). This removes the warnings related to `WARNING: Inferred content type 'jdk.jfr.Period' for option Period`.

The second problem is that there isn't any handling for the value "infinity" when parsing the timespan. The method `parsePersisted()` in LinearKindOfQuantity looks at the persisted string and uses regex to separate the unit from the value. In this case with period however, if the timespan is infinite then the string is just "infinity", so the regex doesn't work and we end up throwing an exception. I took some inspiration from the jfr code [[4]](https://github.com/openjdk/jdk/blob/master/src/jdk.jfr/share/classes/jdk/jfr/internal/settings/PeriodSetting.java#L77), and it handles infinite timespans by checking the string, and if it is "infinity" then returns the max long value [[5]](https://github.com/openjdk/jdk/blob/master/src/jdk.jfr/share/classes/jdk/jfr/internal/Utils.java#L304). I've added a unit test to reinforce this behaviour.

Let me know if this approach is okay, and if there are different options I need to consider.

After these two changes my test output is legible, and I haven't noticed and regressions with uitests or my manual testing. When doing a regular `mvn clean verify` for the application we see a reduction of 12800 logged lines.

[0] https://bugs.openjdk.java.net/browse/JMC-6141
[1] https://github.com/alibaba/dragonwell8_jdk/blob/423386885af50cf6f956d1b1ba159a994045a8ae/src/share/classes/jdk/jfr/internal/settings/PeriodSetting.java/#L43
[2] https://github.com/openjdk/jdk/blob/master/src/jdk.jfr/share/classes/jdk/jfr/internal/settings/PeriodSetting.java#L42
[3] https://github.com/openjdk/jdk/blob/master/src/jdk.jfr/share/classes/jdk/jfr/internal/Type.java#L53
[4] https://github.com/openjdk/jdk/blob/master/src/jdk.jfr/share/classes/jdk/jfr/internal/settings/PeriodSetting.java#L116
[5] https://github.com/openjdk/jdk/blob/master/src/jdk.jfr/share/classes/jdk/jfr/internal/Utils.java#L304

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JMC-6141](https://bugs.openjdk.java.net/browse/JMC-6141): JMC logs warnings when creating recordings


### Reviewers
 * [Marcus Hirt](https://openjdk.java.net/census#hirt) (@thegreystone - **Reviewer**)
 * [Jean-Philippe Bempel](https://openjdk.java.net/census#jpbempel) (@jpbempel - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jmc pull/270/head:pull/270` \
`$ git checkout pull/270`

Update a local copy of the PR: \
`$ git checkout pull/270` \
`$ git pull https://git.openjdk.java.net/jmc pull/270/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 270`

View PR using the GUI difftool: \
`$ git pr show -t 270`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jmc/pull/270.diff">https://git.openjdk.java.net/jmc/pull/270.diff</a>

</details>
