### PR TITLE
7413: Fix building JMC with Docker

### DIFF
--- a/docker/Dockerfile-jmc
+++ b/docker/Dockerfile-jmc
@@ -1,4 +1,4 @@
-FROM openjdk:8-jdk-stretch AS builder
+FROM openjdk:11-jdk-buster AS builder
 
 RUN apt-get update && apt-get install -y maven
 

--- a/docker/Dockerfile-p2
+++ b/docker/Dockerfile-p2
@@ -1,4 +1,4 @@
-FROM openjdk:8-jdk-stretch
+FROM openjdk:11-jdk-buster
 
 RUN apt-get update && apt-get install -y maven
 


### PR DESCRIPTION
Hi,

I noticed that the Docker builds still point to JDK 8 and thus fail with messages like the following.

```
Caused by: java.lang.UnsupportedClassVersionError: org/eclipse/tycho/core/maven/TychoMavenLifecycleParticipant has been compiled by a more recent version of the Java Runtime (class file version 55.0), this version of the Java Runtime only recognizes class file versions up to 52.0
```

This PR therefore upgrades the Docker images to newer JDK 11 images, which fixes the issues described.

This would need a ticket in the bug tracker and I hope you can create this for me. OCA should be signed already, but let me know if I need to confirm something again.

In case you think this is worthwhile, I would appreciate it if this is sponsored.

Cheers,
Christoph

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JMC-7413](https://bugs.openjdk.java.net/browse/JMC-7413): Fix building JMC with Docker


### Reviewers
 * [Marcus Hirt](https://openjdk.java.net/census#hirt) (@thegreystone - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jmc pull/317/head:pull/317` \
`$ git checkout pull/317`

Update a local copy of the PR: \
`$ git checkout pull/317` \
`$ git pull https://git.openjdk.java.net/jmc pull/317/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 317`

View PR using the GUI difftool: \
`$ git pr show -t 317`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jmc/pull/317.diff">https://git.openjdk.java.net/jmc/pull/317.diff</a>

</details>
