### PR TITLE
7902: UseCompressedOopsRule has flipped comparison

### DIFF
--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/memory/CompressedOopsRule.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/memory/CompressedOopsRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/memory/CompressedOopsRule.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/memory/CompressedOopsRule.java
@@ -77,7 +77,7 @@ public class CompressedOopsRule implements IRule {
 		String vmName = items.getAggregate(JdkAggregators.JVM_NAME);
 		if (compressedOops != null && mx != null && vmName != null) {
 			if (vmName.toUpperCase().contains("64-BIT")) { //$NON-NLS-1$
-				if (mx.compareTo(UnitLookup.NUMBER.getUnit(BinaryPrefix.GIBI).quantity(32)) > 0) {
+				if (mx.compareTo(UnitLookup.NUMBER.getUnit(BinaryPrefix.GIBI).quantity(32)) < 0) {
 					if (!compressedOops) {
 						return ResultBuilder.createFor(this, valueProvider).setSeverity(Severity.INFO)
 								.setSummary(Messages.getString(Messages.CompressedOopsRuleFactory_TEXT_INFO))


### PR DESCRIPTION
The UseCompressedOopsRule implementation was checking that CompressedOops were disabled for heaps larger than 32 GiB, this is the opposite of what it should do. Compressed Oops are helpful for _smaller_ heaps.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JMC-7902](https://bugs.openjdk.org/browse/JMC-7902): UseCompressedOopsRule has flipped comparison


### Reviewers
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - Committer) ⚠️ Review applies to [2dff3ea1](https://git.openjdk.org/jmc/pull/432/files/2dff3ea11335f0395b2edd6894cfba3243d2440d)
 * [Brice Dutheil](https://openjdk.org/census#bdutheil) (@bric3 - Author) ⚠️ Review applies to [2dff3ea1](https://git.openjdk.org/jmc/pull/432/files/2dff3ea11335f0395b2edd6894cfba3243d2440d)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmc pull/432/head:pull/432` \
`$ git checkout pull/432`

Update a local copy of the PR: \
`$ git checkout pull/432` \
`$ git pull https://git.openjdk.org/jmc pull/432/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 432`

View PR using the GUI difftool: \
`$ git pr show -t 432`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmc/pull/432.diff">https://git.openjdk.org/jmc/pull/432.diff</a>

</details>
