### PR TITLE
7532: Delay in realtime rending of graphs  in JMX Console

### DIFF
--- a/application/org.openjdk.jmc.greychart.ui/src/main/java/org/openjdk/jmc/greychart/ui/views/ChartComposite.java
+++ b/application/org.openjdk.jmc.greychart.ui/src/main/java/org/openjdk/jmc/greychart/ui/views/ChartComposite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -186,12 +186,7 @@ public class ChartComposite extends SelectionCanvas {
 			((NanosXAxis) getChart().getXAxis()).setRange(m_viewEnd - m_viewWidth, m_viewEnd);
 			m_chart.setXAxis(m_chart.getXAxis());
 			if (IMMEDIATE_DRAWING && isVisible() && !getClientArea().isEmpty()) {
-				GC gc = new GC(this);
-				paint(gc);
-				if (isFocusControl()) {
-					FocusTracker.drawFocusOn(this, gc);
-				}
-				gc.dispose();
+				redraw();
 			} else {
 				redraw();
 				/*

--- a/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/dial/DialViewer.java
+++ b/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/dial/DialViewer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -225,19 +225,8 @@ public class DialViewer extends Composite implements IRefreshable {
 	@Override
 	public boolean refresh() {
 		if (!isDisposed()) {
-			if (IMMEDIATE_DRAWING) {
-				if (isVisible()) {
-					Rectangle area = getClientArea();
-					if (!area.isEmpty()) {
-						GC gc = new GC(this);
-						draw(gc, 0, 0, area.width, area.height, true);
-						// Must redraw focus in the same way as FocusTracker
-						if (isFocusControl()) {
-							FocusTracker.drawFocusOn(this, gc);
-						}
-						gc.dispose();
-					}
-				}
+			if (IMMEDIATE_DRAWING && isVisible() && !getClientArea().isEmpty()) {
+				redraw();
 			} else {
 				redraw();
 			}


### PR DESCRIPTION
Issue: Dials and Charts in JMX Console was not rendering with the change. 

<img width="1302" alt="image-2022-01-18-21-36-49-712" src="https://user-images.githubusercontent.com/97600378/152590022-262d4ce1-fe1a-4b52-bb43-d1b61b96d4d0.png">
 
Root cause: Control redraw() method was conditionally called. This method was called for windows and Linux OS. For mac OS, this redraw() method was not called to solve "console dials causing high CPU load on Mac". But because of this rendering was not happening for dials and charts. 
I do not see any high CPU load (May be issue with older versions of OS). Could you please review the changes and let me know if you see any performance issue with this fix (mainly on macOS) ? 

Fix: Control redraw() method has been called for macOS as well.

<img width="928" alt="Fix_7532" src="https://user-images.githubusercontent.com/97600378/152590703-0c385f22-be14-4ad6-b592-927c37fa2385.png">

