### PR TITLE
7480: Trim method descriptor value

### DIFF
--- a/agent/src/main/java/org/openjdk/jmc/agent/impl/DefaultTransformRegistry.java
+++ b/agent/src/main/java/org/openjdk/jmc/agent/impl/DefaultTransformRegistry.java
@@ -445,7 +445,7 @@ public class DefaultTransformRegistry implements TransformRegistry {
 					if ("name".equals(key)) { //$NON-NLS-1$
 						name = value;
 					} else if ("descriptor".equals(key)) { //$NON-NLS-1$
-						descriptor = value;
+						descriptor = value != null ? value.trim() : null;
 					}
 				}
 			} else if (streamReader.isEndElement()) {

--- a/agent/src/test/java/org/openjdk/jmc/agent/test/TestDefaultTransformRegistry.java
+++ b/agent/src/test/java/org/openjdk/jmc/agent/test/TestDefaultTransformRegistry.java
@@ -34,7 +34,6 @@ package org.openjdk.jmc.agent.test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
@@ -127,7 +126,7 @@ public class TestDefaultTransformRegistry {
 		final String invalidSnippet = XML_EVENT_DESCRIPTION;
 		boolean exceptionThrown = false;
 		try {
-			Set<String> modifiedClassNames = registry.modify(invalidSnippet);
+			registry.modify(invalidSnippet);
 		} catch (Exception e) {
 			e.printStackTrace(System.err);
 			exceptionThrown = true;


### PR DESCRIPTION
Hey @thegreystone, here's a fix for trimming the method signature value when building the method descriptors in the agent. Without this, wrapping the tags around long signatures like that [will fail](https://github.com/moditect/jfrunit-examples/commit/bd4bc8023c760a3d719dc9295cbe010fb56d7f6f#diff-8999381a163c84127b7e94462f39060c054a984904f82c34713d0ade0954e4c5R81):

```
 <descriptor>
   (Ljava/sql/PreparedStatement;Ljava/lang/Object;ILorg/hibernate/type/descriptor/WrapperOptions;)V
</descriptor>
```

Could you log an issue if you think it's a worthwhile fix? The second commit is some unrelated clean-up I did along the way. Thx!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JMC-7480](https://bugs.openjdk.java.net/browse/JMC-7480): Trim method descriptor value


### Reviewers
 * [Marcus Hirt](https://openjdk.java.net/census#hirt) (@thegreystone - **Reviewer**) ⚠️ Review applies to dcf167d0f63697585e81ac6b8185b16225ef6df6


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jmc pull/343/head:pull/343` \
`$ git checkout pull/343`

Update a local copy of the PR: \
`$ git checkout pull/343` \
`$ git pull https://git.openjdk.java.net/jmc pull/343/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 343`

View PR using the GUI difftool: \
`$ git pr show -t 343`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jmc/pull/343.diff">https://git.openjdk.java.net/jmc/pull/343.diff</a>

</details>
