### PR TITLE
7435: Update the maven enforcer plugin

### DIFF
--- a/agent/pom.xml
+++ b/agent/pom.xml
@@ -293,7 +293,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-enforcer-plugin</artifactId>
-				<version>3.0.0-M2</version>
+				<version>3.0.0</version>
 				<executions>
 					<execution>
 						<id>enforce-java</id>

--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,7 @@
 		<maven.buildnumber.version>1.4</maven.buildnumber.version>
 		<maven.deploy.version>2.8.2</maven.deploy.version>
 		<maven.directory.version>0.3.1</maven.directory.version>
-		<maven.enforcer.version>3.0.0-M1</maven.enforcer.version>
+		<maven.enforcer.version>3.0.0</maven.enforcer.version>
 		<maven.resources.version>3.2.0</maven.resources.version>
 		<spotless.version>2.17.2</spotless.version>
 		<spotless.config.path>${basedir}/configuration/ide/eclipse/formatting/formatting.xml</spotless.config.path>

--- a/releng/third-party/pom.xml
+++ b/releng/third-party/pom.xml
@@ -48,7 +48,7 @@
 		<jemmy.version>2.0.0</jemmy.version>
 		<jetty-maven-plugin.version>9.4.33.v20201020</jetty-maven-plugin.version>
 		<lz4.version>1.7.1</lz4.version>
-		<maven-enforcer-plugin.version>3.0.0-M3</maven-enforcer-plugin.version>
+		<maven-enforcer-plugin.version>3.0.0</maven-enforcer-plugin.version>
 		<owasp.encoder.version>1.2.2</owasp.encoder.version>
 		<p2-maven-plugin.version>1.5.0</p2-maven-plugin.version>
 		<twitter4j.core.version>4.0.7</twitter4j.core.version>


### PR DESCRIPTION
Signed-off-by: Patrick Reinhart <patrick@reini.net>

Use latest released final version.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JMC-7435](https://bugs.openjdk.java.net/browse/JMC-7435): Update the maven enforcer plugin


### Reviewers
 * [Marcus Hirt](https://openjdk.java.net/census#hirt) (@thegreystone - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jmc pull/327/head:pull/327` \
`$ git checkout pull/327`

Update a local copy of the PR: \
`$ git checkout pull/327` \
`$ git pull https://git.openjdk.java.net/jmc pull/327/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 327`

View PR using the GUI difftool: \
`$ git pr show -t 327`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jmc/pull/327.diff">https://git.openjdk.java.net/jmc/pull/327.diff</a>

</details>
