### PR TITLE
7858: Upgrade jetty.project in github to 10.0.11

### DIFF
--- a/configuration/ide/eclipse/launchers/JMC-RCP-plug-ins.launch
+++ b/configuration/ide/eclipse/launchers/JMC-RCP-plug-ins.launch
@@ -33,12 +33,12 @@
 -->
 <launchConfiguration type="org.eclipse.pde.ui.RuntimeWorkbench">
 	<setAttribute key="additional_plugins">
-		<setEntry value="org.eclipse.jetty.http:10.0.7:default:true:default:default"/>
-        	<setEntry value="org.eclipse.jetty.io:10.0.7:default:true:default:default"/>
-        	<setEntry value="org.eclipse.jetty.security:10.0.7:default:true:default:default"/>
-        	<setEntry value="org.eclipse.jetty.server:10.0.7:default:true:default:default"/>
-        	<setEntry value="org.eclipse.jetty.servlet:10.0.7:default:true:default:default"/>
-        	<setEntry value="org.eclipse.jetty.util:10.0.7:default:true:default:default"/>
+		<setEntry value="org.eclipse.jetty.http:10.0.11:default:true:default:default"/>
+        	<setEntry value="org.eclipse.jetty.io:10.0.11:default:true:default:default"/>
+        	<setEntry value="org.eclipse.jetty.security:10.0.11:default:true:default:default"/>
+        	<setEntry value="org.eclipse.jetty.server:10.0.11:default:true:default:default"/>
+        	<setEntry value="org.eclipse.jetty.servlet:10.0.11:default:true:default:default"/>
+        	<setEntry value="org.eclipse.jetty.util:10.0.11:default:true:default:default"/>
 	</setAttribute>
 	<booleanAttribute key="append.args" value="true" />
 	<stringAttribute key="application" value="org.openjdk.jmc.rcp.application.app" />

--- a/configuration/ide/eclipse/launchers/JMC-RCP.launch
+++ b/configuration/ide/eclipse/launchers/JMC-RCP.launch
@@ -33,12 +33,12 @@
 -->
 <launchConfiguration type="org.eclipse.pde.ui.RuntimeWorkbench">
 	<setAttribute key="additional_plugins">
-		<setEntry value="org.eclipse.jetty.http:10.0.7:default:true:default:default"/>
-        	<setEntry value="org.eclipse.jetty.io:10.0.7:default:true:default:default"/>
-        	<setEntry value="org.eclipse.jetty.security:10.0.7:default:true:default:default"/>
-        	<setEntry value="org.eclipse.jetty.server:10.0.7:default:true:default:default"/>
-        	<setEntry value="org.eclipse.jetty.servlet:10.0.7:default:true:default:default"/>
-        	<setEntry value="org.eclipse.jetty.util:10.0.7:default:true:default:default"/>
+		<setEntry value="org.eclipse.jetty.http:10.0.11:default:true:default:default"/>
+        	<setEntry value="org.eclipse.jetty.io:10.0.11:default:true:default:default"/>
+        	<setEntry value="org.eclipse.jetty.security:10.0.11:default:true:default:default"/>
+        	<setEntry value="org.eclipse.jetty.server:10.0.11:default:true:default:default"/>
+        	<setEntry value="org.eclipse.jetty.servlet:10.0.11:default:true:default:default"/>
+        	<setEntry value="org.eclipse.jetty.util:10.0.11:default:true:default:default"/>
 	</setAttribute>
 	<booleanAttribute key="append.args" value="true" />
 	<booleanAttribute key="askclear" value="true" />

--- a/releng/platform-definitions/platform-definition-2021-06/platform-definition-2021-06.target
+++ b/releng/platform-definitions/platform-definition-2021-06/platform-definition-2021-06.target
@@ -45,10 +45,10 @@
             <unit id="org.adoptopenjdk.jemmy-browser" version="2.0.0"/>
             <unit id="org.adoptopenjdk.jemmy-core" version="2.0.0"/>
             <unit id="org.adoptopenjdk.jemmy-swt" version="2.0.0"/>
-            <unit id="org.eclipse.jetty.websocket.api" version="10.0.7"/>
-            <unit id="org.eclipse.jetty.websocket.server" version="10.0.7"/>
-            <unit id="org.eclipse.jetty.websocket.servlet" version="10.0.7"/>
-            <unit id="org.eclipse.jetty.websocket.javax.server" version="10.0.7"/>
+            <unit id="org.eclipse.jetty.websocket.api" version="10.0.11"/>
+            <unit id="org.eclipse.jetty.websocket.server" version="10.0.11"/>
+            <unit id="org.eclipse.jetty.websocket.servlet" version="10.0.11"/>
+            <unit id="org.eclipse.jetty.websocket.javax.server" version="10.0.11"/>
             <unit id="org.apache.aries.spifly.dynamic.bundle" version="1.3.4"/>
             <repository location="http://localhost:8080/site"/>
         </location>

--- a/releng/platform-definitions/platform-definition-2021-09/platform-definition-2021-09.target
+++ b/releng/platform-definitions/platform-definition-2021-09/platform-definition-2021-09.target
@@ -45,10 +45,10 @@
             <unit id="org.adoptopenjdk.jemmy-browser" version="2.0.0"/>
             <unit id="org.adoptopenjdk.jemmy-core" version="2.0.0"/>
             <unit id="org.adoptopenjdk.jemmy-swt" version="2.0.0"/>
-            <unit id="org.eclipse.jetty.websocket.api" version="10.0.7"/>
-            <unit id="org.eclipse.jetty.websocket.server" version="10.0.7"/>
-            <unit id="org.eclipse.jetty.websocket.servlet" version="10.0.7"/>
-            <unit id="org.eclipse.jetty.websocket.javax.server" version="10.0.7"/>
+            <unit id="org.eclipse.jetty.websocket.api" version="10.0.11"/>
+            <unit id="org.eclipse.jetty.websocket.server" version="10.0.11"/>
+            <unit id="org.eclipse.jetty.websocket.servlet" version="10.0.11"/>
+            <unit id="org.eclipse.jetty.websocket.javax.server" version="10.0.11"/>
             <unit id="org.apache.aries.spifly.dynamic.bundle" version="1.3.4"/>
             <repository location="http://localhost:8080/site"/>
         </location>

--- a/releng/platform-definitions/platform-definition-2021-12/platform-definition-2021-12.target
+++ b/releng/platform-definitions/platform-definition-2021-12/platform-definition-2021-12.target
@@ -45,10 +45,10 @@
             <unit id="org.adoptopenjdk.jemmy-browser" version="2.0.0"/>
             <unit id="org.adoptopenjdk.jemmy-core" version="2.0.0"/>
             <unit id="org.adoptopenjdk.jemmy-swt" version="2.0.0"/>
-            <unit id="org.eclipse.jetty.websocket.api" version="10.0.7"/>
-            <unit id="org.eclipse.jetty.websocket.server" version="10.0.7"/>
-            <unit id="org.eclipse.jetty.websocket.servlet" version="10.0.7"/>
-            <unit id="org.eclipse.jetty.websocket.javax.server" version="10.0.7"/>
+            <unit id="org.eclipse.jetty.websocket.api" version="10.0.11"/>
+            <unit id="org.eclipse.jetty.websocket.server" version="10.0.11"/>
+            <unit id="org.eclipse.jetty.websocket.servlet" version="10.0.11"/>
+            <unit id="org.eclipse.jetty.websocket.javax.server" version="10.0.11"/>
             <unit id="org.apache.aries.spifly.dynamic.bundle" version="1.3.4"/>
             <repository location="http://localhost:8080/site"/>
         </location>

--- a/releng/platform-definitions/platform-definition-2022-03/platform-definition-2022-03.target
+++ b/releng/platform-definitions/platform-definition-2022-03/platform-definition-2022-03.target
@@ -45,10 +45,10 @@
             <unit id="org.adoptopenjdk.jemmy-browser" version="2.0.0"/>
             <unit id="org.adoptopenjdk.jemmy-core" version="2.0.0"/>
             <unit id="org.adoptopenjdk.jemmy-swt" version="2.0.0"/>
-            <unit id="org.eclipse.jetty.websocket.api" version="10.0.7"/>
-            <unit id="org.eclipse.jetty.websocket.server" version="10.0.7"/>
-            <unit id="org.eclipse.jetty.websocket.servlet" version="10.0.7"/>
-            <unit id="org.eclipse.jetty.websocket.javax.server" version="10.0.7"/>
+            <unit id="org.eclipse.jetty.websocket.api" version="10.0.11"/>
+            <unit id="org.eclipse.jetty.websocket.server" version="10.0.11"/>
+            <unit id="org.eclipse.jetty.websocket.servlet" version="10.0.11"/>
+            <unit id="org.eclipse.jetty.websocket.javax.server" version="10.0.11"/>
             <unit id="org.apache.aries.spifly.dynamic.bundle" version="1.3.4"/>
             <repository location="http://localhost:8080/site"/>
         </location>

--- a/releng/platform-definitions/platform-definition-2022-06/platform-definition-2022-06.target
+++ b/releng/platform-definitions/platform-definition-2022-06/platform-definition-2022-06.target
@@ -45,10 +45,10 @@
             <unit id="org.adoptopenjdk.jemmy-browser" version="2.0.0"/>
             <unit id="org.adoptopenjdk.jemmy-core" version="2.0.0"/>
             <unit id="org.adoptopenjdk.jemmy-swt" version="2.0.0"/>
-            <unit id="org.eclipse.jetty.websocket.api" version="10.0.7"/>
-            <unit id="org.eclipse.jetty.websocket.server" version="10.0.7"/>
-            <unit id="org.eclipse.jetty.websocket.servlet" version="10.0.7"/>
-            <unit id="org.eclipse.jetty.websocket.javax.server" version="10.0.7"/>
+            <unit id="org.eclipse.jetty.websocket.api" version="10.0.11"/>
+            <unit id="org.eclipse.jetty.websocket.server" version="10.0.11"/>
+            <unit id="org.eclipse.jetty.websocket.servlet" version="10.0.11"/>
+            <unit id="org.eclipse.jetty.websocket.javax.server" version="10.0.11"/>
             <unit id="org.apache.aries.spifly.dynamic.bundle" version="1.3.4"/>
             <repository location="http://localhost:8080/site"/>
         </location>

--- a/releng/third-party/pom.xml
+++ b/releng/third-party/pom.xml
@@ -46,7 +46,7 @@
 		<jakarta.activation.version>2.0.1</jakarta.activation.version>
 		<jakarta.mail.version>2.0.1</jakarta.mail.version>
 		<javax.websocket.version>1.1</javax.websocket.version>
-		<jetty.version>10.0.7</jetty.version>
+		<jetty.version>10.0.11</jetty.version>
 		<jemmy.version>2.0.0</jemmy.version>
 		<jetty-maven-plugin.version>9.4.46.v20220331</jetty-maven-plugin.version>
 		<lz4.version>1.8.0</lz4.version>


### PR DESCRIPTION
With eclipse 4.24, default jetty version is 10.0.9. Some important issues have been addressed in latest releases 10.0.10 and 10.0.11. So we need to upgrade jetty to latest version 10.0.11.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JMC-7858](https://bugs.openjdk.org/browse/JMC-7858): Upgrade jetty.project in github to 10.0.11


### Reviewers
 * @bric3 (no known github.com user name / role)
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmc pull/414/head:pull/414` \
`$ git checkout pull/414`

Update a local copy of the PR: \
`$ git checkout pull/414` \
`$ git pull https://git.openjdk.org/jmc pull/414/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 414`

View PR using the GUI difftool: \
`$ git pr show -t 414`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmc/pull/414.diff">https://git.openjdk.org/jmc/pull/414.diff</a>

</details>
