### PR TITLE
7512: Update lz4-java and remove the osgi bundle name override

### DIFF
--- a/application/org.openjdk.jmc.feature.core/feature.xml
+++ b/application/org.openjdk.jmc.feature.core/feature.xml
@@ -84,7 +84,7 @@
          unpack="false"/>
 
    <plugin
-         id="org.lz4.lz4-java"
+         id="lz4-java"
          download-size="0"
          install-size="0"
          version="0.0.0"

--- a/application/org.openjdk.jmc.feature.flightrecorder/feature.xml
+++ b/application/org.openjdk.jmc.feature.flightrecorder/feature.xml
@@ -137,7 +137,7 @@
          unpack="false"/>
 
    <plugin
-         id="org.lz4.lz4-java"
+         id="lz4-java"
          download-size="0"
          install-size="0"
          version="0.0.0"

--- a/core/license/THIRD_PARTY_LICENSES.txt
+++ b/core/license/THIRD_PARTY_LICENSES.txt
@@ -47,7 +47,7 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
 OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ===============================================================================
-## org.lz4:lz4-java@1.7.1 (Apache-2.0)
+## org.lz4:lz4-java@1.8.0 (Apache-2.0)
 
                                 URL for License – http://opensource.org/licenses/Apache-2.0
 

--- a/core/org.openjdk.jmc.common/META-INF/MANIFEST.MF
+++ b/core/org.openjdk.jmc.common/META-INF/MANIFEST.MF
@@ -13,4 +13,4 @@ Export-Package: org.openjdk.jmc.common,
  org.openjdk.jmc.common.util,
  org.openjdk.jmc.common.version
 Automatic-Module-Name: org.openjdk.jmc.common
-Require-Bundle: org.owasp.encoder, org.lz4.lz4-java
+Require-Bundle: org.owasp.encoder, lz4-java

--- a/core/org.openjdk.jmc.common/pom.xml
+++ b/core/org.openjdk.jmc.common/pom.xml
@@ -48,7 +48,7 @@
 		<dependency>
 			<groupId>org.lz4</groupId>
 			<artifactId>lz4-java</artifactId>
-			<version>1.7.1</version>
+			<version>1.8.0</version>
 		</dependency>
 	</dependencies>
 	<properties>

--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/META-INF/MANIFEST.MF
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/META-INF/MANIFEST.MF
@@ -24,5 +24,6 @@ Import-Package: org.openjdk.jmc.common,
  org.openjdk.jmc.flightrecorder.rules,
  org.openjdk.jmc.flightrecorder.rules.tree,
  org.openjdk.jmc.flightrecorder.rules.util,
- org.openjdk.jmc.flightrecorder.stacktrace
+ org.openjdk.jmc.flightrecorder.stacktrace,
+ org.owasp.encoder
 Automatic-Module-Name: org.openjdk.jmc.flightrecorder.rules.jdk

--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/META-INF/MANIFEST.MF
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/META-INF/MANIFEST.MF
@@ -24,6 +24,5 @@ Import-Package: org.openjdk.jmc.common,
  org.openjdk.jmc.flightrecorder.rules,
  org.openjdk.jmc.flightrecorder.rules.tree,
  org.openjdk.jmc.flightrecorder.rules.util,
- org.openjdk.jmc.flightrecorder.stacktrace,
- org.owasp.encoder
+ org.openjdk.jmc.flightrecorder.stacktrace
 Automatic-Module-Name: org.openjdk.jmc.flightrecorder.rules.jdk

--- a/core/org.openjdk.jmc.flightrecorder.serializers/META-INF/MANIFEST.MF
+++ b/core/org.openjdk.jmc.flightrecorder.serializers/META-INF/MANIFEST.MF
@@ -9,4 +9,4 @@ Export-Package: org.openjdk.jmc.flightrecorder.serializers,
  org.openjdk.jmc.flightrecorder.serializers.json,
  org.openjdk.jmc.flightrecorder.serializers.dot
 Automatic-Module-Name: org.openjdk.jmc.flightrecorder.serializers
-Require-Bundle: org.lz4.lz4-java, org.openjdk.jmc.flightrecorder
+Require-Bundle: lz4-java, org.openjdk.jmc.flightrecorder

--- a/core/tests/org.openjdk.jmc.flightrecorder.writer.test/license/THIRD_PARTY_LICENSES.txt
+++ b/core/tests/org.openjdk.jmc.flightrecorder.writer.test/license/THIRD_PARTY_LICENSES.txt
@@ -47,7 +47,7 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
 OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ===============================================================================
-## org.lz4:lz4-java@1.7.1 (Apache-2.0)
+## org.lz4:lz4-java@1.8.0 (Apache-2.0)
 
                                 URL for License – http://opensource.org/licenses/Apache-2.0
 

--- a/releng/platform-definitions/platform-definition-2021-06/platform-definition-2021-06.target
+++ b/releng/platform-definitions/platform-definition-2021-06/platform-definition-2021-06.target
@@ -39,7 +39,7 @@
             <unit id="com.sun.mail.jakarta.mail" version="2.0.1"/>
             <unit id="com.sun.activation.jakarta.activation" version="2.0.1"/>
             <unit id="org.owasp.encoder" version="1.2.3"/>
-            <unit id="org.lz4.lz4-java" version="1.8.0"/>
+            <unit id="lz4-java" version="1.8.0"/>
             <unit id="org.hdrhistogram.HdrHistogram" version="2.1.12"/>
             <unit id="org.adoptopenjdk.jemmy-awt-input" version="2.0.0"/>
             <unit id="org.adoptopenjdk.jemmy-browser" version="2.0.0"/>

--- a/releng/platform-definitions/platform-definition-2021-09/platform-definition-2021-09.target
+++ b/releng/platform-definitions/platform-definition-2021-09/platform-definition-2021-09.target
@@ -39,7 +39,7 @@
             <unit id="com.sun.mail.jakarta.mail" version="2.0.1"/>
             <unit id="com.sun.activation.jakarta.activation" version="2.0.1"/>
             <unit id="org.owasp.encoder" version="1.2.3"/>
-            <unit id="org.lz4.lz4-java" version="1.8.0"/>
+            <unit id="lz4-java" version="1.8.0"/>
             <unit id="org.hdrhistogram.HdrHistogram" version="2.1.12"/>
             <unit id="org.adoptopenjdk.jemmy-awt-input" version="2.0.0"/>
             <unit id="org.adoptopenjdk.jemmy-browser" version="2.0.0"/>

--- a/releng/platform-definitions/platform-definition-2021-12/platform-definition-2021-12.target
+++ b/releng/platform-definitions/platform-definition-2021-12/platform-definition-2021-12.target
@@ -39,7 +39,7 @@
             <unit id="com.sun.mail.jakarta.mail" version="2.0.1"/>
             <unit id="com.sun.activation.jakarta.activation" version="2.0.1"/>
             <unit id="org.owasp.encoder" version="1.2.3"/>
-            <unit id="org.lz4.lz4-java" version="1.8.0"/>
+            <unit id="lz4-java" version="1.8.0"/>
             <unit id="org.hdrhistogram.HdrHistogram" version="2.1.12"/>
             <unit id="org.adoptopenjdk.jemmy-awt-input" version="2.0.0"/>
             <unit id="org.adoptopenjdk.jemmy-browser" version="2.0.0"/>

--- a/releng/third-party/pom.xml
+++ b/releng/third-party/pom.xml
@@ -87,11 +87,6 @@
 								</artifact>
 								<artifact>
 									<id>org.lz4:lz4-java:${lz4.version}</id>
-									<override>true</override>
-									<instructions>
-										<Bundle-Name>org.lz4.lz4-java</Bundle-Name>
-										<Bundle-SymbolicName>org.lz4.lz4-java</Bundle-SymbolicName>
-									</instructions>
 								</artifact>
 								<artifact>
 									<id>org.hdrhistogram:HdrHistogram:${hdrhistogram.version}</id>


### PR DESCRIPTION
The core library dependency decalred in maven is aligned with the one in the .target files, `1.8.0`.

Also I noticed the lz4-java library has an OSGI bundle symbolic name: `lz4-java`, introduced in 1.3.0 : https://github.com/lz4/lz4-java/pull/39/files#diff-e3399fe1dc27b086e517883c6cab943edbfab64139839c965b14db8d11c8a99aR1-R4
However probably due to some previous bugs this required an override, done [here](https://github.com/openjdk/jmc/commit/b6e5bde2f45e7e44f252f42488332fc81b58506b#diff-ae8e739504eac3280387ceb987f669e68fbb07806266732c4ab21409d593b1dcR81-R86), but this may not be necessary anymore. Hence this PR tries to use the actual osgi name.

The change is little, and hopefully won't ripple beyond.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JMC-7512](https://bugs.openjdk.java.net/browse/JMC-7512): Update lz4-java and remove the osgi bundle name override


### Reviewers
 * [Marcus Hirt](https://openjdk.java.net/census#hirt) (@thegreystone - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jmc pull/356/head:pull/356` \
`$ git checkout pull/356`

Update a local copy of the PR: \
`$ git checkout pull/356` \
`$ git pull https://git.openjdk.java.net/jmc pull/356/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 356`

View PR using the GUI difftool: \
`$ git pr show -t 356`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jmc/pull/356.diff">https://git.openjdk.java.net/jmc/pull/356.diff</a>

</details>
