### PR TITLE
7581: Missing required plugins in JMC-RCP and JMC-RCP-plug-ins launcher

### DIFF
--- a/configuration/ide/eclipse/launchers/JMC-RCP-plug-ins.launch
+++ b/configuration/ide/eclipse/launchers/JMC-RCP-plug-ins.launch
@@ -32,7 +32,14 @@
    WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 -->
 <launchConfiguration type="org.eclipse.pde.ui.RuntimeWorkbench">
-	<setAttribute key="additional_plugins" />
+	<setAttribute key="additional_plugins">
+		<setEntry value="org.eclipse.jetty.http:10.0.7:default:true:default:default"/>
+        	<setEntry value="org.eclipse.jetty.io:10.0.7:default:true:default:default"/>
+        	<setEntry value="org.eclipse.jetty.security:10.0.7:default:true:default:default"/>
+        	<setEntry value="org.eclipse.jetty.server:10.0.7:default:true:default:default"/>
+        	<setEntry value="org.eclipse.jetty.servlet:10.0.7:default:true:default:default"/>
+        	<setEntry value="org.eclipse.jetty.util:10.0.7:default:true:default:default"/>
+	</setAttribute>
 	<booleanAttribute key="append.args" value="true" />
 	<stringAttribute key="application" value="org.openjdk.jmc.rcp.application.app" />
 	<booleanAttribute key="askclear" value="true" />

--- a/configuration/ide/eclipse/launchers/JMC-RCP.launch
+++ b/configuration/ide/eclipse/launchers/JMC-RCP.launch
@@ -32,7 +32,14 @@
    WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 -->
 <launchConfiguration type="org.eclipse.pde.ui.RuntimeWorkbench">
-	<setAttribute key="additional_plugins" />
+	<setAttribute key="additional_plugins">
+		<setEntry value="org.eclipse.jetty.http:10.0.7:default:true:default:default"/>
+        	<setEntry value="org.eclipse.jetty.io:10.0.7:default:true:default:default"/>
+        	<setEntry value="org.eclipse.jetty.security:10.0.7:default:true:default:default"/>
+        	<setEntry value="org.eclipse.jetty.server:10.0.7:default:true:default:default"/>
+        	<setEntry value="org.eclipse.jetty.servlet:10.0.7:default:true:default:default"/>
+        	<setEntry value="org.eclipse.jetty.util:10.0.7:default:true:default:default"/>
+	</setAttribute>
 	<booleanAttribute key="append.args" value="true" />
 	<booleanAttribute key="askclear" value="true" />
 	<booleanAttribute key="automaticAdd" value="false" />


### PR DESCRIPTION
Below mentioned required plugins are missing in JMC-RCP and JMC-RCP-plug-ins launcher. Added them as an additional plugins.
org.eclipse.jetty.http (10.0.7)
org.eclipse.jetty.io (10.0.7)
org.eclipse.jetty.security (10.0.7)
org.eclipse.jetty.server (10.0.7)
org.eclipse.jetty.servlet (10.0.7)
org.eclipse.jetty.util (10.0.7)

![MissingRequiredPlugins](https://user-images.githubusercontent.com/97600378/161130307-0e56892a-b435-4db6-bf50-2b9fc121a2db.png)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JMC-7581](https://bugs.openjdk.java.net/browse/JMC-7581): Missing required plugins in JMC-RCP and JMC-RCP-plug-ins launcher


### Reviewers
 * [Jean-Philippe Bempel](https://openjdk.java.net/census#jpbempel) (@jpbempel - Committer)
 * [Marcus Hirt](https://openjdk.java.net/census#hirt) (@thegreystone - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jmc pull/393/head:pull/393` \
`$ git checkout pull/393`

Update a local copy of the PR: \
`$ git checkout pull/393` \
`$ git pull https://git.openjdk.java.net/jmc pull/393/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 393`

View PR using the GUI difftool: \
`$ git pr show -t 393`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jmc/pull/393.diff">https://git.openjdk.java.net/jmc/pull/393.diff</a>

</details>
