### PR TITLE
7360: Provider Name missing for Agent Plugin

### DIFF
--- a/application/org.openjdk.jmc.console.agent/META-INF/MANIFEST.MF
+++ b/application/org.openjdk.jmc.console.agent/META-INF/MANIFEST.MF
@@ -3,6 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: JMC Agent Plugin
 Bundle-SymbolicName: org.openjdk.jmc.console.agent;singleton:=true
 Bundle-Version: 8.1.0.qualifier
+Bundle-Vendor: Oracle Corporation
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.ui,
  org.eclipse.jface.text,

--- a/application/org.openjdk.jmc.console.agent/plugin.xml
+++ b/application/org.openjdk.jmc.console.agent/plugin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--   
-   Copyright (c) 2020, 2021 Oracle and/or its affiliates. All rights reserved.
-   Copyright (c) 2020, 2021 Red Hat Inc. All rights reserved.
+   Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+   Copyright (c) 2021, Red Hat Inc. All rights reserved.
    
    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
    

--- a/application/org.openjdk.jmc.console.agent/pom.xml
+++ b/application/org.openjdk.jmc.console.agent/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--   
-   Copyright (c) 2020, 2021 Oracle and/or its affiliates. All rights reserved.
-   Copyright (c) 2020, 2021 Red Hat Inc. All rights reserved.
+   Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
+   Copyright (c) 2021 Red Hat Inc. All rights reserved.
    
    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
    

--- a/application/org.openjdk.jmc.feature.console.agent/build.properties
+++ b/application/org.openjdk.jmc.feature.console.agent/build.properties
@@ -1,3 +1,37 @@
-bin.includes = feature.xml
+#
+#  Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+#  Copyright (c) 2021, Red Hat Inc. All rights reserved.
+# 
+#  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+#
+#  The contents of this file are subject to the terms of either the Universal Permissive License 
+#  v 1.0 as shown at http://oss.oracle.com/licenses/upl
+#   
+#  or the following license:
+#   
+#  Redistribution and use in source and binary forms, with or without modification, are permitted
+#  provided that the following conditions are met:
+#   
+#  1. Redistributions of source code must retain the above copyright notice, this list of conditions
+#  and the following disclaimer.
+#   
+#  2. Redistributions in binary form must reproduce the above copyright notice, this list of
+#  conditions and the following disclaimer in the documentation and/or other materials provided with
+#  the distribution.
+#   
+#  3. Neither the name of the copyright holder nor the names of its contributors may be used to
+#  endorse or promote products derived from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+#  IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+#  FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+#  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+#  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+#  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+#  WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+bin.includes = feature.xml,\
+               feature.properties
 pde.match.rule.feature=compatible
 pde.match.rule.bundle=compatible

--- a/application/org.openjdk.jmc.feature.console.agent/feature.properties
+++ b/application/org.openjdk.jmc.feature.console.agent/feature.properties
@@ -1,7 +1,7 @@
 #
 #  Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
 #  Copyright (c) 2021, Red Hat Inc. All rights reserved.
-# 
+#
 #  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 #  The contents of this file are subject to the terms of either the Universal Permissive License 
@@ -31,10 +31,8 @@
 #  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
 #  WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
-source.. = src/main/java/,\
-           src/main/resources/
-output.. = target/classes/
-bin.includes = plugin.xml,\
-               META-INF/,\
-               .,\
-               icons/
+name=JMC Agent Plugin
+provider=Oracle Corporation
+copyright=Copyright \u00A9 2021, Oracle and/or its affiliates.
+description=JDK Mission Control plug-in to control JMC agents
+descriptionUrl=http://www.oracle.com/missioncontrol

--- a/application/org.openjdk.jmc.feature.console.agent/feature.xml
+++ b/application/org.openjdk.jmc.feature.console.agent/feature.xml
@@ -34,12 +34,19 @@
 -->
 <feature
       id="org.openjdk.jmc.feature.console.agent"
-      label="JMC Agent Plugin"
-      version="8.1.0.qualifier">
+      label="%name"
+      version="8.1.0.qualifier"
+      provider-name="%provider"
+      license-feature="org.openjdk.jmc.feature.license"
+      license-feature-version="8.1.0.qualifier">
 
-   <description url="http://www.example.com/description">
-      a Mission Control plug-in to control JMC agents
+   <description url="%descriptionUrl">
+      %description
    </description>
+
+   <copyright>
+      %copyright
+   </copyright>
 
    <requires>
       <import feature="org.openjdk.jmc.feature.core" match="equivalent"/>

--- a/application/org.openjdk.jmc.feature.console.agent/pom.xml
+++ b/application/org.openjdk.jmc.feature.console.agent/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--   
-   Copyright (c) 2020, 2021 Oracle and/or its affiliates. All rights reserved.
-   Copyright (c) 2020, 2021 Red Hat Inc. All rights reserved.
+   Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+   Copyright (c) 2021, Red Hat Inc. All rights reserved.
    
    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
    


### PR DESCRIPTION
Configuration fix 
1. Added Bundle-vendor name 
2. Corrected the license header 
3. updated missing configuration parameters in feature.xml

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JMC-7360](https://bugs.openjdk.java.net/browse/JMC-7360): Provider Name missing for Agent Plugin


### Reviewers
 * [Jean-Philippe Bempel](https://openjdk.java.net/census#jpbempel) (@jpbempel - Committer)
 * [Marcus Hirt](https://openjdk.java.net/census#hirt) (@thegreystone - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jmc pull/292/head:pull/292` \
`$ git checkout pull/292`

Update a local copy of the PR: \
`$ git checkout pull/292` \
`$ git pull https://git.openjdk.java.net/jmc pull/292/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 292`

View PR using the GUI difftool: \
`$ git pr show -t 292`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jmc/pull/292.diff">https://git.openjdk.java.net/jmc/pull/292.diff</a>

</details>
