### PR TITLE
7842: JMC agent: policy file is missing entry for test on Windows

### DIFF
--- a/agent/pom.xml
+++ b/agent/pom.xml
@@ -175,7 +175,7 @@
 						<goal>verify</goal>
 					</goals>
 						<configuration>
-							<argLine> -Djava.security.manager -Djava.security.policy=target/test-classes/org/openjdk/jmc/agent/test/failing_control_permission.policy
+							<argLine> -Djdk.io.permissionsUseCanonicalPath=true -Djava.security.manager -Djava.security.policy=target/test-classes/org/openjdk/jmc/agent/test/failing_control_permission.policy
 								-XX:+FlightRecorder -javaagent:target/agent-${revision}${changelist}.jar=target/test-classes/org/openjdk/jmc/agent/test/jfrprobes_template.xml
 								 -cp target/agent-${revision}${changelist}.jar:target/test-classes/ </argLine>
 							<includes>TestPermissionChecks.java</includes>

--- a/agent/src/test/resources/org/openjdk/jmc/agent/test/failing_control_permission.policy
+++ b/agent/src/test/resources/org/openjdk/jmc/agent/test/failing_control_permission.policy
@@ -1,6 +1,7 @@
 grant {
 	permission java.io.FilePermission "target/test-classes/org/openjdk/jmc/agent/test/jfrprobes_template.xml", "read";
 	permission java.io.FilePermission "target/surefire/*", "read";
+	permission java.io.FilePermission "${java.io.tmpdir}/-", "read";
 	permission java.lang.management.ManagementPermission "monitor";
 	permission java.lang.reflect.ReflectPermission "suppressAccessChecks";
 	permission java.lang.RuntimePermission "accessClassInPackage.jdk.internal.misc";

--- a/agent/src/test/resources/org/openjdk/jmc/agent/test/failing_control_permission.policy
+++ b/agent/src/test/resources/org/openjdk/jmc/agent/test/failing_control_permission.policy
@@ -1,6 +1,7 @@
 grant {
 	permission java.io.FilePermission "target/test-classes/org/openjdk/jmc/agent/test/jfrprobes_template.xml", "read";
 	permission java.io.FilePermission "target/surefire/*", "read";
+	permission java.io.FilePermission "target/failsafe-reports", "read,write";
 	permission java.io.FilePermission "${java.io.tmpdir}/-", "read";
 	permission java.lang.management.ManagementPermission "monitor";
 	permission java.lang.reflect.ReflectPermission "suppressAccessChecks";

--- a/scripts/runagenttests.bat
+++ b/scripts/runagenttests.bat
@@ -2,6 +2,5 @@
 
 echo "======== Building and testing agent ========="
 cd agent
-rem The integration tests currently fail on windows - change to "mvn verify" once fixed.
-call mvn %MAVENPARAMS% test || EXIT /B 4
+call mvn %MAVENPARAMS% verify || EXIT /B 4
 echo "======== Finished ==========================="

--- a/scripts/runagenttests.sh
+++ b/scripts/runagenttests.sh
@@ -3,10 +3,5 @@ set -e
 
 echo "======== Building and testing agent ========="
 cd agent
-# The integration tests currently fail on windows - change to "mvn verify" once fixed.
-if [[ $(uname) == MINGW* ]] || [[ $(uname) == CYGWIN* ]]; then
-  sh -c "mvn ${MAVENPARAMS} test"
-else
-  sh -c "mvn ${MAVENPARAMS} verify"
-fi
+sh -c "mvn ${MAVENPARAMS} verify"
 echo "======== Finished ==========================="


### PR DESCRIPTION
This change adds an entry to the test policy file to allow acces to the temporary directory. This is needed since the surefire plugin places it files there on Windows, in contrast to other platforms where they are placed in the target/surefire directory.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JMC-7842](https://bugs.openjdk.org/browse/JMC-7842): JMC agent: policy file is missing entry for test on Windows


### Reviewers
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmc pull/410/head:pull/410` \
`$ git checkout pull/410`

Update a local copy of the PR: \
`$ git checkout pull/410` \
`$ git pull https://git.openjdk.org/jmc pull/410/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 410`

View PR using the GUI difftool: \
`$ git pr show -t 410`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmc/pull/410.diff">https://git.openjdk.org/jmc/pull/410.diff</a>

</details>
