### PR TITLE
7469: Upgrade third parties to latest versions

### DIFF
--- a/application/org.openjdk.jmc.rjmx/META-INF/MANIFEST.MF
+++ b/application/org.openjdk.jmc.rjmx/META-INF/MANIFEST.MF
@@ -6,8 +6,8 @@ Bundle-SymbolicName: org.openjdk.jmc.rjmx;singleton:=true
 Bundle-Version: 8.2.0.qualifier
 Bundle-Activator: org.openjdk.jmc.rjmx.RJMXPlugin
 Eclipse-BuddyPolicy: app
-Import-Package: javax.mail,
- javax.mail.internet
+Import-Package: jakarta.mail,
+ jakarta.mail.internet
 Export-Package: org.openjdk.jmc.rjmx,
  org.openjdk.jmc.rjmx.actionprovider;
   x-friends:="org.openjdk.jmc.console.ui,

--- a/application/org.openjdk.jmc.rjmx/src/main/java/org/openjdk/jmc/rjmx/triggers/actions/internal/TriggerActionMail.java
+++ b/application/org.openjdk.jmc.rjmx/src/main/java/org/openjdk/jmc/rjmx/triggers/actions/internal/TriggerActionMail.java
@@ -36,14 +36,14 @@ import java.util.Date;
 import java.util.Properties;
 import java.util.logging.Level;
 
-import javax.mail.Message;
-import javax.mail.MessagingException;
-import javax.mail.PasswordAuthentication;
-import javax.mail.Session;
-import javax.mail.Transport;
-import javax.mail.URLName;
-import javax.mail.internet.InternetAddress;
-import javax.mail.internet.MimeMessage;
+import jakarta.mail.Message;
+import jakarta.mail.MessagingException;
+import jakarta.mail.PasswordAuthentication;
+import jakarta.mail.Session;
+import jakarta.mail.Transport;
+import jakarta.mail.URLName;
+import jakarta.mail.internet.InternetAddress;
+import jakarta.mail.internet.MimeMessage;
 
 import org.eclipse.osgi.util.NLS;
 

--- a/license/THIRDPARTYREADME.txt
+++ b/license/THIRDPARTYREADME.txt
@@ -225,7 +225,7 @@ to a jury trial in any resulting litigation.
 
 
 %% The following notice is provided with respect to OWASP Java 
-Encoder Project v1.2.2 which may be included with this product.
+Encoder Project v1.2.3 which may be included with this product.
 
           Copyright (c) 2015 Jeff Ichnowski
                   All rights reserved.
@@ -729,7 +729,7 @@ which may be included with this product.
    See the License for the specific language governing permissions and
    limitations under the License.
 
-%% The following notice is provided with respect to Jakarta Mail v1.6.5,
+%% The following notice is provided with respect to Jakarta Mail v2.0.1,
 which may be included with this product.
 
                     Eclipse Public License - v 2.0
@@ -1389,7 +1389,7 @@ None
 Cryptography
 Content may contain encryption software. The country in which you are currently may have restrictions on the import, possession, and use, and/or re-export to another country, of encryption software. BEFORE using any encryption software, please check the country's laws, regulations and policies concerning the import, possession, or use, and re-export of encryption software, to see if this is permitted.
 ------------------------------------------------------------------------------------------------------
-Fourth Party Dependency #1 : Jakarta/JavaBeans Activation Framework (JAF) 1.2.2
+Fourth Party Dependency #1 : Jakarta/JavaBeans Activation Framework (JAF) 2.0.1
 Fourth Party Dependency #1 License & Copyright:
 
 Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
@@ -1500,7 +1500,7 @@ JUnit (4.12)
 * License: Eclipse Public License
 
 %% The following notice is provided with respect to Jakarta Activation
-Framework v1.2.2, which may be included with this product.
+Framework v2.0.1, which may be included with this product.
 
 Jakarta Activation API (JAF) (jakarta.activation:jakarta.activation-api)
 Copyright (c) 1997,2019 Oracle and/or its affiliates. All rights reserved.
@@ -1566,7 +1566,7 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
 ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
-%% The following notice is provided with respect to lz4-java v1.7.1,
+%% The following notice is provided with respect to lz4-java v1.8.0,
 which may be included with this product.
 
 

--- a/releng/platform-definitions/platform-definition-2020-06/platform-definition-2020-06.target
+++ b/releng/platform-definitions/platform-definition-2020-06/platform-definition-2020-06.target
@@ -36,10 +36,10 @@
 <target name="jmc-target-2020-06" sequenceNumber="47">
     <locations>
         <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-            <unit id="com.sun.mail.jakarta.mail" version="1.6.5"/>
-            <unit id="com.sun.activation.jakarta.activation" version="1.2.1"/>
-            <unit id="org.owasp.encoder" version="1.2.2"/>
-            <unit id="org.lz4.lz4-java" version="1.7.1"/>
+            <unit id="com.sun.mail.jakarta.mail" version="2.0.1"/>
+            <unit id="com.sun.activation.jakarta.activation" version="2.0.1"/>
+            <unit id="org.owasp.encoder" version="1.2.3"/>
+            <unit id="org.lz4.lz4-java" version="1.8.0"/>
             <unit id="org.hdrhistogram.HdrHistogram" version="2.1.12"/>
             <unit id="org.adoptopenjdk.jemmy-awt-input" version="2.0.0"/>
             <unit id="org.adoptopenjdk.jemmy-browser" version="2.0.0"/>

--- a/releng/platform-definitions/platform-definition-2020-09/platform-definition-2020-09.target
+++ b/releng/platform-definitions/platform-definition-2020-09/platform-definition-2020-09.target
@@ -36,10 +36,10 @@
 <target name="jmc-target-2020-09" sequenceNumber="47">
     <locations>
         <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-            <unit id="com.sun.mail.jakarta.mail" version="1.6.5"/>
-            <unit id="com.sun.activation.jakarta.activation" version="1.2.1"/>
-            <unit id="org.owasp.encoder" version="1.2.2"/>
-            <unit id="org.lz4.lz4-java" version="1.7.1"/>
+            <unit id="com.sun.mail.jakarta.mail" version="2.0.1"/>
+            <unit id="com.sun.activation.jakarta.activation" version="2.0.1"/>
+            <unit id="org.owasp.encoder" version="1.2.3"/>
+            <unit id="org.lz4.lz4-java" version="1.8.0"/>
             <unit id="org.hdrhistogram.HdrHistogram" version="2.1.12"/>
             <unit id="org.adoptopenjdk.jemmy-awt-input" version="2.0.0"/>
             <unit id="org.adoptopenjdk.jemmy-browser" version="2.0.0"/>

--- a/releng/platform-definitions/platform-definition-2020-12/platform-definition-2020-12.target
+++ b/releng/platform-definitions/platform-definition-2020-12/platform-definition-2020-12.target
@@ -36,10 +36,10 @@
 <target name="jmc-target-2020-12" sequenceNumber="47">
     <locations>
         <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-            <unit id="com.sun.mail.jakarta.mail" version="1.6.5"/>
-            <unit id="com.sun.activation.jakarta.activation" version="1.2.1"/>
-            <unit id="org.owasp.encoder" version="1.2.2"/>
-            <unit id="org.lz4.lz4-java" version="1.7.1"/>
+            <unit id="com.sun.mail.jakarta.mail" version="2.0.1"/>
+            <unit id="com.sun.activation.jakarta.activation" version="2.0.1"/>
+            <unit id="org.owasp.encoder" version="1.2.3"/>
+            <unit id="org.lz4.lz4-java" version="1.8.0"/>
             <unit id="org.hdrhistogram.HdrHistogram" version="2.1.12"/>
             <unit id="org.adoptopenjdk.jemmy-awt-input" version="2.0.0"/>
             <unit id="org.adoptopenjdk.jemmy-browser" version="2.0.0"/>

--- a/releng/platform-definitions/platform-definition-2021-03/platform-definition-2021-03.target
+++ b/releng/platform-definitions/platform-definition-2021-03/platform-definition-2021-03.target
@@ -36,10 +36,10 @@
 <target name="jmc-target-2021-03" sequenceNumber="47">
     <locations>
         <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-            <unit id="com.sun.mail.jakarta.mail" version="1.6.5"/>
-            <unit id="com.sun.activation.jakarta.activation" version="1.2.1"/>
-            <unit id="org.owasp.encoder" version="1.2.2"/>
-            <unit id="org.lz4.lz4-java" version="1.7.1"/>
+            <unit id="com.sun.mail.jakarta.mail" version="2.0.1"/>
+            <unit id="com.sun.activation.jakarta.activation" version="2.0.1"/>
+            <unit id="org.owasp.encoder" version="1.2.3"/>
+            <unit id="org.lz4.lz4-java" version="1.8.0"/>
             <unit id="org.hdrhistogram.HdrHistogram" version="2.1.12"/>
             <unit id="org.adoptopenjdk.jemmy-awt-input" version="2.0.0"/>
             <unit id="org.adoptopenjdk.jemmy-browser" version="2.0.0"/>

--- a/releng/platform-definitions/platform-definition-2021-06/platform-definition-2021-06.target
+++ b/releng/platform-definitions/platform-definition-2021-06/platform-definition-2021-06.target
@@ -36,10 +36,10 @@
 <target name="jmc-target-2021-06" sequenceNumber="47">
     <locations>
         <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-            <unit id="com.sun.mail.jakarta.mail" version="1.6.5"/>
-            <unit id="com.sun.activation.jakarta.activation" version="1.2.1"/>
-            <unit id="org.owasp.encoder" version="1.2.2"/>
-            <unit id="org.lz4.lz4-java" version="1.7.1"/>
+            <unit id="com.sun.mail.jakarta.mail" version="2.0.1"/>
+            <unit id="com.sun.activation.jakarta.activation" version="2.0.1"/>
+            <unit id="org.owasp.encoder" version="1.2.3"/>
+            <unit id="org.lz4.lz4-java" version="1.8.0"/>
             <unit id="org.hdrhistogram.HdrHistogram" version="2.1.12"/>
             <unit id="org.adoptopenjdk.jemmy-awt-input" version="2.0.0"/>
             <unit id="org.adoptopenjdk.jemmy-browser" version="2.0.0"/>

--- a/releng/third-party/pom.xml
+++ b/releng/third-party/pom.xml
@@ -43,15 +43,15 @@
 		<spotless.config.path>${basedir}/../../configuration/ide/eclipse/formatting/formatting.xml</spotless.config.path>
 		<!-- Versions -->
 		<hdrhistogram.version>2.1.12</hdrhistogram.version>
-		<jakarta.activation.version>1.2.1</jakarta.activation.version>
-		<jakarta.mail.version>1.6.5</jakarta.mail.version>
+		<jakarta.activation.version>2.0.1</jakarta.activation.version>
+		<jakarta.mail.version>2.0.1</jakarta.mail.version>
 		<javax.websocket.version>1.1</javax.websocket.version>
 		<jetty.version>10.0.5</jetty.version>
 		<jemmy.version>2.0.0</jemmy.version>
 		<jetty-maven-plugin.version>9.4.43.v20210629</jetty-maven-plugin.version>
-		<lz4.version>1.7.1</lz4.version>
+		<lz4.version>1.8.0</lz4.version>
 		<maven-enforcer-plugin.version>3.0.0</maven-enforcer-plugin.version>
-		<owasp.encoder.version>1.2.2</owasp.encoder.version>
+		<owasp.encoder.version>1.2.3</owasp.encoder.version>
 		<p2-maven-plugin.version>1.5.0</p2-maven-plugin.version>
 		<spifly.version>1.3.4</spifly.version>
 	</properties>


### PR DESCRIPTION
Upgrading following third parties to their latest released versions

jakarta mail - 1.6.5 --> 2.0.1
JavaBeans Activation Framework (JAF) 1.2.2 --> 2.0.1
lz4-java 1.7.1 --> 1.8.0
Owasp encoder 1.2.2 --> 1.2.3

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JMC-7469](https://bugs.openjdk.java.net/browse/JMC-7469): Upgrade third parties to latest versions


### Reviewers
 * [Marcus Hirt](https://openjdk.java.net/census#hirt) (@thegreystone - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jmc pull/341/head:pull/341` \
`$ git checkout pull/341`

Update a local copy of the PR: \
`$ git checkout pull/341` \
`$ git pull https://git.openjdk.java.net/jmc pull/341/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 341`

View PR using the GUI difftool: \
`$ git pr show -t 341`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jmc/pull/341.diff">https://git.openjdk.java.net/jmc/pull/341.diff</a>

</details>
