### PR TITLE
7505: Cannot reset websocket server port to default

### DIFF
--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/preferences/GeneralPage.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/preferences/GeneralPage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -424,6 +424,7 @@ public class GeneralPage extends PreferencePage implements IWorkbenchPreferenceP
 		loadItemListSizeFromPrefStore(true);
 		loadPropertiesArrayStringSizeFromPrefStore(true);
 		loadEditorRuleEvaluationThreadsFromPrefStore(true);
+		loadWebsocketPortFromPrefStore(true);
 		super.performDefaults();
 	}
 


### PR DESCRIPTION
This quick change addresses JMC-7505 [[0]](https://bugs.openjdk.java.net/browse/JMC-7505), in which the Preferences menu does not reset the value of the websocket server port.

The fix is to add the missing call to `loadWebsocketPortFromPrefStore()` in the `performDefaults()`.

Before:
![websocket-reset-before](https://user-images.githubusercontent.com/10425301/149178788-f2a12ee2-d6f7-4438-85f2-a56e11c743d6.gif)

After:
![websocket-reset-after](https://user-images.githubusercontent.com/10425301/149178778-f2d707d3-6a7f-4eb7-a603-b2de63aee319.gif)
