### PR TITLE
7336: Add support for new JFR event systemGC

### DIFF
--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/GarbageCollectionsPage.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/GarbageCollectionsPage.java
@@ -734,9 +734,10 @@ public class GarbageCollectionsPage extends AbstractDataPage {
 			correlateSystemGCEvents(sel, selCopy);
 			return selCopy.stream().map(gc -> gc.gcItem);
 		}
-		
+
 		private void correlateSystemGCEvents(List<GC> sourceGCList, List<GC> destinationGCList) {
-			IItemCollection systemGCEvents = getDataSource().getItems().apply(ItemFilters.type(JdkTypeIDs.GC_COLLECTOR_SYSTEM_GC));
+			IItemCollection systemGCEvents = getDataSource().getItems()
+					.apply(ItemFilters.type(JdkTypeIDs.GC_COLLECTOR_SYSTEM_GC));
 			for (GC gc : sourceGCList) {
 				IItemFilter rangeFilter = RulesToolkit.createRangeFilter(gc.gcItem);
 				IItemCollection correlatedItems = systemGCEvents.apply(rangeFilter);
@@ -746,7 +747,7 @@ public class GarbageCollectionsPage extends AbstractDataPage {
 					}
 				}
 			}
-			
+
 		}
 	}
 

--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/GarbageCollectionsPage.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/GarbageCollectionsPage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -97,6 +97,7 @@ import org.openjdk.jmc.flightrecorder.jdk.JdkFilters;
 import org.openjdk.jmc.flightrecorder.jdk.JdkTypeIDs;
 import org.openjdk.jmc.flightrecorder.rules.jdk.memory.ReferenceStatisticsType;
 import org.openjdk.jmc.flightrecorder.rules.util.JfrRuleTopics;
+import org.openjdk.jmc.flightrecorder.rules.util.RulesToolkit;
 import org.openjdk.jmc.flightrecorder.ui.FlightRecorderUI;
 import org.openjdk.jmc.flightrecorder.ui.IDataPageFactory;
 import org.openjdk.jmc.flightrecorder.ui.IDisplayablePage;
@@ -729,7 +730,23 @@ public class GarbageCollectionsPage extends AbstractDataPage {
 		private Stream<? extends IItem> gcSelectedGcItems() {
 			@SuppressWarnings("unchecked")
 			List<GC> sel = ((IStructuredSelection) gcList.getViewer().getSelection()).toList();
-			return sel.stream().map(gc -> gc.gcItem);
+			List<GC> selCopy = new ArrayList<>(sel);
+			correlateSystemGCEvents(sel, selCopy);
+			return selCopy.stream().map(gc -> gc.gcItem);
+		}
+		
+		private void correlateSystemGCEvents(List<GC> sourceGCList, List<GC> destinationGCList) {
+			IItemCollection systemGCEvents = getDataSource().getItems().apply(ItemFilters.type(JdkTypeIDs.GC_COLLECTOR_SYSTEM_GC));
+			for (GC gc : sourceGCList) {
+				IItemFilter rangeFilter = RulesToolkit.createRangeFilter(gc.gcItem);
+				IItemCollection correlatedItems = systemGCEvents.apply(rangeFilter);
+				for (IItemIterable types : correlatedItems) {
+					for (IItem item : types) {
+						destinationGCList.add(new GC(item, null));
+					}
+				}
+			}
+			
 		}
 	}
 

--- a/core/org.openjdk.jmc.flightrecorder.rules/src/main/java/org/openjdk/jmc/flightrecorder/rules/tree/TimeRangeFilter.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules/src/main/java/org/openjdk/jmc/flightrecorder/rules/tree/TimeRangeFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -59,7 +59,7 @@ public class TimeRangeFilter implements IItemFilter {
 
 		private boolean intersects(IItem o, Range range) {
 			IQuantity startTime = RulesToolkit.getStartTime(o);
-			IQuantity endTime = RulesToolkit.getStartTime(o);
+			IQuantity endTime = RulesToolkit.getEndTime(o);
 
 			if (range.isInside(startTime) || range.isInside(endTime)) {
 				return true;

--- a/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/jdk/JdkTypeIDs.java
+++ b/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/jdk/JdkTypeIDs.java
@@ -160,6 +160,7 @@ public final class JdkTypeIDs {
 	public static final String GC_COLLECTOR_OLD_GARBAGE_COLLECTION = PREFIX + "OldGarbageCollection";
 	public static final String GC_COLLECTOR_PAROLD_GARBAGE_COLLECTION = PREFIX + "ParallelOldGarbageCollection";
 	public static final String GC_COLLECTOR_YOUNG_GARBAGE_COLLECTION = PREFIX + "YoungGarbageCollection";
+	public static final String GC_COLLECTOR_SYSTEM_GC = PREFIX + "SystemGC";
 	public static final String GC_DETAILED_ALLOCATION_REQUIRING_GC = PREFIX + "AllocationRequiringGC";
 	public static final String GC_DETAILED_EVACUATION_FAILED = PREFIX + "EvacuationFailed";
 	public static final String GC_DETAILED_EVACUATION_INFO = PREFIX + "EvacuationInformation";

--- a/core/tests/org.openjdk.jmc.flightrecorder.rules.test/src/test/java/org/openjdk/jmc/flightrecorder/rules/TimeRangeFilterTest.java
+++ b/core/tests/org.openjdk.jmc.flightrecorder.rules.test/src/test/java/org/openjdk/jmc/flightrecorder/rules/TimeRangeFilterTest.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Datadog, Inc. All rights reserved.
+ * 
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * The contents of this file are subject to the terms of either the Universal Permissive License
+ * v 1.0 as shown at http://oss.oracle.com/licenses/upl
+ *
+ * or the following license:
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted
+ * provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions
+ * and the following disclaimer.
+ * 
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other materials provided with
+ * the distribution.
+ * 
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to
+ * endorse or promote products derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+ * WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.openjdk.jmc.flightrecorder.rules;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openjdk.jmc.common.IDescribable;
+import org.openjdk.jmc.common.item.IAccessorKey;
+import org.openjdk.jmc.common.item.IAttribute;
+import org.openjdk.jmc.common.item.ICanonicalAccessorFactory;
+import org.openjdk.jmc.common.item.IItem;
+import org.openjdk.jmc.common.item.IItemFilter;
+import org.openjdk.jmc.common.item.IMemberAccessor;
+import org.openjdk.jmc.common.item.IType;
+import org.openjdk.jmc.common.unit.IQuantity;
+import org.openjdk.jmc.common.unit.UnitLookup;
+import org.openjdk.jmc.common.util.MemberAccessorToolkit;
+import org.openjdk.jmc.flightrecorder.JfrAttributes;
+import org.openjdk.jmc.flightrecorder.rules.util.RulesToolkit;
+
+public class TimeRangeFilterTest {
+
+	@Test
+	public void intersects() {
+		long start1 = System.currentTimeMillis();
+		long end1 = start1 + 1000;
+		MockEventItem item1 = new MockEventItem(UnitLookup.EPOCH_MS.quantity(start1),
+				UnitLookup.EPOCH_MS.quantity(end1));
+		IItemFilter timeRange = RulesToolkit.createRangeFilter(item1);
+		long start2 = start1 - 100;
+		long end2 = start2 + 1000;
+		MockEventItem item2 = new MockEventItem(UnitLookup.EPOCH_MS.quantity(start2),
+				UnitLookup.EPOCH_MS.quantity(end2));
+		Assert.assertTrue(timeRange.getPredicate(item2).test(item2));
+
+		start2 = start1 + 100;
+		end2 = start2 + 1000;
+		item2 = new MockEventItem(UnitLookup.EPOCH_MS.quantity(start2), UnitLookup.EPOCH_MS.quantity(end2));
+		Assert.assertTrue(timeRange.getPredicate(item2).test(item2));
+	}
+
+	private static class MockEventItem implements IItem, IType<IItem> {
+		private IQuantity startTime;
+		private IQuantity endTime;
+
+		public MockEventItem(IQuantity startTime, IQuantity endTime) {
+			this.startTime = startTime;
+			this.endTime = endTime;
+		}
+
+		@Override
+		public IType<IItem> getType() {
+			return this;
+		}
+
+		@Override
+		public String getName() {
+			return "MockEventItem";
+		}
+
+		@Override
+		public String getDescription() {
+			return "MockEventItem";
+		}
+
+		@Override
+		public List<IAttribute<?>> getAttributes() {
+			return Collections.emptyList();
+		}
+
+		@Override
+		public Map<IAccessorKey<?>, ? extends IDescribable> getAccessorKeys() {
+			return Collections.emptyMap();
+		}
+
+		@Override
+		public boolean hasAttribute(ICanonicalAccessorFactory<?> attribute) {
+			return false;
+		}
+
+		@SuppressWarnings("unchecked")
+		@Override
+		public <M> IMemberAccessor<M, IItem> getAccessor(IAccessorKey<M> attribute) {
+			if (attribute.getIdentifier().equals(JfrAttributes.START_TIME.getIdentifier())) {
+				return (IMemberAccessor<M, IItem>) MemberAccessorToolkit
+						.<IItem, IQuantity, IQuantity> constant(startTime);
+			}
+			if (attribute.getIdentifier().equals(JfrAttributes.END_TIME.getIdentifier())) {
+				return (IMemberAccessor<M, IItem>) MemberAccessorToolkit
+						.<IItem, IQuantity, IQuantity> constant(endTime);
+			}
+			return null;
+		}
+
+		@Override
+		public String getIdentifier() {
+			return null;
+		}
+
+	}
+}


### PR DESCRIPTION
`SystemGC` event brings stacktrace when a `System.gc()` is triggered
We can then correlate with GarbageCollection event with "System.gc()"
cause to this new event to be able to show stacktrace in Stacktrace
View/Flameview

<img width="893" alt="Screenshot 2021-09-15 at 22 54 03" src="https://user-images.githubusercontent.com/4610701/133508127-23bb8539-6f67-4e65-be35-6c746e08ced2.png">

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JMC-7336](https://bugs.openjdk.java.net/browse/JMC-7336): Add support for new JFR event systemGC


### Reviewers
 * [Alex Macdonald](https://openjdk.java.net/census#aptmac) (@aptmac - Committer)
 * [Marcus Hirt](https://openjdk.java.net/census#hirt) (@thegreystone - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jmc pull/307/head:pull/307` \
`$ git checkout pull/307`

Update a local copy of the PR: \
`$ git checkout pull/307` \
`$ git pull https://git.openjdk.java.net/jmc pull/307/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 307`

View PR using the GUI difftool: \
`$ git pr show -t 307`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jmc/pull/307.diff">https://git.openjdk.java.net/jmc/pull/307.diff</a>

</details>
