### PR TITLE
7350: [Accessibility, JAWS] [Misc] Deadlinks in Help Page

### DIFF
--- a/application/org.openjdk.jmc.docs/html/GUID-0352E76D-96F5-4EDA-A8DE-88B9E18635B9.htm
+++ b/application/org.openjdk.jmc.docs/html/GUID-0352E76D-96F5-4EDA-A8DE-88B9E18635B9.htm
@@ -27,7 +27,6 @@
 <link rel="next" href="GUID-63742D06-CF58-47F2-9CF2-08C0DB9F09F1.htm" title="Next" type="text/html" />
 </head>
 <body>
-<div class="zz-skip-header"><a href="#BEGIN">Go to primary content</a></div>
 <table class="simple oac_no_warn" summary="" cellspacing="0" cellpadding="0" width="100%">
 <col width="86%" /><col width="*" /><tr valign="bottom">
 <td></td>

--- a/application/org.openjdk.jmc.docs/html/GUID-05BEE8DA-92DD-4D64-8F96-AE3BCA7F1190.htm
+++ b/application/org.openjdk.jmc.docs/html/GUID-05BEE8DA-92DD-4D64-8F96-AE3BCA7F1190.htm
@@ -27,7 +27,6 @@
 <link rel="next" href="GUID-B633156D-F63E-4E09-BBB0-009509FED0B0.htm" title="Next" type="text/html" />
 </head>
 <body>
-<div class="zz-skip-header"><a href="#BEGIN">Go to primary content</a></div>
 <table class="simple oac_no_warn" summary="" cellspacing="0" cellpadding="0" width="100%">
 <col width="86%" /><col width="*" /><tr valign="bottom">
 <td></td>

--- a/application/org.openjdk.jmc.docs/html/GUID-0BFAAA05-CF48-4351-B5FF-AC8E11BAA9DC.htm
+++ b/application/org.openjdk.jmc.docs/html/GUID-0BFAAA05-CF48-4351-B5FF-AC8E11BAA9DC.htm
@@ -27,7 +27,6 @@
 <link rel="next" href="GUID-58C8400F-82C1-4A25-92F2-1A96058C871F.htm" title="Next" type="text/html" />
 </head>
 <body>
-<div class="zz-skip-header"><a href="#BEGIN">Go to primary content</a></div>
 <table class="simple oac_no_warn" summary="" cellspacing="0" cellpadding="0" width="100%">
 <col width="86%" /><col width="*" /><tr valign="bottom">
 <td></td>

--- a/application/org.openjdk.jmc.docs/html/GUID-18677545-5152-4688-8C51-4A1151361BB9.htm
+++ b/application/org.openjdk.jmc.docs/html/GUID-18677545-5152-4688-8C51-4A1151361BB9.htm
@@ -27,7 +27,6 @@
 <link rel="next" href="GUID-D475ABB1-DE41-4A24-8BB8-A058FDDC6645.htm" title="Next" type="text/html" />
 </head>
 <body>
-<div class="zz-skip-header"><a href="#BEGIN">Go to primary content</a></div>
 <table class="simple oac_no_warn" summary="" cellspacing="0" cellpadding="0" width="100%">
 <col width="86%" /><col width="*" /><tr valign="bottom">
 <td></td>

--- a/application/org.openjdk.jmc.docs/html/GUID-2125BB8B-CC13-4125-8562-F0BFD428F1DC.htm
+++ b/application/org.openjdk.jmc.docs/html/GUID-2125BB8B-CC13-4125-8562-F0BFD428F1DC.htm
@@ -27,7 +27,6 @@
 <link rel="next" href="GUID-D319B54B-FB4B-422E-8B92-50F4FFBF1153.htm" title="Next" type="text/html" />
 </head>
 <body>
-<div class="zz-skip-header"><a href="#BEGIN">Go to primary content</a></div>
 <table class="simple oac_no_warn" summary="" cellspacing="0" cellpadding="0" width="100%">
 <col width="86%" /><col width="*" /><tr valign="bottom">
 <td></td>

--- a/application/org.openjdk.jmc.docs/html/GUID-2231E0A6-ECCE-48A6-89DF-7526CC50F280.htm
+++ b/application/org.openjdk.jmc.docs/html/GUID-2231E0A6-ECCE-48A6-89DF-7526CC50F280.htm
@@ -27,7 +27,6 @@
 <link rel="next" href="GUID-A1BCA5DC-0102-4FD4-9D8C-717473025C52.htm" title="Next" type="text/html" />
 </head>
 <body>
-<div class="zz-skip-header"><a href="#BEGIN">Go to primary content</a></div>
 <table class="simple oac_no_warn" summary="" cellspacing="0" cellpadding="0" width="100%">
 <col width="86%" /><col width="*" /><tr valign="bottom">
 <td></td>

--- a/application/org.openjdk.jmc.docs/html/GUID-29C36ED5-88E1-4974-B4B1-EFC683A1575D.htm
+++ b/application/org.openjdk.jmc.docs/html/GUID-29C36ED5-88E1-4974-B4B1-EFC683A1575D.htm
@@ -27,7 +27,6 @@
 <link rel="next" href="GUID-2F693047-FF99-43A2-828C-ED22F1EF5A10.htm" title="Next" type="text/html" />
 </head>
 <body>
-<div class="zz-skip-header"><a href="#BEGIN">Go to primary content</a></div>
 <table class="simple oac_no_warn" summary="" cellspacing="0" cellpadding="0" width="100%">
 <col width="86%" /><col width="*" /><tr valign="bottom">
 <td></td>

--- a/application/org.openjdk.jmc.docs/html/GUID-2AF1BAE8-14F3-4904-85E8-5F333A765B3C.htm
+++ b/application/org.openjdk.jmc.docs/html/GUID-2AF1BAE8-14F3-4904-85E8-5F333A765B3C.htm
@@ -27,7 +27,6 @@
 <link rel="next" href="GUID-D3E9AB4B-17CE-478B-9A1B-2A51FEA920F0.htm" title="Next" type="text/html" />
 </head>
 <body>
-<div class="zz-skip-header"><a href="#BEGIN">Go to primary content</a></div>
 <table class="simple oac_no_warn" summary="" cellspacing="0" cellpadding="0" width="100%">
 <col width="86%" /><col width="*" /><tr valign="bottom">
 <td></td>

--- a/application/org.openjdk.jmc.docs/html/GUID-2BEF3E8A-724C-4EB2-869D-1CE9C83A0772.htm
+++ b/application/org.openjdk.jmc.docs/html/GUID-2BEF3E8A-724C-4EB2-869D-1CE9C83A0772.htm
@@ -27,7 +27,6 @@
 <link rel="next" href="GUID-FA2C4870-8D2F-4627-9DBA-5B530785453A.htm" title="Next" type="text/html" />
 </head>
 <body>
-<div class="zz-skip-header"><a href="#BEGIN">Go to primary content</a></div>
 <table class="simple oac_no_warn" summary="" cellspacing="0" cellpadding="0" width="100%">
 <col width="86%" /><col width="*" /><tr valign="bottom">
 <td></td>

--- a/application/org.openjdk.jmc.docs/html/GUID-2D86C16D-9DFC-4B3E-B7AD-3185418241D1.htm
+++ b/application/org.openjdk.jmc.docs/html/GUID-2D86C16D-9DFC-4B3E-B7AD-3185418241D1.htm
@@ -27,7 +27,6 @@
 <link rel="next" href="GUID-4D1A3616-1FB9-4478-8AB7-1941F3EDF87B.htm" title="Next" type="text/html" />
 </head>
 <body>
-<div class="zz-skip-header"><a href="#BEGIN">Go to primary content</a></div>
 <table class="simple oac_no_warn" summary="" cellspacing="0" cellpadding="0" width="100%">
 <col width="86%" /><col width="*" /><tr valign="bottom">
 <td></td>

--- a/application/org.openjdk.jmc.docs/html/GUID-2E1242E0-8437-467B-9AEC-36AE680733F7.htm
+++ b/application/org.openjdk.jmc.docs/html/GUID-2E1242E0-8437-467B-9AEC-36AE680733F7.htm
@@ -27,7 +27,6 @@
 <link rel="next" href="GUID-D934384D-A13D-46F7-9588-32AE6C901554.htm" title="Next" type="text/html" />
 </head>
 <body>
-<div class="zz-skip-header"><a href="#BEGIN">Go to primary content</a></div>
 <table class="simple oac_no_warn" summary="" cellspacing="0" cellpadding="0" width="100%">
 <col width="86%" /><col width="*" /><tr valign="bottom">
 <td></td>

--- a/application/org.openjdk.jmc.docs/html/GUID-2F693047-FF99-43A2-828C-ED22F1EF5A10.htm
+++ b/application/org.openjdk.jmc.docs/html/GUID-2F693047-FF99-43A2-828C-ED22F1EF5A10.htm
@@ -27,7 +27,6 @@
 <link rel="next" href="GUID-CCA54ADF-B778-4CF3-97D0-A34D2442A4C4.htm" title="Next" type="text/html" />
 </head>
 <body>
-<div class="zz-skip-header"><a href="#BEGIN">Go to primary content</a></div>
 <table class="simple oac_no_warn" summary="" cellspacing="0" cellpadding="0" width="100%">
 <col width="86%" /><col width="*" /><tr valign="bottom">
 <td></td>

--- a/application/org.openjdk.jmc.docs/html/GUID-343C6885-3367-4DDE-9BE5-1A7421CE00A1.htm
+++ b/application/org.openjdk.jmc.docs/html/GUID-343C6885-3367-4DDE-9BE5-1A7421CE00A1.htm
@@ -27,7 +27,6 @@
 <link rel="next" href="GUID-0352E76D-96F5-4EDA-A8DE-88B9E18635B9.htm" title="Next" type="text/html" />
 </head>
 <body>
-<div class="zz-skip-header"><a href="#BEGIN">Go to primary content</a></div>
 <table class="simple oac_no_warn" summary="" cellspacing="0" cellpadding="0" width="100%">
 <col width="86%" /><col width="*" /><tr valign="bottom">
 <td></td>

--- a/application/org.openjdk.jmc.docs/html/GUID-35CEE658-D1BE-456C-84C1-38543BE776AA.htm
+++ b/application/org.openjdk.jmc.docs/html/GUID-35CEE658-D1BE-456C-84C1-38543BE776AA.htm
@@ -27,7 +27,6 @@
 <link rel="next" href="GUID-C661942A-3DCF-40B4-87C3-F5000DE4830E.htm" title="Next" type="text/html" />
 </head>
 <body>
-<div class="zz-skip-header"><a href="#BEGIN">Go to primary content</a></div>
 <table class="simple oac_no_warn" summary="" cellspacing="0" cellpadding="0" width="100%">
 <col width="86%" /><col width="*" /><tr valign="bottom">
 <td></td>

--- a/application/org.openjdk.jmc.docs/html/GUID-3B426495-2A88-49D5-B72A-9013773039B7.htm
+++ b/application/org.openjdk.jmc.docs/html/GUID-3B426495-2A88-49D5-B72A-9013773039B7.htm
@@ -27,7 +27,6 @@
 <link rel="next" href="GUID-2231E0A6-ECCE-48A6-89DF-7526CC50F280.htm" title="Next" type="text/html" />
 </head>
 <body>
-<div class="zz-skip-header"><a href="#BEGIN">Go to primary content</a></div>
 <table class="simple oac_no_warn" summary="" cellspacing="0" cellpadding="0" width="100%">
 <col width="86%" /><col width="*" /><tr valign="bottom">
 <td></td>

--- a/application/org.openjdk.jmc.docs/html/GUID-3EC7E6C3-6A64-4659-B99E-CA675A9F6E0A.htm
+++ b/application/org.openjdk.jmc.docs/html/GUID-3EC7E6C3-6A64-4659-B99E-CA675A9F6E0A.htm
@@ -26,7 +26,6 @@
 <link rel="prev" href="GUID-D722CAC6-84F5-4F36-9B83-66B5C4774821.htm" title="Previous" type="text/html" />
 </head>
 <body>
-<div class="zz-skip-header"><a href="#BEGIN">Go to primary content</a></div>
 <table class="simple oac_no_warn" summary="" cellspacing="0" cellpadding="0" width="100%">
 <col width="86%" /><col width="*" /><tr valign="bottom">
 <td></td>

--- a/application/org.openjdk.jmc.docs/html/GUID-40FF6634-CBCF-4879-A494-52FF7CEFD759.htm
+++ b/application/org.openjdk.jmc.docs/html/GUID-40FF6634-CBCF-4879-A494-52FF7CEFD759.htm
@@ -27,7 +27,6 @@
 <link rel="next" href="GUID-0BFAAA05-CF48-4351-B5FF-AC8E11BAA9DC.htm" title="Next" type="text/html" />
 </head>
 <body>
-<div class="zz-skip-header"><a href="#BEGIN">Go to primary content</a></div>
 <table class="simple oac_no_warn" summary="" cellspacing="0" cellpadding="0" width="100%">
 <col width="86%" /><col width="*" /><tr valign="bottom">
 <td></td>

--- a/application/org.openjdk.jmc.docs/html/GUID-41C663D6-F745-4062-BD32-6F7F2BC001BA.htm
+++ b/application/org.openjdk.jmc.docs/html/GUID-41C663D6-F745-4062-BD32-6F7F2BC001BA.htm
@@ -27,7 +27,6 @@
 <link rel="next" href="GUID-BA742114-2E89-462D-8DCB-4442B3538CFA.htm" title="Next" type="text/html" />
 </head>
 <body>
-<div class="zz-skip-header"><a href="#BEGIN">Go to primary content</a></div>
 <table class="simple oac_no_warn" summary="" cellspacing="0" cellpadding="0" width="100%">
 <col width="86%" /><col width="*" /><tr valign="bottom">
 <td></td>

--- a/application/org.openjdk.jmc.docs/html/GUID-41D47617-4E32-4793-9253-6C2125F21CFF.htm
+++ b/application/org.openjdk.jmc.docs/html/GUID-41D47617-4E32-4793-9253-6C2125F21CFF.htm
@@ -27,7 +27,6 @@
 <link rel="next" href="GUID-B8C17ABE-C0E5-4044-9401-1A01C5EE07E3.htm" title="Next" type="text/html" />
 </head>
 <body>
-<div class="zz-skip-header"><a href="#BEGIN">Go to primary content</a></div>
 <table class="simple oac_no_warn" summary="" cellspacing="0" cellpadding="0" width="100%">
 <col width="86%" /><col width="*" /><tr valign="bottom">
 <td></td>

--- a/application/org.openjdk.jmc.docs/html/GUID-440C24FA-59FD-471D-A1DC-7581C522E54E.htm
+++ b/application/org.openjdk.jmc.docs/html/GUID-440C24FA-59FD-471D-A1DC-7581C522E54E.htm
@@ -27,7 +27,6 @@
 <link rel="next" href="GUID-9EE879C7-3584-4508-8456-B4324097B207-01.htm" title="Next" type="text/html" />
 </head>
 <body>
-<div class="zz-skip-header"><a href="#BEGIN">Go to primary content</a></div>
 <table class="simple oac_no_warn" summary="" cellspacing="0" cellpadding="0" width="100%">
 <col width="86%" /><col width="*" /><tr valign="bottom">
 <td></td>

--- a/application/org.openjdk.jmc.docs/html/GUID-472929AC-C8EA-4857-A14C-603AF91D6957.htm
+++ b/application/org.openjdk.jmc.docs/html/GUID-472929AC-C8EA-4857-A14C-603AF91D6957.htm
@@ -27,7 +27,6 @@
 <link rel="next" href="GUID-591A4D5C-C28B-48CE-9B32-CF798D011E75.htm" title="Next" type="text/html" />
 </head>
 <body>
-<div class="zz-skip-header"><a href="#BEGIN">Go to primary content</a></div>
 <table class="simple oac_no_warn" summary="" cellspacing="0" cellpadding="0" width="100%">
 <col width="86%" /><col width="*" /><tr valign="bottom">
 <td></td>

--- a/application/org.openjdk.jmc.docs/html/GUID-492BB17D-5964-48C3-9212-D4848514437A.htm
+++ b/application/org.openjdk.jmc.docs/html/GUID-492BB17D-5964-48C3-9212-D4848514437A.htm
@@ -27,7 +27,6 @@
 <link rel="next" href="GUID-343C6885-3367-4DDE-9BE5-1A7421CE00A1.htm" title="Next" type="text/html" />
 </head>
 <body>
-<div class="zz-skip-header"><a href="#BEGIN">Go to primary content</a></div>
 <table class="simple oac_no_warn" summary="" cellspacing="0" cellpadding="0" width="100%">
 <col width="86%" /><col width="*" /><tr valign="bottom">
 <td></td>

--- a/application/org.openjdk.jmc.docs/html/GUID-49FF0744-EF9E-41D6-8BF2-5326EAB9921C.htm
+++ b/application/org.openjdk.jmc.docs/html/GUID-49FF0744-EF9E-41D6-8BF2-5326EAB9921C.htm
@@ -27,7 +27,6 @@
 <link rel="next" href="GUID-2BEF3E8A-724C-4EB2-869D-1CE9C83A0772.htm" title="Next" type="text/html" />
 </head>
 <body>
-<div class="zz-skip-header"><a href="#BEGIN">Go to primary content</a></div>
 <table class="simple oac_no_warn" summary="" cellspacing="0" cellpadding="0" width="100%">
 <col width="86%" /><col width="*" /><tr valign="bottom">
 <td></td>

--- a/application/org.openjdk.jmc.docs/html/GUID-4B13023D-6AFA-4563-8532-74871DE29B62.htm
+++ b/application/org.openjdk.jmc.docs/html/GUID-4B13023D-6AFA-4563-8532-74871DE29B62.htm
@@ -27,7 +27,6 @@
 <link rel="next" href="GUID-41C663D6-F745-4062-BD32-6F7F2BC001BA.htm" title="Next" type="text/html" />
 </head>
 <body>
-<div class="zz-skip-header"><a href="#BEGIN">Go to primary content</a></div>
 <table class="simple oac_no_warn" summary="" cellspacing="0" cellpadding="0" width="100%">
 <col width="86%" /><col width="*" /><tr valign="bottom">
 <td></td>

--- a/application/org.openjdk.jmc.docs/html/GUID-4CB43843-B287-487B-B6D6-D5A58CACDD57.htm
+++ b/application/org.openjdk.jmc.docs/html/GUID-4CB43843-B287-487B-B6D6-D5A58CACDD57.htm
@@ -27,7 +27,6 @@
 <link rel="next" href="GUID-DAB13FDA-9430-4457-BFF3-04F9DC0E3977.htm" title="Next" type="text/html" />
 </head>
 <body>
-<div class="zz-skip-header"><a href="#BEGIN">Go to primary content</a></div>
 <table class="simple oac_no_warn" summary="" cellspacing="0" cellpadding="0" width="100%">
 <col width="86%" /><col width="*" /><tr valign="bottom">
 <td></td>

--- a/application/org.openjdk.jmc.docs/html/GUID-4D1A3616-1FB9-4478-8AB7-1941F3EDF87B.htm
+++ b/application/org.openjdk.jmc.docs/html/GUID-4D1A3616-1FB9-4478-8AB7-1941F3EDF87B.htm
@@ -27,7 +27,6 @@
 <link rel="next" href="GUID-97B37847-8E31-43F2-AA78-E5EBD28EC99A.htm" title="Next" type="text/html" />
 </head>
 <body>
-<div class="zz-skip-header"><a href="#BEGIN">Go to primary content</a></div>
 <table class="simple oac_no_warn" summary="" cellspacing="0" cellpadding="0" width="100%">
 <col width="86%" /><col width="*" /><tr valign="bottom">
 <td></td>

--- a/application/org.openjdk.jmc.docs/html/GUID-4F885E48-A548-4140-B985-74B1685BEDEA.htm
+++ b/application/org.openjdk.jmc.docs/html/GUID-4F885E48-A548-4140-B985-74B1685BEDEA.htm
@@ -27,7 +27,6 @@
 <link rel="next" href="GUID-F85CDA8B-CFD2-4155-A140-9DD4079F0139.htm" title="Next" type="text/html" />
 </head>
 <body>
-<div class="zz-skip-header"><a href="#BEGIN">Go to primary content</a></div>
 <table class="simple oac_no_warn" summary="" cellspacing="0" cellpadding="0" width="100%">
 <col width="86%" /><col width="*" /><tr valign="bottom">
 <td></td>

--- a/application/org.openjdk.jmc.docs/html/GUID-58C8400F-82C1-4A25-92F2-1A96058C871F.htm
+++ b/application/org.openjdk.jmc.docs/html/GUID-58C8400F-82C1-4A25-92F2-1A96058C871F.htm
@@ -27,7 +27,6 @@
 <link rel="next" href="GUID-8EA35A18-669C-4EC3-BCEF-7EA7F92BA3EE.htm" title="Next" type="text/html" />
 </head>
 <body>
-<div class="zz-skip-header"><a href="#BEGIN">Go to primary content</a></div>
 <table class="simple oac_no_warn" summary="" cellspacing="0" cellpadding="0" width="100%">
 <col width="86%" /><col width="*" /><tr valign="bottom">
 <td></td>

--- a/application/org.openjdk.jmc.docs/html/GUID-591A4D5C-C28B-48CE-9B32-CF798D011E75.htm
+++ b/application/org.openjdk.jmc.docs/html/GUID-591A4D5C-C28B-48CE-9B32-CF798D011E75.htm
@@ -27,7 +27,6 @@
 <link rel="next" href="GUID-8CC21FED-821F-49B4-BADF-4B5F2AB041A2.htm" title="Next" type="text/html" />
 </head>
 <body>
-<div class="zz-skip-header"><a href="#BEGIN">Go to primary content</a></div>
 <table class="simple oac_no_warn" summary="" cellspacing="0" cellpadding="0" width="100%">
 <col width="86%" /><col width="*" /><tr valign="bottom">
 <td></td>

--- a/application/org.openjdk.jmc.docs/html/GUID-59CA7784-185A-4EED-B523-F640881040FC.htm
+++ b/application/org.openjdk.jmc.docs/html/GUID-59CA7784-185A-4EED-B523-F640881040FC.htm
@@ -27,7 +27,6 @@
 <link rel="next" href="GUID-440C24FA-59FD-471D-A1DC-7581C522E54E.htm" title="Next" type="text/html" />
 </head>
 <body>
-<div class="zz-skip-header"><a href="#BEGIN">Go to primary content</a></div>
 <table class="simple oac_no_warn" summary="" cellspacing="0" cellpadding="0" width="100%">
 <col width="86%" /><col width="*" /><tr valign="bottom">
 <td></td>

--- a/application/org.openjdk.jmc.docs/html/GUID-63742D06-CF58-47F2-9CF2-08C0DB9F09F1.htm
+++ b/application/org.openjdk.jmc.docs/html/GUID-63742D06-CF58-47F2-9CF2-08C0DB9F09F1.htm
@@ -27,7 +27,6 @@
 <link rel="next" href="GUID-A45813E6-C32E-4916-966E-AE24992BB326.htm" title="Next" type="text/html" />
 </head>
 <body>
-<div class="zz-skip-header"><a href="#BEGIN">Go to primary content</a></div>
 <table class="simple oac_no_warn" summary="" cellspacing="0" cellpadding="0" width="100%">
 <col width="86%" /><col width="*" /><tr valign="bottom">
 <td></td>

--- a/application/org.openjdk.jmc.docs/html/GUID-65882C8B-7834-41E4-AA7F-9A82BCE36388.htm
+++ b/application/org.openjdk.jmc.docs/html/GUID-65882C8B-7834-41E4-AA7F-9A82BCE36388.htm
@@ -27,7 +27,6 @@
 <link rel="next" href="GUID-2D86C16D-9DFC-4B3E-B7AD-3185418241D1.htm" title="Next" type="text/html" />
 </head>
 <body>
-<div class="zz-skip-header"><a href="#BEGIN">Go to primary content</a></div>
 <table class="simple oac_no_warn" summary="" cellspacing="0" cellpadding="0" width="100%">
 <col width="86%" /><col width="*" /><tr valign="bottom">
 <td></td>

--- a/application/org.openjdk.jmc.docs/html/GUID-66413CF1-A0E1-43BD-B8DB-9720B112D8F3.htm
+++ b/application/org.openjdk.jmc.docs/html/GUID-66413CF1-A0E1-43BD-B8DB-9720B112D8F3.htm
@@ -27,7 +27,6 @@
 <link rel="next" href="GUID-F94F7FBB-5B53-40A3-854E-8BE8FC172629.htm" title="Next" type="text/html" />
 </head>
 <body>
-<div class="zz-skip-header"><a href="#BEGIN">Go to primary content</a></div>
 <table class="simple oac_no_warn" summary="" cellspacing="0" cellpadding="0" width="100%">
 <col width="86%" /><col width="*" /><tr valign="bottom">
 <td></td>

--- a/application/org.openjdk.jmc.docs/html/GUID-6A66D658-7FD4-4621-9FE7-662D8B8FFACF.htm
+++ b/application/org.openjdk.jmc.docs/html/GUID-6A66D658-7FD4-4621-9FE7-662D8B8FFACF.htm
@@ -27,7 +27,6 @@
 <link rel="next" href="GUID-8E04A807-3D2B-4896-AD06-B0DE61ACBBD9.htm" title="Next" type="text/html" />
 </head>
 <body>
-<div class="zz-skip-header"><a href="#BEGIN">Go to primary content</a></div>
 <table class="simple oac_no_warn" summary="" cellspacing="0" cellpadding="0" width="100%">
 <col width="86%" /><col width="*" /><tr valign="bottom">
 <td></td>

--- a/application/org.openjdk.jmc.docs/html/GUID-6B99EBAD-C94C-4B3D-B7B4-867F408012BF.htm
+++ b/application/org.openjdk.jmc.docs/html/GUID-6B99EBAD-C94C-4B3D-B7B4-867F408012BF.htm
@@ -27,7 +27,6 @@
 <link rel="next" href="GUID-49FF0744-EF9E-41D6-8BF2-5326EAB9921C.htm" title="Next" type="text/html" />
 </head>
 <body>
-<div class="zz-skip-header"><a href="#BEGIN">Go to primary content</a></div>
 <table class="simple oac_no_warn" summary="" cellspacing="0" cellpadding="0" width="100%">
 <col width="86%" /><col width="*" /><tr valign="bottom">
 <td></td>

--- a/application/org.openjdk.jmc.docs/html/GUID-81AD3592-4E3F-4D9E-8877-675CEF333549.htm
+++ b/application/org.openjdk.jmc.docs/html/GUID-81AD3592-4E3F-4D9E-8877-675CEF333549.htm
@@ -27,7 +27,6 @@
 <link rel="next" href="GUID-958F3421-2848-4C34-9A08-681011D409E6.htm" title="Next" type="text/html" />
 </head>
 <body>
-<div class="zz-skip-header"><a href="#BEGIN">Go to primary content</a></div>
 <table class="simple oac_no_warn" summary="" cellspacing="0" cellpadding="0" width="100%">
 <col width="86%" /><col width="*" /><tr valign="bottom">
 <td></td>

--- a/application/org.openjdk.jmc.docs/html/GUID-8626DCFD-B072-4F71-9F38-F5964C51F70E.htm
+++ b/application/org.openjdk.jmc.docs/html/GUID-8626DCFD-B072-4F71-9F38-F5964C51F70E.htm
@@ -27,7 +27,6 @@
 <link rel="next" href="GUID-472929AC-C8EA-4857-A14C-603AF91D6957.htm" title="Next" type="text/html" />
 </head>
 <body>
-<div class="zz-skip-header"><a href="#BEGIN">Go to primary content</a></div>
 <table class="simple oac_no_warn" summary="" cellspacing="0" cellpadding="0" width="100%">
 <col width="86%" /><col width="*" /><tr valign="bottom">
 <td></td>

--- a/application/org.openjdk.jmc.docs/html/GUID-8CC21FED-821F-49B4-BADF-4B5F2AB041A2.htm
+++ b/application/org.openjdk.jmc.docs/html/GUID-8CC21FED-821F-49B4-BADF-4B5F2AB041A2.htm
@@ -27,7 +27,6 @@
 <link rel="next" href="GUID-3B426495-2A88-49D5-B72A-9013773039B7.htm" title="Next" type="text/html" />
 </head>
 <body>
-<div class="zz-skip-header"><a href="#BEGIN">Go to primary content</a></div>
 <table class="simple oac_no_warn" summary="" cellspacing="0" cellpadding="0" width="100%">
 <col width="86%" /><col width="*" /><tr valign="bottom">
 <td></td>

--- a/application/org.openjdk.jmc.docs/html/GUID-8E04A807-3D2B-4896-AD06-B0DE61ACBBD9.htm
+++ b/application/org.openjdk.jmc.docs/html/GUID-8E04A807-3D2B-4896-AD06-B0DE61ACBBD9.htm
@@ -27,7 +27,6 @@
 <link rel="next" href="GUID-4F885E48-A548-4140-B985-74B1685BEDEA.htm" title="Next" type="text/html" />
 </head>
 <body>
-<div class="zz-skip-header"><a href="#BEGIN">Go to primary content</a></div>
 <table class="simple oac_no_warn" summary="" cellspacing="0" cellpadding="0" width="100%">
 <col width="86%" /><col width="*" /><tr valign="bottom">
 <td></td>

--- a/application/org.openjdk.jmc.docs/html/GUID-8EA35A18-669C-4EC3-BCEF-7EA7F92BA3EE.htm
+++ b/application/org.openjdk.jmc.docs/html/GUID-8EA35A18-669C-4EC3-BCEF-7EA7F92BA3EE.htm
@@ -27,7 +27,6 @@
 <link rel="next" href="GUID-66413CF1-A0E1-43BD-B8DB-9720B112D8F3.htm" title="Next" type="text/html" />
 </head>
 <body>
-<div class="zz-skip-header"><a href="#BEGIN">Go to primary content</a></div>
 <table class="simple oac_no_warn" summary="" cellspacing="0" cellpadding="0" width="100%">
 <col width="86%" /><col width="*" /><tr valign="bottom">
 <td></td>

--- a/application/org.openjdk.jmc.docs/html/GUID-953292B2-45D3-4842-9656-DAE88D239BA6.htm
+++ b/application/org.openjdk.jmc.docs/html/GUID-953292B2-45D3-4842-9656-DAE88D239BA6.htm
@@ -27,7 +27,6 @@
 <link rel="next" href="GUID-4B13023D-6AFA-4563-8532-74871DE29B62.htm" title="Next" type="text/html" />
 </head>
 <body>
-<div class="zz-skip-header"><a href="#BEGIN">Go to primary content</a></div>
 <table class="simple oac_no_warn" summary="" cellspacing="0" cellpadding="0" width="100%">
 <col width="86%" /><col width="*" /><tr valign="bottom">
 <td></td>

--- a/application/org.openjdk.jmc.docs/html/GUID-958F3421-2848-4C34-9A08-681011D409E6.htm
+++ b/application/org.openjdk.jmc.docs/html/GUID-958F3421-2848-4C34-9A08-681011D409E6.htm
@@ -27,7 +27,6 @@
 <link rel="next" href="GUID-A27CE821-5AD5-438D-9A2F-D0B45B743EF0.htm" title="Next" type="text/html" />
 </head>
 <body>
-<div class="zz-skip-header"><a href="#BEGIN">Go to primary content</a></div>
 <table class="simple oac_no_warn" summary="" cellspacing="0" cellpadding="0" width="100%">
 <col width="86%" /><col width="*" /><tr valign="bottom">
 <td></td>

--- a/application/org.openjdk.jmc.docs/html/GUID-978B0DFF-5E04-4781-BC0F-A92B8928B0E8.htm
+++ b/application/org.openjdk.jmc.docs/html/GUID-978B0DFF-5E04-4781-BC0F-A92B8928B0E8.htm
@@ -27,7 +27,6 @@
 <link rel="next" href="GUID-4CB43843-B287-487B-B6D6-D5A58CACDD57.htm" title="Next" type="text/html" />
 </head>
 <body>
-<div class="zz-skip-header"><a href="#BEGIN">Go to primary content</a></div>
 <table class="simple oac_no_warn" summary="" cellspacing="0" cellpadding="0" width="100%">
 <col width="86%" /><col width="*" /><tr valign="bottom">
 <td></td>

--- a/application/org.openjdk.jmc.docs/html/GUID-97B37847-8E31-43F2-AA78-E5EBD28EC99A.htm
+++ b/application/org.openjdk.jmc.docs/html/GUID-97B37847-8E31-43F2-AA78-E5EBD28EC99A.htm
@@ -27,7 +27,6 @@
 <link rel="next" href="GUID-2E1242E0-8437-467B-9AEC-36AE680733F7.htm" title="Next" type="text/html" />
 </head>
 <body>
-<div class="zz-skip-header"><a href="#BEGIN">Go to primary content</a></div>
 <table class="simple oac_no_warn" summary="" cellspacing="0" cellpadding="0" width="100%">
 <col width="86%" /><col width="*" /><tr valign="bottom">
 <td></td>

--- a/application/org.openjdk.jmc.docs/html/GUID-9EE879C7-3584-4508-8456-B4324097B207-01.htm
+++ b/application/org.openjdk.jmc.docs/html/GUID-9EE879C7-3584-4508-8456-B4324097B207-01.htm
@@ -27,7 +27,6 @@
 <link rel="next" href="GUID-29C36ED5-88E1-4974-B4B1-EFC683A1575D.htm" title="Next" type="text/html" />
 </head>
 <body>
-<div class="zz-skip-header"><a href="#BEGIN">Go to primary content</a></div>
 <table class="simple oac_no_warn" summary="" cellspacing="0" cellpadding="0" width="100%">
 <col width="86%" /><col width="*" /><tr valign="bottom">
 <td></td>

--- a/application/org.openjdk.jmc.docs/html/GUID-9EE879C7-3584-4508-8456-B4324097B207.htm
+++ b/application/org.openjdk.jmc.docs/html/GUID-9EE879C7-3584-4508-8456-B4324097B207.htm
@@ -27,7 +27,6 @@
 <link rel="next" href="GUID-DE2B88DD-9E08-4C0A-80ED-4684986F3A73.htm" title="Next" type="text/html" />
 </head>
 <body>
-<div class="zz-skip-header"><a href="#BEGIN">Go to primary content</a></div>
 <table class="simple oac_no_warn" summary="" cellspacing="0" cellpadding="0" width="100%">
 <col width="86%" /><col width="*" /><tr valign="bottom">
 <td></td>

--- a/application/org.openjdk.jmc.docs/html/GUID-A1BCA5DC-0102-4FD4-9D8C-717473025C52.htm
+++ b/application/org.openjdk.jmc.docs/html/GUID-A1BCA5DC-0102-4FD4-9D8C-717473025C52.htm
@@ -27,7 +27,6 @@
 <link rel="next" href="GUID-FBC35238-6B6D-4CAC-A407-7AEF95FE7058.htm" title="Next" type="text/html" />
 </head>
 <body>
-<div class="zz-skip-header"><a href="#BEGIN">Go to primary content</a></div>
 <table class="simple oac_no_warn" summary="" cellspacing="0" cellpadding="0" width="100%">
 <col width="86%" /><col width="*" /><tr valign="bottom">
 <td></td>

--- a/application/org.openjdk.jmc.docs/html/GUID-A27CE821-5AD5-438D-9A2F-D0B45B743EF0.htm
+++ b/application/org.openjdk.jmc.docs/html/GUID-A27CE821-5AD5-438D-9A2F-D0B45B743EF0.htm
@@ -27,7 +27,6 @@
 <link rel="next" href="GUID-DDE72C8A-0A15-43F9-A109-EB87804FD480.htm" title="Next" type="text/html" />
 </head>
 <body>
-<div class="zz-skip-header"><a href="#BEGIN">Go to primary content</a></div>
 <table class="simple oac_no_warn" summary="" cellspacing="0" cellpadding="0" width="100%">
 <col width="86%" /><col width="*" /><tr valign="bottom">
 <td></td>

--- a/application/org.openjdk.jmc.docs/html/GUID-A45813E6-C32E-4916-966E-AE24992BB326.htm
+++ b/application/org.openjdk.jmc.docs/html/GUID-A45813E6-C32E-4916-966E-AE24992BB326.htm
@@ -27,7 +27,6 @@
 <link rel="next" href="GUID-C12D23CE-E9DE-4BFA-A310-9AD5B6D835FD.htm" title="Next" type="text/html" />
 </head>
 <body>
-<div class="zz-skip-header"><a href="#BEGIN">Go to primary content</a></div>
 <table class="simple oac_no_warn" summary="" cellspacing="0" cellpadding="0" width="100%">
 <col width="86%" /><col width="*" /><tr valign="bottom">
 <td></td>

--- a/application/org.openjdk.jmc.docs/html/GUID-ABF6E2F7-9FE9-4054-934C-BE05AEA8EDFE.htm
+++ b/application/org.openjdk.jmc.docs/html/GUID-ABF6E2F7-9FE9-4054-934C-BE05AEA8EDFE.htm
@@ -27,7 +27,6 @@
 <link rel="next" href="GUID-492BB17D-5964-48C3-9212-D4848514437A.htm" title="Next" type="text/html" />
 </head>
 <body>
-<div class="zz-skip-header"><a href="#BEGIN">Go to primary content</a></div>
 <table class="simple oac_no_warn" summary="" cellspacing="0" cellpadding="0" width="100%">
 <col width="86%" /><col width="*" /><tr valign="bottom">
 <td></td>

--- a/application/org.openjdk.jmc.docs/html/GUID-B2C0DE8E-376A-4C88-8B11-25B303BED0DF.htm
+++ b/application/org.openjdk.jmc.docs/html/GUID-B2C0DE8E-376A-4C88-8B11-25B303BED0DF.htm
@@ -27,7 +27,6 @@
 <link rel="next" href="GUID-9EE879C7-3584-4508-8456-B4324097B207.htm" title="Next" type="text/html" />
 </head>
 <body>
-<div class="zz-skip-header"><a href="#BEGIN">Go to primary content</a></div>
 <table class="simple oac_no_warn" summary="" cellspacing="0" cellpadding="0" width="100%">
 <col width="86%" /><col width="*" /><tr valign="bottom">
 <td></td>

--- a/application/org.openjdk.jmc.docs/html/GUID-B633156D-F63E-4E09-BBB0-009509FED0B0.htm
+++ b/application/org.openjdk.jmc.docs/html/GUID-B633156D-F63E-4E09-BBB0-009509FED0B0.htm
@@ -27,7 +27,6 @@
 <link rel="next" href="GUID-E898FF59-2205-49AA-918A-1C9F792BFC54.htm" title="Next" type="text/html" />
 </head>
 <body>
-<div class="zz-skip-header"><a href="#BEGIN">Go to primary content</a></div>
 <table class="simple oac_no_warn" summary="" cellspacing="0" cellpadding="0" width="100%">
 <col width="86%" /><col width="*" /><tr valign="bottom">
 <td></td>

--- a/application/org.openjdk.jmc.docs/html/GUID-B8C17ABE-C0E5-4044-9401-1A01C5EE07E3.htm
+++ b/application/org.openjdk.jmc.docs/html/GUID-B8C17ABE-C0E5-4044-9401-1A01C5EE07E3.htm
@@ -27,7 +27,6 @@
 <link rel="next" href="GUID-B2C0DE8E-376A-4C88-8B11-25B303BED0DF.htm" title="Next" type="text/html" />
 </head>
 <body>
-<div class="zz-skip-header"><a href="#BEGIN">Go to primary content</a></div>
 <table class="simple oac_no_warn" summary="" cellspacing="0" cellpadding="0" width="100%">
 <col width="86%" /><col width="*" /><tr valign="bottom">
 <td></td>

--- a/application/org.openjdk.jmc.docs/html/GUID-BA742114-2E89-462D-8DCB-4442B3538CFA.htm
+++ b/application/org.openjdk.jmc.docs/html/GUID-BA742114-2E89-462D-8DCB-4442B3538CFA.htm
@@ -27,7 +27,6 @@
 <link rel="next" href="GUID-35CEE658-D1BE-456C-84C1-38543BE776AA.htm" title="Next" type="text/html" />
 </head>
 <body>
-<div class="zz-skip-header"><a href="#BEGIN">Go to primary content</a></div>
 <table class="simple oac_no_warn" summary="" cellspacing="0" cellpadding="0" width="100%">
 <col width="86%" /><col width="*" /><tr valign="bottom">
 <td></td>

--- a/application/org.openjdk.jmc.docs/html/GUID-BCAF66B8-BC4F-48F3-8453-5AA921067861.htm
+++ b/application/org.openjdk.jmc.docs/html/GUID-BCAF66B8-BC4F-48F3-8453-5AA921067861.htm
@@ -27,7 +27,6 @@
 <link rel="next" href="GUID-81AD3592-4E3F-4D9E-8877-675CEF333549.htm" title="Next" type="text/html" />
 </head>
 <body>
-<div class="zz-skip-header"><a href="#BEGIN">Go to primary content</a></div>
 <table class="simple oac_no_warn" summary="" cellspacing="0" cellpadding="0" width="100%">
 <col width="86%" /><col width="*" /><tr valign="bottom">
 <td></td>

--- a/application/org.openjdk.jmc.docs/html/GUID-C12D23CE-E9DE-4BFA-A310-9AD5B6D835FD.htm
+++ b/application/org.openjdk.jmc.docs/html/GUID-C12D23CE-E9DE-4BFA-A310-9AD5B6D835FD.htm
@@ -27,7 +27,6 @@
 <link rel="next" href="GUID-FEFBE854-3298-46A6-A149-8B48A62330D2.htm" title="Next" type="text/html" />
 </head>
 <body>
-<div class="zz-skip-header"><a href="#BEGIN">Go to primary content</a></div>
 <table class="simple oac_no_warn" summary="" cellspacing="0" cellpadding="0" width="100%">
 <col width="86%" /><col width="*" /><tr valign="bottom">
 <td></td>

--- a/application/org.openjdk.jmc.docs/html/GUID-C661942A-3DCF-40B4-87C3-F5000DE4830E.htm
+++ b/application/org.openjdk.jmc.docs/html/GUID-C661942A-3DCF-40B4-87C3-F5000DE4830E.htm
@@ -27,7 +27,6 @@
 <link rel="next" href="GUID-40FF6634-CBCF-4879-A494-52FF7CEFD759.htm" title="Next" type="text/html" />
 </head>
 <body>
-<div class="zz-skip-header"><a href="#BEGIN">Go to primary content</a></div>
 <table class="simple oac_no_warn" summary="" cellspacing="0" cellpadding="0" width="100%">
 <col width="86%" /><col width="*" /><tr valign="bottom">
 <td></td>

--- a/application/org.openjdk.jmc.docs/html/GUID-CCA54ADF-B778-4CF3-97D0-A34D2442A4C4.htm
+++ b/application/org.openjdk.jmc.docs/html/GUID-CCA54ADF-B778-4CF3-97D0-A34D2442A4C4.htm
@@ -27,7 +27,6 @@
 <link rel="next" href="GUID-D8E21217-2340-4FCD-BF13-BAC45569ED0A.htm" title="Next" type="text/html" />
 </head>
 <body>
-<div class="zz-skip-header"><a href="#BEGIN">Go to primary content</a></div>
 <table class="simple oac_no_warn" summary="" cellspacing="0" cellpadding="0" width="100%">
 <col width="86%" /><col width="*" /><tr valign="bottom">
 <td></td>

--- a/application/org.openjdk.jmc.docs/html/GUID-CD7A11BF-27AE-481A-8158-03ECC2DB9697.htm
+++ b/application/org.openjdk.jmc.docs/html/GUID-CD7A11BF-27AE-481A-8158-03ECC2DB9697.htm
@@ -27,7 +27,6 @@
 <link rel="next" href="GUID-DB152DDE-4694-439D-B8A7-CF1EABFAF795.htm" title="Next" type="text/html" />
 </head>
 <body>
-<div class="zz-skip-header"><a href="#BEGIN">Go to primary content</a></div>
 <table class="simple oac_no_warn" summary="" cellspacing="0" cellpadding="0" width="100%">
 <col width="86%" /><col width="*" /><tr valign="bottom">
 <td></td>

--- a/application/org.openjdk.jmc.docs/html/GUID-D319B54B-FB4B-422E-8B92-50F4FFBF1153.htm
+++ b/application/org.openjdk.jmc.docs/html/GUID-D319B54B-FB4B-422E-8B92-50F4FFBF1153.htm
@@ -27,7 +27,6 @@
 <link rel="next" href="GUID-E7631E91-FDF6-48A1-B5C4-8C0B72E515DA.htm" title="Next" type="text/html" />
 </head>
 <body>
-<div class="zz-skip-header"><a href="#BEGIN">Go to primary content</a></div>
 <table class="simple oac_no_warn" summary="" cellspacing="0" cellpadding="0" width="100%">
 <col width="86%" /><col width="*" /><tr valign="bottom">
 <td></td>

--- a/application/org.openjdk.jmc.docs/html/GUID-D3E9AB4B-17CE-478B-9A1B-2A51FEA920F0.htm
+++ b/application/org.openjdk.jmc.docs/html/GUID-D3E9AB4B-17CE-478B-9A1B-2A51FEA920F0.htm
@@ -27,7 +27,6 @@
 <link rel="next" href="GUID-6B99EBAD-C94C-4B3D-B7B4-867F408012BF.htm" title="Next" type="text/html" />
 </head>
 <body>
-<div class="zz-skip-header"><a href="#BEGIN">Go to primary content</a></div>
 <table class="simple oac_no_warn" summary="" cellspacing="0" cellpadding="0" width="100%">
 <col width="86%" /><col width="*" /><tr valign="bottom">
 <td></td>

--- a/application/org.openjdk.jmc.docs/html/GUID-D475ABB1-DE41-4A24-8BB8-A058FDDC6645.htm
+++ b/application/org.openjdk.jmc.docs/html/GUID-D475ABB1-DE41-4A24-8BB8-A058FDDC6645.htm
@@ -27,7 +27,6 @@
 <link rel="next" href="GUID-2AF1BAE8-14F3-4904-85E8-5F333A765B3C.htm" title="Next" type="text/html" />
 </head>
 <body>
-<div class="zz-skip-header"><a href="#BEGIN">Go to primary content</a></div>
 <table class="simple oac_no_warn" summary="" cellspacing="0" cellpadding="0" width="100%">
 <col width="86%" /><col width="*" /><tr valign="bottom">
 <td></td>

--- a/application/org.openjdk.jmc.docs/html/GUID-D722CAC6-84F5-4F36-9B83-66B5C4774821.htm
+++ b/application/org.openjdk.jmc.docs/html/GUID-D722CAC6-84F5-4F36-9B83-66B5C4774821.htm
@@ -27,7 +27,6 @@
 <link rel="next" href="GUID-3EC7E6C3-6A64-4659-B99E-CA675A9F6E0A.htm" title="Next" type="text/html" />
 </head>
 <body>
-<div class="zz-skip-header"><a href="#BEGIN">Go to primary content</a></div>
 <table class="simple oac_no_warn" summary="" cellspacing="0" cellpadding="0" width="100%">
 <col width="86%" /><col width="*" /><tr valign="bottom">
 <td></td>

--- a/application/org.openjdk.jmc.docs/html/GUID-D8E21217-2340-4FCD-BF13-BAC45569ED0A.htm
+++ b/application/org.openjdk.jmc.docs/html/GUID-D8E21217-2340-4FCD-BF13-BAC45569ED0A.htm
@@ -27,7 +27,6 @@
 <link rel="next" href="GUID-978B0DFF-5E04-4781-BC0F-A92B8928B0E8.htm" title="Next" type="text/html" />
 </head>
 <body>
-<div class="zz-skip-header"><a href="#BEGIN">Go to primary content</a></div>
 <table class="simple oac_no_warn" summary="" cellspacing="0" cellpadding="0" width="100%">
 <col width="86%" /><col width="*" /><tr valign="bottom">
 <td></td>

--- a/application/org.openjdk.jmc.docs/html/GUID-D934384D-A13D-46F7-9588-32AE6C901554.htm
+++ b/application/org.openjdk.jmc.docs/html/GUID-D934384D-A13D-46F7-9588-32AE6C901554.htm
@@ -27,7 +27,6 @@
 <link rel="next" href="GUID-2125BB8B-CC13-4125-8562-F0BFD428F1DC.htm" title="Next" type="text/html" />
 </head>
 <body>
-<div class="zz-skip-header"><a href="#BEGIN">Go to primary content</a></div>
 <table class="simple oac_no_warn" summary="" cellspacing="0" cellpadding="0" width="100%">
 <col width="86%" /><col width="*" /><tr valign="bottom">
 <td></td>

--- a/application/org.openjdk.jmc.docs/html/GUID-DAB13FDA-9430-4457-BFF3-04F9DC0E3977.htm
+++ b/application/org.openjdk.jmc.docs/html/GUID-DAB13FDA-9430-4457-BFF3-04F9DC0E3977.htm
@@ -27,7 +27,6 @@
 <link rel="next" href="GUID-18677545-5152-4688-8C51-4A1151361BB9.htm" title="Next" type="text/html" />
 </head>
 <body>
-<div class="zz-skip-header"><a href="#BEGIN">Go to primary content</a></div>
 <table class="simple oac_no_warn" summary="" cellspacing="0" cellpadding="0" width="100%">
 <col width="86%" /><col width="*" /><tr valign="bottom">
 <td></td>

--- a/application/org.openjdk.jmc.docs/html/GUID-DB152DDE-4694-439D-B8A7-CF1EABFAF795.htm
+++ b/application/org.openjdk.jmc.docs/html/GUID-DB152DDE-4694-439D-B8A7-CF1EABFAF795.htm
@@ -27,7 +27,6 @@
 <link rel="next" href="GUID-6A66D658-7FD4-4621-9FE7-662D8B8FFACF.htm" title="Next" type="text/html" />
 </head>
 <body>
-<div class="zz-skip-header"><a href="#BEGIN">Go to primary content</a></div>
 <table class="simple oac_no_warn" summary="" cellspacing="0" cellpadding="0" width="100%">
 <col width="86%" /><col width="*" /><tr valign="bottom">
 <td></td>

--- a/application/org.openjdk.jmc.docs/html/GUID-DDE72C8A-0A15-43F9-A109-EB87804FD480.htm
+++ b/application/org.openjdk.jmc.docs/html/GUID-DDE72C8A-0A15-43F9-A109-EB87804FD480.htm
@@ -27,7 +27,6 @@
 <link rel="next" href="GUID-D722CAC6-84F5-4F36-9B83-66B5C4774821.htm" title="Next" type="text/html" />
 </head>
 <body>
-<div class="zz-skip-header"><a href="#BEGIN">Go to primary content</a></div>
 <table class="simple oac_no_warn" summary="" cellspacing="0" cellpadding="0" width="100%">
 <col width="86%" /><col width="*" /><tr valign="bottom">
 <td></td>

--- a/application/org.openjdk.jmc.docs/html/GUID-DE2B88DD-9E08-4C0A-80ED-4684986F3A73.htm
+++ b/application/org.openjdk.jmc.docs/html/GUID-DE2B88DD-9E08-4C0A-80ED-4684986F3A73.htm
@@ -27,7 +27,6 @@
 <link rel="next" href="GUID-59CA7784-185A-4EED-B523-F640881040FC.htm" title="Next" type="text/html" />
 </head>
 <body>
-<div class="zz-skip-header"><a href="#BEGIN">Go to primary content</a></div>
 <table class="simple oac_no_warn" summary="" cellspacing="0" cellpadding="0" width="100%">
 <col width="86%" /><col width="*" /><tr valign="bottom">
 <td></td>

--- a/application/org.openjdk.jmc.docs/html/GUID-E7631E91-FDF6-48A1-B5C4-8C0B72E515DA.htm
+++ b/application/org.openjdk.jmc.docs/html/GUID-E7631E91-FDF6-48A1-B5C4-8C0B72E515DA.htm
@@ -27,7 +27,6 @@
 <link rel="next" href="GUID-41D47617-4E32-4793-9253-6C2125F21CFF.htm" title="Next" type="text/html" />
 </head>
 <body>
-<div class="zz-skip-header"><a href="#BEGIN">Go to primary content</a></div>
 <table class="simple oac_no_warn" summary="" cellspacing="0" cellpadding="0" width="100%">
 <col width="86%" /><col width="*" /><tr valign="bottom">
 <td></td>

--- a/application/org.openjdk.jmc.docs/html/GUID-E898FF59-2205-49AA-918A-1C9F792BFC54.htm
+++ b/application/org.openjdk.jmc.docs/html/GUID-E898FF59-2205-49AA-918A-1C9F792BFC54.htm
@@ -27,7 +27,6 @@
 <link rel="next" href="GUID-8626DCFD-B072-4F71-9F38-F5964C51F70E.htm" title="Next" type="text/html" />
 </head>
 <body>
-<div class="zz-skip-header"><a href="#BEGIN">Go to primary content</a></div>
 <table class="simple oac_no_warn" summary="" cellspacing="0" cellpadding="0" width="100%">
 <col width="86%" /><col width="*" /><tr valign="bottom">
 <td></td>

--- a/application/org.openjdk.jmc.docs/html/GUID-ECB99579-0933-45B8-ABC4-9A0EAC2B5E57.htm
+++ b/application/org.openjdk.jmc.docs/html/GUID-ECB99579-0933-45B8-ABC4-9A0EAC2B5E57.htm
@@ -27,7 +27,6 @@
 <link rel="next" href="GUID-953292B2-45D3-4842-9656-DAE88D239BA6.htm" title="Next" type="text/html" />
 </head>
 <body>
-<div class="zz-skip-header"><a href="#BEGIN">Go to primary content</a></div>
 <table class="simple oac_no_warn" summary="" cellspacing="0" cellpadding="0" width="100%">
 <col width="86%" /><col width="*" /><tr valign="bottom">
 <td></td>

--- a/application/org.openjdk.jmc.docs/html/GUID-F85CDA8B-CFD2-4155-A140-9DD4079F0139.htm
+++ b/application/org.openjdk.jmc.docs/html/GUID-F85CDA8B-CFD2-4155-A140-9DD4079F0139.htm
@@ -27,7 +27,6 @@
 <link rel="next" href="GUID-BCAF66B8-BC4F-48F3-8453-5AA921067861.htm" title="Next" type="text/html" />
 </head>
 <body>
-<div class="zz-skip-header"><a href="#BEGIN">Go to primary content</a></div>
 <table class="simple oac_no_warn" summary="" cellspacing="0" cellpadding="0" width="100%">
 <col width="86%" /><col width="*" /><tr valign="bottom">
 <td></td>

--- a/application/org.openjdk.jmc.docs/html/GUID-F94F7FBB-5B53-40A3-854E-8BE8FC172629.htm
+++ b/application/org.openjdk.jmc.docs/html/GUID-F94F7FBB-5B53-40A3-854E-8BE8FC172629.htm
@@ -27,7 +27,6 @@
 <link rel="next" href="GUID-ABF6E2F7-9FE9-4054-934C-BE05AEA8EDFE.htm" title="Next" type="text/html" />
 </head>
 <body>
-<div class="zz-skip-header"><a href="#BEGIN">Go to primary content</a></div>
 <table class="simple oac_no_warn" summary="" cellspacing="0" cellpadding="0" width="100%">
 <col width="86%" /><col width="*" /><tr valign="bottom">
 <td></td>

--- a/application/org.openjdk.jmc.docs/html/GUID-FA2C4870-8D2F-4627-9DBA-5B530785453A.htm
+++ b/application/org.openjdk.jmc.docs/html/GUID-FA2C4870-8D2F-4627-9DBA-5B530785453A.htm
@@ -27,7 +27,6 @@
 <link rel="next" href="GUID-ECB99579-0933-45B8-ABC4-9A0EAC2B5E57.htm" title="Next" type="text/html" />
 </head>
 <body>
-<div class="zz-skip-header"><a href="#BEGIN">Go to primary content</a></div>
 <table class="simple oac_no_warn" summary="" cellspacing="0" cellpadding="0" width="100%">
 <col width="86%" /><col width="*" /><tr valign="bottom">
 <td></td>

--- a/application/org.openjdk.jmc.docs/html/GUID-FBC35238-6B6D-4CAC-A407-7AEF95FE7058.htm
+++ b/application/org.openjdk.jmc.docs/html/GUID-FBC35238-6B6D-4CAC-A407-7AEF95FE7058.htm
@@ -27,7 +27,6 @@
 <link rel="next" href="GUID-65882C8B-7834-41E4-AA7F-9A82BCE36388.htm" title="Next" type="text/html" />
 </head>
 <body>
-<div class="zz-skip-header"><a href="#BEGIN">Go to primary content</a></div>
 <table class="simple oac_no_warn" summary="" cellspacing="0" cellpadding="0" width="100%">
 <col width="86%" /><col width="*" /><tr valign="bottom">
 <td></td>

--- a/application/org.openjdk.jmc.docs/html/GUID-FEFBE854-3298-46A6-A149-8B48A62330D2.htm
+++ b/application/org.openjdk.jmc.docs/html/GUID-FEFBE854-3298-46A6-A149-8B48A62330D2.htm
@@ -27,7 +27,6 @@
 <link rel="next" href="GUID-CD7A11BF-27AE-481A-8158-03ECC2DB9697.htm" title="Next" type="text/html" />
 </head>
 <body>
-<div class="zz-skip-header"><a href="#BEGIN">Go to primary content</a></div>
 <table class="simple oac_no_warn" summary="" cellspacing="0" cellpadding="0" width="100%">
 <col width="86%" /><col width="*" /><tr valign="bottom">
 <td></td>

--- a/application/org.openjdk.jmc.docs/html/title.htm
+++ b/application/org.openjdk.jmc.docs/html/title.htm
@@ -19,7 +19,6 @@
 <link rel="next" href="GUID-05BEE8DA-92DD-4D64-8F96-AE3BCA7F1190.htm" title="Next" type="text/html" />
 </head>
 <body>
-<div class="zz-skip-header"><a href="#BEGIN">Go to primary content</a></div>
 <table class="simple oac_no_warn" summary="" cellspacing="0" cellpadding="0" width="100%">
 <col width="86%" /><col width="*" /><tr valign="bottom">
 <td></td>

--- a/application/org.openjdk.jmc.docs/html/toc.htm
+++ b/application/org.openjdk.jmc.docs/html/toc.htm
@@ -17,7 +17,6 @@
 <link rel="next" href="title.htm" title="Next" type="text/html" />
 </head>
 <body>
-<div class="zz-skip-header"><a href="#BEGIN">Go to primary content</a></div>
 <table class="simple oac_no_warn" summary="" cellspacing="0" cellpadding="0" width="100%">
 <col width="86%" /><col width="*" /><tr valign="bottom">
 <td></td>


### PR DESCRIPTION
This link is present in all the help pages and everywhere its just a dead link. As per the code, it navigates to the begin of the page which is already displayed and no extra navigation is required for the same. I can't find a logical purpose this link serves. Hence, this PR  removes this link from all pages.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JMC-7350](https://bugs.openjdk.org/browse/JMC-7350): [Accessibility, JAWS] [Misc] Deadlinks in Help Page


### Reviewers
 * [Marcus Hirt](https://openjdk.org/census#hirt) (@thegreystone - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmc pull/430/head:pull/430` \
`$ git checkout pull/430`

Update a local copy of the PR: \
`$ git checkout pull/430` \
`$ git pull https://git.openjdk.org/jmc pull/430/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 430`

View PR using the GUI difftool: \
`$ git pr show -t 430`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmc/pull/430.diff">https://git.openjdk.org/jmc/pull/430.diff</a>

</details>
