### PR TITLE
7415: Fix Maven prerequisite in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ Prerequisites for building Mission Control:
 
 1. Install JDK 11, and make sure it is the JDK in use (java -version)
 
-2. Install Maven (version 3.3.x. or above)
+2. Install Maven (version 3.5.x. or above)
 
 On Linux or macOS you can use the build.sh script to build JMC:
 ```


### PR DESCRIPTION
Hi,

I just noticed that the minimum Maven prerequisite is wrong in the README. CI-friendly versions like `revision` and `changelist` are a feature of `3.5.x` and thus `3.3.x` is not sufficient anymore.

I hope you can create a ticket for me and sponsor this.

Cheers,
Christoph

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JMC-7415](https://bugs.openjdk.java.net/browse/JMC-7415): Fix Maven prerequisite in README


### Reviewers
 * [Marcus Hirt](https://openjdk.java.net/census#hirt) (@thegreystone - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jmc pull/318/head:pull/318` \
`$ git checkout pull/318`

Update a local copy of the PR: \
`$ git checkout pull/318` \
`$ git pull https://git.openjdk.java.net/jmc pull/318/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 318`

View PR using the GUI difftool: \
`$ git pr show -t 318`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jmc/pull/318.diff">https://git.openjdk.java.net/jmc/pull/318.diff</a>

</details>
