### PR TITLE
7794: Update the link to the adoptium download site

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Binary distributions of JDK Mission Control are provided by different downstream
 * EA builds of upcoming release
 * Downloadable Eclipse update site archive
 
-[https://adoptium.net/de/jmc](https://adoptium.net/de/jmc)
+[https://adoptium.net/jmc](https://adoptium.net/jmc)
 
 
 ### Azul (Zulu Mission Control)

--- a/README.md
+++ b/README.md
@@ -10,12 +10,12 @@ For more information on Mission Control, see http://www.oracle.com/missioncontro
 ## Downloading Builds
 Binary distributions of JDK Mission Control are provided by different downstream vendors.
 
-### AdoptOpenJDK
+### Eclipse Adoptium
 * Released version
 * EA builds of upcoming release
 * Downloadable Eclipse update site archive
 
-[http://adoptopenjdk.net/jmc](http://adoptopenjdk.net/jmc)
+[https://adoptium.net/de/jmc](https://adoptium.net/de/jmc)
 
 
 ### Azul (Zulu Mission Control)


### PR DESCRIPTION
The AdoptOpenJDK no longer has the latest builds.
Also use https for Links.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 committer)

### Issue
 * [JMC-7794](https://bugs.openjdk.java.net/browse/JMC-7794): Update the link to the adoptium download site


### Reviewers
 * [Marcus Hirt](https://openjdk.java.net/census#hirt) (@thegreystone - **Reviewer**)
 * [Christoph Langer](https://openjdk.java.net/census#clanger) (@RealCLanger - Author)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jmc pull/397/head:pull/397` \
`$ git checkout pull/397`

Update a local copy of the PR: \
`$ git checkout pull/397` \
`$ git pull https://git.openjdk.java.net/jmc pull/397/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 397`

View PR using the GUI difftool: \
`$ git pr show -t 397`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jmc/pull/397.diff">https://git.openjdk.java.net/jmc/pull/397.diff</a>

</details>
