### PR TITLE
7337: JMC fails to parse JFR with events from WebLogic Server

### DIFF
--- a/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/parser/synthetic/SyntheticAttributeExtension.java
+++ b/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/parser/synthetic/SyntheticAttributeExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/parser/synthetic/SyntheticAttributeExtension.java
+++ b/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/parser/synthetic/SyntheticAttributeExtension.java
@@ -203,11 +203,13 @@ public class SyntheticAttributeExtension implements IParserExtension {
 		@Override
 		public void addEvent(Object[] values) {
 			IMCPackage thePackage = (IMCPackage) values[packageFieldIndex];
-			IMCModule exportingModule = thePackage.getModule();
-			Object[] newValues = new Object[values.length + 1];
-			System.arraycopy(values, 0, newValues, 0, values.length);
-			newValues[values.length] = exportingModule;
-			subSink.addEvent(newValues);
+			if (thePackage != null) {
+				IMCModule exportingModule = thePackage.getModule();
+				Object[] newValues = new Object[values.length + 1];
+				System.arraycopy(values, 0, newValues, 0, values.length);
+				newValues[values.length] = exportingModule;
+				subSink.addEvent(newValues);
+			}
 		}
 	}
 }


### PR DESCRIPTION
RC : NPE due to Invalid packageFieldIndex. 
Disassembled the original jfr (attached in jbs) which had 3 chunks out of which the last chunk "WLF_3.jfr" with Event type (a) "com.oracle.weblogic.servlet.ServletRequestRunEvent" was causing the NPE. This could be a corrupt event or in complete event captured in the jfr.  
This is a assertive fix and tried debugging the metadata parse (for any Ignored exception) and didn't find any noticeable place which can lead to events not indexed while collecting the events. 

After this fix compared the number of expected events of (a) with "jfr" tool in "jmc" (for WLF_3.jfr there were 32 events in (a) ) and didn't find any missing ones. 

Steps to re-produce NPE : load [WLS_3.jfr](https://bugs.openjdk.java.net/secure/attachment/95852/WLF_3.jfr.lz4)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * ⚠️ Failed to retrieve information on issue `7337`.


### Reviewers
 * [Marcus Hirt](https://openjdk.java.net/census#hirt) (@thegreystone - **Reviewer**) ⚠️ Review applies to 91016e0854ac093baa4bf380e18db14367679092


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jmc pull/293/head:pull/293` \
`$ git checkout pull/293`

Update a local copy of the PR: \
`$ git checkout pull/293` \
`$ git pull https://git.openjdk.java.net/jmc pull/293/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 293`

View PR using the GUI difftool: \
`$ git pr show -t 293`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jmc/pull/293.diff">https://git.openjdk.java.net/jmc/pull/293.diff</a>

</details>
