### PR TITLE
7463: JfrEditor instances are kept in memory by NavigationHistory

### DIFF
--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/JfrEditor.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/JfrEditor.java
@@ -407,7 +407,7 @@ public class JfrEditor extends EditorPart implements INavigationLocationProvider
 
 	@Override
 	public INavigationLocation createEmptyNavigationLocation() {
-		return new JfrNavigationLocation(this);
+		return new JfrNavigationLocation(this, null);
 	}
 
 	@Override
@@ -415,7 +415,7 @@ public class JfrEditor extends EditorPart implements INavigationLocationProvider
 		if (currentPage == null) {
 			return null;
 		}
-		return new JfrNavigationLocation(this);
+		return new JfrNavigationLocation(this, currentPage);
 	}
 
 	@Override

--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/JfrEditor.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/JfrEditor.java
@@ -407,7 +407,7 @@ public class JfrEditor extends EditorPart implements INavigationLocationProvider
 
 	@Override
 	public INavigationLocation createEmptyNavigationLocation() {
-		return new JfrNavigationLocation(this, null);
+		return new JfrNavigationLocation(this);
 	}
 
 	@Override
@@ -415,7 +415,7 @@ public class JfrEditor extends EditorPart implements INavigationLocationProvider
 		if (currentPage == null) {
 			return null;
 		}
-		return new JfrNavigationLocation(this, currentPage);
+		return new JfrNavigationLocation(this);
 	}
 
 	@Override

--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/JfrNavigationLocation.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/JfrNavigationLocation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -34,26 +34,13 @@ package org.openjdk.jmc.flightrecorder.ui;
 
 import org.eclipse.ui.IMemento;
 import org.eclipse.ui.INavigationLocation;
+import org.eclipse.ui.NavigationLocation;
 
-class JfrNavigationLocation implements INavigationLocation {
-
-	private final JfrEditor m_editor;
-	private final DataPageDescriptor m_page;
-
+class JfrNavigationLocation extends NavigationLocation {
 	private boolean m_disposed;
 
-	public JfrNavigationLocation(JfrEditor editor, DataPageDescriptor page) {
-		m_editor = editor;
-		m_page = page;
-	}
-
-	@Override
-	public void dispose() {
-		m_disposed = true;
-	}
-
-	@Override
-	public void releaseState() {
+	public JfrNavigationLocation(JfrEditor editor) {
+		super(editor);
 	}
 
 	@Override
@@ -62,14 +49,17 @@ class JfrNavigationLocation implements INavigationLocation {
 
 	@Override
 	public void restoreState(IMemento memento) {
+
+	}
+
+	@Override
+	public void releaseState() {
+		super.releaseState();
 		m_disposed = true;
 	}
 
 	@Override
 	public void restoreLocation() {
-		if (!m_disposed) {
-			m_editor.navigateTo(m_page);
-		}
 	}
 
 	@Override
@@ -79,33 +69,13 @@ class JfrNavigationLocation implements INavigationLocation {
 		}
 		if (currentLocation instanceof JfrNavigationLocation) {
 			JfrNavigationLocation that = (JfrNavigationLocation) currentLocation;
-			return that.m_editor == m_editor && that.m_page == m_page;
+			return that.getInput() == this.getInput();
 
 		}
 		return false;
 	}
 
 	@Override
-	public Object getInput() {
-		return null;
-	}
-
-	@Override
-	public String getText() {
-		return m_page.getName() + " [" + m_editor.getPartName() + "]"; //$NON-NLS-1$ //$NON-NLS-2$
-	}
-
-	@Override
-	public String toString() {
-		return super.toString() + '[' + getText() + ']';
-	}
-
-	@Override
-	public void setInput(Object input) {
-	}
-
-	@Override
 	public void update() {
 	}
-
 }

--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/JfrNavigationLocation.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/JfrNavigationLocation.java
@@ -37,10 +37,15 @@ import org.eclipse.ui.INavigationLocation;
 import org.eclipse.ui.NavigationLocation;
 
 class JfrNavigationLocation extends NavigationLocation {
+	private JfrEditor jfrEditor;
+	private DataPageDescriptor page;
 	private boolean m_disposed;
 
-	public JfrNavigationLocation(JfrEditor editor) {
+	public JfrNavigationLocation(JfrEditor editor, DataPageDescriptor page) {
 		super(editor);
+		this.jfrEditor = editor;
+		this.page = page;
+
 	}
 
 	@Override
@@ -55,11 +60,16 @@ class JfrNavigationLocation extends NavigationLocation {
 	@Override
 	public void releaseState() {
 		super.releaseState();
+		jfrEditor = null;
+		page = null;
 		m_disposed = true;
 	}
 
 	@Override
 	public void restoreLocation() {
+		if (!m_disposed) {
+			jfrEditor.navigateTo(page);
+		}
 	}
 
 	@Override
@@ -69,7 +79,7 @@ class JfrNavigationLocation extends NavigationLocation {
 		}
 		if (currentLocation instanceof JfrNavigationLocation) {
 			JfrNavigationLocation that = (JfrNavigationLocation) currentLocation;
-			return that.getInput() == this.getInput();
+			return that.getInput() == this.getInput() && that.page == page;
 
 		}
 		return false;


### PR DESCRIPTION
Provide a sub class of NavigationHistory instead of implementing a
full INavigationHistory.
JfrEditor is not kept anymore when releasing state/disposing.

Provide a sub class of NavigationHistory instead of implementing a
full INavigationHistory.
JfrEditor is not kept anymore when releasing state/disposing.

JMC 8.1, opening 13 recordings, then closing them:
```
COMP11909:~/git/jmc-jpbempel$ jcmd 55089 GC.heap_info
55089:
 garbage-first heap   total 989184K, used 488772K [0x0000000700000000, 0x0000000800000000)
  region size 1024K, 1 young (1024K), 0 survivors (0K)
 Metaspace       used 60486K, capacity 65423K, committed 65584K, reserved 1105920K
  class space    used 6822K, capacity 8453K, committed 8576K, reserved 1048576K
COMP11909:~/git/jmc-jpbempel$ jcmd 55089 GC.run
55089:
Command executed successfully
COMP11909:~/git/jmc-jpbempel$ jcmd 55089 GC.heap_info
55089:
 garbage-first heap   total 989184K, used 488410K [0x0000000700000000, 0x0000000800000000)
  region size 1024K, 1 young (1024K), 0 survivors (0K)
 Metaspace       used 61621K, capacity 66457K, committed 66736K, reserved 1107968K
  class space    used 6938K, capacity 8583K, committed 8704K, reserved 1048576K
```
memory is not released even after GC

JMC 8.2 + fix:
```
COMP11909:~/git/jmc-jpbempel$ jcmd 56259 GC.heap_info
56259:
 garbage-first heap   total 1625088K, used 556392K [0x0000000700000000, 0x0000000800000000)
  region size 1024K, 1 young (1024K), 0 survivors (0K)
 Metaspace       used 61931K, capacity 66724K, committed 66992K, reserved 1107968K
  class space    used 6991K, capacity 8586K, committed 8704K, reserved 1048576K
COMP11909:~/git/jmc-jpbempel$ jcmd 56259 GC.run
56259:
Command executed successfully
COMP11909:~/git/jmc-jpbempel$ jcmd 56259 GC.heap_info
56259:
 garbage-first heap   total 109568K, used 28592K [0x0000000700000000, 0x0000000800000000)
  region size 1024K, 1 young (1024K), 0 survivors (0K)
 Metaspace       used 62269K, capacity 67053K, committed 67248K, reserved 1107968K
  class space    used 6994K, capacity 8588K, committed 8704K, reserved 1048576K
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JMC-7463](https://bugs.openjdk.java.net/browse/JMC-7463): JfrEditor instances are kept in memory by NavigationHistory


### Reviewers
 * [Marcus Hirt](https://openjdk.java.net/census#hirt) (@thegreystone - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jmc pull/338/head:pull/338` \
`$ git checkout pull/338`

Update a local copy of the PR: \
`$ git checkout pull/338` \
`$ git pull https://git.openjdk.java.net/jmc pull/338/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 338`

View PR using the GUI difftool: \
`$ git pr show -t 338`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jmc/pull/338.diff">https://git.openjdk.java.net/jmc/pull/338.diff</a>

</details>
