### PR TITLE
7384: Add option to enable STARTTLS encryption for mail server in communication preference

### DIFF
--- a/application/org.openjdk.jmc.console.ui/src/main/java/org/openjdk/jmc/console/ui/messages/internal/Messages.java
+++ b/application/org.openjdk.jmc.console.ui/src/main/java/org/openjdk/jmc/console/ui/messages/internal/Messages.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -60,6 +60,7 @@ public class Messages extends NLS {
 	public static String CommunicationPage_CAPTION_MAIL_SERVER_USER;
 	public static String CommunicationPage_CAPTION_RETAINED_EVENT_VALUES;
 	public static String CommunicationPage_CAPTION_SECURE_MAIL_SERVER;
+	public static String CommunicationPage_CAPTION_SECURE_MAIL_SERVER_STARTTLS;
 	public static String CommunicationPage_DESCRIPTION;
 	public static String CommunicationPage_UPDATE_INTERVAL_THREAD_STACK0;
 	public static String ConsoleEditorInput_FAILED_TO_OPEN_EDITOR;

--- a/application/org.openjdk.jmc.console.ui/src/main/java/org/openjdk/jmc/console/ui/preferences/CommunicationPage.java
+++ b/application/org.openjdk.jmc.console.ui/src/main/java/org/openjdk/jmc/console/ui/preferences/CommunicationPage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -121,6 +121,11 @@ public class CommunicationPage extends FieldEditorPreferencePage implements IWor
 		BooleanFieldEditor mailServerSecure = new BooleanFieldEditor(PreferencesKeys.PROPERTY_MAIL_SERVER_SECURE,
 				Messages.CommunicationPage_CAPTION_SECURE_MAIL_SERVER, getFieldEditorParent());
 		addField(mailServerSecure);
+
+		BooleanFieldEditor mailServerStarttls = new BooleanFieldEditor(
+				PreferencesKeys.PROPERTY_MAIL_SERVER_STARTTLS_ENCRYPTION,
+				Messages.CommunicationPage_CAPTION_SECURE_MAIL_SERVER_STARTTLS, getFieldEditorParent());
+		addField(mailServerStarttls);
 
 		createCredentialFields();
 		loadCredentials();

--- a/application/org.openjdk.jmc.console.ui/src/main/resources/org/openjdk/jmc/console/ui/messages/internal/messages.properties
+++ b/application/org.openjdk.jmc.console.ui/src/main/resources/org/openjdk/jmc/console/ui/messages/internal/messages.properties
@@ -1,5 +1,5 @@
 #
-#  Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+#  Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
 #
 #  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
@@ -80,6 +80,7 @@ CommunicationPage_CAPTION_MAIL_SERVER_USER=Mail server user:
 CommunicationPage_CAPTION_MAIL_SERVER_PASSWORD=Mail server password:
 CommunicationPage_CAPTION_RETAINED_EVENT_VALUES=Retained event values
 CommunicationPage_CAPTION_SECURE_MAIL_SERVER=Secure mail server (SSL)
+CommunicationPage_CAPTION_SECURE_MAIL_SERVER_STARTTLS=Enable STARTTLS Encryption
 GeneralPage_DESCRIPTION=General settings for the JMX Console.\n\n
 GeneralPage_SHOW_WARNING_BEFORE_UPDATING_HEAP_HISTOGRAM=Show warning before updating heap histogram
 GeneralPage_LIST_AGGREGATE_SIZE=Show tree nodes in groups of:

--- a/application/org.openjdk.jmc.rjmx/src/main/java/org/openjdk/jmc/rjmx/preferences/Initializer.java
+++ b/application/org.openjdk.jmc.rjmx/src/main/java/org/openjdk/jmc/rjmx/preferences/Initializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -53,6 +53,8 @@ public class Initializer extends AbstractPreferenceInitializer {
 		preferences.put(PreferencesKeys.PROPERTY_MAIL_SERVER, PreferencesKeys.DEFAULT_MAIL_SERVER);
 		preferences.putInt(PreferencesKeys.PROPERTY_MAIL_SERVER_PORT, PreferencesKeys.DEFAULT_MAIL_SERVER_PORT);
 		preferences.putBoolean(PreferencesKeys.PROPERTY_MAIL_SERVER_SECURE, PreferencesKeys.DEFAULT_MAIL_SERVER_SECURE);
+		preferences.putBoolean(PreferencesKeys.PROPERTY_MAIL_SERVER_STARTTLS_ENCRYPTION,
+				PreferencesKeys.DEFAULT_MAIL_SERVER_STARTTLS_ENCRYPTION);
 		preferences.put(PreferencesKeys.PROPERTY_MAIL_SERVER_CREDENTIALS,
 				PreferencesKeys.DEFAULT_MAIL_SERVER_CREDENTIALS);
 

--- a/application/org.openjdk.jmc.rjmx/src/main/java/org/openjdk/jmc/rjmx/preferences/PreferencesKeys.java
+++ b/application/org.openjdk.jmc.rjmx/src/main/java/org/openjdk/jmc/rjmx/preferences/PreferencesKeys.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -51,10 +51,12 @@ public class PreferencesKeys {
 	public static final String PROPERTY_MAIL_SERVER = "rjmx.smtp.server"; //$NON-NLS-1$
 	public static final String PROPERTY_MAIL_SERVER_PORT = "rjmx.smtp.server.port"; //$NON-NLS-1$
 	public static final String PROPERTY_MAIL_SERVER_SECURE = "rjmx.smtp.server.secure"; //$NON-NLS-1$
+	public static final String PROPERTY_MAIL_SERVER_STARTTLS_ENCRYPTION = "rjmx.smtp.server.starttls.encryption"; //$NON-NLS-1$
 	public static final String PROPERTY_MAIL_SERVER_CREDENTIALS = "rjmx.smtp.server.credentials"; //$NON-NLS-1$
 	public static final String DEFAULT_MAIL_SERVER = "mail.example.org"; //$NON-NLS-1$
 	public static final int DEFAULT_MAIL_SERVER_PORT = 25;
 	public static final boolean DEFAULT_MAIL_SERVER_SECURE = false;
+	public static final boolean DEFAULT_MAIL_SERVER_STARTTLS_ENCRYPTION = false;
 	public static final String DEFAULT_MAIL_SERVER_USER = ""; //$NON-NLS-1$
 	public static final String DEFAULT_MAIL_SERVER_PASSWORD = ""; //$NON-NLS-1$
 	public static final String DEFAULT_MAIL_SERVER_CREDENTIALS = ""; //$NON-NLS-1$

--- a/application/org.openjdk.jmc.rjmx/src/main/java/org/openjdk/jmc/rjmx/triggers/actions/internal/TriggerActionMail.java
+++ b/application/org.openjdk.jmc.rjmx/src/main/java/org/openjdk/jmc/rjmx/triggers/actions/internal/TriggerActionMail.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -95,6 +95,7 @@ public class TriggerActionMail extends TriggerAction {
 	 */
 	public void sendEMail(String subject, String content) throws MessagingException {
 		Properties props = new Properties();
+		props.put("mail.smtp.starttls.enable", getSmtpSTARTTLS());
 		Session session = Session.getInstance(props, null);
 		UserPassword credentials = getSmtpCredentials();
 		URLName urlName = createURLName(credentials);
@@ -181,6 +182,12 @@ public class TriggerActionMail extends TriggerAction {
 	private Boolean getSmtpSSL() {
 		return RJMXPlugin.getDefault().getRJMXPreferences().getBoolean(PreferencesKeys.PROPERTY_MAIL_SERVER_SECURE,
 				PreferencesKeys.DEFAULT_MAIL_SERVER_SECURE);
+	}
+
+	private Boolean getSmtpSTARTTLS() {
+		return RJMXPlugin.getDefault().getRJMXPreferences().getBoolean(
+				PreferencesKeys.PROPERTY_MAIL_SERVER_STARTTLS_ENCRYPTION,
+				PreferencesKeys.DEFAULT_MAIL_SERVER_STARTTLS_ENCRYPTION);
 	}
 
 	/**


### PR DESCRIPTION
This PR addresses a new enhancement of adding the preference for STARTTLS encryption for the email communications triggered in JMX Console. 

<img width="314" alt="starttls" src="https://user-images.githubusercontent.com/11155712/128935485-139b4558-c6aa-406c-92df-cc78883c8f0c.png">

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JMC-7384](https://bugs.openjdk.java.net/browse/JMC-7384): Add option to enable STARTTLS encryption for mail server in communication preference


### Reviewers
 * [Marcus Hirt](https://openjdk.java.net/census#hirt) (@thegreystone - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jmc pull/303/head:pull/303` \
`$ git checkout pull/303`

Update a local copy of the PR: \
`$ git checkout pull/303` \
`$ git pull https://git.openjdk.java.net/jmc pull/303/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 303`

View PR using the GUI difftool: \
`$ git pr show -t 303`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jmc/pull/303.diff">https://git.openjdk.java.net/jmc/pull/303.diff</a>

</details>
