### PR TITLE
7767: Fix handling of version qualifier in core plugins

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -62,6 +62,7 @@
 		<spotless.version>2.14.0</spotless.version>
 		<maven.directory.version>0.3.1</maven.directory.version>
 		<maven.resources.version>3.2.0</maven.resources.version>
+		<maven.antrun.version>3.0.0</maven.antrun.version>
 		<maven.source.version>3.2.1</maven.source.version>
 		<maven.javadoc.version>3.3.2</maven.javadoc.version>
 		<nexus.staging.version>1.6.8</nexus.staging.version>
@@ -146,7 +147,7 @@
 					<version>${maven.jar.version}</version>
 					<configuration>
 						<archive>
-							<manifestFile>${manifest-location}/MANIFEST.MF</manifestFile>
+							<manifestFile>${project.build.directory}/${manifest-location}/MANIFEST.MF</manifestFile>
 						</archive>
 					</configuration>
 				</plugin>
@@ -196,6 +197,22 @@
 								</resources>
 							</configuration>
 						</execution>
+						<execution>
+							<id>copy-manifest</id>
+							<phase>process-resources</phase>
+							<goals>
+								<goal>copy-resources</goal>
+							</goals>
+							<configuration>
+								<outputDirectory>${project.build.directory}</outputDirectory>
+								<resources>
+									<resource>
+										<targetPath>${project.build.directory}/${manifest-location}</targetPath>
+										<directory>${project.basedir}/${manifest-location}</directory>
+									</resource>
+								</resources>
+							</configuration>
+						</execution>
 					</executions>
 				</plugin>
 			</plugins>
@@ -214,6 +231,47 @@
 						<phase>initialize</phase>
 						<configuration>
 							<property>rootDir</property>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-antrun-plugin</artifactId>
+				<version>${maven.antrun.version}</version>
+				<executions>
+					<execution>
+						<id>check for manifest</id>
+						<phase>compile</phase>
+						<goals>
+							<goal>run</goal>
+						</goals>
+						<configuration>
+							<exportAntProperties>true</exportAntProperties>
+							<target name="check-manifest">
+								<available file="${project.build.directory}/${manifest-location}" property="manifest.present"/>
+							</target>
+						</configuration>
+					</execution>
+					<execution>
+						<id>fix qualifier</id>
+						<phase>compile</phase>
+						<goals>
+							<goal>run</goal>
+						</goals>
+						<configuration>
+							<target name="fix-qualifier" if="${manifest.present}">
+								<tstamp>
+									<format property="buildtimestamp" pattern="yyyyMMddHHmm"/>
+								</tstamp>
+								<condition property="qualifier.value" value=".${buildtimestamp}" else="">
+									<and>
+										<isset property="changelist"/>
+										<equals arg1="${changelist}" arg2="-SNAPSHOT"/>
+									</and>
+								</condition>
+								<replace token=".qualifier" value="${qualifier.value}" dir="${project.build.directory}/${manifest-location}"/>
+							</target>
 						</configuration>
 					</execution>
 				</executions>


### PR DESCRIPTION
This PR adds some maven antrun magic to handle the .qualifier version property in core modules

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JMC-7767](https://bugs.openjdk.java.net/browse/JMC-7767): Fix handling of version qualifier in core plugins


### Reviewers
 * [Marcus Hirt](https://openjdk.java.net/census#hirt) (@thegreystone - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jmc pull/396/head:pull/396` \
`$ git checkout pull/396`

Update a local copy of the PR: \
`$ git checkout pull/396` \
`$ git pull https://git.openjdk.java.net/jmc pull/396/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 396`

View PR using the GUI difftool: \
`$ git pr show -t 396`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jmc/pull/396.diff">https://git.openjdk.java.net/jmc/pull/396.diff</a>

</details>
