### PR TITLE
7539: JDP Tests failing in VPN environments

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -294,7 +294,7 @@ function parseArgs() {
                 runAgentByClass "org.openjdk.jmc.agent.converters.test.InstrumentMeConverter"
                 ;;
             --skipJDPMulticastTests)
-                JVM_ARGUMENTS="${JVM_ARGUMENTS} -DskipJDPMulticastTests=true "
+                JVM_ARGUMENTS="${JVM_ARGUMENTS} -DskipJDPMulticastTests=true"
                 ;;
             *)
                 err_log "unknown arguments: $@"

--- a/core/tests/org.openjdk.jmc.jdp.test/src/test/java/org/openjdk/jmc/jdp/client/JDPClientTest.java
+++ b/core/tests/org.openjdk.jmc.jdp.test/src/test/java/org/openjdk/jmc/jdp/client/JDPClientTest.java
@@ -63,7 +63,7 @@ public class JDPClientTest {
 
 	@Test
 	public void testJDPClient() throws Exception {
-		Assume.assumeTrue(TestToolkit.BROADCASTING_SUPPORTED);
+		Assume.assumeTrue(TestToolkit.areBroadcastingTestsEnabled());
 		JDPClient client = createDefaultClient();
 		JDPServer server = createDefaultServer();
 		client.start();
@@ -85,7 +85,7 @@ public class JDPClientTest {
 
 	@Test
 	public void testChangePacket() throws Exception {
-		Assume.assumeTrue(TestToolkit.BROADCASTING_SUPPORTED);
+		Assume.assumeTrue(TestToolkit.areBroadcastingTestsEnabled());
 		JDPClient client = createDefaultClient();
 		JDPServer server = createDefaultServer();
 		client.start();

--- a/core/tests/org.openjdk.jmc.jdp.test/src/test/java/org/openjdk/jmc/jdp/client/JDPClientTest.java
+++ b/core/tests/org.openjdk.jmc.jdp.test/src/test/java/org/openjdk/jmc/jdp/client/JDPClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/core/tests/org.openjdk.jmc.jdp.test/src/test/java/org/openjdk/jmc/jdp/client/JDPClientTest.java
+++ b/core/tests/org.openjdk.jmc.jdp.test/src/test/java/org/openjdk/jmc/jdp/client/JDPClientTest.java
@@ -41,6 +41,7 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
 
+import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -62,6 +63,7 @@ public class JDPClientTest {
 
 	@Test
 	public void testJDPClient() throws Exception {
+		Assume.assumeTrue(TestToolkit.BROADCASTING_SUPPORTED);
 		JDPClient client = createDefaultClient();
 		JDPServer server = createDefaultServer();
 		client.start();
@@ -83,6 +85,7 @@ public class JDPClientTest {
 
 	@Test
 	public void testChangePacket() throws Exception {
+		Assume.assumeTrue(TestToolkit.BROADCASTING_SUPPORTED);
 		JDPClient client = createDefaultClient();
 		JDPServer server = createDefaultServer();
 		client.start();

--- a/core/tests/org.openjdk.jmc.jdp.test/src/test/java/org/openjdk/jmc/jdp/client/JDPJMXTest.java
+++ b/core/tests/org.openjdk.jmc.jdp.test/src/test/java/org/openjdk/jmc/jdp/client/JDPJMXTest.java
@@ -39,6 +39,7 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 
+import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
 import org.openjdk.jmc.jdp.common.Configuration;
@@ -58,6 +59,7 @@ public class JDPJMXTest {
 
 	@Test
 	public void testJDPClient() throws Exception {
+		Assume.assumeTrue(TestToolkit.BROADCASTING_SUPPORTED);
 		JDPClient client = createDefaultClient();
 		JDPServer server = TestToolkit.createDefaultJMXJDPServer(discoverableID);
 		TestToolkit.printServerSettings(server);

--- a/core/tests/org.openjdk.jmc.jdp.test/src/test/java/org/openjdk/jmc/jdp/client/JDPJMXTest.java
+++ b/core/tests/org.openjdk.jmc.jdp.test/src/test/java/org/openjdk/jmc/jdp/client/JDPJMXTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/core/tests/org.openjdk.jmc.jdp.test/src/test/java/org/openjdk/jmc/jdp/client/JDPJMXTest.java
+++ b/core/tests/org.openjdk.jmc.jdp.test/src/test/java/org/openjdk/jmc/jdp/client/JDPJMXTest.java
@@ -59,7 +59,7 @@ public class JDPJMXTest {
 
 	@Test
 	public void testJDPClient() throws Exception {
-		Assume.assumeTrue(TestToolkit.BROADCASTING_SUPPORTED);
+		Assume.assumeTrue(TestToolkit.areBroadcastingTestsEnabled());
 		JDPClient client = createDefaultClient();
 		JDPServer server = TestToolkit.createDefaultJMXJDPServer(discoverableID);
 		TestToolkit.printServerSettings(server);

--- a/core/tests/org.openjdk.jmc.jdp.test/src/test/java/org/openjdk/jmc/jdp/client/TestToolkit.java
+++ b/core/tests/org.openjdk.jmc.jdp.test/src/test/java/org/openjdk/jmc/jdp/client/TestToolkit.java
@@ -187,7 +187,7 @@ public final class TestToolkit {
 			try (MulticastSocket ssocket = new MulticastSocket(multiCastPort)) {
 				ssocket.setTimeToLive(1);
 				ssocket.joinGroup(multiCastAddress);
-				final DatagramPacket dp = new DatagramPacket(new byte[] { 1 }, 1, multiCastAddress, multiCastPort);
+				final DatagramPacket dp = new DatagramPacket(new byte[] {1}, 1, multiCastAddress, multiCastPort);
 				while (true) {
 					ssocket.send(dp);
 					Thread.sleep(10);

--- a/core/tests/org.openjdk.jmc.jdp.test/src/test/java/org/openjdk/jmc/jdp/client/TestToolkit.java
+++ b/core/tests/org.openjdk.jmc.jdp.test/src/test/java/org/openjdk/jmc/jdp/client/TestToolkit.java
@@ -162,8 +162,7 @@ public final class TestToolkit {
 			InetAddress multiCastAddress = InetAddress.getByName("239.255.255.255");
 			int multiCastPort = 7711;
 			Thread thread = new Thread(() -> {
-				try {
-					MulticastSocket ssocket = new MulticastSocket(multiCastPort);
+				try (MulticastSocket ssocket = new MulticastSocket(multiCastPort)) {
 					ssocket.setTimeToLive(1);
 					ssocket.joinGroup(multiCastAddress);
 					final DatagramPacket dp = new DatagramPacket(new byte[] { 1 }, 1, multiCastAddress, multiCastPort);
@@ -175,15 +174,14 @@ public final class TestToolkit {
 				}
 			});
 			thread.start();
-			try {
-				MulticastSocket socket = new MulticastSocket(multiCastPort);
+			try (MulticastSocket socket = new MulticastSocket(multiCastPort)){
 				socket.joinGroup(multiCastAddress);
 				byte[] buffer = new byte[4096];
 				socket.setSoTimeout(300);
 				socket.receive(new DatagramPacket(buffer, buffer.length));
-				thread.interrupt();
 				return true;
 			} catch (IOException e) {
+			} finally {
 				thread.interrupt();
 			}
 		} catch (UnknownHostException ex) {

--- a/core/tests/org.openjdk.jmc.jdp.test/src/test/java/org/openjdk/jmc/jdp/client/TestToolkit.java
+++ b/core/tests/org.openjdk.jmc.jdp.test/src/test/java/org/openjdk/jmc/jdp/client/TestToolkit.java
@@ -55,6 +55,7 @@ public final class TestToolkit {
 	public static final int TEST_MULTICAST_PORT = 7711;
 	private static final String TEST_MULTICAST_ADDRESS_STRING = "224.0.23.177";
 	public static final InetAddress TEST_MULTICAST_ADDRESS;
+
 	static {
 		InetAddress tmp = null;
 		try {
@@ -155,7 +156,7 @@ public final class TestToolkit {
 	 * See https://bugs.openjdk.java.net/browse/JMC-7539
 	 */
 	public static boolean areBroadcastingTestsEnabled() {
-		if (System.getProperty("skipJDPMulticastTests", "false").equals("true")) {
+		if (Boolean.getBoolean("skipJDPMulticastTests")) {
 			JDPClientTest.LOGGER.log(Level.INFO, "Broadcasting related tests are disabled");
 			return false;
 		}
@@ -167,11 +168,14 @@ public final class TestToolkit {
 				helpMessage += String.format("'sudo route add -host %s -interface en0'", address);
 			} else if (os.startsWith("linux")) {
 				helpMessage += String.format("'sudo ip route add %s dev eth0'", address);
+			} else if (os.startsWith("win")) {
+				helpMessage += String.format("'route add %s <gateway>' in a shell with administrator permissions",
+						address);
 			} else {
 				helpMessage = "";
 			}
 			JDPClientTest.LOGGER.log(Level.WARNING, "Broadcasting does not seem to be possible.\n"
-					+ "This is usually related to VPN. There are four possible ways to remedy this:\n"
+					+ "This is usually related to VPN. There are three possible ways to remedy this:\n"
 					+ "  1. Try to configure your VPN, or perhaps turn it off.\n"
 					+ "  2. Add a proper route for local multicast" + helpMessage + ".\n"
 					+ "  3. If the two above really can't be made to work, use -DskipJDPMulticastTests=true (with Java or maven)\n"

--- a/core/tests/org.openjdk.jmc.jdp.test/src/test/java/org/openjdk/jmc/jdp/client/TestToolkit.java
+++ b/core/tests/org.openjdk.jmc.jdp.test/src/test/java/org/openjdk/jmc/jdp/client/TestToolkit.java
@@ -157,36 +157,37 @@ public final class TestToolkit {
 		return bytes;
 	}
 
-    private static boolean isBroadcastingSupported() {
-        try {
-            InetAddress multiCastAddress = InetAddress.getByName("239.255.255.255");
-            int multiCastPort = 7711;
-            Thread thread = new Thread(() -> {
-                try {
-                    MulticastSocket ssocket = new MulticastSocket(multiCastPort);
-                    ssocket.setTimeToLive(1);
-                    ssocket.joinGroup(multiCastAddress);
-                    final DatagramPacket dp = new DatagramPacket(new byte[]{1}, 1, multiCastAddress, multiCastPort);
-                    while (true) {
-                        ssocket.send(dp);
-                        Thread.sleep(10);
-                    }
-                } catch (InterruptedException | IOException e) {
-                }
-            });
-            thread.start();
-            try {
-                MulticastSocket socket = new MulticastSocket(multiCastPort);
-                socket.joinGroup(multiCastAddress);
-                byte[] buffer = new byte[4096];
-                socket.setSoTimeout(300);
-                socket.receive(new DatagramPacket(buffer, buffer.length));
-                thread.interrupt();
-                return true;
-            } catch (IOException e) {
-                thread.interrupt();
-            }
-        } catch (UnknownHostException ex) {}
-        return false;
-    }
+	private static boolean isBroadcastingSupported() {
+		try {
+			InetAddress multiCastAddress = InetAddress.getByName("239.255.255.255");
+			int multiCastPort = 7711;
+			Thread thread = new Thread(() -> {
+				try {
+					MulticastSocket ssocket = new MulticastSocket(multiCastPort);
+					ssocket.setTimeToLive(1);
+					ssocket.joinGroup(multiCastAddress);
+					final DatagramPacket dp = new DatagramPacket(new byte[] { 1 }, 1, multiCastAddress, multiCastPort);
+					while (true) {
+						ssocket.send(dp);
+						Thread.sleep(10);
+					}
+				} catch (InterruptedException | IOException e) {
+				}
+			});
+			thread.start();
+			try {
+				MulticastSocket socket = new MulticastSocket(multiCastPort);
+				socket.joinGroup(multiCastAddress);
+				byte[] buffer = new byte[4096];
+				socket.setSoTimeout(300);
+				socket.receive(new DatagramPacket(buffer, buffer.length));
+				thread.interrupt();
+				return true;
+			} catch (IOException e) {
+				thread.interrupt();
+			}
+		} catch (UnknownHostException ex) {
+		}
+		return false;
+	}
 }

--- a/core/tests/org.openjdk.jmc.jdp.test/src/test/java/org/openjdk/jmc/jdp/client/TestToolkit.java
+++ b/core/tests/org.openjdk.jmc.jdp.test/src/test/java/org/openjdk/jmc/jdp/client/TestToolkit.java
@@ -171,10 +171,11 @@ public final class TestToolkit {
 				helpMessage = "";
 			}
 			JDPClientTest.LOGGER.log(Level.WARNING, "Broadcasting does not seem to be possible.\n"
-					+ "This is usually related to VPN. There are three possible ways to remedy this:\n"
+					+ "This is usually related to VPN. There are four possible ways to remedy this:\n"
 					+ "  1. Try to configure your VPN, or perhaps turn it off.\n"
-					+ "  2. Add a proper route for local multicast" + helpMessage + "\n"
-					+ "  3. If the two above really can't be made to work, use -DskipJDPMulticastTests=true to skip the tests.");
+					+ "  2. Add a proper route for local multicast" + helpMessage + ".\n"
+					+ "  3. If the two above really can't be made to work, use -DskipJDPMulticastTests=true (with Java or maven)\n"
+					+ "     or --skipJDPMulticastTests (as first argument of the build script)");
 		}
 		return true;
 	}

--- a/core/tests/org.openjdk.jmc.jdp.test/src/test/java/org/openjdk/jmc/jdp/client/TestToolkit.java
+++ b/core/tests/org.openjdk.jmc.jdp.test/src/test/java/org/openjdk/jmc/jdp/client/TestToolkit.java
@@ -165,7 +165,7 @@ public final class TestToolkit {
 				try (MulticastSocket ssocket = new MulticastSocket(multiCastPort)) {
 					ssocket.setTimeToLive(1);
 					ssocket.joinGroup(multiCastAddress);
-					final DatagramPacket dp = new DatagramPacket(new byte[] { 1 }, 1, multiCastAddress, multiCastPort);
+					final DatagramPacket dp = new DatagramPacket(new byte[] {1}, 1, multiCastAddress, multiCastPort);
 					while (true) {
 						ssocket.send(dp);
 						Thread.sleep(10);

--- a/core/tests/org.openjdk.jmc.jdp.test/src/test/java/org/openjdk/jmc/jdp/client/TestToolkit.java
+++ b/core/tests/org.openjdk.jmc.jdp.test/src/test/java/org/openjdk/jmc/jdp/client/TestToolkit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -174,7 +174,7 @@ public final class TestToolkit {
 				}
 			});
 			thread.start();
-			try (MulticastSocket socket = new MulticastSocket(multiCastPort)){
+			try (MulticastSocket socket = new MulticastSocket(multiCastPort)) {
 				socket.joinGroup(multiCastAddress);
 				byte[] buffer = new byte[4096];
 				socket.setSoTimeout(300);


### PR DESCRIPTION
Only run broadcasting related tests when supported.
Tested on Mac M1 with and without VPN.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JMC-7539](https://bugs.openjdk.java.net/browse/JMC-7539): JDP Tests failing in VPN environments


### Reviewers
 * [Christoph Langer](https://openjdk.java.net/census#clanger) (@RealCLanger - Author)
 * [Marcus Hirt](https://openjdk.java.net/census#hirt) (@thegreystone - **Reviewer**) ⚠️ Review applies to f902747c0f88509edf845ff50e9189cc36c89cf7


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jmc pull/369/head:pull/369` \
`$ git checkout pull/369`

Update a local copy of the PR: \
`$ git checkout pull/369` \
`$ git pull https://git.openjdk.java.net/jmc pull/369/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 369`

View PR using the GUI difftool: \
`$ git pr show -t 369`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jmc/pull/369.diff">https://git.openjdk.java.net/jmc/pull/369.diff</a>

</details>
