### PR TITLE
7440: JMC fails on Apple M1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -252,6 +252,11 @@
 							<ws>cocoa</ws>
 							<arch>x86_64</arch>
 						</environment>
+						<environment>
+							<os>macosx</os>
+							<ws>cocoa</ws>
+							<arch>aarch64</arch>
+						</environment>
 					</environments>
 				</configuration>
 			</plugin>
@@ -523,13 +528,34 @@
 							</configuration>
 						</execution>
 						<execution>
-							<id>copy-resources-to-mac</id>
+							<id>copy-resources-to-mac-x86_64</id>
 							<phase>prepare-package</phase>
 							<goals>
 								<goal>copy-resources</goal>
 							</goals>
 							<configuration>
 								<outputDirectory>${project.build.directory}/products/org.openjdk.jmc/macosx/cocoa/x86_64/legal
+								</outputDirectory>
+								<resources>
+									<resource>
+										<directory>${rootDir}/license</directory>
+										<includes>
+											<include>LICENSE.txt</include>
+											<include>THIRDPARTYREADME.txt</include>
+											<include>COPYRIGHT</include>
+										</includes>
+									</resource>
+								</resources>
+							</configuration>
+						</execution>
+						<execution>
+							<id>copy-resources-to-mac-aarch64</id>
+							<phase>prepare-package</phase>
+							<goals>
+								<goal>copy-resources</goal>
+							</goals>
+							<configuration>
+								<outputDirectory>${project.build.directory}/products/org.openjdk.jmc/macosx/cocoa/aarch64/legal
 								</outputDirectory>
 								<resources>
 									<resource>


### PR DESCRIPTION
I would like to add support for the macOS AArch64 platform to JMC. 
Please review this change!

Our build for macOS AArch64 can be downloaded from here: 
https://www.azul.com/products/components/zulu-mission-control/#block-download

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JMC-7440](https://bugs.openjdk.java.net/browse/JMC-7440): JMC fails on Apple M1


### Reviewers
 * [Marcus Hirt](https://openjdk.java.net/census#hirt) (@thegreystone - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jmc pull/334/head:pull/334` \
`$ git checkout pull/334`

Update a local copy of the PR: \
`$ git checkout pull/334` \
`$ git pull https://git.openjdk.java.net/jmc pull/334/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 334`

View PR using the GUI difftool: \
`$ git pr show -t 334`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jmc/pull/334.diff">https://git.openjdk.java.net/jmc/pull/334.diff</a>

</details>
