### PR TITLE
7417: Fix incorrect identifier in result for biased locking revocation rule

### DIFF
--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/latency/BiasedLockingRevocationRule.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/latency/BiasedLockingRevocationRule.java
@@ -112,7 +112,7 @@ public final class BiasedLockingRevocationRule implements IRule {
 	private static final List<TypedPreference<?>> CONFIG_ATTRIBUTES = Arrays.<TypedPreference<?>> asList(WARNING_LIMIT,
 			MAX_NUMBER_OF_CLASSES_TO_REPORT, FILTERED_CLASSES);
 
-	public static final TypedCollectionResult<IMCType> REVOKED_TYPES = new TypedCollectionResult<>("revokedClasses", //$NON-NLS-1$
+	public static final TypedCollectionResult<IMCType> REVOKED_CLASSES = new TypedCollectionResult<>("revokedClasses", //$NON-NLS-1$
 			"Revoked Classes", "Revoked Classes.", UnitLookup.CLASS, IMCType.class);
 	public static final TypedCollectionResult<ClassEntry> REVOCATION_CLASSES = new TypedCollectionResult<>(
 			"revocationClasses", "Revocation Classes", "Revocation Classes", ClassEntry.CLASS_ENTRY, ClassEntry.class); //$NON-NLS-1$
@@ -120,7 +120,7 @@ public final class BiasedLockingRevocationRule implements IRule {
 			"Filtered Types", "Types that were filtered out.", UnitLookup.PLAIN_TEXT, String.class);
 
 	private static final Collection<TypedResult<?>> RESULT_ATTRIBUTES = Arrays
-			.<TypedResult<?>> asList(TypedResult.SCORE, REVOKED_TYPES, REVOCATION_CLASSES, FILTERED_TYPES);
+			.<TypedResult<?>> asList(TypedResult.SCORE, REVOKED_CLASSES, REVOCATION_CLASSES, FILTERED_TYPES);
 
 	private static final Map<String, EventAvailability> REQUIRED_EVENTS = RequiredEventsBuilder.create()
 			.addEventType(JdkTypeIDs.BIASED_LOCK_CLASS_REVOCATION, EventAvailability.ENABLED).build();
@@ -191,7 +191,7 @@ public final class BiasedLockingRevocationRule implements IRule {
 		}
 		return ResultBuilder.createFor(this, valueProvider).setSeverity(Severity.get(totalScore))
 				.setSummary(summary.toString()).setExplanation(explanation.toString())
-				.addResult(REVOKED_TYPES, revokedTypes).addResult(REVOCATION_CLASSES, filteredRevocationClasses)
+				.addResult(REVOKED_CLASSES, revokedTypes).addResult(REVOCATION_CLASSES, filteredRevocationClasses)
 				.addResult(FILTERED_TYPES, filteredTypes).build();
 	}
 

--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/latency/BiasedLockingRevocationRule.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/latency/BiasedLockingRevocationRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/resources/org/openjdk/jmc/flightrecorder/rules/jdk/messages/internal/messages.properties
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/resources/org/openjdk/jmc/flightrecorder/rules/jdk/messages/internal/messages.properties
@@ -74,7 +74,7 @@ BiasedLockingRevocationRule_CONFIG_WARNING_LIMIT_LONG=The number of revocations 
 BiasedLockingRevocationRule_NAME=Biased Locking Revocation
 BiasedLockingRevocationRule_TEXT_OK=No classes were disabled from participating in biased locking
 BiasedLockingRevocationRule_TEXT_REVOKED_CLASSES_FOUND=Fully revoked classes found.
-BiasedLockingRevocationRule_TEXT_REVOKED_CLASSES_FOUND_LONG=The following classes were disabled from using biased locking: {revokedTypes}
+BiasedLockingRevocationRule_TEXT_REVOKED_CLASSES_FOUND_LONG=The following classes were disabled from using biased locking: {revokedClasses}
 BiasedLockingRevocationRule_TEXT_REVOKE_LIMIT_CLASSES_FOUND=Instances of classes were revoked more times than the user configured limit.
 # {revocationClasses} is the user configured revocation limit
 BiasedLockingRevocationRule_TEXT_REVOKE_LIMIT_CLASSES_FOUND_LONG=The following instances of classes were revoked more than the configured limit for this rule (not including disabled classes): {revocationClasses}

--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/resources/org/openjdk/jmc/flightrecorder/rules/jdk/messages/internal/messages.properties
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/resources/org/openjdk/jmc/flightrecorder/rules/jdk/messages/internal/messages.properties
@@ -1,5 +1,5 @@
 #
-#  Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+#  Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
 #
 #  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #


### PR DESCRIPTION
This PR fixes a wrong placeholder in `BiasedLockingRevocationRule_TEXT_REVOKED_CLASSES_FOUND_LONG`.

`BiasedLockingRevocationRule.java` used `{revokedClasses}` for placeholder identifier but `messages.properties` used `{revokedTypes}`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JMC-7417](https://bugs.openjdk.java.net/browse/JMC-7417): Fix incorrect identifier in result for biased locking revocation rule


### Reviewers
 * [Alex Macdonald](https://openjdk.java.net/census#aptmac) (@aptmac - **Reviewer**) ⚠️ Review applies to 24db3838cd918f01c9da08902422b40d66001584
 * [Marcus Hirt](https://openjdk.java.net/census#hirt) (@thegreystone - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jmc pull/309/head:pull/309` \
`$ git checkout pull/309`

Update a local copy of the PR: \
`$ git checkout pull/309` \
`$ git pull https://git.openjdk.java.net/jmc pull/309/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 309`

View PR using the GUI difftool: \
`$ git pr show -t 309`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jmc/pull/309.diff">https://git.openjdk.java.net/jmc/pull/309.diff</a>

</details>
