### PR TITLE
7537: Build script assumes that Darwin always targets x86_64

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,7 +333,11 @@ to use when launching, add -vm and the path to a directory where a JDK java laun
 Here is an example for Mac OS X:
 
 ```bash
+# on x86_64
 target/products/org.openjdk.jmc/macosx/cocoa/x86_64/JDK\ Mission\ Control.app/Contents/MacOS/jmc
+
+# on M1
+target/products/org.openjdk.jmc/macosx/cocoa/aarch64/JDK\ Mission\ Control.app/Contents/MacOS/jmc
 ```
 
 Here is an example for Linux:

--- a/build.sh
+++ b/build.sh
@@ -4,7 +4,10 @@ set -u # a reference to any variable you have not previously defined causes the 
 set -o pipefail # If any command in a pipeline fails, that return code will be used as the return code of the whole pipeline
 
 PROGNAME=$(basename "$0")
-
+ARCH="x86_64"
+if [[ "`uname -m`" =~ "arm64" ]]; then 
+  ARCH="aarch64"
+fi
 JETTY_PID=""
 BASEDIR=""
 JMC_DIR=""
@@ -121,9 +124,9 @@ function packageJmc() {
     mvn package --log-file "${packageLog}"
 
     if [[ "${OSTYPE}" =~ "linux"* ]]; then
-        echo "You can now run jmc by calling \"${PROGNAME} --run\" or \"${BASEDIR}/products/org.openjdk.jmc/linux/gtk/x86_64/JDK\ Mission\ Control/jmc\""
+        echo "You can now run jmc by calling \"${PROGNAME} --run\" or \"${BASEDIR}/products/org.openjdk.jmc/linux/gtk/${ARCH}/JDK\ Mission\ Control/jmc\""
     elif [[ "${OSTYPE}" =~ "darwin"* ]]; then
-        echo "You can now run jmc by calling \"${PROGNAME} --run\" or \"${BASEDIR}/products/org.openjdk.jmc/macosx/cocoa/x86_64/JDK\ Mission\ Control.app/Contents/MacOS/jmc\""
+        echo "You can now run jmc by calling \"${PROGNAME} --run\" or \"${BASEDIR}/products/org.openjdk.jmc/macosx/cocoa/${ARCH}/JDK\ Mission\ Control.app/Contents/MacOS/jmc\""
     else
         err_log "unknown OS type: \"${OSTYPE}\". Please check your package in \"${BASEDIR}/products/org.openjdk.jmc/\""
     fi
@@ -193,9 +196,9 @@ function clean() {
 function run() {
     local path
     if [[ "${OSTYPE}" =~ "linux"* ]]; then
-        path="${BASEDIR}/products/org.openjdk.jmc/linux/gtk/x86_64/JDK Mission Control/jmc"
+        path="${BASEDIR}/products/org.openjdk.jmc/linux/gtk/${ARCH}/JDK Mission Control/jmc"
     elif [[ "${OSTYPE}" =~ "darwin"* ]]; then
-        path="${BASEDIR}/products/org.openjdk.jmc/macosx/cocoa/x86_64/JDK Mission Control.app/Contents/MacOS/jmc"
+        path="${BASEDIR}/products/org.openjdk.jmc/macosx/cocoa/${ARCH}/JDK Mission Control.app/Contents/MacOS/jmc"
     else
         err_log "unknown OS type: ${OSTYPE}"
         exit 1


### PR DESCRIPTION
Tested on Mac M1.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JMC-7537](https://bugs.openjdk.java.net/browse/JMC-7537): Build script assumes that Darwin always targets x86_64


### Reviewers
 * [Marcus Hirt](https://openjdk.java.net/census#hirt) (@thegreystone - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jmc pull/366/head:pull/366` \
`$ git checkout pull/366`

Update a local copy of the PR: \
`$ git checkout pull/366` \
`$ git pull https://git.openjdk.java.net/jmc pull/366/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 366`

View PR using the GUI difftool: \
`$ git pr show -t 366`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jmc/pull/366.diff">https://git.openjdk.java.net/jmc/pull/366.diff</a>

</details>
