### PR TITLE
7231: JMC createReport for JMC8 Automated Analysis fails to evaluate several rules

### DIFF
--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/memory/GcLockerRule.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/memory/GcLockerRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -83,27 +83,29 @@ public class GcLockerRule implements IRule {
 
 	private IResult getResult(
 		IItemCollection items, IPreferenceValueProvider valueProvider, IResultValueProvider resultProvider) {
-		GarbageCollectionsInfo aggregate = resultProvider.getResultValue(GarbageCollectionInfoRule.GC_INFO);
-		if (aggregate != null) {
-			int gcLockers = aggregate.getGcLockers();
-			if (gcLockers > 0) {
-				int gcCount = aggregate.getGcCount();
-				IQuantity limit = valueProvider.getPreferenceValue(GC_LOCKER_RATIO_LIMIT);
-				double ratio = gcLockers / gcCount;
-				double score = RulesToolkit.mapExp74(ratio, limit.doubleValue());
-				return ResultBuilder.createFor(this, valueProvider).setSeverity(Severity.get(score))
-						.setSummary(Messages.getString(Messages.GcLockerRuleFactory_TEXT_INFO))
-						.setExplanation(Messages.getString(Messages.GcLockerRuleFactory_TEXT_INFO_LONG))
-						.addResult(TypedResult.SCORE, UnitLookup.NUMBER_UNITY.quantity(score))
-						.addResult(GC_LOCKER_RATIO, UnitLookup.PERCENT_UNITY.quantity(ratio)).build();
-			} else {
-				return ResultBuilder.createFor(this, valueProvider).setSeverity(Severity.OK)
-						.setSummary(Messages.getString(Messages.GcLockerRuleFactory_TEXT_OK)).build();
+		if (resultProvider != null) {
+			GarbageCollectionsInfo aggregate = resultProvider.getResultValue(GarbageCollectionInfoRule.GC_INFO);
+			if (aggregate != null) {
+				int gcLockers = aggregate.getGcLockers();
+				if (gcLockers > 0) {
+					int gcCount = aggregate.getGcCount();
+					IQuantity limit = valueProvider.getPreferenceValue(GC_LOCKER_RATIO_LIMIT);
+					double ratio = gcLockers / gcCount;
+					double score = RulesToolkit.mapExp74(ratio, limit.doubleValue());
+					return ResultBuilder.createFor(this, valueProvider).setSeverity(Severity.get(score))
+							.setSummary(Messages.getString(Messages.GcLockerRuleFactory_TEXT_INFO))
+							.setExplanation(Messages.getString(Messages.GcLockerRuleFactory_TEXT_INFO_LONG))
+							.addResult(TypedResult.SCORE, UnitLookup.NUMBER_UNITY.quantity(score))
+							.addResult(GC_LOCKER_RATIO, UnitLookup.PERCENT_UNITY.quantity(ratio)).build();
+				} else {
+					return ResultBuilder.createFor(this, valueProvider).setSeverity(Severity.OK)
+							.setSummary(Messages.getString(Messages.GcLockerRuleFactory_TEXT_OK)).build();
+				}
 			}
-		} else {
-			return ResultBuilder.createFor(this, valueProvider).setSeverity(Severity.NA)
-					.setSummary(Messages.getString(Messages.GcLockerRule_TEXT_NA)).build();
 		}
+		return ResultBuilder.createFor(this, valueProvider).setSeverity(Severity.NA)
+				.setSummary(Messages.getString(Messages.GcLockerRule_TEXT_NA)).build();
+
 	}
 
 	@Override

--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/memory/GcStallRule.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/memory/GcStallRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -75,20 +75,28 @@ public class GcStallRule implements IRule {
 		FutureTask<IResult> evaluationTask = new FutureTask<>(new Callable<IResult>() {
 			@Override
 			public IResult call() throws Exception {
-				GarbageCollectionsInfo aggregate = resultProvider.getResultValue(GarbageCollectionInfoRule.GC_INFO);
-				if (aggregate.foundNonRequestedSerialOldGc()) {
-					CollectorType oldCollectorType = CollectorType.getOldCollectorType(items);
-					if (oldCollectorType == CollectorType.CMS) {
-						return ResultBuilder.createFor(GcStallRule.this, valueProvider).setSeverity(Severity.WARNING)
-								.setSummary(Messages.getString(Messages.SerialOldRuleFactory_TEXT_WARN_CMS))
-								.setExplanation(Messages.getString(Messages.SerialOldRuleFactory_TEXT_WARN_CMS_LONG))
-								.build();
-					} else if (oldCollectorType == CollectorType.G1_OLD) {
-						return ResultBuilder.createFor(GcStallRule.this, valueProvider).setSeverity(Severity.WARNING)
-								.setSummary(Messages.getString(Messages.SerialOldRuleFactory_TEXT_WARN_G1))
-								.setExplanation(Messages.getString(Messages.SerialOldRuleFactory_TEXT_WARN_G1_LONG))
-								.build();
+				if (resultProvider != null) {
+					GarbageCollectionsInfo aggregate = resultProvider.getResultValue(GarbageCollectionInfoRule.GC_INFO);
+					if (aggregate.foundNonRequestedSerialOldGc()) {
+						CollectorType oldCollectorType = CollectorType.getOldCollectorType(items);
+						if (oldCollectorType == CollectorType.CMS) {
+							return ResultBuilder.createFor(GcStallRule.this, valueProvider)
+									.setSeverity(Severity.WARNING)
+									.setSummary(Messages.getString(Messages.SerialOldRuleFactory_TEXT_WARN_CMS))
+									.setExplanation(
+											Messages.getString(Messages.SerialOldRuleFactory_TEXT_WARN_CMS_LONG))
+									.build();
+						} else if (oldCollectorType == CollectorType.G1_OLD) {
+							return ResultBuilder.createFor(GcStallRule.this, valueProvider)
+									.setSeverity(Severity.WARNING)
+									.setSummary(Messages.getString(Messages.SerialOldRuleFactory_TEXT_WARN_G1))
+									.setExplanation(Messages.getString(Messages.SerialOldRuleFactory_TEXT_WARN_G1_LONG))
+									.build();
+						}
 					}
+				} else {
+					return ResultBuilder.createFor(GcStallRule.this, valueProvider).setSeverity(Severity.NA)
+							.setSummary(Messages.getString(Messages.GcLockerRule_TEXT_NA)).build();
 				}
 				IQuantity c = items.getAggregate(Aggregators.count(null, null, JdkFilters.CONCURRENT_MODE_FAILURE));
 				if (c != null && c.clampedLongValueIn(NUMBER_UNITY) > 0) {

--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/memory/StringDeduplicationRule.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/memory/StringDeduplicationRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -195,7 +195,8 @@ public class StringDeduplicationRule extends AbstractRule {
 		IQuantity heapUsedRatio = null;
 		if (maxHeapSize != null) {
 			IQuantity avgHeapUsed = items.getAggregate(JdkAggregators.AVG_HEAP_USED_AFTER_GC);
-			heapUsedRatio = UnitLookup.PERCENT_UNITY.quantity(avgHeapUsed.ratioTo(maxHeapSize));
+			if (avgHeapUsed != null)
+				heapUsedRatio = UnitLookup.PERCENT_UNITY.quantity(avgHeapUsed.ratioTo(maxHeapSize));
 			heapInfo = Messages.getString(Messages.StringDeduplicationRule_RESULT_HEAP_USAGE);
 		}
 

--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/memory/SystemGcRule.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/memory/SystemGcRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -96,20 +96,24 @@ public class SystemGcRule implements IRule {
 
 	private IResult getSystemGcResult(
 		IItemCollection items, IPreferenceValueProvider valueProvider, IResultValueProvider resultProvider) {
-		GarbageCollectionsInfo aggregate = resultProvider.getResultValue(GarbageCollectionInfoRule.GC_INFO);
-		IQuantity limit = valueProvider.getPreferenceValue(SYSTEM_GC_RATIO_LIMIT);
-		if (aggregate.getSystemGcCount() > 0) {
-			double systemGcRatio = aggregate.getSystemGcCount() / aggregate.getGcCount();
-			double score = RulesToolkit.mapExp100(systemGcRatio, limit.doubleValue());
-			return ResultBuilder.createFor(this, valueProvider).setSeverity(Severity.get(score))
-					.setSummary(Messages.getString(Messages.SystemGcRuleFactory_TEXT_INFO))
-					.setExplanation(Messages.getString(Messages.SystemGcRuleFactory_TEXT_INFO_LONG))
-					.addResult(TypedResult.SCORE, UnitLookup.NUMBER_UNITY.quantity(score))
-					.addResult(SYSTEM_GC_RATIO, UnitLookup.PERCENT_UNITY.quantity(systemGcRatio)).build();
-		} else {
-			return ResultBuilder.createFor(this, valueProvider).setSeverity(Severity.OK)
-					.setSummary(Messages.getString(Messages.SystemGcRuleFactory_TEXT_OK)).build();
+		if (resultProvider != null) {
+			GarbageCollectionsInfo aggregate = resultProvider.getResultValue(GarbageCollectionInfoRule.GC_INFO);
+			IQuantity limit = valueProvider.getPreferenceValue(SYSTEM_GC_RATIO_LIMIT);
+			if (aggregate.getSystemGcCount() > 0) {
+				double systemGcRatio = aggregate.getSystemGcCount() / aggregate.getGcCount();
+				double score = RulesToolkit.mapExp100(systemGcRatio, limit.doubleValue());
+				return ResultBuilder.createFor(this, valueProvider).setSeverity(Severity.get(score))
+						.setSummary(Messages.getString(Messages.SystemGcRuleFactory_TEXT_INFO))
+						.setExplanation(Messages.getString(Messages.SystemGcRuleFactory_TEXT_INFO_LONG))
+						.addResult(TypedResult.SCORE, UnitLookup.NUMBER_UNITY.quantity(score))
+						.addResult(SYSTEM_GC_RATIO, UnitLookup.PERCENT_UNITY.quantity(systemGcRatio)).build();
+			} else {
+				return ResultBuilder.createFor(this, valueProvider).setSeverity(Severity.OK)
+						.setSummary(Messages.getString(Messages.SystemGcRuleFactory_TEXT_OK)).build();
+			}
 		}
+		return ResultBuilder.createFor(this, valueProvider).setSeverity(Severity.NA)
+				.setSummary(Messages.getString(Messages.GcLockerRule_TEXT_NA)).build();
 	}
 
 	@Override


### PR DESCRIPTION
This PR addresses the NullPointerException issue in core module for the following rules:

1. GCs Caused by System.gc()
2. GCs Caused by Heap Inspection
3. GC Stall
4. String Deduplication
5. GCs Caused by GC Locker

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JMC-7231](https://bugs.openjdk.java.net/browse/JMC-7231): JMC createReport for JMC8 Automated Analysis fails to evaluate several rules


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jmc pull/302/head:pull/302` \
`$ git checkout pull/302`

Update a local copy of the PR: \
`$ git checkout pull/302` \
`$ git pull https://git.openjdk.java.net/jmc pull/302/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 302`

View PR using the GUI difftool: \
`$ git pr show -t 302`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jmc/pull/302.diff">https://git.openjdk.java.net/jmc/pull/302.diff</a>

</details>
