### PR TITLE
7357: Double-Checked Locking in Agent Plugin code

### DIFF
--- a/application/org.openjdk.jmc.console.agent/src/main/java/org/openjdk/jmc/console/agent/manager/model/PresetRepositoryFactory.java
+++ b/application/org.openjdk.jmc.console.agent/src/main/java/org/openjdk/jmc/console/agent/manager/model/PresetRepositoryFactory.java
@@ -45,12 +45,14 @@ public class PresetRepositoryFactory {
 	private static final File PRESET_STORAGE_DIR = AgentPlugin.getDefault().getStateLocation().append(".presets") // $NON-NLS-1$
 			.toFile();
 
-	private static PresetRepository singleton;
+	private volatile static PresetRepository singleton;
 
 	public static PresetRepository createSingleton() {
 		if (singleton == null) {
 			synchronized (PresetRepositoryFactory.class) {
-				singleton = create();
+				if (singleton == null) {
+					singleton = create();
+				}
 			}
 		}
 

--- a/application/org.openjdk.jmc.console.agent/src/main/java/org/openjdk/jmc/console/agent/manager/model/PresetRepositoryFactory.java
+++ b/application/org.openjdk.jmc.console.agent/src/main/java/org/openjdk/jmc/console/agent/manager/model/PresetRepositoryFactory.java
@@ -50,7 +50,7 @@ public class PresetRepositoryFactory {
 	public static PresetRepository createSingleton() {
 		if (singleton == null) {
 			synchronized (PresetRepositoryFactory.class) {
-					singleton = create();
+				singleton = create();
 			}
 		}
 

--- a/application/org.openjdk.jmc.console.agent/src/main/java/org/openjdk/jmc/console/agent/manager/model/PresetRepositoryFactory.java
+++ b/application/org.openjdk.jmc.console.agent/src/main/java/org/openjdk/jmc/console/agent/manager/model/PresetRepositoryFactory.java
@@ -50,9 +50,7 @@ public class PresetRepositoryFactory {
 	public static PresetRepository createSingleton() {
 		if (singleton == null) {
 			synchronized (PresetRepositoryFactory.class) {
-				if (singleton == null) {
 					singleton = create();
-				}
 			}
 		}
 


### PR DESCRIPTION
Trivial Fortify warning fix

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JMC-7357](https://bugs.openjdk.java.net/browse/JMC-7357): Double-Checked Locking in Agent Plugin code


### Reviewers
 * [Jean-Philippe Bempel](https://openjdk.java.net/census#jpbempel) (@jpbempel - Committer)
 * [Marcus Hirt](https://openjdk.java.net/census#hirt) (@thegreystone - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jmc pull/282/head:pull/282` \
`$ git checkout pull/282`

Update a local copy of the PR: \
`$ git checkout pull/282` \
`$ git pull https://git.openjdk.java.net/jmc pull/282/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 282`

View PR using the GUI difftool: \
`$ git pr show -t 282`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jmc/pull/282.diff">https://git.openjdk.java.net/jmc/pull/282.diff</a>

</details>
