### PR TITLE
7801: Fix GHA that is broken due to OpenJDK Update 11.0.15

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -7,9 +7,10 @@ jobs:
     runs-on: 'ubuntu-latest'
     steps:
     - uses: actions/checkout@v1
-    - uses: actions/setup-java@v1
+    - uses: actions/setup-java@v2
       with:
-        java-version: '11'
+        distribution: temurin
+        java-version: '11.0.14'
         java-package: jdk
     - name: Cache local Maven repository
       uses: actions/cache@v2
@@ -31,9 +32,10 @@ jobs:
     runs-on: 'macOS-latest'
     steps:
     - uses: actions/checkout@v1
-    - uses: actions/setup-java@v1
+    - uses: actions/setup-java@v2
       with:
-        java-version: '11'
+        distribution: temurin
+        java-version: '11.0.14'
         java-package: jdk
     - name: Cache local Maven repository
       uses: actions/cache@v2
@@ -55,9 +57,10 @@ jobs:
     runs-on: 'windows-latest'
     steps:
     - uses: actions/checkout@v1
-    - uses: actions/setup-java@v1
+    - uses: actions/setup-java@v2
       with:
-        java-version: '11'
+        distribution: temurin
+        java-version: '11.0.14'
         java-package: jdk
     - name: Cache local Maven repository
       uses: actions/cache@v2


### PR DESCRIPTION
OpenJDK 11.0.15 has introduced a regression that breaks the JMC build on Windows (with JDK-8278356). It will be fixed in OpenJDK 11.0.16 with JDK-8285445.

For now we can workaround the problem by pinning to OpenJDK 11.0.14 in the GHA workflow which should be fine from a security perspective.

I also experimented with adding `-Djdk.io.File.enableADS=true` which is what JDK-8285445 effectively does but to no avail.

The change updates to actions/setup-java@v2 and sets the JDK distribution in use to Temurin.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 committer)

### Issue
 * [JMC-7801](https://bugs.openjdk.java.net/browse/JMC-7801): Fix GHA that is broken due to OpenJDK Update 11.0.15


### Reviewers
 * [Marcus Hirt](https://openjdk.java.net/census#hirt) (@thegreystone - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jmc pull/402/head:pull/402` \
`$ git checkout pull/402`

Update a local copy of the PR: \
`$ git checkout pull/402` \
`$ git pull https://git.openjdk.java.net/jmc pull/402/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 402`

View PR using the GUI difftool: \
`$ git pr show -t 402`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jmc/pull/402.diff">https://git.openjdk.java.net/jmc/pull/402.diff</a>

</details>
