### PR TITLE
7473: Unable to view constants in constant pool page.

### DIFF
--- a/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/internal/parser/ParserStats.java
+++ b/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/internal/parser/ParserStats.java
@@ -295,7 +295,8 @@ public class ParserStats {
 						IMCFrame imcFrame = (stackTrace).getFrames().get(0);
 						String str = StacktraceFormatToolkit.formatFrame(imcFrame,
 								new FrameSeparator(FrameCategorization.METHOD, false));
-						return ((IMemberAccessor<M, IItem>) MemberAccessorToolkit.<IItem, Object, Object> constant(str));
+						return ((IMemberAccessor<M, IItem>) MemberAccessorToolkit
+								.<IItem, Object, Object> constant(str));
 					}
 				}
 				return ((IMemberAccessor<M, IItem>) MemberAccessorToolkit.<IItem, Object, Object> constant(constant));

--- a/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/internal/parser/ParserStats.java
+++ b/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/internal/parser/ParserStats.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2021, Datadog, Inc. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Datadog, Inc. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -290,10 +290,13 @@ public class ParserStats {
 			}
 			if ("constant".equals(attribute.getIdentifier())) {
 				if (constant instanceof IMCStackTrace) {
-					IMCFrame imcFrame = ((IMCStackTrace) constant).getFrames().get(0);
-					String str = StacktraceFormatToolkit.formatFrame(imcFrame,
-							new FrameSeparator(FrameCategorization.METHOD, false));
-					return ((IMemberAccessor<M, IItem>) MemberAccessorToolkit.<IItem, Object, Object> constant(str));
+					IMCStackTrace stackTrace = ((IMCStackTrace) constant);
+					if (!stackTrace.getFrames().isEmpty()) {
+						IMCFrame imcFrame = (stackTrace).getFrames().get(0);
+						String str = StacktraceFormatToolkit.formatFrame(imcFrame,
+								new FrameSeparator(FrameCategorization.METHOD, false));
+						return ((IMemberAccessor<M, IItem>) MemberAccessorToolkit.<IItem, Object, Object> constant(str));
+					}
 				}
 				return ((IMemberAccessor<M, IItem>) MemberAccessorToolkit.<IItem, Object, Object> constant(constant));
 			}


### PR DESCRIPTION
This PR addresses JMC-7473 [[0]](https://bugs.openjdk.java.net/browse/JMC-7473), in which the Constant Pools page throws an exception and does not display. The issue here is in ParserStats, and happens if the stacktrace object doesn't have any frames - but there is a retrieval for the first frame. 

Before:
![2022-01-10-105031_790x151_scrot](https://user-images.githubusercontent.com/10425301/148796099-b32c4802-7b12-4489-ab09-0aa65a73cea9.png)

After:
![2022-01-10-105044_668x458_scrot](https://user-images.githubusercontent.com/10425301/148796118-d066f332-d0a3-4982-9502-b26efd2ef01b.png)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JMC-7473](https://bugs.openjdk.java.net/browse/JMC-7473): Unable to view constants in constant pool page.


### Reviewers
 * [Jean-Philippe Bempel](https://openjdk.java.net/census#jpbempel) (@jpbempel - Committer)
 * [Marcus Hirt](https://openjdk.java.net/census#hirt) (@thegreystone - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jmc pull/348/head:pull/348` \
`$ git checkout pull/348`

Update a local copy of the PR: \
`$ git checkout pull/348` \
`$ git pull https://git.openjdk.java.net/jmc pull/348/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 348`

View PR using the GUI difftool: \
`$ git pr show -t 348`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jmc/pull/348.diff">https://git.openjdk.java.net/jmc/pull/348.diff</a>

</details>
