### PR TITLE
7486: Unable to install Eclipse IDE Plugin

### DIFF
--- a/application/org.openjdk.jmc.feature.flightrecorder/feature.xml
+++ b/application/org.openjdk.jmc.feature.flightrecorder/feature.xml
@@ -179,13 +179,6 @@
          unpack="false"/>
 
    <plugin
-         id="org.eclipse.jetty.websocket.javax.server"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
          id="org.openjdk.jmc.flightrecorder.flameview"
          download-size="0"
          install-size="0"
@@ -205,4 +198,5 @@
          install-size="0"
          version="0.0.0"
          unpack="false"/>
+
 </feature>

--- a/application/org.openjdk.jmc.feature.ide/feature.xml
+++ b/application/org.openjdk.jmc.feature.ide/feature.xml
@@ -76,4 +76,131 @@
          install-size="0"
          version="0.0.0"
          unpack="false"/>
+
+   <plugin
+         id="org.objectweb.asm"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.objectweb.asm.commons"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.objectweb.asm.tree"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.objectweb.asm.util"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.jetty.webapp"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.jetty.security"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.jetty.server"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.jetty.alpn.client"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.jetty.servlet"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.jetty.http"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.jetty.io"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.jetty.util"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.jetty.xml"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.jetty.websocket.core.client"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.jetty.websocket.core.common"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.jetty.websocket.core.server"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.jetty.websocket.common"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.jetty.client"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
 </feature>


### PR DESCRIPTION
**Issue:** Unable to install JMC supported Eclipse IDE Plugin. Some of the dependent plugins are missing. 

**Fix:** Added those dependent plugins in "ide feature" and also deleted one unused plugin from "flight recorder feature".

**Plugins added:**
"org.objectweb.asm",       
"org.objectweb.asm.commons",        
"org.objectweb.asm.tree",      
"org.objectweb.asm.util", 
"org.eclipse.jetty.webapp",        
"org.eclipse.jetty.security",         
"org.eclipse.jetty.server",        
"org.eclipse.jetty.alpn.client",        
"org.eclipse.jetty.servlet",              
"org.eclipse.jetty.http",       
"org.eclipse.jetty.io",       
"org.eclipse.jetty.util",        
"org.eclipse.jetty.xml",       
"org.eclipse.jetty.websocket.core.client",       
"org.eclipse.jetty.websocket.core.common",       
"org.eclipse.jetty.websocket.core.server",      
"org.eclipse.jetty.websocket.common",        
"org.eclipse.jetty.client"

**Plugin removed:**
"org.eclipse.jetty.websocket.javax.server"

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JMC-7486](https://bugs.openjdk.java.net/browse/JMC-7486): Unable to install Eclipse IDE Plugin


### Reviewers
 * [Marcus Hirt](https://openjdk.java.net/census#hirt) (@thegreystone - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jmc pull/377/head:pull/377` \
`$ git checkout pull/377`

Update a local copy of the PR: \
`$ git checkout pull/377` \
`$ git pull https://git.openjdk.java.net/jmc pull/377/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 377`

View PR using the GUI difftool: \
`$ git pr show -t 377`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jmc/pull/377.diff">https://git.openjdk.java.net/jmc/pull/377.diff</a>

</details>
