### PR TITLE
7892: JMC Automated UI MasterPasswordTests is failing

### DIFF
--- a/application/uitests/org.openjdk.jmc.browser.uitest/src/test/java/org/openjdk/jmc/browser/uitest/ConnectionExportImportTest.java
+++ b/application/uitests/org.openjdk.jmc.browser.uitest/src/test/java/org/openjdk/jmc/browser/uitest/ConnectionExportImportTest.java
@@ -132,7 +132,7 @@ public class ConnectionExportImportTest extends MCJemmyTestBase {
 	 */
 	@Test
 	public void testSetMasterPassword() {
-		MC.jvmBrowser.createConnection("localhost", "0", "username", "password", true, "PasswordConnection");
+		MC.jvmBrowser.createConnection("localhost", "0", "username", "Password@123", true, "PasswordConnection");
 		MC.jvmBrowser.deleteItem("PasswordConnection");
 	}
 


### PR DESCRIPTION
The ui test case was not adhering to new password validation requirement, hence it was failing. This PR fixes the issue and uitests are passing after that.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JMC-7892](https://bugs.openjdk.org/browse/JMC-7892): JMC Automated UI MasterPasswordTests is failing


### Reviewers
 * [Marcus Hirt](https://openjdk.org/census#hirt) (@thegreystone - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmc pull/427/head:pull/427` \
`$ git checkout pull/427`

Update a local copy of the PR: \
`$ git checkout pull/427` \
`$ git pull https://git.openjdk.org/jmc pull/427/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 427`

View PR using the GUI difftool: \
`$ git pr show -t 427`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmc/pull/427.diff">https://git.openjdk.org/jmc/pull/427.diff</a>

</details>
