### PR TITLE
7813: Unable to open Help page in macOS M1 when JMC started with JDK11

### DIFF
--- a/application/org.openjdk.jmc.docs/META-INF/MANIFEST.MF
+++ b/application/org.openjdk.jmc.docs/META-INF/MANIFEST.MF
@@ -6,3 +6,4 @@ Bundle-SymbolicName: org.openjdk.jmc.docs;singleton:=true
 Bundle-Version: 8.3.0.qualifier
 Bundle-Vendor: Oracle Corporation
 Automatic-Module-Name: org.openjdk.jmc.docs
+Require-Bundle: org.eclipse.jdt.core


### PR DESCRIPTION
By adding 'org.eclipse.jdt.core' bundle as an explicit dependency to our documentation bundle as direct dependency, we can fix this issue. This fixes the old issue [JMC-7321](https://bugs.openjdk.org/browse/JMC-7321) as well. 

This is just a workaround. 
Proper solution is, org.apache.jasper.glassfish package must be updated to contain a more up to date JDT compiler and this updated package must be used as a dependency by the documentation bundle. (In Progress)

Details can be found in below link. [https://bugs.eclipse.org/bugs/show_bug.cgi?id=574937](https://bugs.eclipse.org/bugs/show_bug.cgi?id=574937)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JMC-7813](https://bugs.openjdk.org/browse/JMC-7813): Unable to open Help page in macOS M1 when JMC started with JDK11


### Reviewers
 * [Marcus Hirt](https://openjdk.org/census#hirt) (@thegreystone - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmc pull/428/head:pull/428` \
`$ git checkout pull/428`

Update a local copy of the PR: \
`$ git checkout pull/428` \
`$ git pull https://git.openjdk.org/jmc pull/428/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 428`

View PR using the GUI difftool: \
`$ git pr show -t 428`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmc/pull/428.diff">https://git.openjdk.org/jmc/pull/428.diff</a>

</details>
