### PR TITLE
7328: Incorrect sort order in method profiling page

### DIFF
--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/common/ItemHistogram.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/common/ItemHistogram.java
@@ -234,7 +234,7 @@ public class ItemHistogram {
 			List<IColumn> columns = new ArrayList<>();
 			IMemberAccessor<?, Object> keyAccessor = AggregationGrid::getKey;
 			ColumnLabelProvider keyLp = new DelegatingLabelProvider(labelProvider, keyAccessor);
-			columns.add(new ColumnBuilder(colLabel, KEY_COL_ID, keyAccessor).labelProvider(keyLp).build());
+			columns.add(new ColumnBuilder(colLabel, KEY_COL_ID, keyAccessor, keyLp).build());
 			columns.addAll(this.columns);
 			return build(container, columns, classifier, tableSettings, border);
 		}

--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/internal/MethodWithFrameTypeLabelProvider.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/internal/MethodWithFrameTypeLabelProvider.java
@@ -129,10 +129,12 @@ public class MethodWithFrameTypeLabelProvider extends ColumnLabelProvider {
 		} else if (key instanceof IMCFrame) {
 			key = ((IMCFrame) key).getMethod();
 		}
+		if (key instanceof IMCMethod) {
+			return FormatToolkit.getHumanReadable((IMCMethod) key, false, false, true, true, true, false, false);
+		}
 		if (key instanceof IDisplayable) {
 			return ((IDisplayable) key).displayUsing(IDisplayable.EXACT);
 		}
-		// IMCMethod falling through to TypeHandling
 		return TypeHandling.getValueString(key);
 	};
 

--- a/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/column/ColumnBuilder.java
+++ b/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/column/ColumnBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -155,9 +155,20 @@ public class ColumnBuilder {
 
 	@SuppressWarnings("unchecked")
 	public <T> ColumnBuilder(String name, String id, IMemberAccessor<?, T> cellAccessor) {
+		this(name, id, cellAccessor,
+				new DelegatingLabelProvider(DEFAULT_LP, (IMemberAccessor<?, Object>) cellAccessor));
+	}
+
+	/**
+	 * Users of this method must ensure that all elements in the tree/table is of type T. This
+	 * constructor will ensure that the comparator is aligned with the label provider.
+	 */
+	@SuppressWarnings("unchecked")
+	public <T> ColumnBuilder(String name, String id, IMemberAccessor<?, T> cellAccessor,
+			ColumnLabelProvider labelProvider) {
 		column = new Column(name, id);
 		column.cellAccessor = (IMemberAccessor<?, Object>) cellAccessor;
-		column.labelProvider = new DelegatingLabelProvider(DEFAULT_LP, column.cellAccessor);
+		column.labelProvider = labelProvider;
 		column.comparator = new OptimisticComparator(column.cellAccessor, column.labelProvider);
 	}
 

--- a/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/internal/parser/LoaderContext.java
+++ b/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/internal/parser/LoaderContext.java
@@ -37,7 +37,6 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 

--- a/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/internal/parser/ParserStats.java
+++ b/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/internal/parser/ParserStats.java
@@ -210,6 +210,7 @@ public class ParserStats {
 			return false;
 		}
 
+		@SuppressWarnings("unchecked")
 		@Override
 		public <M> IMemberAccessor<M, IItem> getAccessor(IAccessorKey<M> attribute) {
 			if ("name".equals(attribute.getIdentifier())) {
@@ -265,6 +266,7 @@ public class ParserStats {
 			return false;
 		}
 
+		@SuppressWarnings("unchecked")
 		@Override
 		public <M> IMemberAccessor<M, IItem> getAccessor(IAccessorKey<M> attribute) {
 			if ("typeName".equals(attribute.getIdentifier())) {

--- a/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/internal/parser/v0/EventParserManager.java
+++ b/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/internal/parser/v0/EventParserManager.java
@@ -48,7 +48,6 @@ import org.openjdk.jmc.flightrecorder.internal.parser.v0.model.EventTypeDescript
 import org.openjdk.jmc.flightrecorder.internal.parser.v0.model.ProducerDescriptor;
 import org.openjdk.jmc.flightrecorder.internal.parser.v0.model.ValueDescriptor;
 import org.openjdk.jmc.flightrecorder.internal.util.JfrInternalConstants;
-import org.openjdk.jmc.flightrecorder.jdk.JdkTypeIDs;
 import org.openjdk.jmc.flightrecorder.messages.internal.Messages;
 import org.openjdk.jmc.flightrecorder.parser.IEventSink;
 import org.openjdk.jmc.flightrecorder.parser.IEventSinkFactory;

--- a/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/internal/parser/v1/SpecificReaders.java
+++ b/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/internal/parser/v1/SpecificReaders.java
@@ -33,12 +33,11 @@
  */
 package org.openjdk.jmc.flightrecorder.internal.parser.v1;
 
+import java.io.IOException;
+import java.util.logging.Logger;
+
 import org.openjdk.jmc.common.unit.ContentType;
 import org.openjdk.jmc.flightrecorder.internal.InvalidJfrFileException;
-
-import java.io.IOException;
-import java.lang.reflect.Field;
-import java.util.logging.Logger;
 
 public class SpecificReaders {
 	private static Logger LOG = Logger.getLogger(SpecificReaders.class.getName());


### PR DESCRIPTION
Also fixing some import warnings.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JMC-7328](https://bugs.openjdk.java.net/browse/JMC-7328): Incorrect sort order in method profiling page


### Reviewers
 * [Jean-Philippe Bempel](https://openjdk.java.net/census#jpbempel) (@jpbempel - Committer)
 * [Alex Macdonald](https://openjdk.java.net/census#aptmac) (@aptmac - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jmc pull/276/head:pull/276` \
`$ git checkout pull/276`

Update a local copy of the PR: \
`$ git checkout pull/276` \
`$ git pull https://git.openjdk.java.net/jmc pull/276/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 276`

View PR using the GUI difftool: \
`$ git pr show -t 276`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jmc/pull/276.diff">https://git.openjdk.java.net/jmc/pull/276.diff</a>

</details>
