### PR TITLE
7091: JOverflow Instance View table should be sortable by clicking headers

### DIFF
--- a/application/org.openjdk.jmc.joverflow.ui/src/main/java/org/openjdk/jmc/joverflow/ui/viewers/JavaThingTreeViewer.java
+++ b/application/org.openjdk.jmc.joverflow.ui/src/main/java/org/openjdk/jmc/joverflow/ui/viewers/JavaThingTreeViewer.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2019, Red Hat Inc. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2021, Red Hat Inc. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -42,9 +42,12 @@ import org.eclipse.jface.viewers.ColumnLabelProvider;
 import org.eclipse.jface.viewers.ITreeContentProvider;
 import org.eclipse.jface.viewers.TreeViewer;
 import org.eclipse.jface.viewers.TreeViewerColumn;
+import org.eclipse.jface.viewers.Viewer;
+import org.eclipse.jface.viewers.ViewerComparator;
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.events.SelectionEvent;
+import org.eclipse.swt.events.SelectionListener;
 import org.eclipse.swt.widgets.Composite;
-
 import org.openjdk.jmc.joverflow.heap.model.JavaField;
 import org.openjdk.jmc.joverflow.heap.model.JavaObject;
 import org.openjdk.jmc.joverflow.heap.model.JavaObjectArray;
@@ -53,17 +56,49 @@ import org.openjdk.jmc.joverflow.heap.model.JavaValueArray;
 import org.openjdk.jmc.joverflow.ui.model.JavaThingItem;
 
 public class JavaThingTreeViewer<T extends JavaThingItem> extends TreeViewer {
+	private static final String ELLIPSIS = "..."; //$NON-NLS-1$
+	private static final String NAME_COLUMN = "Name"; //$NON-NLS-1$
+	private static final String SIZE_COLUMN = "Size"; //$NON-NLS-1$
+	private static final String VALUE_COLUMN = "Value"; //$NON-NLS-1$
+
 	public JavaThingTreeViewer(Composite parent, int style) {
 		super(parent, style);
 
 		setContentProvider(new JavaThingItemContentProvider());
 
-		createTreeViewerColumn("Name", T::getName);
-		createTreeViewerColumn("Value", T::getValue);
-		createTreeViewerColumn("Size", T::getSize);
+		createTreeViewerColumn(NAME_COLUMN, T::getName);
+		createTreeViewerColumn(VALUE_COLUMN, T::getValue);
+		createTreeViewerColumn(SIZE_COLUMN, T::getSize);
 
 		getTree().setLinesVisible(true);
 		getTree().setHeaderVisible(true);
+
+		setComparator(new ViewerComparator() {
+			@Override
+			public int compare(Viewer viewer, Object e1, Object e2) {
+				JavaThingItem item1 = (JavaThingItem) e1;
+				JavaThingItem item2 = (JavaThingItem) e2;
+				// keep the overflow ellipsis row at the bottom of the view
+				if (item1.getName().equals(ELLIPSIS)) {
+					return SWT.MAX;
+				} else if (item2.getName().equals(ELLIPSIS)) {
+					return -SWT.MAX;
+				}
+				int result = 0;
+				int sortDirection = getTree().getSortDirection() == SWT.UP ? 1
+						: getTree().getSortDirection() == SWT.DOWN ? -1 : SWT.NONE;
+				if (getTree().getSortColumn() != null) {
+					if (getTree().getSortColumn().getText().equals(NAME_COLUMN)) {
+						result = item1.getName().compareTo(item2.getName());
+					} else if (getTree().getSortColumn().getText().equals(VALUE_COLUMN)) {
+						result = item1.getValue().compareTo(item2.getValue());
+					} else if (getTree().getSortColumn().getText().equals(SIZE_COLUMN)) {
+						result = Integer.parseInt(item1.getSize()) - Integer.parseInt(item2.getSize());
+					}
+				}
+				return result * sortDirection;
+			}
+		});
 	}
 
 	private void createTreeViewerColumn(String label, Function<T, String> labelProvider) {
@@ -77,6 +112,24 @@ public class JavaThingTreeViewer<T extends JavaThingItem> extends TreeViewer {
 			@Override
 			public String getText(Object element) {
 				return labelProvider.apply((T) element);
+			}
+		});
+
+		column.getColumn().addSelectionListener(new SelectionListener() {
+			@Override
+			public void widgetSelected(SelectionEvent e) {
+				int newSortDirection = SWT.DOWN;
+				if (getTree().getSortColumn() != null
+						&& getTree().getSortColumn().getText().equals(column.getColumn().getText())) {
+					newSortDirection = getTree().getSortDirection() == SWT.UP ? SWT.DOWN : SWT.UP;
+				}
+				getTree().setSortColumn(column.getColumn());
+				getTree().setSortDirection(newSortDirection);
+				refresh();
+			}
+
+			@Override
+			public void widgetDefaultSelected(SelectionEvent e) {
 			}
 		});
 	}


### PR DESCRIPTION
This PR addresses JMC-7091 [[0]](https://bugs.openjdk.java.net/browse/JMC-7091), in which the tree viewer in the JOverflow instances tab does not allow the table to be sorted via the column headers. Currently the viewer column headers do not perform any action when clicked. Now a comparator have been added to the viewer which sorts based on the column header (String comparison for the Name & Value columns, Integer for the Size column).

Screenshot:
![2021-10-14-142941_1074x516_scrot](https://user-images.githubusercontent.com/10425301/137375980-daa9e849-5aec-41c8-9cb5-00104a15e682.png)

Gif:
![7091](https://user-images.githubusercontent.com/10425301/137375958-a9186bf8-36ea-43e3-91b5-ee85aaca9037.gif)

[0] https://bugs.openjdk.java.net/browse/JMC-7091

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JMC-7091](https://bugs.openjdk.java.net/browse/JMC-7091): JOverflow Instance View table should be sortable by clicking headers


### Reviewers
 * [Marcus Hirt](https://openjdk.java.net/census#hirt) (@thegreystone - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jmc pull/322/head:pull/322` \
`$ git checkout pull/322`

Update a local copy of the PR: \
`$ git checkout pull/322` \
`$ git pull https://git.openjdk.java.net/jmc pull/322/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 322`

View PR using the GUI difftool: \
`$ git pr show -t 322`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jmc/pull/322.diff">https://git.openjdk.java.net/jmc/pull/322.diff</a>

</details>
