### PR TITLE
7541: Switch to using 2021-09 by default

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -135,6 +135,9 @@
 		</profile>
 		<profile>
 			<id>2021-09</id>
+			<activation>
+				<activeByDefault>true</activeByDefault>
+			</activation>
 			<build>
 				<plugins>
 					<plugin>
@@ -156,9 +159,6 @@
 		</profile>
 		<profile>
 			<id>2021-06</id>
-			<activation>
-				<activeByDefault>true</activeByDefault>
-			</activation>
 			<build>
 				<plugins>
 					<plugin>


### PR DESCRIPTION
This is the platform that Oracle will use when releasing, so might as well make it the default.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JMC-7541](https://bugs.openjdk.java.net/browse/JMC-7541): Switch to using 2021-09 by default


### Reviewers
 * [Christoph Langer](https://openjdk.java.net/census#clanger) (@RealCLanger - Author)
 * [Jean-Philippe Bempel](https://openjdk.java.net/census#jpbempel) (@jpbempel - Committer)
 * [Henrik Dafgård](https://openjdk.java.net/census#hdafgard) (@Gunde - **Reviewer**)
 * @bric3 (no known github.com user name / role)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jmc pull/371/head:pull/371` \
`$ git checkout pull/371`

Update a local copy of the PR: \
`$ git checkout pull/371` \
`$ git pull https://git.openjdk.java.net/jmc pull/371/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 371`

View PR using the GUI difftool: \
`$ git pr show -t 371`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jmc/pull/371.diff">https://git.openjdk.java.net/jmc/pull/371.diff</a>

</details>
