### PR TITLE
7531: Update jetty websocket third party

### DIFF
--- a/releng/platform-definitions/platform-definition-2020-09/platform-definition-2020-09.target
+++ b/releng/platform-definitions/platform-definition-2020-09/platform-definition-2020-09.target
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
-   Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+   Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
    Copyright (c) 2020, 2021, Datadog, Inc. All rights reserved.
 
    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
@@ -45,10 +45,10 @@
             <unit id="org.adoptopenjdk.jemmy-browser" version="2.0.0"/>
             <unit id="org.adoptopenjdk.jemmy-core" version="2.0.0"/>
             <unit id="org.adoptopenjdk.jemmy-swt" version="2.0.0"/>
-            <unit id="org.eclipse.jetty.websocket.api" version="10.0.5"/>
-            <unit id="org.eclipse.jetty.websocket.server" version="10.0.5"/>
-            <unit id="org.eclipse.jetty.websocket.servlet" version="10.0.5"/>
-            <unit id="org.eclipse.jetty.websocket.javax.server" version="10.0.5"/>
+            <unit id="org.eclipse.jetty.websocket.api" version="10.0.7"/>
+            <unit id="org.eclipse.jetty.websocket.server" version="10.0.7"/>
+            <unit id="org.eclipse.jetty.websocket.servlet" version="10.0.7"/>
+            <unit id="org.eclipse.jetty.websocket.javax.server" version="10.0.7"/>
             <unit id="org.apache.aries.spifly.dynamic.bundle" version="1.3.4"/>
             <repository location="http://localhost:8080/site"/>
         </location>

--- a/releng/platform-definitions/platform-definition-2020-12/platform-definition-2020-12.target
+++ b/releng/platform-definitions/platform-definition-2020-12/platform-definition-2020-12.target
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
-   Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+   Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
    Copyright (c) 2020, 2021, Datadog, Inc. All rights reserved.
 
    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
@@ -45,10 +45,10 @@
             <unit id="org.adoptopenjdk.jemmy-browser" version="2.0.0"/>
             <unit id="org.adoptopenjdk.jemmy-core" version="2.0.0"/>
             <unit id="org.adoptopenjdk.jemmy-swt" version="2.0.0"/>
-            <unit id="org.eclipse.jetty.websocket.api" version="10.0.5"/>
-            <unit id="org.eclipse.jetty.websocket.server" version="10.0.5"/>
-            <unit id="org.eclipse.jetty.websocket.servlet" version="10.0.5"/>
-            <unit id="org.eclipse.jetty.websocket.javax.server" version="10.0.5"/>
+            <unit id="org.eclipse.jetty.websocket.api" version="10.0.7"/>
+            <unit id="org.eclipse.jetty.websocket.server" version="10.0.7"/>
+            <unit id="org.eclipse.jetty.websocket.servlet" version="10.0.7"/>
+            <unit id="org.eclipse.jetty.websocket.javax.server" version="10.0.7"/>
             <unit id="org.apache.aries.spifly.dynamic.bundle" version="1.3.4"/>
             <repository location="http://localhost:8080/site"/>
         </location>

--- a/releng/platform-definitions/platform-definition-2021-03/platform-definition-2021-03.target
+++ b/releng/platform-definitions/platform-definition-2021-03/platform-definition-2021-03.target
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
-   Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+   Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
    Copyright (c) 2021, Datadog, Inc. All rights reserved.
 
    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
@@ -45,10 +45,10 @@
             <unit id="org.adoptopenjdk.jemmy-browser" version="2.0.0"/>
             <unit id="org.adoptopenjdk.jemmy-core" version="2.0.0"/>
             <unit id="org.adoptopenjdk.jemmy-swt" version="2.0.0"/>
-            <unit id="org.eclipse.jetty.websocket.api" version="10.0.5"/>
-            <unit id="org.eclipse.jetty.websocket.server" version="10.0.5"/>
-            <unit id="org.eclipse.jetty.websocket.servlet" version="10.0.5"/>
-            <unit id="org.eclipse.jetty.websocket.javax.server" version="10.0.5"/>
+            <unit id="org.eclipse.jetty.websocket.api" version="10.0.7"/>
+            <unit id="org.eclipse.jetty.websocket.server" version="10.0.7"/>
+            <unit id="org.eclipse.jetty.websocket.servlet" version="10.0.7"/>
+            <unit id="org.eclipse.jetty.websocket.javax.server" version="10.0.7"/>
             <unit id="org.apache.aries.spifly.dynamic.bundle" version="1.3.4"/>
             <repository location="http://localhost:8080/site"/>
         </location>

--- a/releng/platform-definitions/platform-definition-2021-06/platform-definition-2021-06.target
+++ b/releng/platform-definitions/platform-definition-2021-06/platform-definition-2021-06.target
@@ -45,10 +45,10 @@
             <unit id="org.adoptopenjdk.jemmy-browser" version="2.0.0"/>
             <unit id="org.adoptopenjdk.jemmy-core" version="2.0.0"/>
             <unit id="org.adoptopenjdk.jemmy-swt" version="2.0.0"/>
-            <unit id="org.eclipse.jetty.websocket.api" version="10.0.5"/>
-            <unit id="org.eclipse.jetty.websocket.server" version="10.0.5"/>
-            <unit id="org.eclipse.jetty.websocket.servlet" version="10.0.5"/>
-            <unit id="org.eclipse.jetty.websocket.javax.server" version="10.0.5"/>
+            <unit id="org.eclipse.jetty.websocket.api" version="10.0.7"/>
+            <unit id="org.eclipse.jetty.websocket.server" version="10.0.7"/>
+            <unit id="org.eclipse.jetty.websocket.servlet" version="10.0.7"/>
+            <unit id="org.eclipse.jetty.websocket.javax.server" version="10.0.7"/>
             <unit id="org.apache.aries.spifly.dynamic.bundle" version="1.3.4"/>
             <repository location="http://localhost:8080/site"/>
         </location>

--- a/releng/platform-definitions/platform-definition-2021-09/platform-definition-2021-09.target
+++ b/releng/platform-definitions/platform-definition-2021-09/platform-definition-2021-09.target
@@ -45,10 +45,10 @@
             <unit id="org.adoptopenjdk.jemmy-browser" version="2.0.0"/>
             <unit id="org.adoptopenjdk.jemmy-core" version="2.0.0"/>
             <unit id="org.adoptopenjdk.jemmy-swt" version="2.0.0"/>
-            <unit id="org.eclipse.jetty.websocket.api" version="10.0.5"/>
-            <unit id="org.eclipse.jetty.websocket.server" version="10.0.5"/>
-            <unit id="org.eclipse.jetty.websocket.servlet" version="10.0.5"/>
-            <unit id="org.eclipse.jetty.websocket.javax.server" version="10.0.5"/>
+            <unit id="org.eclipse.jetty.websocket.api" version="10.0.7"/>
+            <unit id="org.eclipse.jetty.websocket.server" version="10.0.7"/>
+            <unit id="org.eclipse.jetty.websocket.servlet" version="10.0.7"/>
+            <unit id="org.eclipse.jetty.websocket.javax.server" version="10.0.7"/>
             <unit id="org.apache.aries.spifly.dynamic.bundle" version="1.3.4"/>
             <repository location="http://localhost:8080/site"/>
         </location>

--- a/releng/platform-definitions/platform-definition-2021-12/platform-definition-2021-12.target
+++ b/releng/platform-definitions/platform-definition-2021-12/platform-definition-2021-12.target
@@ -45,10 +45,10 @@
             <unit id="org.adoptopenjdk.jemmy-browser" version="2.0.0"/>
             <unit id="org.adoptopenjdk.jemmy-core" version="2.0.0"/>
             <unit id="org.adoptopenjdk.jemmy-swt" version="2.0.0"/>
-            <unit id="org.eclipse.jetty.websocket.api" version="10.0.5"/>
-            <unit id="org.eclipse.jetty.websocket.server" version="10.0.5"/>
-            <unit id="org.eclipse.jetty.websocket.servlet" version="10.0.5"/>
-            <unit id="org.eclipse.jetty.websocket.javax.server" version="10.0.5"/>
+            <unit id="org.eclipse.jetty.websocket.api" version="10.0.7"/>
+            <unit id="org.eclipse.jetty.websocket.server" version="10.0.7"/>
+            <unit id="org.eclipse.jetty.websocket.servlet" version="10.0.7"/>
+            <unit id="org.eclipse.jetty.websocket.javax.server" version="10.0.7"/>
             <unit id="org.apache.aries.spifly.dynamic.bundle" version="1.3.4"/>
             <repository location="http://localhost:8080/site"/>
         </location>

--- a/releng/third-party/pom.xml
+++ b/releng/third-party/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-   Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+   Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
 
    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
@@ -46,7 +46,7 @@
 		<jakarta.activation.version>2.0.1</jakarta.activation.version>
 		<jakarta.mail.version>2.0.1</jakarta.mail.version>
 		<javax.websocket.version>1.1</javax.websocket.version>
-		<jetty.version>10.0.5</jetty.version>
+		<jetty.version>10.0.7</jetty.version>
 		<jemmy.version>2.0.0</jemmy.version>
 		<jetty-maven-plugin.version>9.4.43.v20210629</jetty-maven-plugin.version>
 		<lz4.version>1.8.0</lz4.version>


### PR DESCRIPTION
This PR upgrades Jetty websocket third party from 10.0.5 to 10.0.7.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JMC-7531](https://bugs.openjdk.java.net/browse/JMC-7531): Update jetty websocket third party


### Reviewers
 * [Marcus Hirt](https://openjdk.java.net/census#hirt) (@thegreystone - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jmc pull/364/head:pull/364` \
`$ git checkout pull/364`

Update a local copy of the PR: \
`$ git checkout pull/364` \
`$ git pull https://git.openjdk.java.net/jmc pull/364/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 364`

View PR using the GUI difftool: \
`$ git pr show -t 364`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jmc/pull/364.diff">https://git.openjdk.java.net/jmc/pull/364.diff</a>

</details>
