### PR TITLE
7467: Only use one version of d3

### DIFF
--- a/application/org.openjdk.jmc.flightrecorder.graphview/pom.xml
+++ b/application/org.openjdk.jmc.flightrecorder.graphview/pom.xml
@@ -65,7 +65,7 @@
 							<goal>wget</goal>
 						</goals>
 						<configuration>
-							<url>https://d3js.org/d3.v5.min.js</url>
+							<url>https://d3js.org/d3.v6.min.js</url>
 							<unpack>false</unpack>
 							<outputDirectory>${download-maven-plugin.output}</outputDirectory>
 							<skipCache>true</skipCache>

--- a/application/org.openjdk.jmc.flightrecorder.graphview/pom.xml
+++ b/application/org.openjdk.jmc.flightrecorder.graphview/pom.xml
@@ -59,7 +59,7 @@
 				<version>${download.maven.plugin.version}</version>
 				<executions>
 					<execution>
-						<id>d3-v5-js</id>
+						<id>download-d3</id>
 						<phase>${download-maven-plugin.phase}</phase>
 						<goals>
 							<goal>wget</goal>
@@ -73,7 +73,7 @@
 						</configuration>
 					</execution>
 					<execution>
-						<id>wasm</id>
+						<id>download-wasm</id>
 						<phase>${download-maven-plugin.phase}</phase>
 						<goals>
 							<goal>wget</goal>
@@ -87,7 +87,7 @@
 						</configuration>
 					</execution>
 					<execution>
-						<id>d3-graphviz-js</id>
+						<id>download-graphviz</id>
 						<phase>${download-maven-plugin.phase}</phase>
 						<goals>
 							<goal>wget</goal>
@@ -101,7 +101,7 @@
 						</configuration>
 					</execution>
 					<execution>
-						<id>graphvizlib-wasm</id>
+						<id>download-graphvizlib-wasm</id>
 						<phase>${download-maven-plugin.phase}</phase>
 						<goals>
 							<goal>wget</goal>

--- a/application/org.openjdk.jmc.flightrecorder.graphview/src/main/java/org/openjdk/jmc/flightrecorder/graphview/views/GraphView.java
+++ b/application/org.openjdk.jmc.flightrecorder.graphview/src/main/java/org/openjdk/jmc/flightrecorder/graphview/views/GraphView.java
@@ -86,14 +86,14 @@ import org.openjdk.jmc.ui.misc.DisplayToolkit;
 public class GraphView extends ViewPart implements ISelectionListener {
 	private static final String HTML_PAGE;
 	static {
-		String jsD3V5 = "jslibs/d3.v5.min.js";
+		String jsD3 = "jslibs/d3.v6.min.js";
 		String jsGraphviz = "jslibs/index.js";
 		String wasmGraphviz = "jslibs/graphvizlib.wasm";
 		String jsGraphizD3 = "jslibs/d3-graphviz.js";
 
 		String wasmBase64 = loadBase64FromFile(wasmGraphviz);
 
-		HTML_PAGE = String.format(loadStringFromFile("page.template"), loadLibraries(jsD3V5),
+		HTML_PAGE = String.format(loadStringFromFile("page.template"), loadLibraries(jsD3),
 				// we inline base64 wasm in the library code to avoid fetching it at runtime
 				loadStringFromFile(jsGraphviz, "wasmBinaryFile=\"graphvizlib.wasm\";",
 						"wasmBinaryFile=dataURIPrefix + '" + wasmBase64 + "';"),


### PR DESCRIPTION
Updating v5 to v6.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JMC-7467](https://bugs.openjdk.java.net/browse/JMC-7467): Only use one version of d3


### Reviewers
 * @bric3 (no known github.com user name / role)
 * [Alex Macdonald](https://openjdk.java.net/census#aptmac) (@aptmac - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jmc pull/372/head:pull/372` \
`$ git checkout pull/372`

Update a local copy of the PR: \
`$ git checkout pull/372` \
`$ git pull https://git.openjdk.java.net/jmc pull/372/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 372`

View PR using the GUI difftool: \
`$ git pr show -t 372`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jmc/pull/372.diff">https://git.openjdk.java.net/jmc/pull/372.diff</a>

</details>
