### PR TITLE
7872: Adding artifacts to third-party pom file, which are not getting resolved by maven

### DIFF
--- a/application/org.openjdk.jmc.flightrecorder.dependencyview/src/main/java/org/openjdk/jmc/flightrecorder/dependencyview/DependencyView.java
+++ b/application/org.openjdk.jmc.flightrecorder.dependencyview/src/main/java/org/openjdk/jmc/flightrecorder/dependencyview/DependencyView.java
@@ -89,13 +89,9 @@ public class DependencyView extends ViewPart implements ISelectionListener {
 	private static final String HTML_PAGE;
 	static {
 		String jsD3V6 = "jslibs/d3.v6.min.js";
-		HTML_PAGE = String.format(
-				loadStringFromFile("page.template"),
-				loadLibraries(jsD3V6),
-				loadStringFromFile("main.js"),
-				loadStringFromFile("utils.js"),
-				loadStringFromFile("hierarchical-edge.js"),
-				loadStringFromFile("chord.js"));
+		HTML_PAGE = String.format(loadStringFromFile("page.template"), loadLibraries(jsD3V6),
+				loadStringFromFile("main.js"), loadStringFromFile("utils.js"),
+				loadStringFromFile("hierarchical-edge.js"), loadStringFromFile("chord.js"));
 	}
 
 	private enum ModelState {
@@ -135,8 +131,12 @@ public class DependencyView extends ViewPart implements ISelectionListener {
 	}
 
 	private enum DiagramType {
-		EDGE_BUNDLING(Messages.getString(Messages.DEPENDENCYVIEW_EDGE_BUNDLING_DIAGRAM), IAction.AS_RADIO_BUTTON, dependencyViewImageDescriptor("edge.png")),
-		CHORD(Messages.getString(Messages.DEPENDENCYVIEW_CHORD_DIAGRAM), IAction.AS_RADIO_BUTTON, dependencyViewImageDescriptor("chord.png"));
+		EDGE_BUNDLING(Messages.getString(
+				Messages.DEPENDENCYVIEW_EDGE_BUNDLING_DIAGRAM), IAction.AS_RADIO_BUTTON, dependencyViewImageDescriptor(
+						"edge.png")),
+		CHORD(Messages.getString(
+				Messages.DEPENDENCYVIEW_CHORD_DIAGRAM), IAction.AS_RADIO_BUTTON, dependencyViewImageDescriptor(
+						"chord.png"));
 
 		private final String message;
 		private final int action;
@@ -166,7 +166,8 @@ public class DependencyView extends ViewPart implements ISelectionListener {
 				diagramType = type;
 				if (currentItems != null) {
 					String eventsJson = IItemCollectionJsonSerializer.toJsonString(currentItems);
-					browser.execute(String.format("updateGraph(`%s`, %d, `%s`);", eventsJson, packageDepth, diagramType.name()));
+					browser.execute(String.format("updateGraph(`%s`, %d, `%s`);", eventsJson, packageDepth,
+							diagramType.name()));
 				}
 			}
 		}
@@ -202,9 +203,7 @@ public class DependencyView extends ViewPart implements ISelectionListener {
 		super.init(site, memento);
 		IToolBarManager toolBar = site.getActionBars().getToolBarManager();
 		ChangeDiagramTypeAction[] chartTypeActions = new ChangeDiagramTypeAction[] {
-				new ChangeDiagramTypeAction(DiagramType.CHORD),
-				new ChangeDiagramTypeAction(DiagramType.EDGE_BUNDLING)
-		};
+				new ChangeDiagramTypeAction(DiagramType.CHORD), new ChangeDiagramTypeAction(DiagramType.EDGE_BUNDLING)};
 		Stream.of(chartTypeActions).forEach(toolBar::add);
 		toolBar.add(new Separator());
 		toolBar.add(new PackageDepthSelection());
@@ -252,7 +251,8 @@ public class DependencyView extends ViewPart implements ISelectionListener {
 
 		private void populate(Menu menu) {
 			for (Pair<String, Integer> item : depths) {
-				ActionContributionItem actionItem = new ActionContributionItem(new SetPackageDepth(item, item.right == packageDepth));
+				ActionContributionItem actionItem = new ActionContributionItem(
+						new SetPackageDepth(item, item.right == packageDepth));
 				actionItem.fill(menu, -1);
 			}
 		}
@@ -334,7 +334,8 @@ public class DependencyView extends ViewPart implements ISelectionListener {
 	private void setViewerInput(String eventsJson, int packageDepth) {
 		browser.setText(HTML_PAGE);
 		browser.addListener(SWT.Resize, event -> {
-			browser.execute(String.format("updateGraph(`%s`, %d, `%s`);", eventsJson, packageDepth, diagramType.name()));
+			browser.execute(
+					String.format("updateGraph(`%s`, %d, `%s`);", eventsJson, packageDepth, diagramType.name()));
 		});
 
 		browser.addProgressListener(new ProgressAdapter() {
@@ -350,13 +351,14 @@ public class DependencyView extends ViewPart implements ISelectionListener {
 			@Override
 			public void completed(ProgressEvent event) {
 				browser.removeProgressListener(this);
-				browser.execute(String.format("updateGraph(`%s`, %d, `%s`);", eventsJson, packageDepth, diagramType.name()));
+				browser.execute(
+						String.format("updateGraph(`%s`, %d, `%s`);", eventsJson, packageDepth, diagramType.name()));
 				loaded = true;
 			}
 		});
 	}
 
-	private static String loadLibraries(String... libs) {
+	private static String loadLibraries(String ... libs) {
 		if (libs == null || libs.length == 0) {
 			return "";
 		} else {

--- a/releng/third-party/pom.xml
+++ b/releng/third-party/pom.xml
@@ -113,6 +113,18 @@
 									<id>org.eclipse.jetty.websocket:websocket-jetty-api:${jetty.version}</id>
 								</artifact>
 								<artifact>
+									<id>org.eclipse.jetty:jetty-security:${jetty.version}</id>
+								</artifact>
+								<artifact>
+									<id>org.eclipse.jetty:jetty-server:${jetty.version}</id>
+								</artifact>
+								<artifact>
+									<id>org.eclipse.jetty.websocket:websocket-core-server:${jetty.version}</id>
+								</artifact>
+								<artifact>
+									<id>org.eclipse.jetty:jetty-xml:${jetty.version}</id>
+								</artifact>
+								<artifact>
 									<id>org.apache.aries.spifly:org.apache.aries.spifly.dynamic.bundle:${spifly.version}</id>
 								</artifact>
 							</artifacts>


### PR DESCRIPTION
Sometimes below mentioned artifacts are not getting resolved by *mvn p2:site*. 
* jetty-security
* jetty-server
* websocket-core-server
* jetty-xml

These plugins will be missing in jmc -> releng -> third-party -> target ->repository -> plugins.
So adding these to third-party pom file. Adding these artifacts is not creating any effect on existing behavior. These artifacts will be just hosted on local p2 site.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JMC-7872](https://bugs.openjdk.org/browse/JMC-7872): Adding artifacts to third-party pom file, which are not getting resolved by maven


### Reviewers
 * [Marcus Hirt](https://openjdk.org/census#hirt) (@thegreystone - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmc pull/418/head:pull/418` \
`$ git checkout pull/418`

Update a local copy of the PR: \
`$ git checkout pull/418` \
`$ git pull https://git.openjdk.org/jmc pull/418/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 418`

View PR using the GUI difftool: \
`$ git pr show -t 418`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmc/pull/418.diff">https://git.openjdk.org/jmc/pull/418.diff</a>

</details>
