### PR TITLE
7409: Update the spotless maven plugin

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -58,7 +58,7 @@
 		<manifest-location>META-INF</manifest-location>
 		<maven.jar.version>3.2.0</maven.jar.version>
 		<maven.bundle.version>5.1.1</maven.bundle.version>
-		<spotless.version>2.5.0</spotless.version>
+		<spotless.version>2.14.0</spotless.version>
 		<maven.directory.version>0.3.1</maven.directory.version>
 		<maven.resources.version>3.2.0</maven.resources.version>
 		<maven.source.version>3.2.1</maven.source.version>

--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
 		<maven.directory.version>0.3.1</maven.directory.version>
 		<maven.enforcer.version>3.0.0-M1</maven.enforcer.version>
 		<maven.resources.version>3.2.0</maven.resources.version>
-		<spotless.version>2.5.0</spotless.version>
+		<spotless.version>2.14.0</spotless.version>
 		<spotless.config.path>${basedir}/configuration/ide/eclipse/formatting/formatting.xml</spotless.config.path>
 		<spotbugs.version>4.2.2</spotbugs.version>
 		<buildId>${user.name}</buildId>


### PR DESCRIPTION
Modifier order cleanup amazingly enough not yet supported by Eclipse:
https://bugs.eclipse.org/bugs/show_bug.cgi?id=322494

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JMC-7409](https://bugs.openjdk.java.net/browse/JMC-7409): Update the spotless maven plugin


### Reviewers
 * [Jean-Philippe Bempel](https://openjdk.java.net/census#jpbempel) (@jpbempel - Committer)
 * [Henrik Dafgård](https://openjdk.java.net/census#hdafgard) (@Gunde - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jmc pull/312/head:pull/312` \
`$ git checkout pull/312`

Update a local copy of the PR: \
`$ git checkout pull/312` \
`$ git pull https://git.openjdk.java.net/jmc pull/312/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 312`

View PR using the GUI difftool: \
`$ git pr show -t 312`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jmc/pull/312.diff">https://git.openjdk.java.net/jmc/pull/312.diff</a>

</details>
