### PR TITLE
7349: JFR Parser struct types hashcode is not stable

### DIFF
--- a/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/internal/parser/v1/StructTypes.java
+++ b/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/internal/parser/v1/StructTypes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -648,6 +648,8 @@ class StructTypes {
 		public Object bytecodeIndex;
 		public Object type;
 
+		private boolean isParsed = false;
+
 		@Override
 		public Integer getFrameLineNumber() {
 			return (Integer) lineNumber;
@@ -678,6 +680,7 @@ class StructTypes {
 
 		@Override
 		public int hashCode() {
+			ensureParsed();
 			final int prime = 31;
 			int result = 1;
 			result = prime * result + Objects.hashCode(method);
@@ -689,6 +692,7 @@ class StructTypes {
 
 		@Override
 		public boolean equals(Object obj) {
+			ensureParsed();
 			if (this == obj) {
 				return true;
 			} else if (obj instanceof JfrFrame) {
@@ -698,12 +702,23 @@ class StructTypes {
 			}
 			return false;
 		}
+
+		private void ensureParsed() {
+			if (!isParsed) {
+				// The 'type' field is used in hashCode and equality computations but may change when parsed
+				// Force parsing the field to make the hashCode and equality computations to perform consistently
+				getType();
+				isParsed = true;
+			}
+		}
 	}
 
 	static class JfrStackTrace implements IMCStackTrace {
 
 		public Object frames;
 		public Object truncated;
+
+		private boolean isParsed = false;
 
 		@SuppressWarnings("unchecked")
 		@Override
@@ -724,6 +739,7 @@ class StructTypes {
 
 		@Override
 		public int hashCode() {
+			ensureParsed();
 			final int prime = 31;
 			int result = 1;
 			result = prime * result + Objects.hashCode(frames);
@@ -733,6 +749,7 @@ class StructTypes {
 
 		@Override
 		public boolean equals(Object obj) {
+			ensureParsed();
 			if (this == obj) {
 				return true;
 			} else if (obj instanceof JfrStackTrace) {
@@ -742,5 +759,13 @@ class StructTypes {
 			return false;
 		}
 
+		private void ensureParsed() {
+			if (!isParsed) {
+				// The 'frames' field is used in hashCode and equality computations but may change when parsed
+				// Force parsing the field to make the hashCode and equality computations to perform consistently
+				getFrames();
+				isParsed = true;
+			}
+		}
 	}
 }


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JMC-7349](https://bugs.openjdk.java.net/browse/JMC-7349): JFR Parser struct types hashcode is not stable


### Reviewers
 * [Marcus Hirt](https://openjdk.java.net/census#hirt) (@thegreystone - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jmc pull/287/head:pull/287` \
`$ git checkout pull/287`

Update a local copy of the PR: \
`$ git checkout pull/287` \
`$ git pull https://git.openjdk.java.net/jmc pull/287/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 287`

View PR using the GUI difftool: \
`$ git pr show -t 287`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jmc/pull/287.diff">https://git.openjdk.java.net/jmc/pull/287.diff</a>

</details>
