### PR TITLE
6817: AutoBoxing rule can crash due to null dereference

### DIFF
--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/memory/AutoBoxingRule.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/memory/AutoBoxingRule.java
@@ -187,7 +187,9 @@ public class AutoBoxingRule extends AbstractRule {
 					} else if (firstBranch.getEndFork().getBranchCount() > 0) {
 						secondFrame = firstBranch.getEndFork().getBranch(0).getFirstFrame();
 					}
-					secondFrameFromMostAllocated = secondFrame.getFrame();
+					if (secondFrame != null) {
+						secondFrameFromMostAllocated = secondFrame.getFrame();
+					}
 				}
 				allocationSizeByType.put(method.getType(), total);
 			}


### PR DESCRIPTION
Hypothetical solution to hypothetical problem.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JMC-6817](https://bugs.openjdk.java.net/browse/JMC-6817): AutoBoxing rule can crash due to null dereference


### Reviewers
 * [Guru Hb](https://openjdk.java.net/census#ghb) (@guruhb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jmc pull/286/head:pull/286` \
`$ git checkout pull/286`

Update a local copy of the PR: \
`$ git checkout pull/286` \
`$ git pull https://git.openjdk.java.net/jmc pull/286/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 286`

View PR using the GUI difftool: \
`$ git pr show -t 286`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jmc/pull/286.diff">https://git.openjdk.java.net/jmc/pull/286.diff</a>

</details>
