### PR TITLE
7371: Make Skara realize master is now 8.2

### DIFF
--- a/.jcheck/conf
+++ b/.jcheck/conf
@@ -36,7 +36,7 @@
 [general]
 project=jmc
 jbs=jmc
-version=8.1.0
+version=8.2.0
 
 [checks]
 error=author,reviewers,merge,message,issues


### PR DESCRIPTION
Will do a proper update, including splash, later this weekend.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JMC-7371](https://bugs.openjdk.java.net/browse/JMC-7371): Make Skara realize master is now 8.2


### Reviewers
 * [Jean-Philippe Bempel](https://openjdk.java.net/census#jpbempel) (@jpbempel - Committer)
 * [Henrik Dafgård](https://openjdk.java.net/census#hdafgard) (@Gunde - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jmc pull/297/head:pull/297` \
`$ git checkout pull/297`

Update a local copy of the PR: \
`$ git checkout pull/297` \
`$ git pull https://git.openjdk.java.net/jmc pull/297/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 297`

View PR using the GUI difftool: \
`$ git pr show -t 297`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jmc/pull/297.diff">https://git.openjdk.java.net/jmc/pull/297.diff</a>

</details>
