### PR TITLE
7324: Update eclipse version and Min JDK required in Update Site landing pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,7 +366,7 @@ application/org.openjdk.jmc.updatesite.ide/target/
 To install it into Eclipe, simply open Eclipse and select Help | Install New Software... In the dialog, click Add... and then click the Archive... button. Select the built update site, e.g. 
 
 ```bash
-application/org.openjdk.jmc.updatesite.ide/target/org.openjdk.jmc.updatesite.ide-8.0.0-SNAPSHOT.zip
+application/org.openjdk.jmc.updatesite.ide/target/org.openjdk.jmc.updatesite.ide-8.1.0-SNAPSHOT.zip
 ```
 
 ## Setting up Development Environment

--- a/application/org.openjdk.jmc.rcp.application/src/main/resources/org/openjdk/jmc/rcp/application/messages.properties
+++ b/application/org.openjdk.jmc.rcp.application/src/main/resources/org/openjdk/jmc/rcp/application/messages.properties
@@ -53,4 +53,4 @@ LockedWorkspaceDialog_LOCKED_WORKSPACE1_TEXT=The workspace for Mission Control i
 LockedWorkspaceDialog_LOCKED_WORKSPACE3_TEXT=Are you sure you want to proceed?
 LockedWorkspaceDialog_OK_BUTTON_TEXT=Ok
 LockedWorkspaceDialog_CANCEL_BUTTON_TEXT=Cancel
-JMC_RCP_P2_UPDATESITE_NICK_NAME=JDK Mission Control 8.0.0 RCP Update Site
+JMC_RCP_P2_UPDATESITE_NICK_NAME=JDK Mission Control 8.1.0 RCP Update Site

--- a/application/org.openjdk.jmc.rcp.application/src/main/resources/updatesites.properties
+++ b/application/org.openjdk.jmc.rcp.application/src/main/resources/updatesites.properties
@@ -33,7 +33,7 @@
 
 # To use with file with JMC, use -Dorg.openjdk.jmc.updatesites.properties=<location of file>
 
-# "{0}" will be replaced by the version number of JDK Mission Control, e.g. "8.0.0"
+# "{0}" will be replaced by the version number of JDK Mission Control, e.g. "8.1.0"
 # Add one or more properties on the form of:
 # updatesite.<number from 0 and up>=<URL, possibly including {0} to represent the JMC version>
 # Example:

--- a/application/org.openjdk.jmc.updatesite.ide/src/main/resources/index.html
+++ b/application/org.openjdk.jmc.updatesite.ide/src/main/resources/index.html
@@ -49,10 +49,10 @@
 				<p>This update site also includes plug-ins for the Eclipse IDE designed to either extend JDK Mission Control in various ways 
 					or assist in developing such extensions.<p>
 
-                <p><font color="#DE2516"><b>Version 8.0.0</b></font> is now available. It supports the HotSpot VM (Oracle JDK 8 and up, OpenJDK 11).
+                <p><font color="#DE2516"><b>Version 8.1.0</b></font> is now available. It supports the HotSpot VM (Oracle JDK 8 and up, OpenJDK 11).
                 For JRockit JVM support, use an Oracle&reg; JRockit Mission Control 4.x version.</p>
 
-                <p><font color="#DE2516">Note that any prior versions of JMC <b>MUST BE UNINSTALLED</b> from Eclipse before installing JMC 8.0.0.</font></p>
+                <p><font color="#DE2516">Note that any prior versions of JMC <b>MUST BE UNINSTALLED</b> from Eclipse before installing JMC 8.1.0.</font></p>
                 
                 <p class="section-header"><b>Key Features</b></p>
 
@@ -73,10 +73,10 @@
                 <p class="section-header"><b>Requirements</b></p>
 
                 <ul>
-                  <li>Requires Eclipse 4.16 or later.</li>
+                  <li>Requires Eclipse 4.19 or later.</li>
                   <li>Requires any previously installed versions of JMC 4.x, 5.x, 6.x or 7.x to be uninstalled before installing JMC 8.</li>
-                  <li>Note that you need to run your Eclipse on a JDK (version 8 or above) installation for all features to work. For more information on this, 
-                  	especially for JDK 9, please see the <a href="run-on-jdk-instructions/index.html">Run Eclipse on JDK HOWTO</a>.</li>
+                  <li>Note that you need to run your Eclipse on a JDK (version 11 or above) installation for all features to work. For more information on this,
+			please see the <a href="run-on-jdk-instructions/index.html">Run Eclipse on JDK HOWTO</a>.</li>
                 </ul>
 
                 <center>
@@ -92,7 +92,7 @@
               <td width="1" bgcolor="#CCCCCC"></td>
               <td class="body-text">
                 <b>What is new?</b><br>
-                <font color="#DE2516"><b>Version 8.0.0</b></font> is now available. It supports the HotSpot VM and JDK Flight Recorder.<br><br>
+                <font color="#DE2516"><b>Version 8.1.0</b></font> is now available. It supports the HotSpot VM and JDK Flight Recorder.<br><br>
                 <img src="images/bullet-arrow-red.gif" alt="Bullet">
                 Release Notes can be found on the <a href="https://www.oracle.com/technetwork/java/javaseproducts/mission-control/index.html"> JDK Mission Control home page</a><br>
                 
@@ -110,7 +110,7 @@
                 <br>
                 
                 <b>Prerequisites</b><br>
-                JDK Mission Control is a set of plug-ins for Eclipse 4.16 or later.<br><br>
+                JDK Mission Control is a set of plug-ins for Eclipse 4.19 or later.<br><br>
 
                 <img src="images/bullet-arrow-red.gif" alt="Bullet">
                 <a href="http://www.eclipse.org/downloads/">

--- a/application/org.openjdk.jmc.updatesite.ide/src/main/resources/run-on-jdk-instructions/index.html
+++ b/application/org.openjdk.jmc.updatesite.ide/src/main/resources/run-on-jdk-instructions/index.html
@@ -34,9 +34,9 @@
 	<p>To fully take advantage of running JDK Mission Control in your Eclipse IDE, you need to run Eclipse on a JDK installation. <br>
 	Attaching to locally running JVMs will only work if you're running with a JDK. </p>
 	<p>Follow the instructions below to run on a HotSpot JDK.</p>
-	<p>The easiest way to change the JVM on which to start Eclipse is by modifying the eclipse.ini file. You can also set the -vm on the command line used to start Eclipse. In windows you would typically do that in the shortcut you use to launch Eclipse. Here is an example ini file:  <blockquote> <p><code>-showsplash<br>org.eclipse.platform<br>-vm <br>D:/java/jdk1.8.0_261/bin/</code></p></blockquote> 
-	<p>You can also configure JVM options by using -vmargs on commandline or eclipse.ini:  <blockquote> <p><code>-showsplash<br>org.eclipse.platform<br>-vm <br>D:/java/jdk1.8.0_261/bin/<br>-vmargs<br>&lt;JVM options on separate lines&gt;</code></p></blockquote> 
-	<p>If you use JDK 11 (or later) to run Eclipse, the following JVM options are needed for JDK Mission Control to work properly:</p>
+	<p>The easiest way to change the JVM on which to start Eclipse is by modifying the eclipse.ini file. You can also set the -vm on the command line used to start Eclipse. In windows you would typically do that in the shortcut you use to launch Eclipse. Here is an example ini file:  <blockquote> <p><code>-showsplash<br>org.eclipse.platform<br>-vm <br>D:/java/jdk-11.0.11/bin/</code></p></blockquote>
+	<p>You can also configure JVM options by using -vmargs on commandline or eclipse.ini:  <blockquote> <p><code>-showsplash<br>org.eclipse.platform<br>-vm <br>D:/java/jdk-11.0.11/bin/<br>-vmargs<br>&lt;JVM options on separate lines&gt;</code></p></blockquote>
+	<p>The following JVM options are needed for JDK Mission Control to work properly:</p>
 	 <blockquote> <p><code>-Djdk.attach.allowAttachSelf=true
 	 <br>--add-exports=java.xml/com.sun.org.apache.xerces.internal.parsers=ALL-UNNAMED
 	 <br>--add-exports=jdk.internal.jvmstat/sun.jvmstat.monitor=ALL-UNNAMED
@@ -57,6 +57,7 @@
 
       <tr>
         <td class="footer">
+          Copyright &copy; 1999, 2021, Oracle and/or its affiliates.<br>
           Oracle is a registered trademark of Oracle Corporation and/or its<br>
           affiliates. Other names may be trademarks of their respective owners.<br>
           Eclipse is a trademark of Eclipse Foundation, Inc.

--- a/application/org.openjdk.jmc.updatesite.ide/src/main/resources/update-site-instructions/index.html
+++ b/application/org.openjdk.jmc.updatesite.ide/src/main/resources/update-site-instructions/index.html
@@ -39,11 +39,11 @@
           facility. The following URL functions as an update site. Novice users can follow
           the step-by-step instructions.<br><br>
           
-          <b>http://download.oracle.com/technology/products/missioncontrol/updatesites/openjdk/8.0.0/eclipse/</b><br><br>
+          <b>http://download.oracle.com/technology/products/missioncontrol/updatesites/openjdk/8.1.0/eclipse/</b><br><br>
 
           <p class="section-header"><b>Step-by-Step Instructions</b></p>
           
-          Before starting, make sure that you have downloaded and installed Eclipse 4.16 or later.
+          Before starting, make sure that you have downloaded and installed Eclipse 4.19 or later.
         </td>
       </tr>
 
@@ -76,7 +76,7 @@
                 <ol start="2">
                   <li>
                     <p>Fill in the following URL in the <b>Work with:</b> text field:</p>
-                        <p><b>https://download.oracle.com/technology/products/missioncontrol/updatesites/openjdk/8.0.0/eclipse/</b></p>
+                        <p><b>https://download.oracle.com/technology/products/missioncontrol/updatesites/openjdk/8.1.0/eclipse/</b></p>
                         <p>Press the return key.</p>
                   </li>
                 </ol>

--- a/application/org.openjdk.jmc.updatesite.rcp/src/main/resources/index.html
+++ b/application/org.openjdk.jmc.updatesite.rcp/src/main/resources/index.html
@@ -117,7 +117,7 @@
                 <p class="section-header"><b>Requirements</b></p>
 
                 <ul>
-                  <li>Requires JDK Mission Control RCP Edition 8.0.0</li>
+                  <li>Requires JDK Mission Control RCP Edition 8.1.0</li>
                 </ul>
 
                 <center>


### PR DESCRIPTION
With Eclipse 4.19 JMC can't be used with Boot JDK 8. Currently the Update sites landing page and README.txt had instruction on how JMC can be used with JDK8 (Which is not valid any more). 

Updated instruction to use JMC with JDK 11 and above.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JMC-7324](https://bugs.openjdk.java.net/browse/JMC-7324): Update eclipse version and Min JDK required in Update Site landing pages


### Reviewers
 * [Marcus Hirt](https://openjdk.java.net/census#hirt) (@thegreystone - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jmc pull/278/head:pull/278` \
`$ git checkout pull/278`

Update a local copy of the PR: \
`$ git checkout pull/278` \
`$ git pull https://git.openjdk.java.net/jmc pull/278/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 278`

View PR using the GUI difftool: \
`$ git pr show -t 278`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jmc/pull/278.diff">https://git.openjdk.java.net/jmc/pull/278.diff</a>

</details>
