### PR TITLE
7482: Confusing display of stack traces when selecting event types with no events

### DIFF
--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/JfrEditor.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/JfrEditor.java
@@ -195,6 +195,10 @@ public class JfrEditor extends EditorPart implements INavigationLocationProvider
 		return p;
 	}
 
+	public IPageUI getCurrentPageUI() {
+		return this.currentPageUI;
+	}
+
 	@Override
 	public IDisplayablePage getDisplayablePage(DataPageDescriptor page) {
 		return pageMap.computeIfAbsent(page, this::buildPage);


### PR DESCRIPTION
…th no events

In EventBrowser page, when there is no selection all events are
considered but if there is a selection we filtered events based on
this selection event if there is no events

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JMC-7482](https://bugs.openjdk.java.net/browse/JMC-7482): Confusing display of stack traces when selecting event types with no events


### Reviewers
 * [Alex Macdonald](https://openjdk.java.net/census#aptmac) (@aptmac - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jmc pull/344/head:pull/344` \
`$ git checkout pull/344`

Update a local copy of the PR: \
`$ git checkout pull/344` \
`$ git pull https://git.openjdk.java.net/jmc pull/344/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 344`

View PR using the GUI difftool: \
`$ git pr show -t 344`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jmc/pull/344.diff">https://git.openjdk.java.net/jmc/pull/344.diff</a>

</details>
