### PR TITLE
7540: IItemCollectionJsonSerializerTest.java might fail on Windows due to line endings

### DIFF
--- a/core/tests/org.openjdk.jmc.flightrecorder.serializers.test/src/test/java/org/openjdk/jmc/flightrecorder/serializers/json/test/IItemCollectionJsonSerializerTest.java
+++ b/core/tests/org.openjdk.jmc.flightrecorder.serializers.test/src/test/java/org/openjdk/jmc/flightrecorder/serializers/json/test/IItemCollectionJsonSerializerTest.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2021, Datadog, Inc. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Datadog, Inc. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -66,7 +66,7 @@ public class IItemCollectionJsonSerializerTest {
 
 		String actual = IItemCollectionJsonSerializer.toJsonString(testRecording);
 
-		assertEquals(expected, actual);
+		assertEquals(expected.replaceAll("\\r\\n", "\n"), actual.replaceAll("\\r\\n", "\n"));
 	}
 
 	private String readResource(String resourcePath) throws IOException {


### PR DESCRIPTION
Fix test IItemCollectionJsonSerializerTest.java

The line endings should be normalized, to avoid errors on Windows due to incompatible line ending formats.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JMC-7540](https://bugs.openjdk.java.net/browse/JMC-7540): IItemCollectionJsonSerializerTest.java might fail on Windows due to line endings


### Reviewers
 * [Marcus Hirt](https://openjdk.java.net/census#hirt) (@thegreystone - **Reviewer**) ⚠️ Review applies to 4249103d1be4ade2b0c975fa62c1efb29c3d4d1e


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jmc pull/370/head:pull/370` \
`$ git checkout pull/370`

Update a local copy of the PR: \
`$ git checkout pull/370` \
`$ git pull https://git.openjdk.java.net/jmc pull/370/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 370`

View PR using the GUI difftool: \
`$ git pr show -t 370`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jmc/pull/370.diff">https://git.openjdk.java.net/jmc/pull/370.diff</a>

</details>
