### PR TITLE
7834: Improve GitHub Actions validation workflow

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,83 +1,48 @@
-name: validate
+name: Validation
 
-on: [push, pull_request]
+on: [push, workflow_dispatch]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
-  linux:
-    runs-on: 'ubuntu-latest'
+  build_and_test:
+    name: Build and Test on ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ['ubuntu-latest', 'macOS-latest', 'windows-latest']
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+       shell: bash
+    env:
+      MAVEN_OPTS: -Xmx2048m
+      MAVENPARAMS: --no-transfer-progress
     steps:
-    - uses: actions/checkout@v1
-    - uses: actions/setup-java@v2
+    - name: Checkout repository
+      uses: actions/checkout@v3
+    - name: Set up Java
+      uses: actions/setup-java@v3
       with:
         distribution: temurin
         java-version: '11.0.14'
         java-package: jdk
     - name: Cache local Maven repository
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/.m2/repository
         key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
         restore-keys: |
-          ${{ runner.os }}-maven-
+          ${{ runner.os }}-maven
+    - name: Build & test core
+      run: ./scripts/runcoretests.sh
+    - name: Start P2 repository
+      run: ./scripts/startp2.sh
+    - name: Build & test application
+      run: ./scripts/runapptests.sh
+    - name: Build & test agent
+      run: ./scripts/runagenttests.sh
     - name: Check formatting
       run: ./scripts/checkformatting.sh
-    - name: Run core tests
-      run: ./scripts/runcoretests.sh
-    - name: Run application tests
-      run: ./scripts/runapptests.sh
-    - name: Run agent tests
-      run: ./scripts/runagenttests.sh
-
-  mac:
-    runs-on: 'macOS-latest'
-    steps:
-    - uses: actions/checkout@v1
-    - uses: actions/setup-java@v2
-      with:
-        distribution: temurin
-        java-version: '11.0.14'
-        java-package: jdk
-    - name: Cache local Maven repository
-      uses: actions/cache@v2
-      with:
-        path: ~/.m2/repository
-        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-        restore-keys: |
-          ${{ runner.os }}-maven-
-    - name: Check formatting
-      run: ./scripts/checkformatting.sh
-    - name: Run core tests
-      run: ./scripts/runcoretests.sh
-    - name: Run application tests
-      run: ./scripts/runapptests.sh
-    - name: Run agent tests
-      run: ./scripts/runagenttests.sh
-
-  win:
-    runs-on: 'windows-latest'
-    steps:
-    - uses: actions/checkout@v1
-    - uses: actions/setup-java@v2
-      with:
-        distribution: temurin
-        java-version: '11.0.14'
-        java-package: jdk
-    - name: Cache local Maven repository
-      uses: actions/cache@v2
-      with:
-        path: ~/.m2/repository
-        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-        restore-keys: |
-          ${{ runner.os }}-maven-
-    - name: Check formatting
-      run: .\scripts\checkformatting.bat
-      shell: cmd
-    - name: Run core tests
-      run: .\scripts\runcoretests.bat
-      shell: cmd
-    - name: Run application tests
-      run: .\scripts\runapptests.bat
-      shell: cmd
-    - name: Run agent tests
-      run: .\scripts\runagenttests.bat
-      shell: cmd

--- a/scripts/checkformatting.bat
+++ b/scripts/checkformatting.bat
@@ -1,19 +1,12 @@
 @echo off
-echo "======== Building p2 repo ==================="
-cd releng\third-party
-call mvn p2:site || EXIT /B 1
-echo "======== Starting p2 repo ==================="
-start /B cmd /C "mvn jetty:run"
-cd ..\..\core
-echo "======== Installing core ===================="
-call mvn install || EXIT /B 2
+
 echo "======== Running spotless for core =========="
-call mvn spotless:check || EXIT /B 3
-cd ..
-echo "======== Running spotless for agent =========="
-cd agent
-call mvn spotless:check || EXIT /B 4
-cd ..
+cd core
+call mvn %MAVENPARAMS% spotless:check || EXIT /B 5
+echo "======== Running spotless for agent ========="
+cd ..\agent
+call mvn %MAVENPARAMS% spotless:check || EXIT /B 6
 echo "======== Running spotless for application ==="
-call mvn -Puitests spotless:check || EXIT /B 5
+cd ..
+call mvn %MAVENPARAMS% -Puitests spotless:check || EXIT /B 7
 echo "======== Finished ==========================="

--- a/scripts/checkformatting.sh
+++ b/scripts/checkformatting.sh
@@ -1,23 +1,13 @@
 #!/bin/sh -l
-
 set -e
-echo "======== Building p2 repo ==================="
-cd releng/third-party
-sh -c "mvn p2:site"
-echo "======== Starting p2 repo ==================="
-sh -c "nohup mvn jetty:run &"
-cd ../..
-echo "======== Installing core ===================="
-cd core
-sh -c "mvn install"
-echo "======== Running spotless for core =========="
-sh -c "mvn spotless:check"
-cd ..
-echo "======== Running spotless for agent ========="
-cd agent
-sh -c "mvn spotless:check"
-cd ..
-echo "======== Running spotless for application ==="
-sh -c "mvn -Puitests spotless:check"
-echo "======== Finished ==========================="
 
+echo "======== Running spotless for core =========="
+cd core
+sh -c "mvn ${MAVENPARAMS} spotless:check"
+echo "======== Running spotless for agent ========="
+cd ../agent
+sh -c "mvn ${MAVENPARAMS} spotless:check"
+echo "======== Running spotless for application ==="
+cd ..
+sh -c "mvn ${MAVENPARAMS} -Puitests spotless:check"
+echo "======== Finished ==========================="

--- a/scripts/runagenttests.bat
+++ b/scripts/runagenttests.bat
@@ -1,7 +1,7 @@
 @echo off
-echo "======== Running agent tests ================"
-cd agent
-rem The integration tests fail on windows - change to "mvn verify" once fixed.
-mvn test
-echo "======== Finished ==========================="
 
+echo "======== Building and testing agent ========="
+cd agent
+rem The integration tests currently fail on windows - change to "mvn verify" once fixed.
+call mvn %MAVENPARAMS% test || EXIT /B 4
+echo "======== Finished ==========================="

--- a/scripts/runagenttests.sh
+++ b/scripts/runagenttests.sh
@@ -1,8 +1,12 @@
 #!/bin/sh -l
-
 set -e
-echo "======== Running agent tests ================"
-cd agent
-mvn verify
-echo "======== Finished ==========================="
 
+echo "======== Building and testing agent ========="
+cd agent
+# The integration tests currently fail on windows - change to "mvn verify" once fixed.
+if [[ $(uname) == MINGW* ]] || [[ $(uname) == CYGWIN* ]]; then
+  sh -c "mvn ${MAVENPARAMS} test"
+else
+  sh -c "mvn ${MAVENPARAMS} verify"
+fi
+echo "======== Finished ==========================="

--- a/scripts/runapptests.bat
+++ b/scripts/runapptests.bat
@@ -1,14 +1,7 @@
 @echo off
-REM Seems we need to restart repo
-cd releng\third-party
-echo "======== Starting p2 repo ==================="
-start /B cmd /C "mvn jetty:run"
-cd ..\..\core
-REM Seems we need to re-install core
-echo "======== Installing core ===================="
-call mvn install
-cd ..
-echo "======== Running application tests =========="
-mvn verify
-echo "======== Finished ==========================="
 
+rem Note that core must have been installed, and the p2 repo started
+rem before running this.
+echo "======== Building and testing application ==="
+call mvn %MAVENPARAMS% verify || EXIT /B 3
+echo "======== Finished ==========================="

--- a/scripts/runapptests.sh
+++ b/scripts/runapptests.sh
@@ -1,9 +1,8 @@
 #!/bin/sh -l
-
 set -e
+
 # Note that core must have been installed, and the p2 repo started
 # before running this.
-echo "======== Running application tests =========="
-sh -c "mvn verify"
+echo "======== Building and testing application ==="
+sh -c "mvn ${MAVENPARAMS} verify"
 echo "======== Finished ==========================="
-

--- a/scripts/runcoretests.bat
+++ b/scripts/runcoretests.bat
@@ -1,6 +1,6 @@
 @echo off
-echo "======== Running core tests ================="
-cd core
-mvn verify
-echo "======== Finished ==========================="
 
+echo "======== Installing and testing core ========"
+cd core
+call mvn %MAVENPARAMS% install || EXIT /B 2
+echo "======== Finished ==========================="

--- a/scripts/runcoretests.sh
+++ b/scripts/runcoretests.sh
@@ -1,8 +1,7 @@
 #!/bin/sh -l
-
 set -e
-echo "======== Running core tests ================="
-cd core
-mvn verify
-echo "======== Finished ==========================="
 
+echo "======== Installing and testing core ========"
+cd core
+sh -c "mvn ${MAVENPARAMS} install"
+echo "======== Finished ==========================="

--- a/scripts/startp2.bat
+++ b/scripts/startp2.bat
@@ -1,0 +1,8 @@
+@echo off
+
+echo "======== Building p2 repo ==================="
+cd releng\third-party
+call mvn %MAVENPARAMS% p2:site || EXIT /B 1
+echo "======== Starting p2 repo ==================="
+start /B cmd /C "mvn %MAVENPARAMS% jetty:run"
+echo "======== Done ==============================="

--- a/scripts/startp2.sh
+++ b/scripts/startp2.sh
@@ -1,0 +1,9 @@
+#!/bin/sh -l
+set -e
+
+echo "======== Building p2 repo ==================="
+cd releng/third-party
+sh -c "mvn ${MAVENPARAMS} p2:site"
+echo "======== Starting p2 repo ==================="
+sh -c "nohup mvn ${MAVENPARAMS} jetty:run &"
+echo "======== Done ==============================="


### PR DESCRIPTION
Improve validation workflow.

- It should not run on "pull_request" (OpenJDK repos don't allow this but will transfer results of push runs in forked repositories into status checks of PRs)
- A possibility to trigger the workflow manually via "workflow_dispatch" would be nice
- Updates to a branch should cancel running actions in favor of a new run to save resources
- The workflow script can have less redundant code by using a matrix strategy for the different operating systems that are tested
- Used actions can be version-bumped
- Naming of some steps can be improved
- The test steps and their order can be improved to make the steps more logical and explicit:
  1. Build&Test core
  2. Start P2 repository
  3. Build&Test application
  4. Build&Test agent
  5. Run spotless
- Use maven option --no-transfer-progress to get less noisy logs

Now also the Windows actions run in the bash shell and use the .sh scripts instead of their .bat counterparts.
One could think of deleting them but maybe they are used elsewhere, so keep them (up to date).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JMC-7834](https://bugs.openjdk.org/browse/JMC-7834): Improve GitHub Actions validation workflow


### Reviewers
 * [Marcus Hirt](https://openjdk.org/census#hirt) (@thegreystone - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmc pull/407/head:pull/407` \
`$ git checkout pull/407`

Update a local copy of the PR: \
`$ git checkout pull/407` \
`$ git pull https://git.openjdk.org/jmc pull/407/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 407`

View PR using the GUI difftool: \
`$ git pr show -t 407`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmc/pull/407.diff">https://git.openjdk.org/jmc/pull/407.diff</a>

</details>
