### PR TITLE
7074: Smart pruning of graphs to make it possible to sensibly render larger graphs

### DIFF
--- a/application/org.openjdk.jmc.flightrecorder.graphview/src/main/java/org/openjdk/jmc/flightrecorder/graphview/views/GraphView.java
+++ b/application/org.openjdk.jmc.flightrecorder.graphview/src/main/java/org/openjdk/jmc/flightrecorder/graphview/views/GraphView.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2019, 2020, Datadog, Inc. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Datadog, Inc. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -78,6 +78,7 @@ import org.openjdk.jmc.common.util.StringToolkit;
 import org.openjdk.jmc.flightrecorder.serializers.dot.DotSerializer;
 import org.openjdk.jmc.flightrecorder.stacktrace.FrameSeparator;
 import org.openjdk.jmc.flightrecorder.stacktrace.FrameSeparator.FrameCategorization;
+import org.openjdk.jmc.flightrecorder.stacktrace.graph.Pruning;
 import org.openjdk.jmc.flightrecorder.stacktrace.graph.StacktraceGraphModel;
 import org.openjdk.jmc.flightrecorder.ui.FlightRecorderUI;
 import org.openjdk.jmc.ui.common.util.AdapterUtil;
@@ -134,12 +135,18 @@ public class GraphView extends ViewPart implements ISelectionListener {
 			if (isInvalid) {
 				return;
 			}
+
+			model = Pruning.prune(model, maxNodesRendered, false);
+			int currentNodeCount = model.getNodes().size();
 			String dotString = GraphView.toDot(model, maxNodesRendered);
 			if (isInvalid) {
 				return;
 			} else {
 				view.modelState = ModelState.FINISHED;
-				DisplayToolkit.inDisplayThread().execute(() -> view.setModel(items, dotString));
+				DisplayToolkit.inDisplayThread().execute(() -> {
+					view.setModel(items, dotString);
+					view.nodeThresholdSelection.setText(String.valueOf(currentNodeCount));
+				});
 			}
 		}
 	}
@@ -164,6 +171,7 @@ public class GraphView extends ViewPart implements ISelectionListener {
 	private volatile ModelState modelState = ModelState.NONE;
 	private ModelRebuildRunnable modelRebuildRunnable;
 	private int maxNodesRendered = 100;
+	private NodeThresholdSelection nodeThresholdSelection;
 
 	@Override
 	public void init(IViewSite site, IMemento memento) throws PartInitException {
@@ -171,7 +179,8 @@ public class GraphView extends ViewPart implements ISelectionListener {
 		frameSeparator = new FrameSeparator(FrameCategorization.METHOD, false);
 
 		IToolBarManager toolBar = site.getActionBars().getToolBarManager();
-		toolBar.add(new NodeThresholdSelection());
+		nodeThresholdSelection = new NodeThresholdSelection();
+		toolBar.add(nodeThresholdSelection);
 
 		getSite().getPage().addSelectionListener(this);
 	}
@@ -184,8 +193,9 @@ public class GraphView extends ViewPart implements ISelectionListener {
 
 	private class NodeThresholdSelection extends Action implements IMenuCreator {
 		private Menu menu;
-		private final List<Pair<String, Integer>> items = Arrays.asList(new Pair<>("100", 100), new Pair<>("500", 500),
-				new Pair<>("1000", 1000));
+		private final List<Pair<String, Integer>> items = Arrays.asList(new Pair<>("10", 10), new Pair<>("20", 20),
+				new Pair<>("30", 30), new Pair<>("40", 40), new Pair<>("50", 50), new Pair<>("100", 100),
+				new Pair<>("500", 500), new Pair<>("1000", 1000));
 
 		NodeThresholdSelection() {
 			super("Max Nodes", IAction.AS_DROP_DOWN_MENU);

--- a/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/stacktrace/graph/Edge.java
+++ b/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/stacktrace/graph/Edge.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2019, 2021, Datadog, Inc. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Datadog, Inc. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -50,12 +50,13 @@ public final class Edge {
 	 * @param to
 	 *            non null to node.
 	 */
-	public Edge(Node from, Node to) {
+	public Edge(Node from, Node to, double value) {
 		if (from == null || to == null) {
 			throw new NullPointerException("Nodes must not be null");
 		}
 		this.from = from;
 		this.to = to;
+		this.value = value;
 	}
 
 	public Node getFrom() {

--- a/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/stacktrace/graph/Node.java
+++ b/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/stacktrace/graph/Node.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2019, 2021, Datadog, Inc. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Datadog, Inc. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -33,6 +33,9 @@
  */
 package org.openjdk.jmc.flightrecorder.stacktrace.graph;
 
+import java.util.HashMap;
+import java.util.Map;
+
 /**
  * A node in the graph of aggregated stack traces.
  */
@@ -46,6 +49,42 @@ public final class Node {
 	 * The frame associated with this node.
 	 */
 	private final AggregatableFrame frame;
+
+	static class NodeWrapper {
+		int nodeId;
+		Node node;
+
+		NodeWrapper(int nodeId, Node node) {
+			this.nodeId = nodeId;
+			this.node = node;
+		}
+
+		@Override
+		public int hashCode() {
+			final int prime = 31;
+			int result = 1;
+			result = prime * result + nodeId;
+			return result;
+		}
+
+		@Override
+		public boolean equals(Object obj) {
+			if (this == obj)
+				return true;
+			if (obj == null)
+				return false;
+			if (getClass() != obj.getClass())
+				return false;
+			NodeWrapper other = (NodeWrapper) obj;
+			if (nodeId != other.nodeId)
+				return false;
+			return true;
+		}
+
+	}
+
+	private final Map<NodeWrapper, Edge> in = new HashMap<>();
+	private final Map<NodeWrapper, Edge> out = new HashMap<>();
 
 	/**
 	 * The number of times being the top frame.
@@ -130,5 +169,13 @@ public final class Node {
 	public String toString() {
 		return String.format("%s counts:%d(%d),weights:%.2f(%.2f)", frame.toString(), count, cumulativeCount, weight,
 				cumulativeWeight);
+	}
+
+	Map<NodeWrapper, Edge> getIn() {
+		return in;
+	}
+
+	Map<NodeWrapper, Edge> getOut() {
+		return out;
 	}
 }

--- a/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/stacktrace/graph/Pruning.java
+++ b/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/stacktrace/graph/Pruning.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2019, 2022, Datadog, Inc. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.

--- a/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/stacktrace/graph/Pruning.java
+++ b/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/stacktrace/graph/Pruning.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) 2019, 2022, Datadog, Inc. All rights reserved.
+ *
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * The contents of this file are subject to the terms of either the Universal Permissive License
+ * v 1.0 as shown at http://oss.oracle.com/licenses/upl
+ *
+ * or the following license:
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted
+ * provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions
+ * and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other materials provided with
+ * the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to
+ * endorse or promote products derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+ * WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.openjdk.jmc.flightrecorder.stacktrace.graph;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.openjdk.jmc.flightrecorder.stacktrace.graph.Node.NodeWrapper;
+
+// implementation based on https://github.com/google/pprof/blob/83db2b799d1f74c40857232cb5eb4c60379fe6c2/internal/report/report.go#L124
+public class Pruning {
+	public static StacktraceGraphModel prune(StacktraceGraphModel model, int maxNodeCount, boolean trimLowFrequency) {
+		// first phase: cutoff
+		long totalValue = model.getNodes().stream().mapToLong(node -> node.count).sum();
+		if (trimLowFrequency) {
+			double nodeFraction = 0.005;
+			long nodeCutoff = Math.round(totalValue * nodeFraction);
+			if (nodeCutoff > 0) {
+				model = discardLowFrequencyNodes(model, nodeCutoff);
+			}
+		}
+		// second phase: entropy
+		Map<Integer, Long> nodeScores = new HashMap<>();
+		for (Node node : model.getNodes()) {
+			long score = entropyScore(node);
+			nodeScores.put(node.getNodeId(), score);
+		}
+		// sort
+		List<Node> sortedNodes = new ArrayList<Node>(model.getNodes());
+		sortedNodes.sort((n1, n2) -> {
+			long score1 = nodeScores.get(n1.getNodeId());
+			long score2 = nodeScores.get(n2.getNodeId());
+			return -Long.compare(score1, score2);
+		});
+		if (trimLowFrequency) {
+			double edgeFraction = 0.001;
+			long edgeCutoff = Math.round(totalValue * edgeFraction);
+			trimLowFrequencyEdges(sortedNodes, edgeCutoff);
+		}
+		// selectTopNodes
+		return selectTopNode(model, sortedNodes, maxNodeCount);
+	}
+
+	private static StacktraceGraphModel discardLowFrequencyNodes(StacktraceGraphModel model, long nodeCutoff) {
+		Set<AggregatableFrame> cutNodes = new HashSet<>(model.getNodes().size());
+		for (Node node : model.getNodes()) {
+			if (node.cumulativeWeight < nodeCutoff) {
+				continue;
+			}
+			cutNodes.add(node.getFrame());
+		}
+		return new StacktraceGraphModel(model, cutNodes);
+	}
+
+	private static StacktraceGraphModel selectTopNode(
+		StacktraceGraphModel model, Collection<Node> sortedNodes, int maxCount) {
+		Set<AggregatableFrame> cutNodes = new HashSet<>(model.getNodes().size());
+		int count = 0;
+		for (Node node : sortedNodes) {
+			cutNodes.add(node.getFrame());
+			count++;
+			if (count >= maxCount) {
+				break;
+			}
+		}
+		return new StacktraceGraphModel(model, cutNodes);
+	}
+
+	private static int trimLowFrequencyEdges(Collection<Node> sortedNode, long edgeCutoff) {
+		int droppedEdges = 0;
+		for (Node node : sortedNode) {
+
+			for (Map.Entry<NodeWrapper, Edge> entry : new HashSet<>(node.getIn().entrySet())) {
+				if (entry.getValue().value < edgeCutoff) {
+					node.getIn().remove(entry.getKey());
+					entry.getKey().node.getOut().remove(new NodeWrapper(node.getNodeId(), node));
+					droppedEdges++;
+				}
+			}
+		}
+		return droppedEdges;
+	}
+
+	private static long entropyScore(Node node) {
+		double score = 0;
+		if (node.getIn().isEmpty()) {
+			score++;
+		} else {
+			score += edgeEntropyScore(node, node.getIn().values(), 0);
+		}
+		if (node.getOut().isEmpty()) {
+			score++;
+		} else {
+			score += edgeEntropyScore(node, node.getOut().values(), node.weight);
+		}
+		return Math.round(score * node.cumulativeWeight + node.weight);
+	}
+
+	private static double edgeEntropyScore(Node node, Collection<Edge> edges, double self) {
+		double score = 0;
+		double total = self;
+		for (Edge edge : edges) {
+			if (edge.getValue() > 0) {
+				total += Math.abs(edge.getValue());
+			}
+		}
+		if (total > 0) {
+			for (Edge edge : edges) {
+				double frac = Math.abs(edge.getValue()) / total;
+				score += -frac * Math.log(frac);
+			}
+			if (self > 0) {
+				double frac = Math.abs(self) / total;
+				score += -frac * Math.log(frac);
+			}
+		}
+		return score;
+	}
+
+}

--- a/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/stacktrace/graph/StacktraceGraphModel.java
+++ b/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/stacktrace/graph/StacktraceGraphModel.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2019, 2021, Datadog, Inc. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Datadog, Inc. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -38,6 +38,7 @@ import static org.openjdk.jmc.flightrecorder.JfrAttributes.EVENT_STACKTRACE;
 import java.io.File;
 import java.io.IOException;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -58,6 +59,7 @@ import org.openjdk.jmc.flightrecorder.JfrLoaderToolkit;
 import org.openjdk.jmc.flightrecorder.jdk.JdkFilters;
 import org.openjdk.jmc.flightrecorder.stacktrace.FrameSeparator;
 import org.openjdk.jmc.flightrecorder.stacktrace.FrameSeparator.FrameCategorization;
+import org.openjdk.jmc.flightrecorder.stacktrace.graph.Node.NodeWrapper;
 
 /**
  * A model for holding multiple stack traces and their relations to each other as a directed graph.
@@ -110,7 +112,14 @@ public final class StacktraceGraphModel {
 		this.frameSeparator = frameSeparator;
 		this.items = items;
 		this.attribute = attribute;
-		buildModel();
+		buildModel(Collections.emptySet());
+	}
+
+	StacktraceGraphModel(StacktraceGraphModel model, Set<AggregatableFrame> keptNodes) {
+		this.frameSeparator = model.frameSeparator;
+		this.items = model.items;
+		this.attribute = model.attribute;
+		buildModel(keptNodes);
 	}
 
 	public Collection<Edge> getEdges() {
@@ -258,13 +267,13 @@ public final class StacktraceGraphModel {
 				nodes.size(), edges.size(), nodes.toString(), edges.toString());
 	}
 
-	private void buildModel() {
+	private void buildModel(Set<AggregatableFrame> keptNodes) {
 		for (IItemIterable iterable : items) {
 			IMemberAccessor<IMCStackTrace, IItem> stacktraceAccessor = getAccessor(iterable, EVENT_STACKTRACE);
 			if (stacktraceAccessor == null) {
 				continue;
 			}
-			iterable.forEach((item) -> addItem(item, stacktraceAccessor, getAccessor(iterable, attribute)));
+			iterable.forEach((item) -> addItem(item, stacktraceAccessor, getAccessor(iterable, attribute), keptNodes));
 		}
 	}
 
@@ -274,7 +283,7 @@ public final class StacktraceGraphModel {
 
 	private void addItem(
 		IItem item, IMemberAccessor<IMCStackTrace, IItem> stackTraceAccessor,
-		IMemberAccessor<IQuantity, IItem> quantityAccessor) {
+		IMemberAccessor<IQuantity, IItem> quantityAccessor, Set<AggregatableFrame> keptNodes) {
 		IMCStackTrace stackTrace = stackTraceAccessor.getMember(item);
 		if (stackTrace == null) {
 			return;
@@ -284,7 +293,7 @@ public final class StacktraceGraphModel {
 			return;
 		}
 
-		double value = 0;
+		double value = 1;
 		if (quantityAccessor != null) {
 			value = quantityAccessor.getMember(item).doubleValue();
 		}
@@ -293,47 +302,61 @@ public final class StacktraceGraphModel {
 		// actually responsible for whatever is being tracked (e.g. the method being on
 		// CPU, the method triggering the allocation etc) - it is for this node we
 		// increment the count...
-		IMCFrame firstFrame = frames.get(0);
-		Node n = getOrCreateNode(firstFrame);
-		totalTraceCount++;
-		n.count++;
-		n.weight += value;
+		AggregatableFrame firstFrame = new AggregatableFrame(frameSeparator, frames.get(0));
+		if (keepFrame(keptNodes, firstFrame)) {
+			Node n = getOrCreateNode(firstFrame);
+			totalTraceCount++;
+			n.count++;
+			n.weight += value;
 
-		// Next go through all frames from the thread root, and up the cumulative counts
-		for (int i = frames.size() - 1; i > 0; i--) {
-			// Process two frames sliding window, from and to
-			IMCFrame currentFrame = frames.get(i);
-			IMCFrame nextFrame = frames.get(i - 1);
+			// Next go through all frames from the thread root, and up the cumulative counts
+			for (int i = frames.size() - 1; i > 0; i--) {
+				// Process two frames sliding window, from and to
+				AggregatableFrame currentFrame = new AggregatableFrame(frameSeparator, frames.get(i));
+				AggregatableFrame nextFrame = new AggregatableFrame(frameSeparator, frames.get(i - 1));
 
-			Node currentNode = getOrCreateNode(currentFrame);
-			Node nextNode = getOrCreateNode(nextFrame);
-
-			currentNode.cumulativeCount++;
-			nextNode.cumulativeCount++;
-			currentNode.cumulativeWeight += value;
-			nextNode.cumulativeWeight += value;
-			Edge e = getOrCreateLink(currentNode, nextNode);
-			e.count++;
-			totalEdgeCount++;
+				if (keepFrame(keptNodes, currentFrame)) {
+					Node currentNode = getOrCreateNode(currentFrame);
+					currentNode.cumulativeCount++;
+					currentNode.cumulativeWeight += value;
+					if (keepFrame(keptNodes, nextFrame)) {
+						Node nextNode = getOrCreateNode(nextFrame);
+						nextNode.cumulativeCount++;
+						nextNode.cumulativeWeight += value;
+						Edge e = getOrCreateLink(currentNode, nextNode, value);
+						e.count++;
+						totalEdgeCount++;
+					}
+				}
+			}
 		}
+	}
+
+	private boolean keepFrame(Set<AggregatableFrame> keptNodes, AggregatableFrame frame) {
+		return keptNodes.isEmpty() || keptNodes.contains(frame);
 	}
 
 	private Node getOrCreateNode(IMCFrame frame) {
 		AggregatableFrame aframe = new AggregatableFrame(frameSeparator, frame);
-		Node n = nodes.get(aframe);
+		return getOrCreateNode(aframe);
+	}
+
+	private Node getOrCreateNode(AggregatableFrame frame) {
+		Node n = nodes.get(frame);
 		if (n == null) {
-			n = new Node(Integer.valueOf(nodeCounter++), aframe);
-			nodes.put(aframe, n);
+			n = new Node(Integer.valueOf(nodeCounter++), frame);
+			nodes.put(frame, n);
 		}
 		return n;
 	}
 
-	private Edge getOrCreateLink(Node fromNode, Node toNode) {
+	private Edge getOrCreateLink(Node fromNode, Node toNode, double value) {
 		if (!edges.containsKey(fromNode.getNodeId())) {
-			Edge edge = new Edge(fromNode, toNode);
+			Edge edge = new Edge(fromNode, toNode, value);
 			Set<Edge> newEdgeSet = new HashSet<>();
 			newEdgeSet.add(edge);
 			edges.put(fromNode.getNodeId(), newEdgeSet);
+			updateNodeEdges(fromNode, toNode, edge, value);
 			return edge;
 		}
 		Set<Edge> toSet = edges.get(fromNode.getNodeId());
@@ -344,9 +367,19 @@ public final class StacktraceGraphModel {
 				return edge;
 			}
 		}
-		Edge edge = new Edge(fromNode, toNode);
+		Edge edge = new Edge(fromNode, toNode, value);
 		toSet.add(edge);
+		updateNodeEdges(fromNode, toNode, edge, value);
 		return edge;
+	}
+
+	private void updateNodeEdges(Node fromNode, Node toNode, Edge edge, double value) {
+		Edge outEdge = fromNode.getOut().get(new NodeWrapper(toNode.getNodeId(), toNode));
+		if (outEdge != null) {
+			outEdge.value += value;
+		}
+		fromNode.getOut().put(new NodeWrapper(toNode.getNodeId(), toNode), edge);
+		toNode.getIn().put(new NodeWrapper(fromNode.getNodeId(), fromNode), edge);
 	}
 
 	public static void main(String[] args) throws IOException, CouldNotLoadRecordingException {


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JMC-7074](https://bugs.openjdk.org/browse/JMC-7074): Smart pruning of graphs to make it possible to sensibly render larger graphs


### Reviewers
 * [Marcus Hirt](https://openjdk.org/census#hirt) (@thegreystone - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmc pull/349/head:pull/349` \
`$ git checkout pull/349`

Update a local copy of the PR: \
`$ git checkout pull/349` \
`$ git pull https://git.openjdk.org/jmc pull/349/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 349`

View PR using the GUI difftool: \
`$ git pr show -t 349`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmc/pull/349.diff">https://git.openjdk.org/jmc/pull/349.diff</a>

</details>
