### PR TITLE
7447: Add serializers and writer modules to core test coverage

### DIFF
--- a/core/coverage/pom.xml
+++ b/core/coverage/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-   Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
-   Copyright (c) 2019, 2020, Red Hat Inc. All rights reserved.
+   Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
+   Copyright (c) 2019, 2021, Red Hat Inc. All rights reserved.
 
    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
@@ -71,6 +71,16 @@
 		</dependency>
 		<dependency>
 			<groupId>org.openjdk.jmc</groupId>
+			<artifactId>flightrecorder.serializers</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.openjdk.jmc</groupId>
+			<artifactId>flightrecorder.writer</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.openjdk.jmc</groupId>
 			<artifactId>jdp</artifactId>
 			<version>${project.version}</version>
 		</dependency>
@@ -102,7 +112,20 @@
 		</dependency>
 		<dependency>
 			<groupId>org.openjdk.jmc</groupId>
+			<artifactId>flightrecorder.serializers.test</artifactId>
+			<scope>test</scope>
+			<version>${project.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.openjdk.jmc</groupId>
+			<artifactId>flightrecorder.writer.test</artifactId>
+			<scope>test</scope>
+			<version>${project.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.openjdk.jmc</groupId>
 			<artifactId>jdp.test</artifactId>
+			<scope>test</scope>
 			<version>${project.version}</version>
 		</dependency>
 	</dependencies>


### PR DESCRIPTION
This PR addresses JMC-7447 [[0]](https://bugs.openjdk.java.net/browse/JMC-7447), in which the core coverage reports are missing the serializers and writer modules. The changes here simply add the missing modules to the coverage dependency list.

Additionally, the jdp.test module is missing the `<scope>test</scope>` attribute, so I've added it in here.

[0] https://bugs.openjdk.java.net/browse/JMC-7447

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JMC-7447](https://bugs.openjdk.java.net/browse/JMC-7447): Add serializers and writer modules to core test coverage


### Reviewers
 * [Marcus Hirt](https://openjdk.java.net/census#hirt) (@thegreystone - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jmc pull/335/head:pull/335` \
`$ git checkout pull/335`

Update a local copy of the PR: \
`$ git checkout pull/335` \
`$ git pull https://git.openjdk.java.net/jmc pull/335/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 335`

View PR using the GUI difftool: \
`$ git pr show -t 335`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jmc/pull/335.diff">https://git.openjdk.java.net/jmc/pull/335.diff</a>

</details>
