### PR TITLE
7338: Add parser support for frame types generated by async-profiler

### DIFF
--- a/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/IMCFrame.java
+++ b/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/IMCFrame.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -62,6 +62,18 @@ public interface IMCFrame {
 	 * The frame was executed as code that was inlined by the Java JIT compiler.
 	 */
 	INLINED,
+	/**
+	 * The frame was executed as native code, most probably a C function.
+	 */
+	NATIVE,
+	/**
+	 * The frame was executed as native code compiled from C++.
+	 */
+	CPP,
+	/**
+	 * The frame was executed as kernel native code.
+	 */
+	KERNEL,
 	/**
 	 * The frame compilation type is unknown.
 	 */

--- a/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/internal/util/ParserToolkit.java
+++ b/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/internal/util/ParserToolkit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -79,6 +79,15 @@ public final class ParserToolkit {
 		}
 		if ("Inlined".equals(type)) { //$NON-NLS-1$
 			return IMCFrame.Type.INLINED;
+		}
+		if ("Native".equals(type)) { //$NON-NLS-1$
+			return IMCFrame.Type.NATIVE;
+		}
+		if ("C++".equals(type)) { //$NON-NLS-1$
+			return IMCFrame.Type.CPP;
+		}
+		if ("Kernel".equals(type)) { //$NON-NLS-1$
+			return IMCFrame.Type.KERNEL;
 		}
 		return IMCFrame.Type.UNKNOWN;
 	}


### PR DESCRIPTION
Async Profiler (https://github.com/jvm-profiling-tools/async-profiler) is able to generate JFR recordings with CPU and allocation sample events spanning full-stack (from Java to OS/kernel).
It is adding three new frame types for this reason:

- Native (C)
- C++
- Kernel
 

Currently, the JMC parser will process all those frame types as 'UNKNOWN'. Although it is not breaking the rendering it would be nice to be able to get more info about the actual frame type.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JMC-7338](https://bugs.openjdk.java.net/browse/JMC-7338): Add parser support for frame types generated by async-profiler


### Reviewers
 * [Marcus Hirt](https://openjdk.java.net/census#hirt) (@thegreystone - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jmc pull/274/head:pull/274` \
`$ git checkout pull/274`

Update a local copy of the PR: \
`$ git checkout pull/274` \
`$ git pull https://git.openjdk.java.net/jmc pull/274/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 274`

View PR using the GUI difftool: \
`$ git pr show -t 274`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jmc/pull/274.diff">https://git.openjdk.java.net/jmc/pull/274.diff</a>

</details>
