### PR TITLE
7765: Bump some Maven plugins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,9 @@ workspace/
 dependency-reduced-pom.xml
 .flattened-pom.xml
 
+# Ignore tycho consumer pom
+.tycho-consumer-pom.xml
+
 # Ignore coverage report
 core/coverage/coverage-report
 application/coverage/coverage-report

--- a/agent/pom.xml
+++ b/agent/pom.xml
@@ -75,7 +75,7 @@
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>
 		<asm.version>8.0.1</asm.version>
-		<junit.version>4.13.1</junit.version>
+		<junit.version>4.13.2</junit.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<spotless.version>1.26.0</spotless.version>
 		<spotless.config.path>${basedir}/../configuration/ide/eclipse/formatting/formatting.xml</spotless.config.path>

--- a/agent/pom.xml
+++ b/agent/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--   
-   Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+   Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
    
    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
    

--- a/application/org.openjdk.jmc.feature.pde/feature.xml
+++ b/application/org.openjdk.jmc.feature.pde/feature.xml
@@ -52,7 +52,6 @@
       <import plugin="org.eclipse.core.runtime"/>
       <import plugin="org.eclipse.pde.ui"/>
       <import plugin="org.eclipse.core.resources"/>
-      <import plugin="org.openjdk.jmc.pde" match="equivalent"/>
       <import plugin="org.eclipse.pde.core"/>
       <import feature="org.openjdk.jmc.feature.console" match="equivalent"/>
    </requires>

--- a/application/org.openjdk.jmc.feature.pde/feature.xml
+++ b/application/org.openjdk.jmc.feature.pde/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--   
-   Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+   Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
    
    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
    

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -37,7 +37,7 @@
 	<groupId>org.openjdk.jmc</groupId>
 	<artifactId>missioncontrol.core</artifactId>
 	<version>${revision}${changelist}</version>
-        <name>JDK Mission Control Core</name>
+	<name>JDK Mission Control Core</name>
 	<packaging>pom</packaging>
 	<description>JDK Mission Control is an advanced set of tools that enables
 		efficient and detailed analysis of the extensive of data collected by
@@ -66,7 +66,7 @@
 		<maven.javadoc.version>3.3.2</maven.javadoc.version>
 		<nexus.staging.version>1.6.8</nexus.staging.version>
 		<maven.gpg.version>1.6</maven.gpg.version>
-		<build.helper.maven.version>3.2.0</build.helper.maven.version>
+		<build.helper.maven.version>3.3.0</build.helper.maven.version>
 		<spotless.config.path>${basedir}/../configuration/ide/eclipse/formatting/formatting.xml</spotless.config.path>
 	</properties>
 	<url>http://jdk.java.net/jmc</url>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -63,7 +63,7 @@
 		<maven.directory.version>0.3.1</maven.directory.version>
 		<maven.resources.version>3.2.0</maven.resources.version>
 		<maven.source.version>3.2.1</maven.source.version>
-		<maven.javadoc.version>3.2.0</maven.javadoc.version>
+		<maven.javadoc.version>3.3.2</maven.javadoc.version>
 		<nexus.staging.version>1.6.8</nexus.staging.version>
 		<maven.gpg.version>1.6</maven.gpg.version>
 		<build.helper.maven.version>3.2.0</build.helper.maven.version>

--- a/core/tests/pom.xml
+++ b/core/tests/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--   
-   Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+   Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
    Copyright (c) 2021, Datadog, Inc. All rights reserved.
    
    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
@@ -63,7 +63,6 @@
 		<junit.jupiter.engine.version>5.5.2</junit.jupiter.engine.version>
 		<mockito.core.version>3.12.4</mockito.core.version>
 		<mockito.inline.version>3.12.4</mockito.inline.version>
-		<build.helper.maven.version>3.2.0</build.helper.maven.version>
 		<surefireArgLine></surefireArgLine>
 	</properties>
 	<profiles>

--- a/core/tests/pom.xml
+++ b/core/tests/pom.xml
@@ -57,13 +57,12 @@
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>
 		<spotless.config.path>${basedir}/../../configuration/ide/eclipse/formatting/formatting.xml</spotless.config.path>
-		<junit.version>4.13.1</junit.version>
-		<maven.javadoc.version>3.2.0</maven.javadoc.version>
+		<junit.version>4.13.2</junit.version>
 		<junit.jupiter.api.version>5.5.2</junit.jupiter.api.version>
 		<junit.jupiter.params.version>5.5.2</junit.jupiter.params.version>
 		<junit.jupiter.engine.version>5.5.2</junit.jupiter.engine.version>
-		<mockito.core.version>3.7.7</mockito.core.version>
-		<mockito.inline.version>3.7.7</mockito.inline.version>
+		<mockito.core.version>3.12.4</mockito.core.version>
+		<mockito.inline.version>3.12.4</mockito.inline.version>
 		<build.helper.maven.version>3.2.0</build.helper.maven.version>
 		<surefireArgLine></surefireArgLine>
 	</properties>

--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@
 		<changelist>-SNAPSHOT</changelist>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-		<tycho.version>2.5.0</tycho.version>
+		<tycho.version>2.7.1</tycho.version>
 		<maven.buildnumber.version>1.4</maven.buildnumber.version>
 		<maven.deploy.version>2.8.2</maven.deploy.version>
 		<maven.directory.version>0.3.1</maven.directory.version>

--- a/releng/pom.xml
+++ b/releng/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--   
-   Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+   Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
    
    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
    

--- a/releng/third-party/pom.xml
+++ b/releng/third-party/pom.xml
@@ -48,11 +48,11 @@
 		<javax.websocket.version>1.1</javax.websocket.version>
 		<jetty.version>10.0.7</jetty.version>
 		<jemmy.version>2.0.0</jemmy.version>
-		<jetty-maven-plugin.version>9.4.43.v20210629</jetty-maven-plugin.version>
+		<jetty-maven-plugin.version>9.4.46.v20220331</jetty-maven-plugin.version>
 		<lz4.version>1.8.0</lz4.version>
 		<maven-enforcer-plugin.version>3.0.0</maven-enforcer-plugin.version>
 		<owasp.encoder.version>1.2.3</owasp.encoder.version>
-		<p2-maven-plugin.version>1.5.0</p2-maven-plugin.version>
+		<p2-maven-plugin.version>2.0.0</p2-maven-plugin.version>
 		<spifly.version>1.3.4</spifly.version>
 	</properties>
 


### PR DESCRIPTION
Several maven plugins should be updated to a more current version. 

Here's a list with some reasoning:
junit 4.13.1 -> 4.13.2 (minor update)
maven javadoc 3.2.0 -> 3.3.2 (bugfixes, e.g. support javadoc generation with modular JDKs)
mockito 3.7.7 -> 3.12.4 (bugfixes to support newer JDKs, e.g. 17)
tycho 2.5.0 -> 2.7.1 (bugfixes, prepare JDK17 support)
jetty maven plugin 9.4.43.v20210629 -> 9.4.46.v20220331 (minor updates, only used for p2 server during build)
p2-maven-plugin 1.5.0 -> 2.0.0 (prepare JDK 17 support)
build-helper-maven-plugin 3.2.0 -> 3.3.0 (minor update)

To support latest tycho, I added a directive to ignore tycho-consumer-pom.xml to .gitignore. These files seem to be generated by the new tycho version.

I also had to make a small adaption to application/org.openjdk.jmc.feature.pde/feature.xml to overcome https://github.com/eclipse/tycho/issues/876

In core/tests/pom.xml I removed the entry for maven.javadoc.version since it is inherited from the parent pom.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JMC-7765](https://bugs.openjdk.java.net/browse/JMC-7765): Bump some Maven plugins


### Reviewers
 * [Marcus Hirt](https://openjdk.java.net/census#hirt) (@thegreystone - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jmc pull/395/head:pull/395` \
`$ git checkout pull/395`

Update a local copy of the PR: \
`$ git checkout pull/395` \
`$ git pull https://git.openjdk.java.net/jmc pull/395/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 395`

View PR using the GUI difftool: \
`$ git pr show -t 395`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jmc/pull/395.diff">https://git.openjdk.java.net/jmc/pull/395.diff</a>

</details>
