### PR TITLE
7446: Add Maven profile for enabling test coverage

### DIFF
--- a/application/coverage/pom.xml
+++ b/application/coverage/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!--
-   Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
-   Copyright (c) 2019, 2020, Red Hat Inc. All rights reserved.
+   Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
+   Copyright (c) 2019, 2021, Red Hat Inc. All rights reserved.
 
    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
@@ -39,7 +39,7 @@
 		<artifactId>missioncontrol.application</artifactId>
 		<version>${revision}${changelist}</version>
 	</parent>
-	<artifactId>coverage</artifactId>
+	<artifactId>coverage.application</artifactId>
 	<name>Code coverage report jmc/application</name>
 	<packaging>pom</packaging>
 
@@ -48,6 +48,11 @@
 	</properties>
 
 	<dependencies>
+		<dependency>
+			<groupId>org.jacoco</groupId>
+			<artifactId>jacoco-maven-plugin</artifactId>
+			<version>0.8.7</version>
+		</dependency>
 		<!-- First all the modules in application/ -->
 		<dependency>
 			<groupId>org.openjdk.jmc</groupId>
@@ -490,7 +495,7 @@
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.8.7</version>
+				<version>${jacoco.plugin.version}</version>
 				<executions>
 					<execution>
 						<id>report-aggregate</id>

--- a/application/pom.xml
+++ b/application/pom.xml
@@ -45,6 +45,7 @@
 		<spotless.config.path>${basedir}/../configuration/ide/eclipse/formatting/formatting.xml</spotless.config.path>
 		<jfr.tests/>
 		<jfr.vmargs>-XX:+FlightRecorder</jfr.vmargs>
+		<jacoco.plugin.version>0.8.7</jacoco.plugin.version>
 	</properties>
 
 	<modules>
@@ -116,9 +117,14 @@
 		<module>org.openjdk.jmc.updatesite.rcp</module>
 		<module>l10n</module>
 		<module>tests</module>
-		<module>coverage</module>
 	</modules>
 	<profiles>
+		<profile>
+			<id>coverage</id>
+			<modules>
+				<module>coverage</module>
+			</modules>
+		</profile>
 		<profile>
 			<id>no-jfr</id>
 			<activation>
@@ -180,11 +186,6 @@
 			<groupId>org.openjdk.jmc</groupId>
 			<artifactId>flightrecorder.test</artifactId>
 			<version>${revision}${changelist}</version>
-		</dependency>
-		<dependency>
-			<groupId>org.jacoco</groupId>
-			<artifactId>jacoco-maven-plugin</artifactId>
-			<version>0.8.7</version>
 		</dependency>
 	</dependencies>
 	<build>

--- a/application/tests/pom.xml
+++ b/application/tests/pom.xml
@@ -105,32 +105,39 @@
 				<test.excludes>${test.excludes.default}</test.excludes>
 			</properties>
 		</profile>
+		<profile>
+			<id>coverage</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.jacoco</groupId>
+						<artifactId>jacoco-maven-plugin</artifactId>
+						<version>${jacoco.plugin.version}</version>
+						<executions>
+							<execution>
+								<id>pre-unit-test</id>
+								<goals>
+									<goal>prepare-agent</goal>
+								</goals>
+								<configuration>
+									<propertyName>surefireArgLine</propertyName>
+								</configuration>
+							</execution>
+							<execution>
+								<id>post-unit-test</id>
+								<phase>verify</phase>
+								<goals>
+									<goal>report</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
 	</profiles>
 	<build>
 		<plugins>
-			<plugin>
-				<groupId>org.jacoco</groupId>
-				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.8.7</version>
-				<executions>
-					<execution>
-						<id>pre-unit-test</id>
-						<goals>
-							<goal>prepare-agent</goal>
-						</goals>
-						<configuration>
-							<propertyName>surefireArgLine</propertyName>
-						</configuration>
-					</execution>
-					<execution>
-					        <id>post-unit-test</id>
-					        <phase>verify</phase>
-					        <goals>
-					                <goal>report</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
 			<plugin>
 				<groupId>org.eclipse.tycho</groupId>
 				<artifactId>tycho-surefire-plugin</artifactId>

--- a/application/uitests/pom.xml
+++ b/application/uitests/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--   
-   Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+   Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
    
    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
    
@@ -50,7 +50,6 @@
 		<test.excludes.default>**/*$*</test.excludes.default>
 		<ui.test.excludes>**/uitest/**,${test.excludes.default}</ui.test.excludes>
 		<spotless.config.path>${basedir}/../../configuration/ide/eclipse/formatting/formatting.xml</spotless.config.path>
-		<jacoco.plugin.version>0.8.7</jacoco.plugin.version>
 		<jmc.version>${revision}${changelist}</jmc.version>
 	</properties>
 	
@@ -157,32 +156,56 @@
 				<ui.test.osappargs>--launcher.appendVmargs</ui.test.osappargs>
 			</properties>
 		</profile>
+		<profile>
+			<id>coverage</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.jacoco</groupId>
+						<artifactId>jacoco-maven-plugin</artifactId>
+						<version>${jacoco.plugin.version}</version>
+						<executions>
+							<execution>
+								<id>pre-unit-test</id>
+								<goals>
+									<goal>prepare-agent</goal>
+								</goals>
+								<configuration>
+									<propertyName>surefireArgLine</propertyName>
+								</configuration>
+							</execution>
+							<execution>
+								<id>post-unit-test</id>
+								<phase>verify</phase>
+								<goals>
+									<goal>report</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+					<plugin>
+						<groupId>org.eclipse.tycho</groupId>
+						<artifactId>tycho-surefire-plugin</artifactId>
+						<version>${tycho.version}</version>
+						<configuration>
+							<product>org.openjdk.jmc.rcp.application.product</product>
+							<application>org.openjdk.jmc.rcp.application.app</application>
+							<argLine>${ui.test.vmargs} ${ui.test.osvmargs} ${surefireArgLine}</argLine>
+							<appArgLine>-nl en -consoleLog ${ui.test.osappargs}</appArgLine>
+							<useUIHarness>${ui.test.run}</useUIHarness>
+							<useUIThread>false</useUIThread>
+							<failIfNoTests>false</failIfNoTests>
+							<includes>${test.includes}</includes>
+							<!--  To be used along with the maven toolchains plugin
+							<useJDK>SYSTEM</useJDK> -->
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
 	</profiles>
 	<build>
 		<plugins>
-			<plugin>
-				<groupId>org.jacoco</groupId>
-				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>${jacoco.plugin.version}</version>
-				<executions>
-					<execution>
-						<id>pre-unit-test</id>
-						<goals>
-							<goal>prepare-agent</goal>
-						</goals>
-						<configuration>
-							<propertyName>surefireArgLine</propertyName>
-						</configuration>
-					</execution>
-					<execution>
-						<id>post-unit-test</id>
-						<phase>verify</phase>
-						<goals>
-							<goal>report</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
 			<plugin>
 				<groupId>org.eclipse.tycho</groupId>
 				<artifactId>tycho-surefire-plugin</artifactId>
@@ -190,11 +213,10 @@
 				<configuration>
 					<product>org.openjdk.jmc.rcp.application.product</product>
 					<application>org.openjdk.jmc.rcp.application.app</application>
-					<argLine>${ui.test.vmargs} ${ui.test.osvmargs} ${surefireArgLine}</argLine>
+					<argLine>${ui.test.vmargs} ${ui.test.osvmargs}</argLine>
 					<appArgLine>-nl en -consoleLog ${ui.test.osappargs}</appArgLine>
 					<useUIHarness>${ui.test.run}</useUIHarness>
 					<useUIThread>false</useUIThread>
-					<testFailureIgnore>false</testFailureIgnore>
 					<failIfNoTests>false</failIfNoTests>
 					<includes>${test.includes}</includes>
 					<!--  To be used along with the maven toolchains plugin

--- a/core/coverage/pom.xml
+++ b/core/coverage/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-   Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
-   Copyright (c) 2019, 2020, Red Hat Inc. All rights reserved.
+   Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
+   Copyright (c) 2019, 2021, Red Hat Inc. All rights reserved.
 
    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
@@ -39,7 +39,7 @@
 		<artifactId>missioncontrol.core</artifactId>
 		<version>${revision}${changelist}</version>
 	</parent>
-	<artifactId>coverage</artifactId>
+	<artifactId>coverage.core</artifactId>
 	<name>Code coverage report jmc/core</name>
 	<packaging>pom</packaging>
 
@@ -111,7 +111,7 @@
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.8.7</version>
+				<version>${jacoco.plugin.version}</version>
 				<executions>
 					<execution>
 						<id>report-aggregate</id>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -56,6 +56,7 @@
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>
 		<manifest-location>META-INF</manifest-location>
+		<jacoco.plugin.version>0.8.7</jacoco.plugin.version>
 		<maven.jar.version>3.2.0</maven.jar.version>
 		<maven.bundle.version>5.1.1</maven.bundle.version>
 		<spotless.version>2.14.0</spotless.version>
@@ -116,8 +117,15 @@
 		<module>org.openjdk.jmc.flightrecorder.writer</module>
 		<module>org.openjdk.jmc.jdp</module>
 		<module>tests</module>
-		<module>coverage</module>
 	</modules>
+	<profiles>
+		<profile>
+			<id>coverage</id>
+			<modules>
+				<module>coverage</module>
+			</modules>
+		</profile>
+	</profiles>
 	<distributionManagement>
 		<repository>
 			<id>jmc-publish</id>

--- a/core/tests/pom.xml
+++ b/core/tests/pom.xml
@@ -65,6 +65,7 @@
 		<mockito.core.version>3.7.7</mockito.core.version>
 		<mockito.inline.version>3.7.7</mockito.inline.version>
 		<build.helper.maven.version>3.2.0</build.helper.maven.version>
+		<surefireArgLine></surefireArgLine>
 	</properties>
 	<profiles>
 		<profile>
@@ -111,6 +112,36 @@
 				<test.excludes>${test.excludes.default}</test.excludes>
 			</properties>
 		</profile>
+		<profile>
+			<id>coverage</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.jacoco</groupId>
+						<artifactId>jacoco-maven-plugin</artifactId>
+						<version>${jacoco.plugin.version}</version>
+						<executions>
+							<execution>
+								<id>pre-unit-test</id>
+								<goals>
+									<goal>prepare-agent</goal>
+								</goals>
+								<configuration>
+									<propertyName>surefireArgLine</propertyName>
+								</configuration>
+							</execution>
+							<execution>
+								<id>post-unit-test</id>
+								<phase>verify</phase>
+								<goals>
+									<goal>report</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
 	</profiles>
 	<dependencyManagement>
 		<dependencies>
@@ -125,34 +156,11 @@
 	<build>
 		<plugins>
 			<plugin>
-				<groupId>org.jacoco</groupId>
-				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.8.6</version>
-				<executions>
-					<execution>
-						<id>pre-unit-test</id>
-						<goals>
-							<goal>prepare-agent</goal>
-						</goals>
-						<configuration>
-							<propertyName>surefireArgLine</propertyName>
-						</configuration>
-					</execution>
-					<execution>
-						<id>post-unit-test</id>
-						<phase>verify</phase>
-						<goals>
-							<goal>report</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
 				<version>2.22.0</version>
 				<configuration>
-					<argLine>-Duser.language=en -Duser.region=nl -Duser.timezone=GMT -Djava.locale.providers=COMPAT ${surefireArgLine}</argLine>
+					<argLine>-Duser.language=en -Duser.region=nl -Duser.timezone=GMT -Djava.locale.providers=COMPAT @{surefireArgLine}</argLine>
 					<includes>${test.includes}</includes>
 					<excludes>${test.excludes}</excludes>
 					<failIfNoTests>${fail.if.no.tests}</failIfNoTests>


### PR DESCRIPTION
This PR addresses JMC-7446 [[0]](https://bugs.openjdk.java.net/browse/JMC-7446), in which it would be nice to have a Maven profile for enabling test coverage.

At the moment, test coverage is enabled by default with no way of disabling it. This PR adds a Maven profile (in a similar vein to how uitests are run) that allows coverage reports to be enabled or disabled as desired. This profile is included in both the core and application poms.

Usage: `mvn clean install -P coverage`, or `mvn clean verify -P coverage -P uitests`, etc.

[0] https://bugs.openjdk.java.net/browse/JMC-7446

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JMC-7446](https://bugs.openjdk.java.net/browse/JMC-7446): Add Maven profile for enabling test coverage


### Reviewers
 * [Marcus Hirt](https://openjdk.java.net/census#hirt) (@thegreystone - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jmc pull/336/head:pull/336` \
`$ git checkout pull/336`

Update a local copy of the PR: \
`$ git checkout pull/336` \
`$ git pull https://git.openjdk.java.net/jmc pull/336/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 336`

View PR using the GUI difftool: \
`$ git pr show -t 336`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jmc/pull/336.diff">https://git.openjdk.java.net/jmc/pull/336.diff</a>

</details>
