### PR TITLE
7414: Avoid volatile writes from Atomics default values

### DIFF
--- a/agent/src/test/java/org/openjdk/jmc/agent/converters/test/TestConverterTransforms.java
+++ b/agent/src/test/java/org/openjdk/jmc/agent/converters/test/TestConverterTransforms.java
@@ -57,7 +57,7 @@ import org.openjdk.jmc.agent.impl.DefaultTransformRegistry;
 import org.openjdk.jmc.agent.test.util.TestToolkit;
 
 public class TestConverterTransforms {
-	private static AtomicInteger runCount = new AtomicInteger(0);
+	private static AtomicInteger runCount = new AtomicInteger();
 
 	public static String getTemplate() throws IOException {
 		return TestToolkit.readTemplate(TestConverterTransforms.class, TestToolkit.DEFAULT_TEMPLATE_NAME);

--- a/agent/src/test/java/org/openjdk/jmc/agent/test/TestJFRTransformer.java
+++ b/agent/src/test/java/org/openjdk/jmc/agent/test/TestJFRTransformer.java
@@ -57,7 +57,7 @@ import org.openjdk.jmc.agent.impl.DefaultTransformRegistry;
 import org.openjdk.jmc.agent.test.util.TestToolkit;
 
 public class TestJFRTransformer {
-	private static AtomicInteger runCount = new AtomicInteger(0);
+	private static AtomicInteger runCount = new AtomicInteger();
 
 	@Test
 	public void testRunTransforms()

--- a/application/org.openjdk.jmc.rjmx/src/main/java/org/openjdk/jmc/rjmx/internal/RJMXConnection.java
+++ b/application/org.openjdk.jmc.rjmx/src/main/java/org/openjdk/jmc/rjmx/internal/RJMXConnection.java
@@ -107,7 +107,7 @@ public class RJMXConnection implements Closeable, IMBeanHelperService {
 	 */
 	private static final long VALUE_RECALIBRATION_INTERVAL = 120000;
 	private static final long REMOTE_START_TIME_UNDEFINED = -1;
-	private static final AtomicInteger CONNECTION_COUNTER = new AtomicInteger(0);
+	private static final AtomicInteger CONNECTION_COUNTER = new AtomicInteger();
 
 	// The ConnectionDescriptor used to create this RJMXConnection
 	private final IConnectionDescriptor m_connectionDescriptor;

--- a/application/tests/org.openjdk.jmc.rjmx.test/src/test/java/org/openjdk/jmc/rjmx/test/synthetic/TestNotification.java
+++ b/application/tests/org.openjdk.jmc.rjmx.test/src/test/java/org/openjdk/jmc/rjmx/test/synthetic/TestNotification.java
@@ -45,7 +45,7 @@ import javax.management.openmbean.SimpleType;
 import org.openjdk.jmc.rjmx.subscription.internal.AbstractSyntheticNotification;
 
 public class TestNotification extends AbstractSyntheticNotification {
-	private final static AtomicInteger THREAD_ID_PROVIDER = new AtomicInteger(0);
+	private final static AtomicInteger THREAD_ID_PROVIDER = new AtomicInteger();
 	private final int notificationId = THREAD_ID_PROVIDER.getAndIncrement();
 	private final ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor(new ThreadFactory() {
 		@Override

--- a/core/org.openjdk.jmc.flightrecorder.writer/src/main/java/org/openjdk/jmc/flightrecorder/writer/RecordingImpl.java
+++ b/core/org.openjdk.jmc.flightrecorder.writer/src/main/java/org/openjdk/jmc/flightrecorder/writer/RecordingImpl.java
@@ -90,7 +90,7 @@ public final class RecordingImpl extends Recording {
 
 	private final OutputStream outputStream;
 
-	private final AtomicBoolean closed = new AtomicBoolean(false);
+	private final AtomicBoolean closed = new AtomicBoolean();
 
 	private final BlockingDeque<LEB128Writer> chunkDataQueue = new LinkedBlockingDeque<>();
 	private final ExecutorService chunkDataMergingService = Executors.newSingleThreadExecutor();


### PR DESCRIPTION
Hi,

this PR changes calls like `new AtomicInteger(0)` to `new AtomicInteger()` in order to avoid volatile writes.

This would need a ticket in the bug tracker and I hope you can create this for me. OCA should be signed already, but let me know if I need to confirm something again.

In case you think this is worthwhile, I would appreciate it if this is sponsored.

Cheers,
Christoph

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JMC-7414](https://bugs.openjdk.java.net/browse/JMC-7414): Avoid volatile writes from Atomics default values


### Reviewers
 * [Marcus Hirt](https://openjdk.java.net/census#hirt) (@thegreystone - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jmc pull/315/head:pull/315` \
`$ git checkout pull/315`

Update a local copy of the PR: \
`$ git checkout pull/315` \
`$ git pull https://git.openjdk.java.net/jmc pull/315/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 315`

View PR using the GUI difftool: \
`$ git pr show -t 315`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jmc/pull/315.diff">https://git.openjdk.java.net/jmc/pull/315.diff</a>

</details>
