### PR TITLE
7862: Platform-definitions-2022-06.target file has space in pde version

### DIFF
--- a/releng/platform-definitions/platform-definition-2022-06/platform-definition-2022-06.target
+++ b/releng/platform-definitions/platform-definition-2022-06/platform-definition-2022-06.target
@@ -54,7 +54,7 @@
         </location>
         <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
             <unit id="org.eclipse.equinox.executable.feature.group" version="3.8.1700.v20220509-0833"/>
-            <unit id="org.eclipse.pde.feature.group" version=" 3.14.1200.v20220607-0700"/>
+            <unit id="org.eclipse.pde.feature.group" version="3.14.1200.v20220607-0700"/>
             <unit id="org.eclipse.platform.sdk" version="4.24.0.I20220607-0700"/>
             <repository location="http://download.eclipse.org/releases/2022-06/"/>
         </location>


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JMC-7862](https://bugs.openjdk.org/browse/JMC-7862): Platform-definitions-2022-06.target file has space in pde version


### Reviewers
 * [Marcus Hirt](https://openjdk.org/census#hirt) (@thegreystone - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmc pull/417/head:pull/417` \
`$ git checkout pull/417`

Update a local copy of the PR: \
`$ git checkout pull/417` \
`$ git pull https://git.openjdk.org/jmc pull/417/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 417`

View PR using the GUI difftool: \
`$ git pr show -t 417`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmc/pull/417.diff">https://git.openjdk.org/jmc/pull/417.diff</a>

</details>
