### PR TITLE
7353: JMC fails to build because it can't download babel dependency

### DIFF
--- a/releng/platform-definitions/platform-definition-2021-03/platform-definition-2021-03.target
+++ b/releng/platform-definitions/platform-definition-2021-03/platform-definition-2021-03.target
@@ -55,9 +55,9 @@
             <repository location="http://download.eclipse.org/releases/2021-03/"/>
         </location>
         <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-            <unit id="org.eclipse.babel.nls_eclipse_ja.feature.group" version="4.19.0.v20210327020002"/>
-            <unit id="org.eclipse.babel.nls_eclipse_zh.feature.group" version="4.19.0.v20210327020002"/>
-            <repository location="https://archive.eclipse.org/technology/babel/update-site/R0.18.3/2021-03/"/>
+            <unit id="org.eclipse.babel.nls_eclipse_ja.feature.group" version="4.19.0.v20210630075054"/>
+            <unit id="org.eclipse.babel.nls_eclipse_zh.feature.group" version="4.19.0.v20210630075054"/>
+            <repository location="https://archive.eclipse.org/technology/babel/update-site/R0.19.0/2021-03/"/>
         </location>
     </locations>
     <targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>


### PR DESCRIPTION
This PR addresses JMC-7353 [[0]](https://bugs.openjdk.java.net/browse/JMC-7353) (and JMC-7356 [[1]](https://bugs.openjdk.java.net/browse/JMC-7356)), in which JMC cannot build because the babel dependency is unable to be downloaded: 
```
[ERROR] All attempts to read artifact osgi.bundle,org.eclipse.compare.core.nl_ja,4.19.0.v20210327020002 failed:
[ERROR] An error occurred while transferring artifact canonical: osgi.bundle,org.eclipse.compare.core.nl_ja,4.19.0.v20210327020002 from repository
https://archive.eclipse.org/technology/babel/update-site/R0.18.3/2021-03
```

This is due to a recent update to babel for platforms 2020-12 and 2021-03 (and 2021-06, but that doesn't affect us yet ..) [[2]](https://www.eclipse.org/babel/downloads.php), which resulted in a new url being required to fetch the current supported version of babel for 2021-03. This PR updates the url and version of babel for the 2021-03 target platform.

Note that there is also an updated link for the 2020-12 babel, but the older babel isn't causing any problems downloading at the moment, so I've decided to only update the 2021-03 target platform here. 

To verify this you can blow-up your ~/.m2 folder and try a clean install with 2021-03 as the active platform.

[0] https://bugs.openjdk.java.net/browse/JMC-7353
[1] https://bugs.openjdk.java.net/browse/JMC-7356
[2] https://www.eclipse.org/babel/downloads.php

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JMC-7353](https://bugs.openjdk.java.net/browse/JMC-7353): JMC fails to build because it can't download babel dependency


### Reviewers
 * [Marcus Hirt](https://openjdk.java.net/census#hirt) (@thegreystone - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jmc pull/281/head:pull/281` \
`$ git checkout pull/281`

Update a local copy of the PR: \
`$ git checkout pull/281` \
`$ git pull https://git.openjdk.java.net/jmc pull/281/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 281`

View PR using the GUI difftool: \
`$ git pr show -t 281`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jmc/pull/281.diff">https://git.openjdk.java.net/jmc/pull/281.diff</a>

</details>
