### PR TITLE
7243: Resolve discrepancy between JDK attributes coming from different JDK versions

### DIFF
--- a/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/jdk/JdkAttributes.java
+++ b/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/jdk/JdkAttributes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -757,8 +757,21 @@ public final class JdkAttributes {
 			PERCENTAGE);
 	public static final IAttribute<IQuantity> THREAD_USER_CPU_LOAD = Attribute.attr("user", //$NON-NLS-1$
 			Messages.getString(Messages.ATTR_USER_LOAD), Messages.getString(Messages.ATTR_USER_LOAD_DESC), PERCENTAGE);
-	public static final IAttribute<IMCThread> JAVA_THREAD = Attribute.attr("thread", //$NON-NLS-1$
+
+	public static final IAttribute<IMCThread> JAVA_THREAD_POSTJDK9 = Attribute.attr("thread", //$NON-NLS-1$
 			Messages.getString(Messages.ATTR_JAVA_THREAD), Messages.getString(Messages.ATTR_JAVA_THREAD_DESC), THREAD);
+	public static final IAttribute<IMCThread> JAVA_THREAD_PREJDK9 = Attribute.attr("javalangthread", //$NON-NLS-1$
+			Messages.getString(Messages.ATTR_JAVA_THREAD), Messages.getString(Messages.ATTR_JAVA_THREAD_DESC), THREAD);
+
+	public static final IAttribute<IMCThread> JAVA_THREAD = Attribute.canonicalize(new Attribute<IMCThread>("(thread)", //$NON-NLS-1$
+			Messages.getString(Messages.ATTR_JAVA_THREAD), Messages.getString(Messages.ATTR_JAVA_THREAD_DESC), THREAD) { //$NON-NLS-2$
+		@Override
+		public <U> IMemberAccessor<IMCThread, U> customAccessor(IType<U> type) {
+			final IMemberAccessor<IMCThread, U> postJDK9Accessor = JAVA_THREAD_POSTJDK9.getAccessor(type);
+			final IMemberAccessor<IMCThread, U> preJDK9Accessor = JAVA_THREAD_PREJDK9.getAccessor(type);
+			return postJDK9Accessor == null ? preJDK9Accessor : postJDK9Accessor;
+		}
+	});
 
 	public static final IAttribute<String> SHUTDOWN_REASON = attr("reason", //$NON-NLS-1$
 			Messages.getString(Messages.ATTR_SHUTDOWN_REASON), Messages.getString(Messages.ATTR_SHUTDOWN_REASON_DESC),


### PR DESCRIPTION
This PR resolves the issue of thread attribute discrepancy between different JDK versions.

The issue had two parts - first one was already resolved as part of another bug, second part will be fixed as part of this PR.

1. switchRate attribute in JDK 11 onwards have the content type as frequency but pre JDK 11 the content type was number.
2. Pre JDK 9 the attribute name was javalangthread whereas post JDK 9 its thread.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JMC-7243](https://bugs.openjdk.org/browse/JMC-7243): Resolve discrepancy between JDK attributes coming from different JDK versions


### Reviewers
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - Committer)
 * [Marcus Hirt](https://openjdk.org/census#hirt) (@thegreystone - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmc pull/411/head:pull/411` \
`$ git checkout pull/411`

Update a local copy of the PR: \
`$ git checkout pull/411` \
`$ git pull https://git.openjdk.org/jmc pull/411/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 411`

View PR using the GUI difftool: \
`$ git pr show -t 411`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmc/pull/411.diff">https://git.openjdk.org/jmc/pull/411.diff</a>

</details>
