### PR TITLE
7806: Add an export option for Stacktraces in collapsed format

### DIFF
--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/views/stacktrace/StacktraceView.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/views/stacktrace/StacktraceView.java
@@ -50,7 +50,6 @@ import org.eclipse.core.runtime.IAdapterFactory;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.jface.action.Action;
 import org.eclipse.jface.action.IAction;
-import org.eclipse.jface.action.IMenuListener;
 import org.eclipse.jface.action.IMenuManager;
 import org.eclipse.jface.action.IToolBarManager;
 import org.eclipse.jface.action.MenuManager;
@@ -202,8 +201,8 @@ public class StacktraceView extends ViewPart implements ISelectionListener {
 		@Override
 		public void run() {
 			System.err.println("Export to collapsed");
-			String content = CollapsedSerializer.toCollapsed(
-					new StacktraceTreeModel(itemsToShow, new FrameSeparator(FrameCategorization.METHOD, false), false));
+			String content = CollapsedSerializer.toCollapsed(new StacktraceTreeModel(itemsToShow,
+					new FrameSeparator(FrameCategorization.METHOD, false), false, currentAttribute));
 			ClipboardManager.setClipboardContents(new Object[] {content}, new Transfer[] {TextTransfer.getInstance()});
 		}
 	}

--- a/core/org.openjdk.jmc.flightrecorder.serializers/META-INF/MANIFEST.MF
+++ b/core/org.openjdk.jmc.flightrecorder.serializers/META-INF/MANIFEST.MF
@@ -7,6 +7,7 @@ Bundle-Version: 9.0.0.qualifier
 Bundle-Vendor: Oracle Corporation
 Export-Package: org.openjdk.jmc.flightrecorder.serializers,
  org.openjdk.jmc.flightrecorder.serializers.json,
- org.openjdk.jmc.flightrecorder.serializers.dot
+ org.openjdk.jmc.flightrecorder.serializers.dot, 
+ org.openjdk.jmc.flightrecorder.serializers.stacktraces
 Require-Bundle: org.openjdk.jmc.flightrecorder
 Automatic-Module-Name: org.openjdk.jmc.flightrecorder.serializers

--- a/core/org.openjdk.jmc.flightrecorder.serializers/build.properties
+++ b/core/org.openjdk.jmc.flightrecorder.serializers/build.properties
@@ -1,6 +1,6 @@
 #
-#  Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
-#  Copyright (c) 2021, Datadog, Inc. All rights reserved.
+#  Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
+#  Copyright (c) 2021, 2023, Datadog, Inc. All rights reserved.
 #
 #  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #

--- a/core/org.openjdk.jmc.flightrecorder.serializers/src/main/java/org/openjdk/jmc/flightrecorder/serializers/stacktraces/CollapsedSerializer.java
+++ b/core/org.openjdk.jmc.flightrecorder.serializers/src/main/java/org/openjdk/jmc/flightrecorder/serializers/stacktraces/CollapsedSerializer.java
@@ -1,3 +1,36 @@
+/*
+ * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2023, Datadog, Inc. All rights reserved.
+ *
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * The contents of this file are subject to the terms of either the Universal Permissive License
+ * v 1.0 as shown at http://oss.oracle.com/licenses/upl
+ *
+ * or the following license:
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted
+ * provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions
+ * and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other materials provided with
+ * the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to
+ * endorse or promote products derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+ * WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 package org.openjdk.jmc.flightrecorder.serializers.stacktraces;
 
 import org.openjdk.jmc.flightrecorder.stacktrace.tree.AggregatableFrame;
@@ -8,8 +41,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Converts a {@link StacktraceTreeModel} to a collapsed format that can be used
- * as input for the flamegraph perl script from https://github.com/brendangregg/FlameGraph
+ * Converts a {@link StacktraceTreeModel} to a collapsed format that can be used as input for the
+ * flamegraph perl script from https://github.com/brendangregg/FlameGraph repository.
  */
 public class CollapsedSerializer {
 
@@ -45,9 +78,5 @@ public class CollapsedSerializer {
 			sb.append(";");
 		}
 		sb.append(frame.getHumanReadableShortString());
-	}
-
-	public static void main(String[] args) {
-
 	}
 }

--- a/core/org.openjdk.jmc.flightrecorder.serializers/src/main/java/org/openjdk/jmc/flightrecorder/serializers/stacktraces/CollapsedSerializer.java
+++ b/core/org.openjdk.jmc.flightrecorder.serializers/src/main/java/org/openjdk/jmc/flightrecorder/serializers/stacktraces/CollapsedSerializer.java
@@ -1,0 +1,53 @@
+package org.openjdk.jmc.flightrecorder.serializers.stacktraces;
+
+import org.openjdk.jmc.flightrecorder.stacktrace.tree.AggregatableFrame;
+import org.openjdk.jmc.flightrecorder.stacktrace.tree.Node;
+import org.openjdk.jmc.flightrecorder.stacktrace.tree.StacktraceTreeModel;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Converts a {@link StacktraceTreeModel} to a collapsed format that can be used
+ * as input for the flamegraph perl script from https://github.com/brendangregg/FlameGraph
+ */
+public class CollapsedSerializer {
+
+	/**
+	 * Serializes a {@link StacktraceTreeModel} to collasped format.
+	 *
+	 * @param model
+	 *            the {@link StacktraceTreeModel} to serialize to collapsed format.
+	 * @return a String containing the serialized model.
+	 */
+	public static String toCollapsed(StacktraceTreeModel model) {
+		StringBuilder sb = new StringBuilder();
+		List<String> lines = new ArrayList<>();
+		toCollapsed(sb, lines, model, model.getRoot());
+		return String.join("\n", lines);
+	}
+
+	private static void toCollapsed(StringBuilder sb, List<String> lines, StacktraceTreeModel model, Node node) {
+		if (!node.isRoot()) {
+			appendFrame(sb, node.getFrame(), node.getCumulativeWeight());
+		}
+		if (node.getChildren().isEmpty()) {
+			lines.add(sb.toString() + " " + (int) node.getCumulativeWeight());
+			return;
+		}
+		for (Node child : node.getChildren()) {
+			toCollapsed(new StringBuilder(sb), lines, model, child);
+		}
+	}
+
+	private static void appendFrame(StringBuilder sb, AggregatableFrame frame, double value) {
+		if (sb.length() > 0) {
+			sb.append(";");
+		}
+		sb.append(frame.getHumanReadableShortString());
+	}
+
+	public static void main(String[] args) {
+
+	}
+}

--- a/core/tests/org.openjdk.jmc.flightrecorder.serializers.test/src/main/java/org/openjdk/jmc/flightrecorder/serializers/stacktraces/test/CollapsedSerializerTest.java
+++ b/core/tests/org.openjdk.jmc.flightrecorder.serializers.test/src/main/java/org/openjdk/jmc/flightrecorder/serializers/stacktraces/test/CollapsedSerializerTest.java
@@ -1,0 +1,56 @@
+package org.openjdk.jmc.flightrecorder.serializers.stacktraces.test;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.openjdk.jmc.common.item.IItemCollection;
+import org.openjdk.jmc.common.test.TestToolkit;
+import org.openjdk.jmc.common.test.io.IOResourceSet;
+import org.openjdk.jmc.flightrecorder.CouldNotLoadRecordingException;
+import org.openjdk.jmc.flightrecorder.serializers.dot.DotSerializer;
+import org.openjdk.jmc.flightrecorder.serializers.dot.test.DotSerializerTest;
+import org.openjdk.jmc.flightrecorder.serializers.json.FlameGraphJsonSerializer;
+import org.openjdk.jmc.flightrecorder.serializers.json.test.FlameGraphJsonSerializerTest;
+import org.openjdk.jmc.flightrecorder.serializers.stacktraces.CollapsedSerializer;
+import org.openjdk.jmc.flightrecorder.stacktrace.FrameSeparator;
+import org.openjdk.jmc.flightrecorder.stacktrace.graph.StacktraceGraphModel;
+import org.openjdk.jmc.flightrecorder.stacktrace.tree.StacktraceTreeModel;
+import org.openjdk.jmc.flightrecorder.test.util.RecordingToolkit;
+import org.openjdk.jmc.flightrecorder.test.util.StacktraceTestToolkit;
+
+import java.io.BufferedWriter;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.Writer;
+
+public class CollapsedSerializerTest {
+	private static final boolean INVERTED_STACKS = true;
+	private static final boolean REGULAR_STACKS = false;
+	private static final FrameSeparator METHOD_SEPARATOR = new FrameSeparator(FrameSeparator.FrameCategorization.METHOD,
+			false);
+
+	private static IItemCollection testRecording;
+
+	@BeforeClass
+	public static void beforeAll() throws IOException, CouldNotLoadRecordingException {
+		IOResourceSet[] testResources = StacktraceTestToolkit.getTestResources();
+		IOResourceSet resourceSet = testResources[0];
+		testRecording = RecordingToolkit.getFlightRecording(resourceSet);
+	}
+
+	@Test
+	public void testSerializeKnownRecording() throws IOException, CouldNotLoadRecordingException {
+		IItemCollection collection = RecordingToolkit.getFlightRecording(
+				TestToolkit.getNamedResource(FlameGraphJsonSerializerTest.class, "recordings", "hotmethods.jfr"));
+		assertNotNull(collection);
+		String collapsed = CollapsedSerializer.toCollapsed(new StacktraceTreeModel(collection,
+				new FrameSeparator(FrameSeparator.FrameCategorization.METHOD, false)));
+		System.out.println(collapsed);
+		try (Writer bw = new FileWriter("/tmp/hotmethods.collapsed")) {
+			bw.write(collapsed);
+		}
+	}
+
+}

--- a/core/tests/org.openjdk.jmc.flightrecorder.serializers.test/src/main/java/org/openjdk/jmc/flightrecorder/serializers/stacktraces/test/CollapsedSerializerTest.java
+++ b/core/tests/org.openjdk.jmc.flightrecorder.serializers.test/src/main/java/org/openjdk/jmc/flightrecorder/serializers/stacktraces/test/CollapsedSerializerTest.java
@@ -1,45 +1,54 @@
+/*
+ * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2023, Datadog, Inc. All rights reserved.
+ *
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * The contents of this file are subject to the terms of either the Universal Permissive License
+ * v 1.0 as shown at http://oss.oracle.com/licenses/upl
+ *
+ * or the following license:
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted
+ * provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions
+ * and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other materials provided with
+ * the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to
+ * endorse or promote products derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+ * WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 package org.openjdk.jmc.flightrecorder.serializers.stacktraces.test;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
 
-import org.junit.BeforeClass;
+import java.io.IOException;
+
 import org.junit.Test;
 import org.openjdk.jmc.common.item.IItemCollection;
-import org.openjdk.jmc.common.test.TestToolkit;
-import org.openjdk.jmc.common.test.io.IOResourceSet;
 import org.openjdk.jmc.flightrecorder.CouldNotLoadRecordingException;
-import org.openjdk.jmc.flightrecorder.serializers.dot.DotSerializer;
-import org.openjdk.jmc.flightrecorder.serializers.dot.test.DotSerializerTest;
-import org.openjdk.jmc.flightrecorder.serializers.json.FlameGraphJsonSerializer;
 import org.openjdk.jmc.flightrecorder.serializers.json.test.FlameGraphJsonSerializerTest;
 import org.openjdk.jmc.flightrecorder.serializers.stacktraces.CollapsedSerializer;
 import org.openjdk.jmc.flightrecorder.stacktrace.FrameSeparator;
-import org.openjdk.jmc.flightrecorder.stacktrace.graph.StacktraceGraphModel;
 import org.openjdk.jmc.flightrecorder.stacktrace.tree.StacktraceTreeModel;
 import org.openjdk.jmc.flightrecorder.test.util.RecordingToolkit;
-import org.openjdk.jmc.flightrecorder.test.util.StacktraceTestToolkit;
-
-import java.io.BufferedWriter;
-import java.io.FileWriter;
-import java.io.IOException;
-import java.io.Writer;
+import org.openjdk.jmc.test.TestToolkit;
 
 public class CollapsedSerializerTest {
-	private static final boolean INVERTED_STACKS = true;
-	private static final boolean REGULAR_STACKS = false;
-	private static final FrameSeparator METHOD_SEPARATOR = new FrameSeparator(FrameSeparator.FrameCategorization.METHOD,
-			false);
-
-	private static IItemCollection testRecording;
-
-	@BeforeClass
-	public static void beforeAll() throws IOException, CouldNotLoadRecordingException {
-		IOResourceSet[] testResources = StacktraceTestToolkit.getTestResources();
-		IOResourceSet resourceSet = testResources[0];
-		testRecording = RecordingToolkit.getFlightRecording(resourceSet);
-	}
-
 	@Test
 	public void testSerializeKnownRecording() throws IOException, CouldNotLoadRecordingException {
 		IItemCollection collection = RecordingToolkit.getFlightRecording(
@@ -47,10 +56,16 @@ public class CollapsedSerializerTest {
 		assertNotNull(collection);
 		String collapsed = CollapsedSerializer.toCollapsed(new StacktraceTreeModel(collection,
 				new FrameSeparator(FrameSeparator.FrameCategorization.METHOD, false)));
-		System.out.println(collapsed);
-		try (Writer bw = new FileWriter("/tmp/hotmethods.collapsed")) {
-			bw.write(collapsed);
-		}
+		String[] lines = collapsed.split("\n");
+		assertEquals(15, lines.length);
+		assertEquals(
+				"Thread.run();Worker.run();HolderOfUniqueValues.initialize(int);LinkedList.add(Object);LinkedList.linkLast(Object) 2068",
+				lines[0]);
+		assertEquals("Thread.run();Worker.run();HolderOfUniqueValues.initialize(int);Integer.valueOf(int) 1536",
+				lines[1]);
+		assertEquals(
+				"HotMethods.main(String[]);BufferedInputStream.read();BufferedInputStream.fill();FileInputStream.read(byte[], int, int);FileInputStream.readBytes(byte[], int, int) 4906",
+				lines[14]);
 	}
 
 }


### PR DESCRIPTION
Add a new context menu when clicking on stacktrace view to export
selected stacktraces as collapsed format. With this format it's
easy to manipulate/filter stacktraces as text file and generate
a flamegraph with the perl script from the flamegraph repository
(https://github.com/brendangregg/FlameGraph)

The generated content is copied into the clipboard.

<img width="936" alt="Screenshot 2022-07-08 at 15 49 18" src="https://user-images.githubusercontent.com/4610701/178006101-f3ffba80-6332-4673-bc8e-299321bd6979.png">

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JMC-7806](https://bugs.openjdk.org/browse/JMC-7806): Add an export option for Stacktraces in collapsed format (**Enhancement** - P4)


### Reviewers
 * [Marcus Hirt](https://openjdk.org/census#hirt) (@thegreystone - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmc.git pull/409/head:pull/409` \
`$ git checkout pull/409`

Update a local copy of the PR: \
`$ git checkout pull/409` \
`$ git pull https://git.openjdk.org/jmc.git pull/409/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 409`

View PR using the GUI difftool: \
`$ git pr show -t 409`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmc/pull/409.diff">https://git.openjdk.org/jmc/pull/409.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jmc/pull/409#issuecomment-1780809517)