### PR TITLE
7856: Fix errors in Eclipse projects after JMC-7769

### DIFF
--- a/core/tests/org.openjdk.jmc.common.test/.classpath
+++ b/core/tests/org.openjdk.jmc.common.test/.classpath
@@ -1,10 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="src" output="target/test-classes" path="src/main/java">
+	<classpathentry kind="src" output="target/classes" path="src/main/java">
 		<attributes>
 			<attribute name="optional" value="true"/>
 			<attribute name="maven.pomderived" value="true"/>
-			<attribute name="test" value="true"/>
 		</attributes>
 	</classpathentry>
 	<classpathentry excluding="**" kind="src" output="target/classes" path="src/main/resources">
@@ -21,6 +20,13 @@
 	<classpathentry kind="con" path="org.eclipse.m2e.MAVEN2_CLASSPATH_CONTAINER">
 		<attributes>
 			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" output="target/test-classes" path="src/test/java">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="test" value="true"/>
 		</attributes>
 	</classpathentry>
 	<classpathentry kind="output" path="target/classes"/>

--- a/core/tests/org.openjdk.jmc.common.test/build.properties
+++ b/core/tests/org.openjdk.jmc.common.test/build.properties
@@ -32,8 +32,7 @@
 #
 source.. = src/main/java/,\
            src/main/resources/
-output.. = target/test-classes,\
-           target/classes/
+output.. = target/classes/
 bin.includes = META-INF/,\
                .
 pde.match.rule.bundle=compatible

--- a/core/tests/org.openjdk.jmc.common.test/pom.xml
+++ b/core/tests/org.openjdk.jmc.common.test/pom.xml
@@ -41,6 +41,7 @@
 	<artifactId>common.test</artifactId>
 	<properties>
 		<spotless.config.path>${basedir}/../../../configuration/ide/eclipse/formatting/formatting.xml</spotless.config.path>
+		<fail.if.no.tests>false</fail.if.no.tests>
 	</properties>
 	<packaging>jar</packaging>
 	<dependencies>
@@ -54,7 +55,4 @@
 			<artifactId>junit</artifactId>
 		</dependency>
 	</dependencies>
-	<build>
-		<testSourceDirectory>${project.basedir}/src/main/java</testSourceDirectory>
-	</build>
 </project>


### PR DESCRIPTION
[JMC-7769](https://bugs.openjdk.org/browse/JMC-7769) cleaned up the project layout for missioncontrol core, especially the test projects.
However, after that patch, an Eclipse IDE setup shows errors in test projects of the application, e.g. in org.openjdk.jmc.rjmx.test.

This is caused by an issue in project setup of core/tests/org.openjdk.jmc.common.test, which is a prerequisite to some other test projects.
Class files are generated into the target/test-classes folder but Eclipse only exposes target/classes to dependent projects.

The fix is to set up org.openjdk.jmc.common.test like a general library project, only using src/main/java -> target/classes.

Because it is a module of missioncontrol.core.tests, the property `fail.if.no.tests=false` needs to be set, otherwise the build fails because tests would be expected.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JMC-7856](https://bugs.openjdk.org/browse/JMC-7856): Fix errors in Eclipse projects after JMC-7769


### Reviewers
 * [Marcus Hirt](https://openjdk.org/census#hirt) (@thegreystone - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmc pull/413/head:pull/413` \
`$ git checkout pull/413`

Update a local copy of the PR: \
`$ git checkout pull/413` \
`$ git pull https://git.openjdk.org/jmc pull/413/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 413`

View PR using the GUI difftool: \
`$ git pr show -t 413`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmc/pull/413.diff">https://git.openjdk.org/jmc/pull/413.diff</a>

</details>
