### PR TITLE
6792: Outline shows as not available when starting up with open recording

### DIFF
--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/FlightRecorderUI.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/FlightRecorderUI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -234,6 +234,7 @@ public final class FlightRecorderUI extends MCAbstractUIPlugin {
 				for (IEditorReference er : wp.getEditorReferences()) {
 					if ((editor = er.getEditor(false)) instanceof JfrEditor) {
 						((JfrEditor) editor).refreshPages();
+						((JfrEditor) editor).setFocus();
 					}
 				}
 			}


### PR DESCRIPTION
Problem: On Re-launch of JMC, previously opened JFR gets loaded and shown in JFR editor. But the outline appears blank. Workaround is to click on the JFR Editor. Please refer the attached files.

![OutlineIsBlank](https://user-images.githubusercontent.com/97600378/151947215-0a445f64-f4f8-43bd-9936-11ddf9ad4f66.jpg)

Fix: On Re-launch of JMC, setting the focus on active JFR editor. This solves the problem and outline gets displayed properly.

![OutlineGetsDisplayed](https://user-images.githubusercontent.com/97600378/151947205-25d9d5dd-5256-4f3f-ba97-327b7ea6b406.jpg)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JMC-6792](https://bugs.openjdk.java.net/browse/JMC-6792): Outline shows as not available when starting up with open recording


### Reviewers
 * [Marcus Hirt](https://openjdk.java.net/census#hirt) (@thegreystone - **Reviewer**)
 * [Alex Macdonald](https://openjdk.java.net/census#aptmac) (@aptmac - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jmc pull/373/head:pull/373` \
`$ git checkout pull/373`

Update a local copy of the PR: \
`$ git checkout pull/373` \
`$ git pull https://git.openjdk.java.net/jmc pull/373/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 373`

View PR using the GUI difftool: \
`$ git pr show -t 373`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jmc/pull/373.diff">https://git.openjdk.java.net/jmc/pull/373.diff</a>

</details>
