### PR TITLE
TBD - allow callers to provide ExecutorService to FlightRecordingLoader

### DIFF
--- a/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/JfrLoaderToolkit.java
+++ b/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/JfrLoaderToolkit.java
@@ -39,6 +39,7 @@ import java.io.SequenceInputStream;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.ExecutorService;
 
 import org.openjdk.jmc.common.io.IOToolkit;
 import org.openjdk.jmc.common.item.IItemCollection;
@@ -89,6 +90,21 @@ public class JfrLoaderToolkit {
 	 *
 	 * @param stream
 	 *            the input stream to read the recording from
+	 * @param executorService
+	 *            the executor service to read chunks in
+	 * @return the events in the recording
+	 */
+	public static IItemCollection loadEvents(InputStream stream, ExecutorService executorService)
+			throws IOException, CouldNotLoadRecordingException {
+		return loadEvents(stream, ParserExtensionRegistry.getParserExtensions(), executorService);
+	}
+
+	/**
+	 * Loads a potentially zipped or gzipped input stream using the parser extensions loaded from
+	 * the java service loader
+	 *
+	 * @param stream
+	 *            the input stream to read the recording from
 	 * @param extensions
 	 *            the extensions to use when parsing the file
 	 * @return the events in the recording
@@ -97,6 +113,25 @@ public class JfrLoaderToolkit {
 			throws CouldNotLoadRecordingException, IOException {
 		try (InputStream in = IOToolkit.openUncompressedStream(stream)) {
 			return EventCollection.build(FlightRecordingLoader.loadStream(in, extensions, false, true));
+		}
+	}
+
+	/**
+	 * Loads a potentially zipped or gzipped input stream using the parser extensions loaded from
+	 * the java service loader
+	 *
+	 * @param stream
+	 *            the input stream to read the recording from
+	 * @param extensions
+	 *            the extensions to use when parsing the file
+	 * @return the events in the recording
+	 */
+	public static IItemCollection loadEvents(
+		InputStream stream, List<? extends IParserExtension> extensions, ExecutorService executorService)
+			throws CouldNotLoadRecordingException, IOException {
+		try (InputStream in = IOToolkit.openUncompressedStream(stream)) {
+			return EventCollection
+					.build(FlightRecordingLoader.loadStream(in, extensions, false, true, executorService));
 		}
 	}
 


### PR DESCRIPTION
`FlightRecordingLoader` creates a cached thread pool by default per JFR file which leads to high `Thread` creation and high RSS when used in a backend application, despite not being noticeable in a desktop application.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Commit message must refer to an issue
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmc pull/434/head:pull/434` \
`$ git checkout pull/434`

Update a local copy of the PR: \
`$ git checkout pull/434` \
`$ git pull https://git.openjdk.org/jmc pull/434/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 434`

View PR using the GUI difftool: \
`$ git pr show -t 434`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmc/pull/434.diff">https://git.openjdk.org/jmc/pull/434.diff</a>

</details>
