### PR TITLE
7332: Show stacktraces for constant values from stacktrace pool

### DIFF
--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/ConstantPoolsPage.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/ConstantPoolsPage.java
@@ -113,6 +113,7 @@ public class ConstantPoolsPage extends AbstractDataPage {
 		private static final String SASH_ELEMENT = "sash"; //$NON-NLS-1$
 
 		private final IItemCollection constPoolItems;
+		private final IPageContainer container;
 		private final SashForm sash;
 		private final ItemHistogram byTypeTable;
 		private final ItemHistogram constantValueTable;
@@ -124,6 +125,7 @@ public class ConstantPoolsPage extends AbstractDataPage {
 		private ItemHistogramWithInput constantHistogram;
 
 		ConstantPoolsPageUi(Composite parent, FormToolkit toolkit, IPageContainer pageContainer, IState state) {
+			container = pageContainer;
 			constPoolItems = getDataSource().getConstantPools();
 			selectionConstPoolItems = constPoolItems;
 			selectionConstantItems = getDataSource().getConstants();
@@ -153,6 +155,7 @@ public class ConstantPoolsPage extends AbstractDataPage {
 			byTypeHistogram = new ItemHistogramWithInput(byTypeTable);
 			constantHistogram = new ItemHistogramWithInput(constantValueTable);
 			byTypeHistogram.addListener(this::typeHistogramListener);
+			constantHistogram.addListener(container::showSelection);
 
 			PersistableSashForm.loadState(sash, state.getChild(SASH_ELEMENT));
 			byTypeFilter.loadState(state.getChild(TYPE_FILTER));
@@ -164,6 +167,7 @@ public class ConstantPoolsPage extends AbstractDataPage {
 			IItemCollection filteredItems = getDataSource().getConstants()
 					.apply(ItemFilters.equals(JdkAttributes.CONSTANT_TYPE, poolName));
 			constantHistogram.setInput(filteredItems);
+			container.showSelection(filteredItems);
 		}
 
 		private void onTypeFilterChange(IItemFilter filter) {
@@ -192,5 +196,4 @@ public class ConstantPoolsPage extends AbstractDataPage {
 	public IPageUI display(Composite parent, FormToolkit toolkit, IPageContainer pageContainer, IState state) {
 		return new ConstantPoolsPageUi(parent, toolkit, pageContainer, state);
 	}
-
 }

--- a/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/internal/parser/ParserStats.java
+++ b/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/internal/parser/ParserStats.java
@@ -281,15 +281,17 @@ public class ParserStats {
 			}
 			if ("constant".equals(attribute.getIdentifier())) {
 				if (constant instanceof IMCStackTrace) {
-					IMCFrame imcFrame = ((IMCStackTrace)constant).getFrames().get(0);
-					String str = StacktraceFormatToolkit.formatFrame(imcFrame, new FrameSeparator(FrameCategorization.METHOD, false));
+					IMCFrame imcFrame = ((IMCStackTrace) constant).getFrames().get(0);
+					String str = StacktraceFormatToolkit.formatFrame(imcFrame,
+							new FrameSeparator(FrameCategorization.METHOD, false));
 					return ((IMemberAccessor<M, IItem>) MemberAccessorToolkit.<IItem, Object, Object> constant(str));
 				}
 				return ((IMemberAccessor<M, IItem>) MemberAccessorToolkit.<IItem, Object, Object> constant(constant));
 			}
 			if ("stackTrace".equals(attribute.getIdentifier())) {
 				if (constant instanceof IMCStackTrace) {
-					return (IMemberAccessor<M, IItem>) MemberAccessorToolkit.<IItem, IMCStackTrace, IMCStackTrace>constant((IMCStackTrace)constant);
+					return (IMemberAccessor<M, IItem>) MemberAccessorToolkit
+							.<IItem, IMCStackTrace, IMCStackTrace> constant((IMCStackTrace) constant);
 				}
 			}
 			return null;

--- a/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/internal/parser/ParserStats.java
+++ b/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/internal/parser/ParserStats.java
@@ -34,6 +34,7 @@
 package org.openjdk.jmc.flightrecorder.internal.parser;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -45,6 +46,8 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
 
 import org.openjdk.jmc.common.IDescribable;
+import org.openjdk.jmc.common.IMCFrame;
+import org.openjdk.jmc.common.IMCStackTrace;
 import org.openjdk.jmc.common.collection.FastAccessNumberMap;
 import org.openjdk.jmc.common.item.IAccessorKey;
 import org.openjdk.jmc.common.item.IAttribute;
@@ -55,9 +58,13 @@ import org.openjdk.jmc.common.item.IMemberAccessor;
 import org.openjdk.jmc.common.item.IType;
 import org.openjdk.jmc.common.item.ItemCollectionToolkit;
 import org.openjdk.jmc.common.unit.IQuantity;
+import org.openjdk.jmc.common.unit.StructContentType;
 import org.openjdk.jmc.common.unit.UnitLookup;
 import org.openjdk.jmc.common.util.MemberAccessorToolkit;
 import org.openjdk.jmc.flightrecorder.IParserStats.IEventStats;
+import org.openjdk.jmc.flightrecorder.stacktrace.FrameSeparator;
+import org.openjdk.jmc.flightrecorder.stacktrace.FrameSeparator.FrameCategorization;
+import org.openjdk.jmc.flightrecorder.stacktrace.StacktraceFormatToolkit;
 
 public class ParserStats {
 	private short majorVersion;
@@ -197,7 +204,7 @@ public class ParserStats {
 
 		@Override
 		public List<IAttribute<?>> getAttributes() {
-			return null;
+			return Collections.emptyList();
 		}
 
 		@Override
@@ -253,7 +260,7 @@ public class ParserStats {
 
 		@Override
 		public List<IAttribute<?>> getAttributes() {
-			return null;
+			return Collections.emptyList();
 		}
 
 		@Override
@@ -273,7 +280,17 @@ public class ParserStats {
 				return ((IMemberAccessor<M, IItem>) MemberAccessorToolkit.<IItem, Object, Object> constant(typeName));
 			}
 			if ("constant".equals(attribute.getIdentifier())) {
+				if (constant instanceof IMCStackTrace) {
+					IMCFrame imcFrame = ((IMCStackTrace)constant).getFrames().get(0);
+					String str = StacktraceFormatToolkit.formatFrame(imcFrame, new FrameSeparator(FrameCategorization.METHOD, false));
+					return ((IMemberAccessor<M, IItem>) MemberAccessorToolkit.<IItem, Object, Object> constant(str));
+				}
 				return ((IMemberAccessor<M, IItem>) MemberAccessorToolkit.<IItem, Object, Object> constant(constant));
+			}
+			if ("stackTrace".equals(attribute.getIdentifier())) {
+				if (constant instanceof IMCStackTrace) {
+					return (IMemberAccessor<M, IItem>) MemberAccessorToolkit.<IItem, IMCStackTrace, IMCStackTrace>constant((IMCStackTrace)constant);
+				}
 			}
 			return null;
 		}


### PR DESCRIPTION
Replace the default Object.ToString of JfrStackTraces by the top frame
and linked to the StacktraceView for better visualization

Example:
<img width="882" alt="Screenshot 2021-09-06 at 17 21 42" src="https://user-images.githubusercontent.com/4610701/132238400-702bfeeb-b368-4501-b022-72d4f326b461.png">

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JMC-7332](https://bugs.openjdk.java.net/browse/JMC-7332): Show stacktraces for constant values from stacktrace pool


### Reviewers
 * [Marcus Hirt](https://openjdk.java.net/census#hirt) (@thegreystone - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jmc pull/305/head:pull/305` \
`$ git checkout pull/305`

Update a local copy of the PR: \
`$ git checkout pull/305` \
`$ git pull https://git.openjdk.java.net/jmc pull/305/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 305`

View PR using the GUI difftool: \
`$ git pr show -t 305`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jmc/pull/305.diff">https://git.openjdk.java.net/jmc/pull/305.diff</a>

</details>
