### PR TITLE
7503: Fix serializers.test dependency

### DIFF
--- a/core/tests/org.openjdk.jmc.flightrecorder.serializers.test/pom.xml
+++ b/core/tests/org.openjdk.jmc.flightrecorder.serializers.test/pom.xml
@@ -46,6 +46,13 @@
 	<dependencies>
            <dependency>
                    <groupId>org.openjdk.jmc</groupId>
+                   <artifactId>flightrecorder.test</artifactId>
+                   <type>test-jar</type>
+                   <scope>test</scope>
+                   <version>${project.version}</version>
+           </dependency>
+           <dependency>
+                   <groupId>org.openjdk.jmc</groupId>
                    <artifactId>common.test</artifactId>
                    <type>test-jar</type>
                    <scope>test</scope>
@@ -59,11 +66,6 @@
            <dependency>
                    <groupId>org.openjdk.jmc</groupId>
                    <artifactId>flightrecorder</artifactId>
-                   <version>${project.version}</version>
-           </dependency>
-           <dependency>
-                   <groupId>org.openjdk.jmc</groupId>
-                   <artifactId>flightrecorder.test</artifactId>
                    <version>${project.version}</version>
            </dependency>
            <dependency>


### PR DESCRIPTION
This simple fix properly declares the `flightrecorder.test` dependency as a `test-jar`. This fixes compilation issues in IntelliJ especially.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JMC-7503](https://bugs.openjdk.java.net/browse/JMC-7503): Fix serializers.test dependency


### Reviewers
 * [Marcus Hirt](https://openjdk.java.net/census#hirt) (@thegreystone - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jmc pull/351/head:pull/351` \
`$ git checkout pull/351`

Update a local copy of the PR: \
`$ git checkout pull/351` \
`$ git pull https://git.openjdk.java.net/jmc pull/351/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 351`

View PR using the GUI difftool: \
`$ git pr show -t 351`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jmc/pull/351.diff">https://git.openjdk.java.net/jmc/pull/351.diff</a>

</details>
