### PR TITLE
7468: Fix jdp test coverage

### DIFF
--- a/core/tests/org.openjdk.jmc.jdp.test/pom.xml
+++ b/core/tests/org.openjdk.jmc.jdp.test/pom.xml
@@ -64,7 +64,7 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
 				<configuration>
-					<argLine>-Djava.net.preferIPv4Stack=true</argLine>
+					<argLine>-Djava.net.preferIPv4Stack=true @{surefireArgLine}</argLine>
 				</configuration>
 			</plugin>
 		</plugins>


### PR DESCRIPTION
This PR addresses JMC-7468 [[0]](https://bugs.openjdk.java.net/browse/JMC-7468), in which the jdp test coverage is not added to the core coverage report.

The one-liner fix here is to make sure the argLine used by Jacoco is not overwritten by the surefire-plugin in the jdp.test pom.

Before (0%):
![2021-12-03-141742_1091x251_scrot](https://user-images.githubusercontent.com/10425301/144663611-4424aae8-947c-4006-a26d-335ab325bfef.png)

After (60%):
![2021-12-03-144244_1092x258_scrot](https://user-images.githubusercontent.com/10425301/144663625-5fc72bc8-c243-4f86-b00a-6f9d6a8cc3e7.png)

[0] https://bugs.openjdk.java.net/browse/JMC-7468

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JMC-7468](https://bugs.openjdk.java.net/browse/JMC-7468): Fix jdp test coverage


### Reviewers
 * [Marcus Hirt](https://openjdk.java.net/census#hirt) (@thegreystone - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jmc pull/340/head:pull/340` \
`$ git checkout pull/340`

Update a local copy of the PR: \
`$ git checkout pull/340` \
`$ git pull https://git.openjdk.java.net/jmc pull/340/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 340`

View PR using the GUI difftool: \
`$ git pr show -t 340`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jmc/pull/340.diff">https://git.openjdk.java.net/jmc/pull/340.diff</a>

</details>
