### PR TITLE
7437: Fix require bundle error in Eclipse

### DIFF
--- a/core/tests/org.openjdk.jmc.flightrecorder.rules.test/META-INF/MANIFEST.MF
+++ b/core/tests/org.openjdk.jmc.flightrecorder.rules.test/META-INF/MANIFEST.MF
@@ -10,5 +10,5 @@ Require-Bundle: org.junit,
  org.openjdk.jmc.common.test,
  org.openjdk.jmc.flightrecorder,
  org.openjdk.jmc.flightrecorder.test,
- org.openjdk.jmc.flightrecorder.rules,
+ org.openjdk.jmc.flightrecorder.rules
 Automatic-Module-Name: org.openjdk.jmc.flightrecorder.rules.test


### PR DESCRIPTION
Removing extra comma making Eclipse complain.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JMC-7437](https://bugs.openjdk.java.net/browse/JMC-7437): Fix require bundle error in Eclipse


### Reviewers
 * [Alex Macdonald](https://openjdk.java.net/census#aptmac) (@aptmac - Committer)
 * [Henrik Dafgård](https://openjdk.java.net/census#hdafgard) (@Gunde - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jmc pull/331/head:pull/331` \
`$ git checkout pull/331`

Update a local copy of the PR: \
`$ git checkout pull/331` \
`$ git pull https://git.openjdk.java.net/jmc pull/331/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 331`

View PR using the GUI difftool: \
`$ git pr show -t 331`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jmc/pull/331.diff">https://git.openjdk.java.net/jmc/pull/331.diff</a>

</details>
