### PR TITLE
4792: Stop using System.out/err.println and e.printStackTrace

### DIFF
--- a/agent/src/main/java/org/openjdk/jmc/agent/impl/DefaultTransformRegistry.java
+++ b/agent/src/main/java/org/openjdk/jmc/agent/impl/DefaultTransformRegistry.java
@@ -284,7 +284,7 @@ public class DefaultTransformRegistry implements TransformRegistry {
 				streamReader.next();
 			}
 		} catch (XMLStreamException e) {
-			e.printStackTrace();
+			logger.log(Level.SEVERE, "", e);
 		}
 	}
 

--- a/agent/src/main/java/org/openjdk/jmc/agent/impl/DefaultTransformRegistry.java
+++ b/agent/src/main/java/org/openjdk/jmc/agent/impl/DefaultTransformRegistry.java
@@ -284,7 +284,7 @@ public class DefaultTransformRegistry implements TransformRegistry {
 				streamReader.next();
 			}
 		} catch (XMLStreamException e) {
-			logger.log(Level.SEVERE, "", e);
+			logger.log(Level.SEVERE, "Failed to parse global config", e);
 		}
 	}
 

--- a/agent/src/main/java/org/openjdk/jmc/agent/jfrlegacy/impl/JFRUtils.java
+++ b/agent/src/main/java/org/openjdk/jmc/agent/jfrlegacy/impl/JFRUtils.java
@@ -76,9 +76,7 @@ public class JFRUtils {
 			return producerClass.getDeclaredMethod("addEvent", Class.class);
 		} catch (NoSuchMethodException | SecurityException e) {
 			// This should never happen
-			Agent.getLogger().severe("Failed to find the addEvent method of the producer.");
-			Agent.getLogger().severe("No BCI generated JFR events will be available.");
-			Agent.getLogger().log(Level.SEVERE, "", e);
+			Agent.getLogger().log(Level.SEVERE, "Failed to find the addEvent method of the producer. No BCI generated JFR events will be available.", e);
 		}
 		return null;
 	}
@@ -92,10 +90,7 @@ public class JFRUtils {
 			registerMethod.invoke(producer);
 			return producer;
 		} catch (Exception e) {
-			Agent.getLogger().severe(
-					"Failed to create producer for Oracle JDK7/8 JVM. Ensure that the JVM was started with -XX:+UnlockCommercialFeatures and -XX:+FlightRecorder.");
-			Agent.getLogger().severe("No BCI generated JFR events will be available.");
-			Agent.getLogger().log(Level.SEVERE, "", e);
+			Agent.getLogger().log(Level.SEVERE, "Failed to create producer for Oracle JDK7/8 JVM. Ensure that the JVM was started with -XX:+UnlockCommercialFeatures and -XX:+FlightRecorder. No BCI generated JFR events will be available.", e);
 		}
 		return null;
 	}

--- a/agent/src/main/java/org/openjdk/jmc/agent/jfrlegacy/impl/JFRUtils.java
+++ b/agent/src/main/java/org/openjdk/jmc/agent/jfrlegacy/impl/JFRUtils.java
@@ -76,7 +76,9 @@ public class JFRUtils {
 			return producerClass.getDeclaredMethod("addEvent", Class.class);
 		} catch (NoSuchMethodException | SecurityException e) {
 			// This should never happen
-			Agent.getLogger().log(Level.SEVERE, "Failed to find the addEvent method of the producer. No BCI generated JFR events will be available.", e);
+			Agent.getLogger().log(Level.SEVERE,
+					"Failed to find the addEvent method of the producer. No BCI generated JFR events will be available.",
+					e);
 		}
 		return null;
 	}
@@ -90,7 +92,9 @@ public class JFRUtils {
 			registerMethod.invoke(producer);
 			return producer;
 		} catch (Exception e) {
-			Agent.getLogger().log(Level.SEVERE, "Failed to create producer for Oracle JDK7/8 JVM. Ensure that the JVM was started with -XX:+UnlockCommercialFeatures and -XX:+FlightRecorder. No BCI generated JFR events will be available.", e);
+			Agent.getLogger().log(Level.SEVERE,
+					"Failed to create producer for Oracle JDK7/8 JVM. Ensure that the JVM was started with -XX:+UnlockCommercialFeatures and -XX:+FlightRecorder. No BCI generated JFR events will be available.",
+					e);
 		}
 		return null;
 	}

--- a/agent/src/main/java/org/openjdk/jmc/agent/jfrlegacy/impl/JFRUtils.java
+++ b/agent/src/main/java/org/openjdk/jmc/agent/jfrlegacy/impl/JFRUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -78,7 +78,7 @@ public class JFRUtils {
 			// This should never happen
 			Agent.getLogger().severe("Failed to find the addEvent method of the producer.");
 			Agent.getLogger().severe("No BCI generated JFR events will be available.");
-			e.printStackTrace();
+			Agent.getLogger().log(Level.SEVERE, "", e);
 		}
 		return null;
 	}
@@ -95,7 +95,7 @@ public class JFRUtils {
 			Agent.getLogger().severe(
 					"Failed to create producer for Oracle JDK7/8 JVM. Ensure that the JVM was started with -XX:+UnlockCommercialFeatures and -XX:+FlightRecorder.");
 			Agent.getLogger().severe("No BCI generated JFR events will be available.");
-			e.printStackTrace();
+			Agent.getLogger().log(Level.SEVERE, "", e);
 		}
 		return null;
 	}

--- a/application/org.openjdk.jmc.alert/src/main/java/org/openjdk/jmc/alert/TriggerActionThreadStackDump.java
+++ b/application/org.openjdk.jmc.alert/src/main/java/org/openjdk/jmc/alert/TriggerActionThreadStackDump.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -35,6 +35,7 @@ package org.openjdk.jmc.alert;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.logging.Logger;
 
 import org.eclipse.osgi.util.NLS;
 
@@ -51,6 +52,7 @@ import org.openjdk.jmc.ui.common.resource.MCFile;
  * notification and shows the thread dump as an application alert, logs the thread dump, or both.
  */
 public class TriggerActionThreadStackDump extends TriggerAction {
+	private final static Logger LOGGER = Logger.getLogger("org.openjdk.jmc.alert"); //$NON-NLS-1$
 	private static final String XML_ELEMENT_LOG_TO_FILE = "log_to_file"; //$NON-NLS-1$
 	private static final String XML_ELEMENT_SHOW_APPLICATION_ALERT = "show_application_alert"; //$NON-NLS-1$
 	private static final String XML_ELEMENT_APPEND = "append"; //$NON-NLS-1$
@@ -82,7 +84,7 @@ public class TriggerActionThreadStackDump extends TriggerAction {
 			InputStream stream = new ByteArrayInputStream(data.getBytes(StandardCharsets.UTF_8));
 			IDESupportToolkit.writeAsJob(jobName, file, stream, isAppend());
 		} else {
-			System.out.println(data);
+			LOGGER.info(data);
 		}
 	}
 

--- a/application/org.openjdk.jmc.browser.attach/src/main/java/org/openjdk/jmc/browser/attach/LocalConnectionDescriptor.java
+++ b/application/org.openjdk.jmc.browser.attach/src/main/java/org/openjdk/jmc/browser/attach/LocalConnectionDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -45,6 +45,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import javax.management.remote.JMXServiceURL;
 
@@ -61,6 +62,7 @@ import com.sun.tools.attach.VirtualMachine;
  */
 public class LocalConnectionDescriptor implements IConnectionDescriptor {
 
+	private final static Logger LOGGER = Logger.getLogger("org.openjdk.jmc.browser.attach"); //$NON-NLS-1$
 	private static final String SELF_HOST_NAME = "localhost"; //$NON-NLS-1$
 	private static final String ATTACH_TIMED_OUT_ERROR_MESSAGE = "Timed out attempting to attach to target JVM!"; //$NON-NLS-1$
 	private static final String COULD_NOT_RETRIEVE_URL_ERROR_MESSAGE = "Could not retrieve the in-memory service URL after starting the in-memory agent!"; //$NON-NLS-1$
@@ -156,7 +158,7 @@ public class LocalConnectionDescriptor implements IConnectionDescriptor {
 				url = ConnectionToolkit.createServiceURL(SELF_HOST_NAME, 0);
 			} catch (MalformedURLException e) {
 				// Not going to happen...
-				e.printStackTrace();
+				LOGGER.log(Level.SEVERE, "", e);
 			}
 		} else {
 			try {

--- a/application/org.openjdk.jmc.browser.attach/src/main/java/org/openjdk/jmc/browser/attach/LocalConnectionDescriptor.java
+++ b/application/org.openjdk.jmc.browser.attach/src/main/java/org/openjdk/jmc/browser/attach/LocalConnectionDescriptor.java
@@ -158,7 +158,7 @@ public class LocalConnectionDescriptor implements IConnectionDescriptor {
 				url = ConnectionToolkit.createServiceURL(SELF_HOST_NAME, 0);
 			} catch (MalformedURLException e) {
 				// Not going to happen...
-				LOGGER.log(Level.SEVERE, "", e);
+				LOGGER.log(Level.SEVERE, "Failed to parse url", e);
 			}
 		} else {
 			try {

--- a/application/org.openjdk.jmc.commands/src/main/java/org/openjdk/jmc/commands/CommandFactory.java
+++ b/application/org.openjdk.jmc.commands/src/main/java/org/openjdk/jmc/commands/CommandFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -36,6 +36,8 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IConfigurationElement;
@@ -48,6 +50,7 @@ import org.eclipse.core.runtime.Platform;
  * Class that creates a list of the available commands in the system.
  */
 class CommandFactory {
+	private final static Logger LOGGER = Logger.getLogger("org.openjdk.jmc.commands"); //$NON-NLS-1$
 	private static final String DESCRIPTION = "description"; //$NON-NLS-1$
 	private static final String IDENTIFIER = "identifier"; //$NON-NLS-1$
 	private static final String NAME = "name"; //$NON-NLS-1$
@@ -84,7 +87,7 @@ class CommandFactory {
 				try {
 					commands.add(createCommand(configurationElement));
 				} catch (Exception e) {
-					System.err.println(e.getMessage());
+					LOGGER.severe(e.getMessage());
 				}
 			}
 		}
@@ -119,7 +122,7 @@ class CommandFactory {
 					command.setCommandHelper((ICommandHelper) o);
 				}
 			} catch (CoreException e) {
-				e.printStackTrace();
+				LOGGER.log(Level.SEVERE, "", e);
 				throw new Exception("Error creating type completion object", e); //$NON-NLS-1$
 			}
 		}

--- a/application/org.openjdk.jmc.commands/src/main/java/org/openjdk/jmc/commands/CommandFactory.java
+++ b/application/org.openjdk.jmc.commands/src/main/java/org/openjdk/jmc/commands/CommandFactory.java
@@ -122,7 +122,7 @@ class CommandFactory {
 					command.setCommandHelper((ICommandHelper) o);
 				}
 			} catch (CoreException e) {
-				LOGGER.log(Level.SEVERE, "", e);
+				LOGGER.log(Level.SEVERE, "Failed to create type completion object", e);
 				throw new Exception("Error creating type completion object", e); //$NON-NLS-1$
 			}
 		}

--- a/application/org.openjdk.jmc.console.twitter/src/main/java/org/openjdk/jmc/console/twitter/TwitterPlugin.java
+++ b/application/org.openjdk.jmc.console.twitter/src/main/java/org/openjdk/jmc/console/twitter/TwitterPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -152,7 +152,7 @@ public class TwitterPlugin extends AbstractUIPlugin {
 			}
 		} catch (URISyntaxException e) {
 			// Should never happen...
-			e.printStackTrace();
+			LOGGER.log(Level.SEVERE, "", e);
 		}
 		return new TwitterFactory(cb.build());
 	}

--- a/application/org.openjdk.jmc.console.twitter/src/main/java/org/openjdk/jmc/console/twitter/TwitterPlugin.java
+++ b/application/org.openjdk.jmc.console.twitter/src/main/java/org/openjdk/jmc/console/twitter/TwitterPlugin.java
@@ -152,7 +152,7 @@ public class TwitterPlugin extends AbstractUIPlugin {
 			}
 		} catch (URISyntaxException e) {
 			// Should never happen...
-			LOGGER.log(Level.SEVERE, "", e);
+			LOGGER.log(Level.SEVERE, "Failed to parse URI", e);
 		}
 		return new TwitterFactory(cb.build());
 	}

--- a/application/org.openjdk.jmc.console.ui.mbeanbrowser/src/main/java/org/openjdk/jmc/console/ui/mbeanbrowser/tree/MBeanTreeSectionPart.java
+++ b/application/org.openjdk.jmc.console.ui.mbeanbrowser/src/main/java/org/openjdk/jmc/console/ui/mbeanbrowser/tree/MBeanTreeSectionPart.java
@@ -155,8 +155,8 @@ public class MBeanTreeSectionPart extends MCSectionPart implements IMBeanPropert
 			}
 			MBeanBrowserPlugin.getDefault().getLogger().warning("Couldn't find " + bean + " in MBean tree"); //$NON-NLS-1$ //$NON-NLS-2$
 		} catch (Exception e) {
-			MBeanBrowserPlugin.getDefault().getLogger().log(Level.SEVERE, "", e);
-			MBeanBrowserPlugin.getDefault().getLogger().warning("Failed to select OperatingSystem bean: " + e); //$NON-NLS-1$
+			MBeanBrowserPlugin.getDefault().getLogger().log(Level.WARNING, "Failed to select OperatingSystem bean: ", //$NON-NLS-1$
+					e);
 		}
 	}
 

--- a/application/org.openjdk.jmc.console.ui.mbeanbrowser/src/main/java/org/openjdk/jmc/console/ui/mbeanbrowser/tree/MBeanTreeSectionPart.java
+++ b/application/org.openjdk.jmc.console.ui.mbeanbrowser/src/main/java/org/openjdk/jmc/console/ui/mbeanbrowser/tree/MBeanTreeSectionPart.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -36,6 +36,8 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import javax.management.MBeanServerConnection;
 import javax.management.ObjectName;
@@ -153,7 +155,7 @@ public class MBeanTreeSectionPart extends MCSectionPart implements IMBeanPropert
 			}
 			MBeanBrowserPlugin.getDefault().getLogger().warning("Couldn't find " + bean + " in MBean tree"); //$NON-NLS-1$ //$NON-NLS-2$
 		} catch (Exception e) {
-			e.printStackTrace();
+			MBeanBrowserPlugin.getDefault().getLogger().log(Level.SEVERE, "", e);
 			MBeanBrowserPlugin.getDefault().getLogger().warning("Failed to select OperatingSystem bean: " + e); //$NON-NLS-1$
 		}
 	}

--- a/application/org.openjdk.jmc.console.ui.notification/src/main/java/org/openjdk/jmc/console/ui/notification/widget/ActionChooser.java
+++ b/application/org.openjdk.jmc.console.ui.notification/src/main/java/org/openjdk/jmc/console/ui/notification/widget/ActionChooser.java
@@ -176,7 +176,7 @@ public class ActionChooser {
 				ITriggerAction na = af.createAction(name);
 				m_actionsCache.put(na.getName(), na);
 			} catch (Exception e) {
-				LOGGER.log(Level.SEVERE, "", e);
+				LOGGER.log(Level.SEVERE, "Failed to create trigger action", e);
 			}
 		}
 		if (notificationRule.getAction() != null) {

--- a/application/org.openjdk.jmc.console.ui.notification/src/main/java/org/openjdk/jmc/console/ui/notification/widget/ActionChooser.java
+++ b/application/org.openjdk.jmc.console.ui.notification/src/main/java/org/openjdk/jmc/console/ui/notification/widget/ActionChooser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -35,6 +35,8 @@ package org.openjdk.jmc.console.ui.notification.widget;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import org.eclipse.jface.preference.JFacePreferences;
 import org.eclipse.jface.resource.JFaceResources;
@@ -73,6 +75,7 @@ import org.openjdk.jmc.ui.uibuilder.IUIBuilder;
  * Component that chooses a NotificationAction. Uses a StackLayout for each action
  */
 public class ActionChooser {
+	private final static Logger LOGGER = Logger.getLogger("org.openjdk.jmc.console.ui.notification.widget"); //$NON-NLS-1$
 
 	public interface ComponentFactory {
 		Composite createComponent(Composite parent, ITriggerAction action);
@@ -173,7 +176,7 @@ public class ActionChooser {
 				ITriggerAction na = af.createAction(name);
 				m_actionsCache.put(na.getName(), na);
 			} catch (Exception e) {
-				e.printStackTrace();
+				LOGGER.log(Level.SEVERE, "", e);
 			}
 		}
 		if (notificationRule.getAction() != null) {

--- a/application/org.openjdk.jmc.console.ui.notification/src/main/java/org/openjdk/jmc/console/ui/notification/widget/ConstraintChooser.java
+++ b/application/org.openjdk.jmc.console.ui.notification/src/main/java/org/openjdk/jmc/console/ui/notification/widget/ConstraintChooser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -34,6 +34,8 @@ package org.openjdk.jmc.console.ui.notification.widget;
 
 import java.util.HashMap;
 import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import org.eclipse.jface.viewers.CheckStateChangedEvent;
 import org.eclipse.jface.viewers.CheckboxTableViewer;
@@ -68,6 +70,8 @@ import org.openjdk.jmc.ui.uibuilder.IUIBuilder;
  * Component that selects NotificationConstraints. Uses a StackLayout
  */
 public class ConstraintChooser {
+	private final static Logger LOGGER = Logger.getLogger("org.openjdk.jmc.console.ui.notification.widget"); //$NON-NLS-1$
+
 	public class TriggerContentProvider extends AbstractStructuredContentProvider {
 		@Override
 		public Object[] getElements(Object inputElement) {
@@ -141,7 +145,7 @@ public class ConstraintChooser {
 				ITriggerConstraint nc = af.createConstraint(name);
 				m_constraintCache.put(nc.getName(), nc);
 			} catch (Exception e) {
-				e.printStackTrace();
+				LOGGER.log(Level.SEVERE, "", e);
 			}
 		}
 

--- a/application/org.openjdk.jmc.console.ui.notification/src/main/java/org/openjdk/jmc/console/ui/notification/widget/ConstraintChooser.java
+++ b/application/org.openjdk.jmc.console.ui.notification/src/main/java/org/openjdk/jmc/console/ui/notification/widget/ConstraintChooser.java
@@ -145,7 +145,7 @@ public class ConstraintChooser {
 				ITriggerConstraint nc = af.createConstraint(name);
 				m_constraintCache.put(nc.getName(), nc);
 			} catch (Exception e) {
-				LOGGER.log(Level.SEVERE, "", e);
+				LOGGER.log(Level.SEVERE, "Failed to create trigger constraint", e);
 			}
 		}
 

--- a/application/org.openjdk.jmc.console.ui.subscriptions/src/main/java/org/openjdk/jmc/console/ui/subscriptions/SubscriptionsSectionPart.java
+++ b/application/org.openjdk.jmc.console.ui.subscriptions/src/main/java/org/openjdk/jmc/console/ui/subscriptions/SubscriptionsSectionPart.java
@@ -216,7 +216,7 @@ public class SubscriptionsSectionPart extends MCSectionPart {
 					try {
 						Thread.sleep(DEFAULT_REFRESH_TIME);
 					} catch (InterruptedException e) {
-						LOGGER.log(Level.SEVERE, "", e);
+						LOGGER.log(Level.SEVERE, "Sleep interrupted", e);
 					}
 				}
 			}

--- a/application/org.openjdk.jmc.console.ui.subscriptions/src/main/java/org/openjdk/jmc/console/ui/subscriptions/SubscriptionsSectionPart.java
+++ b/application/org.openjdk.jmc.console.ui.subscriptions/src/main/java/org/openjdk/jmc/console/ui/subscriptions/SubscriptionsSectionPart.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -36,6 +36,8 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Observable;
 import java.util.Observer;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import org.eclipse.jface.action.Action;
 import org.eclipse.jface.viewers.TableViewer;
@@ -64,6 +66,7 @@ import org.openjdk.jmc.ui.misc.MCSectionPart;
 import org.openjdk.jmc.ui.misc.MementoToolkit;
 
 public class SubscriptionsSectionPart extends MCSectionPart {
+	private final static Logger LOGGER = Logger.getLogger("org.openjdk.jmc.console.ui.subscriptions"); //$NON-NLS-1$
 
 	private class ClearStatisticsAction extends Action {
 		public ClearStatisticsAction() {
@@ -213,7 +216,7 @@ public class SubscriptionsSectionPart extends MCSectionPart {
 					try {
 						Thread.sleep(DEFAULT_REFRESH_TIME);
 					} catch (InterruptedException e) {
-						e.printStackTrace();
+						LOGGER.log(Level.SEVERE, "", e);
 					}
 				}
 			}

--- a/application/org.openjdk.jmc.flightrecorder.controlpanel.ui.configuration/src/main/java/org/openjdk/jmc/flightrecorder/controlpanel/ui/configuration/model/xml/XMLModel.java
+++ b/application/org.openjdk.jmc.flightrecorder.controlpanel.ui.configuration/src/main/java/org/openjdk/jmc/flightrecorder/controlpanel/ui/configuration/model/xml/XMLModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -50,6 +50,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Observable;
 import java.util.Stack;
+import java.util.logging.Logger;
 
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.parsers.SAXParser;
@@ -319,8 +320,9 @@ public final class XMLModel extends Observable {
 				// NOTE: This will only keep one result per node, although many may have been found.
 				m_resultLookup.put(r.getObject(), r);
 				if (r.isError()) {
-					// FIXME: Get a logger when this is in a better bundle.
-					System.out.println(r.getObject() + ": " + r.getText()); //$NON-NLS-1$
+					Logger logger = Logger
+							.getLogger("org.openjdk.jmc.flightrecorder.controlpanel.ui.configuration.model.xml"); //$NON-NLS-1$
+					logger.severe(r.getObject() + ": " + r.getText()); //$NON-NLS-1$
 				}
 			}
 		}

--- a/application/org.openjdk.jmc.flightrecorder.controlpanel.ui/src/main/java/org/openjdk/jmc/flightrecorder/controlpanel/ui/actions/PrintRecordingDescriptorAction.java
+++ b/application/org.openjdk.jmc.flightrecorder.controlpanel.ui/src/main/java/org/openjdk/jmc/flightrecorder/controlpanel/ui/actions/PrintRecordingDescriptorAction.java
@@ -110,7 +110,7 @@ public class PrintRecordingDescriptorAction implements IUserAction, IGraphical {
 			printDivider(writer);
 			writer.flush();
 		} catch (Throwable t) {
-			LOGGER.log(Level.SEVERE, "", t);
+			LOGGER.log(Level.SEVERE, "Failed to print recording info", t);
 		}
 	}
 
@@ -222,11 +222,11 @@ public class PrintRecordingDescriptorAction implements IUserAction, IGraphical {
 				printRecordingInfo(System.err);
 			}
 		} catch (IllegalArgumentException e) {
-			LOGGER.log(Level.SEVERE, "", e);
+			LOGGER.log(Level.SEVERE, "Failed to execute print recording info", e);
 		} catch (ConnectionException e) {
-			LOGGER.log(Level.SEVERE, "", e);
+			LOGGER.log(Level.SEVERE, "Failed to execute print recording info", e);
 		} catch (ServiceNotAvailableException e) {
-			LOGGER.log(Level.SEVERE, "", e);
+			LOGGER.log(Level.SEVERE, "Failed to execute print recording info", e);
 		} finally {
 			IOToolkit.closeSilently(handle);
 			IOToolkit.closeSilently(newOut);

--- a/application/org.openjdk.jmc.flightrecorder.controlpanel.ui/src/main/java/org/openjdk/jmc/flightrecorder/controlpanel/ui/actions/PrintRecordingDescriptorAction.java
+++ b/application/org.openjdk.jmc.flightrecorder.controlpanel.ui/src/main/java/org/openjdk/jmc/flightrecorder/controlpanel/ui/actions/PrintRecordingDescriptorAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -40,6 +40,8 @@ import java.io.PrintStream;
 import java.io.PrintWriter;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import java.util.SortedSet;
 import java.util.TreeSet;
 
@@ -67,6 +69,8 @@ import org.openjdk.jmc.ui.misc.IGraphical;
  */
 @SuppressWarnings("nls")
 public class PrintRecordingDescriptorAction implements IUserAction, IGraphical {
+	private final static Logger LOGGER = Logger.getLogger("org.openjdk.jmc.flightrecorder.controlpanel.ui.actions"); //$NON-NLS-1$
+
 	private final IRecordingDescriptor recording;
 	private IFlightRecorderService flightRecorderService;
 	private final RecordingProvider rec;
@@ -106,7 +110,7 @@ public class PrintRecordingDescriptorAction implements IUserAction, IGraphical {
 			printDivider(writer);
 			writer.flush();
 		} catch (Throwable t) {
-			t.printStackTrace();
+			LOGGER.log(Level.SEVERE, "", t);
 		}
 	}
 
@@ -218,11 +222,11 @@ public class PrintRecordingDescriptorAction implements IUserAction, IGraphical {
 				printRecordingInfo(System.err);
 			}
 		} catch (IllegalArgumentException e) {
-			e.printStackTrace();
+			LOGGER.log(Level.SEVERE, "", e);
 		} catch (ConnectionException e) {
-			e.printStackTrace();
+			LOGGER.log(Level.SEVERE, "", e);
 		} catch (ServiceNotAvailableException e) {
-			e.printStackTrace();
+			LOGGER.log(Level.SEVERE, "", e);
 		} finally {
 			IOToolkit.closeSilently(handle);
 			IOToolkit.closeSilently(newOut);

--- a/application/org.openjdk.jmc.flightrecorder.controlpanel.ui/src/main/java/org/openjdk/jmc/flightrecorder/controlpanel/ui/model/ConfigurationRepositoryFactory.java
+++ b/application/org.openjdk.jmc.flightrecorder.controlpanel.ui/src/main/java/org/openjdk/jmc/flightrecorder/controlpanel/ui/model/ConfigurationRepositoryFactory.java
@@ -110,10 +110,12 @@ public class ConfigurationRepositoryFactory {
 					repository.add(template);
 				} catch (IOException e) {
 					// FIXME: Better exception handling
-					ControlPanel.getDefault().getLogger().log(Level.SEVERE, "", e);
+					ControlPanel.getDefault().getLogger().log(Level.SEVERE,
+							"Failed to load local template file " + file, e);
 				} catch (ParseException e) {
 					// FIXME: Better exception handling
-					ControlPanel.getDefault().getLogger().log(Level.SEVERE, "", e);
+					ControlPanel.getDefault().getLogger().log(Level.SEVERE,
+							"Failed to parse local template file " + file, e);
 				}
 			}
 		}

--- a/application/org.openjdk.jmc.flightrecorder.controlpanel.ui/src/main/java/org/openjdk/jmc/flightrecorder/controlpanel/ui/model/ConfigurationRepositoryFactory.java
+++ b/application/org.openjdk.jmc.flightrecorder.controlpanel.ui/src/main/java/org/openjdk/jmc/flightrecorder/controlpanel/ui/model/ConfigurationRepositoryFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -110,10 +110,10 @@ public class ConfigurationRepositoryFactory {
 					repository.add(template);
 				} catch (IOException e) {
 					// FIXME: Better exception handling
-					e.printStackTrace();
+					ControlPanel.getDefault().getLogger().log(Level.SEVERE, "", e);
 				} catch (ParseException e) {
 					// FIXME: Better exception handling
-					e.printStackTrace();
+					ControlPanel.getDefault().getLogger().log(Level.SEVERE, "", e);
 				}
 			}
 		}

--- a/application/org.openjdk.jmc.flightrecorder.controlpanel.ui/src/main/java/org/openjdk/jmc/flightrecorder/controlpanel/ui/wizards/RecordingWizardModel.java
+++ b/application/org.openjdk.jmc.flightrecorder.controlpanel.ui/src/main/java/org/openjdk/jmc/flightrecorder/controlpanel/ui/wizards/RecordingWizardModel.java
@@ -237,13 +237,13 @@ public class RecordingWizardModel extends Observable {
 					repo.add(new EventConfiguration(EventConfiguration.createModel(templateXML),
 							VolatileStorageDelegate.getOnServerDelegate()));
 				} catch (ParseException e) {
-					ControlPanel.getDefault().getLogger().log(Level.SEVERE, "", e);
+					ControlPanel.getDefault().getLogger().log(Level.SEVERE, "Failed to parse template", e);
 				} catch (IOException e) {
-					ControlPanel.getDefault().getLogger().log(Level.SEVERE, "", e);
+					ControlPanel.getDefault().getLogger().log(Level.SEVERE, "Failed to load template", e);
 				}
 			}
 		} catch (FlightRecorderException e) {
-			ControlPanel.getDefault().getLogger().log(Level.SEVERE, "", e);
+			ControlPanel.getDefault().getLogger().log(Level.SEVERE, "Failed to load server templates", e);
 		}
 		// Force sorting and changes to be cleared. No one is actually listening.
 		repo.notifyObservers();

--- a/application/org.openjdk.jmc.flightrecorder.controlpanel.ui/src/main/java/org/openjdk/jmc/flightrecorder/controlpanel/ui/wizards/RecordingWizardModel.java
+++ b/application/org.openjdk.jmc.flightrecorder.controlpanel.ui/src/main/java/org/openjdk/jmc/flightrecorder/controlpanel/ui/wizards/RecordingWizardModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -237,13 +237,13 @@ public class RecordingWizardModel extends Observable {
 					repo.add(new EventConfiguration(EventConfiguration.createModel(templateXML),
 							VolatileStorageDelegate.getOnServerDelegate()));
 				} catch (ParseException e) {
-					e.printStackTrace();
+					ControlPanel.getDefault().getLogger().log(Level.SEVERE, "", e);
 				} catch (IOException e) {
-					e.printStackTrace();
+					ControlPanel.getDefault().getLogger().log(Level.SEVERE, "", e);
 				}
 			}
 		} catch (FlightRecorderException e) {
-			e.printStackTrace();
+			ControlPanel.getDefault().getLogger().log(Level.SEVERE, "", e);
 		}
 		// Force sorting and changes to be cleared. No one is actually listening.
 		repo.notifyObservers();

--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/JfrEditor.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/JfrEditor.java
@@ -380,7 +380,7 @@ public class JfrEditor extends EditorPart implements INavigationLocationProvider
 			try {
 				getSite().getPage().showView(CONTENT_OUTLINE_VIEW_ID, null, IWorkbenchPage.VIEW_VISIBLE);
 			} catch (PartInitException e) {
-				FlightRecorderUI.getDefault().getLogger().log(Level.SEVERE, "", e);
+				FlightRecorderUI.getDefault().getLogger().log(Level.SEVERE, "Failed to show outline view", e);
 			}
 			ruleEngine.setStreamModel(items);
 			refreshPages();

--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/JfrEditor.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/JfrEditor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -380,7 +380,7 @@ public class JfrEditor extends EditorPart implements INavigationLocationProvider
 			try {
 				getSite().getPage().showView(CONTENT_OUTLINE_VIEW_ID, null, IWorkbenchPage.VIEW_VISIBLE);
 			} catch (PartInitException e) {
-				e.printStackTrace();
+				FlightRecorderUI.getDefault().getLogger().log(Level.SEVERE, "", e);
 			}
 			ruleEngine.setStreamModel(items);
 			refreshPages();

--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/common/DataPageToolkit.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/common/DataPageToolkit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -51,6 +51,8 @@ import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -163,6 +165,7 @@ import org.openjdk.jmc.ui.misc.OverlayImageDescriptor;
 import org.openjdk.jmc.ui.misc.SWTColorToolkit;
 
 public class DataPageToolkit {
+	private final static Logger LOGGER = Logger.getLogger("org.openjdk.jmc.flightrecorder.ui.common"); //$NON-NLS-1$
 
 	public static final IColorProvider<IItem> ITEM_COLOR = item -> TypeLabelProvider
 			.getColorOrDefault(item.getType().getIdentifier());
@@ -1100,8 +1103,7 @@ public class DataPageToolkit {
 						imageLabel.getParent().layout();
 						setPageComplete(isPageComplete());
 					} catch (Exception e) {
-						// FIXME: Add proper logging
-						e.printStackTrace();
+						LOGGER.log(Level.SEVERE, "", e);
 					}
 				}
 

--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/common/DataPageToolkit.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/common/DataPageToolkit.java
@@ -1103,7 +1103,7 @@ public class DataPageToolkit {
 						imageLabel.getParent().layout();
 						setPageComplete(isPageComplete());
 					} catch (Exception e) {
-						LOGGER.log(Level.SEVERE, "", e);
+						LOGGER.log(Level.SEVERE, "Failed to load image " + filename, e);
 					}
 				}
 

--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/itemhandler/HistogramSequence.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/itemhandler/HistogramSequence.java
@@ -162,7 +162,7 @@ class HistogramSequence {
 				try {
 					buildHistogram();
 				} catch (Exception e) {
-					LOGGER.log(Level.SEVERE, "", e);
+					LOGGER.log(Level.SEVERE, "Failed to build histogram", e);
 				}
 			}
 			refreshViewer();
@@ -179,7 +179,7 @@ class HistogramSequence {
 			try {
 				buildHistogram();
 			} catch (Exception e) {
-				LOGGER.log(Level.SEVERE, "", e);
+				LOGGER.log(Level.SEVERE, "Failed to build histogram", e);
 			}
 			refreshViewer();
 			onGroup();

--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/itemhandler/HistogramSequence.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/itemhandler/HistogramSequence.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -36,6 +36,8 @@ import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.function.Consumer;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -69,6 +71,7 @@ import org.openjdk.jmc.ui.column.TableSettings;
 import org.openjdk.jmc.ui.handlers.MCContextMenuManager;
 
 class HistogramSequence {
+	private final static Logger LOGGER = Logger.getLogger("org.openjdk.jmc.flightrecorder.ui.pages.itemhandler"); //$NON-NLS-1$
 
 	private static final ImageDescriptor IMAGE_DESCRIPTOR_GROUP_BY = FlightRecorderUI.getDefault()
 			.getMCImageDescriptor(ImageConstants.ICON_GROUP_BY);
@@ -159,7 +162,7 @@ class HistogramSequence {
 				try {
 					buildHistogram();
 				} catch (Exception e) {
-					e.printStackTrace();
+					LOGGER.log(Level.SEVERE, "", e);
 				}
 			}
 			refreshViewer();
@@ -176,7 +179,7 @@ class HistogramSequence {
 			try {
 				buildHistogram();
 			} catch (Exception e) {
-				e.printStackTrace();
+				LOGGER.log(Level.SEVERE, "", e);
 			}
 			refreshViewer();
 			onGroup();

--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/preferences/RulesPage.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/preferences/RulesPage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -208,7 +208,7 @@ public class RulesPage extends PreferencePage implements IWorkbenchPreferencePag
 			checkedRuleIDs.forEach(id -> ignoredState.createChild(IGNORED_RULES).putString(RULE_ID, id));
 			getPreferenceStore().setValue(IGNORED_RULES, ignoredState.toString());
 		} catch (IOException e) {
-			e.printStackTrace();
+			FlightRecorderUI.getDefault().getLogger().log(Level.SEVERE, "", e);
 		}
 	}
 

--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/preferences/RulesPage.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/preferences/RulesPage.java
@@ -208,7 +208,7 @@ public class RulesPage extends PreferencePage implements IWorkbenchPreferencePag
 			checkedRuleIDs.forEach(id -> ignoredState.createChild(IGNORED_RULES).putString(RULE_ID, id));
 			getPreferenceStore().setValue(IGNORED_RULES, ignoredState.toString());
 		} catch (IOException e) {
-			FlightRecorderUI.getDefault().getLogger().log(Level.SEVERE, "", e);
+			FlightRecorderUI.getDefault().getLogger().log(Level.SEVERE, "Failed to store ignored rules", e);
 		}
 	}
 

--- a/application/org.openjdk.jmc.joverflow/src/main/java/org/openjdk/jmc/joverflow/descriptors/CollectionDescriptors.java
+++ b/application/org.openjdk.jmc.joverflow/src/main/java/org/openjdk/jmc/joverflow/descriptors/CollectionDescriptors.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -36,6 +36,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.logging.Logger;
 
 import org.openjdk.jmc.joverflow.heap.model.JavaClass;
 import org.openjdk.jmc.joverflow.heap.model.JavaLazyReadObject;
@@ -49,6 +50,7 @@ import org.openjdk.jmc.joverflow.util.ClassUtils;
 /**
  */
 public class CollectionDescriptors implements Constants {
+	private final static Logger LOGGER = Logger.getLogger("org.openjdk.jmc.joverflow.descriptors"); //$NON-NLS-1$
 
 	private static final String[] EMPTY_STRS = new String[] {};
 	private static final JavaClass[] EMPTY_CLZ = new JavaClass[] {};
@@ -439,7 +441,7 @@ public class CollectionDescriptors implements Constants {
 					}
 				}
 				if (clazz == null) {
-					System.err.println("CollectionDescriptors: Class " + classNames[i] + " not found");
+					LOGGER.severe("CollectionDescriptors: Class " + classNames[i] + " not found");
 				}
 			}
 			if (clazz != null) {

--- a/application/org.openjdk.jmc.joverflow/src/main/java/org/openjdk/jmc/joverflow/descriptors/ConcurrentHashMapDescriptorForJdk8.java
+++ b/application/org.openjdk.jmc.joverflow/src/main/java/org/openjdk/jmc/joverflow/descriptors/ConcurrentHashMapDescriptorForJdk8.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -32,6 +32,8 @@
  */
 package org.openjdk.jmc.joverflow.descriptors;
 
+import java.util.logging.Logger;
+
 import org.openjdk.jmc.joverflow.heap.model.JavaClass;
 import org.openjdk.jmc.joverflow.heap.model.JavaHeapObject;
 import org.openjdk.jmc.joverflow.heap.model.JavaLazyReadObject;
@@ -44,6 +46,7 @@ import org.openjdk.jmc.joverflow.support.Constants;
 // @SuppressWarnings("unused")
 public class ConcurrentHashMapDescriptorForJdk8 extends AbstractCollectionDescriptor
 		implements CollectionInstanceDescriptor.CapacityDifferentFromSize, Constants {
+	private final static Logger LOGGER = Logger.getLogger("org.openjdk.jmc.joverflow.descriptors"); //$NON-NLS-1$
 
 	private final Factory factory;
 	private int cachedNumElements = -1;
@@ -226,7 +229,7 @@ public class ConcurrentHashMapDescriptorForJdk8 extends AbstractCollectionDescri
 						result += key.getSize();
 					} else {
 						// I don't think it can be anything else
-						System.err.println("Unexpected nodeKeyField: " + nodeKeyField.getClass().getName());
+						LOGGER.severe("Unexpected nodeKeyField: " + nodeKeyField.getClass().getName());
 					}
 				}
 				JavaThing nodeValField = node.getField(factory.nodeValFieldIdx);
@@ -239,7 +242,7 @@ public class ConcurrentHashMapDescriptorForJdk8 extends AbstractCollectionDescri
 						JavaClass val = (JavaClass) nodeValField;
 						result += val.getSize();
 					} else {
-						System.err.println("Unexpected nodeValField: " + nodeValField.getClass().getName());
+						LOGGER.severe("Unexpected nodeValField: " + nodeValField.getClass().getName());
 					}
 				}
 				JavaThing nextNodeThing = node.getField(factory.nodeNextFieldIdx);

--- a/application/org.openjdk.jmc.joverflow/src/main/java/org/openjdk/jmc/joverflow/heap/parser/CachedReadBuffer.java
+++ b/application/org.openjdk.jmc.joverflow/src/main/java/org/openjdk/jmc/joverflow/heap/parser/CachedReadBuffer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -34,6 +34,7 @@ package org.openjdk.jmc.joverflow.heap.parser;
 
 import java.io.IOException;
 import java.io.RandomAccessFile;
+import java.util.logging.Logger;
 
 /**
  * The implementation of ReadBuffer that uses in-heap, pure Java LRU disk cache. This cache consists
@@ -57,6 +58,7 @@ import java.io.RandomAccessFile;
  * to swap out.
  */
 public class CachedReadBuffer extends ReadBuffer {
+	private final static Logger LOGGER = Logger.getLogger("org.openjdk.jmc.joverflow.heap.parser"); //$NON-NLS-1$
 	private static final int PAGE_SIZE_MAGNITUDE = 19; // 512KB, seems optimal from experiments
 	private static final int PAGE_SIZE = 1 << PAGE_SIZE_MAGNITUDE;
 	private static final int PAGE_START_MASK = ~(PAGE_SIZE - 1);
@@ -114,19 +116,19 @@ public class CachedReadBuffer extends ReadBuffer {
 		prereadPages(pagePool);
 
 		long memForCache = (long) numPgsInPool * PAGE_SIZE;
-		System.err.println("\nDisk cache size set to " + (memForCache >> 20) + "MB");
+		LOGGER.fine("\nDisk cache size set to " + (memForCache >> 20) + "MB");
 
 		if (DEBUG_PERF) {
 			// Track how well the cached pages are utilized...
-			System.err.println("CRB: numPagesInPool = " + numPgsInPool);
+			LOGGER.fine("CRB: numPagesInPool = " + numPgsInPool);
 			numPageSwaps = 1; // To avoid accidental division by zero
 			Thread observer = new Thread() {
 				@Override
 				public void run() {
 					while (true) {
-						System.err.println("CRB: swps = " + numPageSwaps + ", swps/pg = "
-								+ (numPageSwaps / numPagesInPool) + ", relpos = " + (lastReadPos * 100 / fileSize) + "%"
-								+ ", reads/swps = " + (numReads / numPageSwaps) + ", numChanges = " + numChanges);
+						LOGGER.fine("CRB: swps = " + numPageSwaps + ", swps/pg = " + (numPageSwaps / numPagesInPool)
+								+ ", relpos = " + (lastReadPos * 100 / fileSize) + "%" + ", reads/swps = "
+								+ (numReads / numPageSwaps) + ", numChanges = " + numChanges);
 						try {
 							Thread.sleep(500);
 						} catch (InterruptedException ex) {

--- a/application/org.openjdk.jmc.joverflow/src/main/java/org/openjdk/jmc/joverflow/heap/parser/FileReadBuffer.java
+++ b/application/org.openjdk.jmc.joverflow/src/main/java/org/openjdk/jmc/joverflow/heap/parser/FileReadBuffer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -34,11 +34,15 @@ package org.openjdk.jmc.joverflow.heap.parser;
 
 import java.io.IOException;
 import java.io.RandomAccessFile;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * Implementation of ReadBuffer using a RandomAccessFile
  */
 class FileReadBuffer extends ReadBuffer {
+	private final static Logger LOGGER = Logger.getLogger("org.openjdk.jmc.joverflow.heap.parser"); //$NON-NLS-1$
+
 	/** underlying file to read */
 	private RandomAccessFile file;
 
@@ -96,7 +100,7 @@ class FileReadBuffer extends ReadBuffer {
 		try {
 			file.close();
 		} catch (IOException ex) {
-			System.err.println("Failed to close file " + file + ": " + ex);
+			LOGGER.severe("Failed to close file " + file + ": " + ex);
 		}
 	}
 }

--- a/application/org.openjdk.jmc.joverflow/src/main/java/org/openjdk/jmc/joverflow/stats/DetailedStatsCalculator.java
+++ b/application/org.openjdk.jmc.joverflow/src/main/java/org/openjdk/jmc/joverflow/stats/DetailedStatsCalculator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -248,7 +248,6 @@ class DetailedStatsCalculator implements ProblemChecker, Constants {
 			}
 			classDesc.addProblematicCollection(problemKind, implSize);
 			refChain.recordCurrentRefChainForColCluster(col, colDesc, problemKind, implSize);
-//			System.out.println("Empty collection, impl size = " + implSize);
 			return colDesc;
 		}
 
@@ -273,8 +272,6 @@ class DetailedStatsCalculator implements ProblemChecker, Constants {
 				}
 				classDesc.addProblematicCollection(problemKind, ovhd);
 				refChain.recordCurrentRefChainForColCluster(col, colDesc, problemKind, ovhd);
-//				System.out.println(
-//						problemKind + " collection, nEls = " + nEls + ", capacity = " + capacity + ", ovhd = " + ovhd);
 			}
 		}
 

--- a/application/org.openjdk.jmc.joverflow/src/main/java/org/openjdk/jmc/joverflow/stats/HeapScaner.java
+++ b/application/org.openjdk.jmc.joverflow/src/main/java/org/openjdk/jmc/joverflow/stats/HeapScaner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -33,6 +33,7 @@
 package org.openjdk.jmc.joverflow.stats;
 
 import java.util.List;
+import java.util.logging.Logger;
 
 import org.openjdk.jmc.joverflow.heap.model.JavaClass;
 import org.openjdk.jmc.joverflow.heap.model.JavaHeapObject;
@@ -46,6 +47,7 @@ import org.openjdk.jmc.joverflow.heap.parser.HprofParsingCancelledException;
  * Base functionality that's common for all heap scaners.
  */
 abstract class HeapScaner {
+	private final static Logger LOGGER = Logger.getLogger("org.openjdk.jmc.joverflow.stats"); //$NON-NLS-1$
 
 	protected final Snapshot snapshot;
 	private final InterimRefChain refChain;
@@ -136,8 +138,8 @@ abstract class HeapScaner {
 		}
 
 		if (REPORT_UNVISITED) {
-			System.out.println("\rDebug info:");
-			System.out.println("Objects unreachable from GC roots: " + (currentProcessedObjNo - nObjsBefore));
+			LOGGER.info("\rDebug info:");
+			LOGGER.info("Objects unreachable from GC roots: " + (currentProcessedObjNo - nObjsBefore));
 		}
 	}
 

--- a/application/org.openjdk.jmc.joverflow/src/main/java/org/openjdk/jmc/joverflow/stats/InterimRefChainStack.java
+++ b/application/org.openjdk.jmc.joverflow/src/main/java/org/openjdk/jmc/joverflow/stats/InterimRefChainStack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -33,6 +33,7 @@
 package org.openjdk.jmc.joverflow.stats;
 
 import java.util.ArrayList;
+import java.util.logging.Logger;
 
 import org.openjdk.jmc.joverflow.descriptors.CollectionClassDescriptor;
 import org.openjdk.jmc.joverflow.descriptors.CollectionDescriptors;
@@ -486,16 +487,18 @@ class InterimRefChainStack extends InterimRefChain {
 
 	/** Debugging: print all the elements of the current reference chain as-is. */
 	public void printFullRefChain() {
-		System.out.print(curRootRefChainElement.getRoot().getTypeName());
-		System.out.print("  ");
+		Logger logger = Logger.getLogger("org.openjdk.jmc.joverflow.stats"); //$NON-NLS-1$
+		StringBuilder sb = new StringBuilder();
+		sb.append(curRootRefChainElement.getRoot().getTypeName());
+		sb.append("  ");
 
 		int chainSizeMinusOne = refChain.size() - 1;
 		for (int i = 0; i < chainSizeMinusOne; i++) {
 			JavaHeapObject javaHeapObj = (JavaHeapObject) refChain.get(i++);
 			int idx = ((IndexContainer) refChain.get(i)).get();
-			System.out.print("-->" + getFullLinkDesc(javaHeapObj, idx));
+			sb.append("-->" + getFullLinkDesc(javaHeapObj, idx));
 		}
-		System.out.println();
+		logger.fine(sb.toString());
 	}
 
 	/**

--- a/application/org.openjdk.jmc.joverflow/src/main/java/org/openjdk/jmc/joverflow/stats/LongLivedStringClustersCalculator.java
+++ b/application/org.openjdk.jmc.joverflow/src/main/java/org/openjdk/jmc/joverflow/stats/LongLivedStringClustersCalculator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -35,6 +35,7 @@ package org.openjdk.jmc.joverflow.stats;
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.logging.Logger;
 
 import org.openjdk.jmc.joverflow.batch.BatchProblemRecorder;
 import org.openjdk.jmc.joverflow.batch.DetailedStats;
@@ -50,6 +51,8 @@ import org.openjdk.jmc.joverflow.support.ReferenceChain;
  * the same cluster shows up in two out of three dumps.
  */
 public class LongLivedStringClustersCalculator {
+	private static final Logger LOGGER = Logger.getLogger("org.openjdk.jmc.joverflow.stats"); //$NON-NLS-1$
+
 	private final int numDumps;
 	private final List<ReferencedObjCluster.DupStrings> dupStringsToFields[];
 
@@ -106,9 +109,9 @@ public class LongLivedStringClustersCalculator {
 			}
 		}
 
-		System.out.println("\nLONG-LIVED FIELDS:");
+		LOGGER.info("\nLONG-LIVED FIELDS:");
 		for (String longLivedField : longLivedFields) {
-			System.out.println(longLivedField);
+			LOGGER.info(longLivedField);
 		}
 	}
 

--- a/application/org.openjdk.jmc.joverflow/src/main/java/org/openjdk/jmc/joverflow/util/StringInterner.java
+++ b/application/org.openjdk.jmc.joverflow/src/main/java/org/openjdk/jmc/joverflow/util/StringInterner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -33,6 +33,7 @@
 package org.openjdk.jmc.joverflow.util;
 
 import java.lang.ref.WeakReference;
+import java.util.logging.Logger;
 
 /**
  * Functionality for custom interning (deduplicating) strings. The main API, internString() and
@@ -51,6 +52,7 @@ import java.lang.ref.WeakReference;
  */
 @SuppressWarnings("unchecked")
 public class StringInterner {
+	private final static Logger LOGGER = Logger.getLogger("org.openjdk.jmc.joverflow.util"); //$NON-NLS-1$
 
 	private static final WeakReference<String> table[];
 	private static int size;
@@ -158,9 +160,9 @@ public class StringInterner {
 				}
 			}
 		}
-		System.out.println("Table size: " + table.length + ", null entries: " + numNullEntries);
-		System.out.println("Num calls (may be off due to overflowing): " + numCalls);
-		System.out.println("Num resets: " + numResets);
+		LOGGER.info("Table size: " + table.length + ", null entries: " + numNullEntries);
+		LOGGER.info("Num calls (may be off due to overflowing): " + numCalls);
+		LOGGER.info("Num resets: " + numResets);
 	}
 
 	/**

--- a/application/org.openjdk.jmc.osgi.extension/src/org/openjdk/jmc/osgi/extension/ExtClassLoaderHook.java
+++ b/application/org.openjdk.jmc.osgi.extension/src/org/openjdk/jmc/osgi/extension/ExtClassLoaderHook.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -37,6 +37,8 @@ import java.nio.file.Paths;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import org.eclipse.osgi.internal.framework.EquinoxConfiguration;
 import org.eclipse.osgi.internal.hookregistry.ClassLoaderHook;
@@ -52,7 +54,8 @@ import org.osgi.framework.wiring.BundleWiring;
  * Hook javafx-swt.jar to OSGi default classloader
  */
 public class ExtClassLoaderHook extends ClassLoaderHook {
-
+	
+	private final static Logger LOGGER = Logger.getLogger("org.openjdk.jmc.osgi.extension"); //$NON-NLS-1$
 	private static final String SWT_SYMBOLIC_NAME = "org.eclipse.swt";
 	private static final String FX_SWT_SYMBOLIC_NAME = "javafx.swt";
 	private static final String JAVAFX_SWT_JAR__NAME = "javafx-swt.jar";
@@ -90,7 +93,7 @@ public class ExtClassLoaderHook extends ClassLoaderHook {
 					this.classLoader = (ClassLoader) moduleLayerClass.getMethod("findLoader", String.class)
 							.invoke(newModuleLayer, FX_SWT_SYMBOLIC_NAME);
 				} catch (Throwable t) {
-					System.err.println(t.getMessage());
+					LOGGER.severe(t.getMessage());
 				}
 			}
 			return this.classLoader.loadClass(name);
@@ -118,7 +121,7 @@ public class ExtClassLoaderHook extends ClassLoaderHook {
 							try {
 								bundle.start();
 							} catch (BundleException e) {
-								e.printStackTrace();
+								LOGGER.log(Level.SEVERE, "", e);
 							}
 						}
 						return bundle.adapt(BundleWiring.class).getClassLoader();
@@ -126,7 +129,7 @@ public class ExtClassLoaderHook extends ClassLoaderHook {
 				}
 			}
 		} catch (Throwable t) {
-			System.err.println(t.getMessage());
+			LOGGER.severe(t.getMessage());
 		}
 		return null;
 	}

--- a/application/org.openjdk.jmc.osgi.extension/src/org/openjdk/jmc/osgi/extension/ExtClassLoaderHook.java
+++ b/application/org.openjdk.jmc.osgi.extension/src/org/openjdk/jmc/osgi/extension/ExtClassLoaderHook.java
@@ -121,7 +121,7 @@ public class ExtClassLoaderHook extends ClassLoaderHook {
 							try {
 								bundle.start();
 							} catch (BundleException e) {
-								LOGGER.log(Level.SEVERE, "", e);
+								LOGGER.log(Level.SEVERE, "Failed to start bundle", e);
 							}
 						}
 						return bundle.adapt(BundleWiring.class).getClassLoader();

--- a/application/org.openjdk.jmc.rcp.application/src/main/java/org/openjdk/jmc/rcp/logging/LoggingToolkit.java
+++ b/application/org.openjdk.jmc.rcp.application/src/main/java/org/openjdk/jmc/rcp/logging/LoggingToolkit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -90,6 +90,7 @@ public final class LoggingToolkit {
 			} catch (Exception e) {
 				getLogger().log(Level.WARNING, "Could not initialize debug logger", e); //$NON-NLS-1$
 				System.err.println("WARNING: Could not initialize debug logger"); //$NON-NLS-1$
+				getLogger().log(Level.WARNING, "", e);
 				e.printStackTrace();
 			}
 		} else if (file == null || file.trim().equals("")) //$NON-NLS-1$
@@ -99,6 +100,7 @@ public final class LoggingToolkit {
 			} catch (Exception e) {
 				getLogger().log(Level.WARNING, "Could not initialize default logger", e); //$NON-NLS-1$
 				System.err.println("WARNING: Could not initialize default logger"); //$NON-NLS-1$
+				getLogger().log(Level.WARNING, "", e);
 				e.printStackTrace();
 			}
 		} else {
@@ -114,6 +116,7 @@ public final class LoggingToolkit {
 			} catch (Exception e) {
 				getLogger().log(Level.WARNING, "Could not initialize user logger", e); //$NON-NLS-1$
 				System.err.println("WARNING: Could not initialize user logger"); //$NON-NLS-1$
+				getLogger().log(Level.WARNING, "", e);
 				e.printStackTrace();
 			}
 		}

--- a/application/org.openjdk.jmc.rjmx.services.jfr/src/main/java/org/openjdk/jmc/rjmx/services/jfr/internal/RecordingOptionsToolkitV1.java
+++ b/application/org.openjdk.jmc.rjmx.services.jfr/src/main/java/org/openjdk/jmc/rjmx/services/jfr/internal/RecordingOptionsToolkitV1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -45,6 +45,8 @@ import static org.openjdk.jmc.flightrecorder.configuration.recording.RecordingOp
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import javax.management.openmbean.CompositeData;
 import javax.management.openmbean.CompositeDataSupport;
@@ -66,6 +68,8 @@ import org.openjdk.jmc.rjmx.services.jfr.FlightRecorderException;
  * Toolkit for handling marshalling of RecordingOptions for JFR 1.0 (JDK 7/8).
  */
 public final class RecordingOptionsToolkitV1 {
+	private final static Logger LOGGER = Logger.getLogger("org.openjdk.jmc.rjmx.services.jfr.internal"); //$NON-NLS-1$
+
 	private final static Map<String, OpenTypeConverter<?, ?>> CONVERTERS_BY_REC_OPTION_KEY;
 
 	private final static String[] NAMES;
@@ -123,7 +127,7 @@ public final class RecordingOptionsToolkitV1 {
 			return new CompositeType("RecordingOptions", "Recording Options", names, descriptions, openTypes); //$NON-NLS-1$ //$NON-NLS-2$
 		} catch (Exception e) {
 			// Will not ever happen!
-			e.printStackTrace();
+			LOGGER.log(Level.SEVERE, "", e);
 			return null;
 		}
 	}
@@ -145,8 +149,7 @@ public final class RecordingOptionsToolkitV1 {
 				try {
 					values[i] = toOpenTypeWithCast(converter, value);
 				} catch (QuantityConversionException e) {
-					// FIXME: Add proper logging here
-					e.printStackTrace();
+					LOGGER.log(Level.SEVERE, "", e);
 				}
 			}
 		}
@@ -190,8 +193,7 @@ public final class RecordingOptionsToolkitV1 {
 					EventOptionsToolkitV1.putWithCast(options, key, converter, openValue);
 				}
 			} catch (QuantityConversionException e) {
-				// FIXME: Add proper logging here
-				e.printStackTrace();
+				LOGGER.log(Level.SEVERE, "", e);
 			}
 		}
 		return options;

--- a/application/org.openjdk.jmc.rjmx.services.jfr/src/main/java/org/openjdk/jmc/rjmx/services/jfr/internal/RecordingOptionsToolkitV1.java
+++ b/application/org.openjdk.jmc.rjmx.services.jfr/src/main/java/org/openjdk/jmc/rjmx/services/jfr/internal/RecordingOptionsToolkitV1.java
@@ -127,7 +127,7 @@ public final class RecordingOptionsToolkitV1 {
 			return new CompositeType("RecordingOptions", "Recording Options", names, descriptions, openTypes); //$NON-NLS-1$ //$NON-NLS-2$
 		} catch (Exception e) {
 			// Will not ever happen!
-			LOGGER.log(Level.SEVERE, "", e);
+			LOGGER.log(Level.SEVERE, "Failed to create composite type", e);
 			return null;
 		}
 	}
@@ -149,7 +149,7 @@ public final class RecordingOptionsToolkitV1 {
 				try {
 					values[i] = toOpenTypeWithCast(converter, value);
 				} catch (QuantityConversionException e) {
-					LOGGER.log(Level.SEVERE, "", e);
+					LOGGER.log(Level.SEVERE, "Failed to convert to open type", e);
 				}
 			}
 		}
@@ -193,7 +193,7 @@ public final class RecordingOptionsToolkitV1 {
 					EventOptionsToolkitV1.putWithCast(options, key, converter, openValue);
 				}
 			} catch (QuantityConversionException e) {
-				LOGGER.log(Level.SEVERE, "", e);
+				LOGGER.log(Level.SEVERE, "Failed to convert options", e);
 			}
 		}
 		return options;

--- a/application/org.openjdk.jmc.rjmx/src/main/java/org/openjdk/jmc/rjmx/subscription/internal/AbstractSyntheticNotification.java
+++ b/application/org.openjdk.jmc.rjmx/src/main/java/org/openjdk/jmc/rjmx/subscription/internal/AbstractSyntheticNotification.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -79,7 +79,6 @@ public abstract class AbstractSyntheticNotification implements ISyntheticNotific
 			broadcaster.sendNotification(notification);
 		} catch (Exception e) {
 			RJMXPlugin.getDefault().getLogger().log(Level.WARNING, "Unable to trigger notification!", e); //$NON-NLS-1$
-			e.printStackTrace();
 		}
 	}
 

--- a/application/org.openjdk.jmc.rjmx/src/main/java/org/openjdk/jmc/rjmx/triggers/actions/internal/TriggerActionHPROF.java
+++ b/application/org.openjdk.jmc.rjmx/src/main/java/org/openjdk/jmc/rjmx/triggers/actions/internal/TriggerActionHPROF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -33,6 +33,7 @@
 package org.openjdk.jmc.rjmx.triggers.actions.internal;
 
 import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import javax.management.MBeanInfo;
 import javax.management.MBeanOperationInfo;
@@ -50,6 +51,8 @@ import org.openjdk.jmc.ui.common.util.Filename;
  * This notification action triggers a hprof dump.
  */
 public class TriggerActionHPROF extends TriggerAction {
+	private final static Logger LOGGER = Logger.getLogger("org.openjdk.jmc.rjmx.triggers.actions.internal"); //$NON-NLS-1$
+
 	private final static ObjectName HOTSPOT;
 	private final static String HPROF_OPERATION_NAME = "dumpHeap"; //$NON-NLS-1$
 
@@ -59,8 +62,7 @@ public class TriggerActionHPROF extends TriggerAction {
 			hs = new ObjectName("com.sun.management:type=HotSpotDiagnostic"); //$NON-NLS-1$
 		} catch (Exception e) {
 			// This should really never ever happen!
-			System.out.println("Could not create the HotSpotDiagnostic MBean ObjectName!"); //$NON-NLS-1$
-			e.printStackTrace();
+			LOGGER.log(Level.SEVERE, "Could not create the HotSpotDiagnostic MBean ObjectName!", e); //$NON-NLS-1$
 		}
 		HOTSPOT = hs;
 	}

--- a/application/org.openjdk.jmc.rjmx/src/main/java/org/openjdk/jmc/rjmx/triggers/extension/internal/ExtensionLoader.java
+++ b/application/org.openjdk.jmc.rjmx/src/main/java/org/openjdk/jmc/rjmx/triggers/extension/internal/ExtensionLoader.java
@@ -106,7 +106,7 @@ public class ExtensionLoader<T> {
 			m_extensions.put(className, element);
 			m_prototypes.add(prototype);
 		} catch (CoreException e) {
-			LOGGER.log(Level.SEVERE, "", e);
+			LOGGER.log(Level.SEVERE, "Failed to initialize extension", e);
 		}
 	}
 

--- a/application/org.openjdk.jmc.rjmx/src/main/java/org/openjdk/jmc/rjmx/triggers/extension/internal/ExtensionLoader.java
+++ b/application/org.openjdk.jmc.rjmx/src/main/java/org/openjdk/jmc/rjmx/triggers/extension/internal/ExtensionLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -35,6 +35,8 @@ package org.openjdk.jmc.rjmx.triggers.extension.internal;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IConfigurationElement;
@@ -48,6 +50,8 @@ import org.eclipse.core.runtime.Platform;
  * Helper class for loading extensions
  */
 public class ExtensionLoader<T> {
+	private final static Logger LOGGER = Logger.getLogger("org.openjdk.jmc.rjmx.triggers.extension.internal"); //$NON-NLS-1$
+
 	private final String m_extensionPoint;
 	private final String m_extensionName;
 	private final HashMap<String, IConfigurationElement> m_extensions = new HashMap<>();
@@ -85,9 +89,7 @@ public class ExtensionLoader<T> {
 				}
 			}
 		} catch (InvalidRegistryObjectException iroe) {
-			// FIXME: Better error handling
-			System.err.println("Extension point not valid."); //$NON-NLS-1$
-			System.err.println(iroe.getMessage());
+			LOGGER.log(Level.SEVERE, "Extension point not valid.", iroe); //$NON-NLS-1$
 		}
 	}
 
@@ -104,7 +106,7 @@ public class ExtensionLoader<T> {
 			m_extensions.put(className, element);
 			m_prototypes.add(prototype);
 		} catch (CoreException e) {
-			e.printStackTrace();
+			LOGGER.log(Level.SEVERE, "", e);
 		}
 	}
 

--- a/application/org.openjdk.jmc.rjmx/src/main/java/org/openjdk/jmc/rjmx/triggers/extension/internal/TriggerFactory.java
+++ b/application/org.openjdk.jmc.rjmx/src/main/java/org/openjdk/jmc/rjmx/triggers/extension/internal/TriggerFactory.java
@@ -110,7 +110,7 @@ public class TriggerFactory implements INotificationFactory {
 			return element.createExecutableExtension(XML_CLASS_ATTRIBUTE);
 		} catch (CoreException e) {
 			// FIXME: We must have error handling here
-			LOGGER.log(Level.SEVERE, "", e);
+			LOGGER.log(Level.SEVERE, "Failed to create executable extension", e);
 		}
 		return null;
 	}

--- a/application/org.openjdk.jmc.rjmx/src/main/java/org/openjdk/jmc/rjmx/triggers/extension/internal/TriggerFactory.java
+++ b/application/org.openjdk.jmc.rjmx/src/main/java/org/openjdk/jmc/rjmx/triggers/extension/internal/TriggerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -32,6 +32,9 @@
  */
 package org.openjdk.jmc.rjmx.triggers.extension.internal;
 
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IConfigurationElement;
 
@@ -50,6 +53,8 @@ import org.openjdk.jmc.rjmx.triggers.internal.RegistryEntry;
  */
 public class TriggerFactory implements INotificationFactory {
 	// FIXME: Important, we need to add better error handling.
+
+	private final static Logger LOGGER = Logger.getLogger("org.openjdk.jmc.rjmx.triggers.extension.internal"); //$NON-NLS-1$
 
 	private static final String XML_CLASS_ATTRIBUTE = "class"; //$NON-NLS-1$
 
@@ -105,7 +110,7 @@ public class TriggerFactory implements INotificationFactory {
 			return element.createExecutableExtension(XML_CLASS_ATTRIBUTE);
 		} catch (CoreException e) {
 			// FIXME: We must have error handling here
-			e.printStackTrace();
+			LOGGER.log(Level.SEVERE, "", e);
 		}
 		return null;
 	}

--- a/application/org.openjdk.jmc.rjmx/src/main/java/org/openjdk/jmc/rjmx/triggers/fields/internal/Field.java
+++ b/application/org.openjdk.jmc.rjmx/src/main/java/org/openjdk/jmc/rjmx/triggers/fields/internal/Field.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -35,6 +35,7 @@ package org.openjdk.jmc.rjmx.triggers.fields.internal;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.Iterator;
+import java.util.logging.Logger;
 
 import org.w3c.dom.Element;
 
@@ -47,6 +48,8 @@ import org.openjdk.jmc.rjmx.triggers.ISetting;
  * This class is responsible for capturing configuration options. Clients should not subclass
  */
 abstract public class Field implements ISetting {
+	private final static Logger LOGGER = Logger.getLogger("org.openjdk.jmc.rjmx.triggers.fields.internal"); //$NON-NLS-1$
+
 	private final String m_id;
 	private final String m_name;
 	private final String m_description;
@@ -224,7 +227,7 @@ abstract public class Field implements ISetting {
 		try {
 			XmlToolkit.setSetting(node, getId(), object);
 		} catch (Exception e) {
-			System.out.println('|' + object + '|');
+			LOGGER.severe('|' + object + '|');
 		}
 	}
 

--- a/application/org.openjdk.jmc.ui.common/src/main/java/org/openjdk/jmc/ui/common/security/SecurityManagerFactory.java
+++ b/application/org.openjdk.jmc.ui.common/src/main/java/org/openjdk/jmc/ui/common/security/SecurityManagerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -32,6 +32,9 @@
  */
 package org.openjdk.jmc.ui.common.security;
 
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
 /**
  * This is the global security manager factory for Mission Control. You can only have one
  * SecurityManager, and it is initialized at start. It can not be changed once initialized. The only
@@ -40,6 +43,7 @@ package org.openjdk.jmc.ui.common.security;
  * The class must implement ISecurityManager, and it must have a default constructor.
  */
 public final class SecurityManagerFactory {
+	private final static Logger LOGGER = Logger.getLogger("org.openjdk.jmc.ui.common.security"); //$NON-NLS-1$
 
 	private static ISecurityManager instance;
 
@@ -51,8 +55,8 @@ public final class SecurityManagerFactory {
 				instance = (ISecurityManager) c.newInstance();
 			}
 		} catch (Exception e) {
-			System.out.println("Could not create Security manager for className. Using default! Exception was:"); //$NON-NLS-1$
-			e.printStackTrace();
+			LOGGER.log(Level.SEVERE, "Could not create Security manager for className. Using default! Exception was:", //$NON-NLS-1$
+					e);
 		}
 	}
 

--- a/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/charts/XYQuantities.java
+++ b/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/charts/XYQuantities.java
@@ -356,7 +356,7 @@ public abstract class XYQuantities<P> implements IXYDisplayableSet<P, IQuantity>
 			try {
 				return (ISpan) clone();
 			} catch (CloneNotSupportedException e) {
-				LOGGER.log(Level.SEVERE, "", e);
+				LOGGER.log(Level.SEVERE, "Failed to clone span", e);
 				return this;
 			}
 		}

--- a/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/charts/XYQuantities.java
+++ b/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/charts/XYQuantities.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -38,6 +38,8 @@ import java.awt.geom.Rectangle2D;
 import java.lang.reflect.Array;
 import java.util.Collections;
 import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import org.openjdk.jmc.common.IDisplayable;
 import org.openjdk.jmc.common.unit.IQuantity;
@@ -55,6 +57,8 @@ import org.openjdk.jmc.ui.charts.IChartInfoVisitor.ISpan;
  * @param <P>
  */
 public abstract class XYQuantities<P> implements IXYDisplayableSet<P, IQuantity> {
+	private final static Logger LOGGER = Logger.getLogger("org.openjdk.jmc.ui.charts"); //$NON-NLS-1$
+
 	private final P payload;
 	protected final SubdividedQuantityRange xRange;
 	protected IQuantity maxY;
@@ -352,7 +356,7 @@ public abstract class XYQuantities<P> implements IXYDisplayableSet<P, IQuantity>
 			try {
 				return (ISpan) clone();
 			} catch (CloneNotSupportedException e) {
-				e.printStackTrace();
+				LOGGER.log(Level.SEVERE, "", e);
 				return this;
 			}
 		}

--- a/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/item/PersistableItemFilter.java
+++ b/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/item/PersistableItemFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -33,6 +33,9 @@
 package org.openjdk.jmc.common.item;
 
 import static org.openjdk.jmc.common.item.Attribute.attr;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import org.openjdk.jmc.common.IState;
 import org.openjdk.jmc.common.IStateful;
@@ -112,6 +115,7 @@ public abstract class PersistableItemFilter implements IItemFilter, IStateful {
 		}
 	};
 
+	private final static Logger LOGGER = Logger.getLogger("org.openjdk.jmc.common.item"); //$NON-NLS-1$
 	private static final String KEY_KIND = "kind"; //$NON-NLS-1$
 	static final String KEY_FILTER = "filter"; //$NON-NLS-1$
 	// FIXME: Rename "field" identifier which is now an attribute id
@@ -249,7 +253,7 @@ public abstract class PersistableItemFilter implements IItemFilter, IStateful {
 			try {
 				return persister.parsePersisted(persistedValue);
 			} catch (QuantityConversionException e) {
-				e.printStackTrace();
+				LOGGER.log(Level.SEVERE, "", e);
 			}
 		}
 		return null;

--- a/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/item/PersistableItemFilter.java
+++ b/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/item/PersistableItemFilter.java
@@ -253,7 +253,7 @@ public abstract class PersistableItemFilter implements IItemFilter, IStateful {
 			try {
 				return persister.parsePersisted(persistedValue);
 			} catch (QuantityConversionException e) {
-				LOGGER.log(Level.SEVERE, "", e);
+				LOGGER.log(Level.SEVERE, "Failed to parse value from attibute " + key, e);
 			}
 		}
 		return null;

--- a/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/internal/EventAppearance.java
+++ b/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/internal/EventAppearance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -39,6 +39,8 @@ import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import java.util.Properties;
 import java.util.regex.Pattern;
 
@@ -57,6 +59,7 @@ import java.util.regex.Pattern;
  * flightrecorder.jdk package and perhaps rename it to something more related to path segments.
  */
 public class EventAppearance {
+	private final static Logger LOGGER = Logger.getLogger("org.openjdk.jmc.flightrecorder.internal"); //$NON-NLS-1$
 	private static final Pattern PATH_SPLIT_REGEX = Pattern.compile("\\/"); //$NON-NLS-1$
 	private static final Map<String, String> HUMAN_NAMES;
 	static {
@@ -80,11 +83,10 @@ public class EventAppearance {
 			if (in != null) {
 				properties.load(in);
 			} else {
-				System.err.println("Couldn't find file '" + fileName + "'"); //$NON-NLS-1$ //$NON-NLS-2$
+				LOGGER.severe("Couldn't find file '" + fileName + "'"); //$NON-NLS-1$ //$NON-NLS-2$
 			}
 		} catch (IOException e) {
-			System.err.println("Problem loading file '" + fileName + "'"); //$NON-NLS-1$ //$NON-NLS-2$
-			e.printStackTrace();
+			LOGGER.log(Level.SEVERE, "Problem loading file '" + fileName + "'", e); //$NON-NLS-1$ //$NON-NLS-2$
 		}
 		return properties;
 	}

--- a/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/parser/synthetic/SettingsTransformer.java
+++ b/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/parser/synthetic/SettingsTransformer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -41,6 +41,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.logging.Logger;
 
 import org.openjdk.jmc.common.item.IAttribute;
 import org.openjdk.jmc.common.unit.IQuantity;
@@ -57,7 +58,8 @@ import org.openjdk.jmc.flightrecorder.parser.ValueField;
  * data will be passed through mostly untouched.
  */
 class SettingsTransformer implements IEventSink {
-
+	private final static Logger LOGGER = Logger.getLogger("org.openjdk.jmc.flightrecorder.parser.synthetic"); //$NON-NLS-1$
+	
 	/**
 	 * Fix for JDK-8157024, the code cache stats unallocatedCapacity event is written as KiB but
 	 * reported as B. This is fixed in JDK9, but we need to perform this transformation for
@@ -286,9 +288,7 @@ class SettingsTransformer implements IEventSink {
 							|| (OracleJdkTypeIDsPre11.JDK9_RECORDING_SETTING.equals(identifier) && st.isValidV1())) {
 						return st;
 					} else {
-						// FIXME: Avoid System.err.println
-						System.err
-								.println("Cannot create SettingsTransformer from fields: " + dataStructure.toString()); //$NON-NLS-1$
+						LOGGER.severe("Cannot create SettingsTransformer from fields: " + dataStructure.toString()); //$NON-NLS-1$
 					}
 				} else if (OracleJdkTypeIDsPre11.RECORDINGS.equals(identifier)) {
 					/*

--- a/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/parser/synthetic/SettingsTransformer.java
+++ b/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/parser/synthetic/SettingsTransformer.java
@@ -59,7 +59,7 @@ import org.openjdk.jmc.flightrecorder.parser.ValueField;
  */
 class SettingsTransformer implements IEventSink {
 	private final static Logger LOGGER = Logger.getLogger("org.openjdk.jmc.flightrecorder.parser.synthetic"); //$NON-NLS-1$
-	
+
 	/**
 	 * Fix for JDK-8157024, the code cache stats unallocatedCapacity event is written as KiB but
 	 * reported as B. This is fixed in JDK9, but we need to perform this transformation for

--- a/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/util/ChunkReader.java
+++ b/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/util/ChunkReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -43,6 +43,8 @@ import java.nio.MappedByteBuffer;
 import java.nio.channels.FileChannel;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import org.openjdk.jmc.common.io.IOToolkit;
 import org.openjdk.jmc.flightrecorder.JfrLoaderToolkit;
@@ -57,6 +59,7 @@ import org.openjdk.jmc.flightrecorder.internal.util.DataInputToolkit;
  * {@link ByteArrayInputStream} and using the {@link JfrLoaderToolkit}.
  */
 public final class ChunkReader {
+	private final static Logger LOGGER = Logger.getLogger("org.openjdk.jmc.flightrecorder.util"); //$NON-NLS-1$
 	private static final byte[] JFR_MAGIC_BYTES = new byte[] {'F', 'L', 'R', 0};
 	private static final int[] JFR_MAGIC = new int[] {'F', 'L', 'R', 0};
 	private static final int ZIP_MAGIC[] = new int[] {31, 139};
@@ -116,7 +119,7 @@ public final class ChunkReader {
 					file.close();
 				} catch (IOException e) {
 					// Shouldn't happen.
-					e.printStackTrace();
+					LOGGER.log(Level.SEVERE, "", e);
 				}
 			}
 			return hasNext;

--- a/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/util/ChunkReader.java
+++ b/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/util/ChunkReader.java
@@ -119,7 +119,7 @@ public final class ChunkReader {
 					file.close();
 				} catch (IOException e) {
 					// Shouldn't happen.
-					LOGGER.log(Level.SEVERE, "", e);
+					LOGGER.log(Level.SEVERE, "Failed to close file", e);
 				}
 			}
 			return hasNext;


### PR DESCRIPTION
replaced by java.util.logging logging

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JMC-4792](https://bugs.openjdk.java.net/browse/JMC-4792): Stop using System.out/err.println and e.printStackTrace


### Reviewers
 * [Marcus Hirt](https://openjdk.java.net/census#hirt) (@thegreystone - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jmc pull/272/head:pull/272` \
`$ git checkout pull/272`

Update a local copy of the PR: \
`$ git checkout pull/272` \
`$ git pull https://git.openjdk.java.net/jmc pull/272/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 272`

View PR using the GUI difftool: \
`$ git pr show -t 272`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jmc/pull/272.diff">https://git.openjdk.java.net/jmc/pull/272.diff</a>

</details>
