### PR TITLE
7933: Avoid volatile writes for default field values

### DIFF
--- a/agent/src/main/java/org/openjdk/jmc/agent/impl/DefaultTransformRegistry.java
+++ b/agent/src/main/java/org/openjdk/jmc/agent/impl/DefaultTransformRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -92,7 +92,7 @@ public class DefaultTransformRegistry implements TransformRegistry {
 	// First step in update should be to check if we even have transformations for the given class
 	private final HashMap<String, List<TransformDescriptor>> transformData = new HashMap<>();
 
-	private volatile boolean revertInstrumentation = false;
+	private volatile boolean revertInstrumentation;
 
 	private String currentConfiguration = "";
 

--- a/application/org.openjdk.jmc.console.jconsole/src/main/java/org/openjdk/jmc/console/jconsole/tabs/JConsolePluginTabbedPane.java
+++ b/application/org.openjdk.jmc.console.jconsole/src/main/java/org/openjdk/jmc/console/jconsole/tabs/JConsolePluginTabbedPane.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -69,7 +69,7 @@ public class JConsolePluginTabbedPane extends JTabbedPane {
 	private static final long serialVersionUID = 1L;
 	private final List<JConsolePlugin> plugins = new ArrayList<>();
 	private final Map<JConsolePlugin, SwingWorker<?, ?>> swingWorkers = new HashMap<>();
-	private volatile boolean disposeTimerTask = false;
+	private volatile boolean disposeTimerTask;
 	private final MissionControlContext ctx;
 
 	public JConsolePluginTabbedPane(IConnectionHandle connectionHandle) {

--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/overview/ResultOverview.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/overview/ResultOverview.java
@@ -267,7 +267,7 @@ public class ResultOverview extends AbstractDataPage implements IPageUI {
 		form.getToolBarManager().update(true);
 	}
 
-	private volatile boolean isUpdated = false;
+	private volatile boolean isUpdated;
 
 	public void updateRule(IResult result) {
 		if (displayReport && report != null) {

--- a/application/org.openjdk.jmc.greychart/src/main/java/org/openjdk/jmc/greychart/providers/AveragingProvider.java
+++ b/application/org.openjdk.jmc.greychart/src/main/java/org/openjdk/jmc/greychart/providers/AveragingProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -62,7 +62,7 @@ public final class AveragingProvider implements OptimizingProvider {
 	private int m_requestedResolution = 0;
 	private long m_requestedStartX = Long.MIN_VALUE;
 	private long m_requestedEndX = Long.MAX_VALUE;
-	private volatile boolean dataChangeOccured = false;
+	private volatile boolean dataChangeOccured;
 
 	public AveragingProvider(DataSeries<IXYData> s, double yMultiplier, XAxis xAxis, CancelService cancelService) {
 		m_dataSeries = s;

--- a/application/org.openjdk.jmc.greychart/src/main/java/org/openjdk/jmc/greychart/providers/IntermediateStackingProvider.java
+++ b/application/org.openjdk.jmc.greychart/src/main/java/org/openjdk/jmc/greychart/providers/IntermediateStackingProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -62,7 +62,7 @@ public class IntermediateStackingProvider implements OptimizingProvider {
 	private StackingBuffer m_sampleBuffer;
 
 	private int m_lastSubSampleWidth = -1;
-	private volatile boolean dataChangeOccured = false;
+	private volatile boolean dataChangeOccured;
 
 	/**
 	 * @param topProvider

--- a/application/org.openjdk.jmc.greychart/src/main/java/org/openjdk/jmc/greychart/providers/SampleCountingProvider.java
+++ b/application/org.openjdk.jmc.greychart/src/main/java/org/openjdk/jmc/greychart/providers/SampleCountingProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -66,7 +66,7 @@ public class SampleCountingProvider implements OptimizingProvider {
 	private long m_requestedStartX = Long.MIN_VALUE;
 	private long m_requestedEndX = Long.MAX_VALUE;
 
-	private volatile boolean dataChangeOccured = false;
+	private volatile boolean dataChangeOccured;
 	private final boolean m_integrate;
 
 	public SampleCountingProvider(DataSeries<IXYData> s, double yMultiplier, XAxis xAxis, CancelService cancelService,

--- a/application/org.openjdk.jmc.greychart/src/main/java/org/openjdk/jmc/greychart/providers/SubsamplingProvider.java
+++ b/application/org.openjdk.jmc.greychart/src/main/java/org/openjdk/jmc/greychart/providers/SubsamplingProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -68,7 +68,7 @@ public final class SubsamplingProvider implements OptimizingProvider {
 	private int m_requestedResolution = 0;
 	private long m_requestedStartX = Long.MIN_VALUE;
 	private long m_requestedEndX = Long.MAX_VALUE;
-	private volatile boolean dataChangeOccured = false;
+	private volatile boolean dataChangeOccured;
 	private final boolean m_integrate;
 	private final CancelService m_cancelService;
 

--- a/application/org.openjdk.jmc.joverflow/src/main/java/org/openjdk/jmc/joverflow/util/NumberToObjectMap.java
+++ b/application/org.openjdk.jmc.joverflow/src/main/java/org/openjdk/jmc/joverflow/util/NumberToObjectMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -51,7 +51,7 @@ public abstract class NumberToObjectMap<V> {
 	protected int[] nextElement;
 	protected int firstElementIdx, prevAddedElementIdx;
 
-	private volatile Collection<V> valuesCollectionView = null;
+	private volatile Collection<V> valuesCollectionView;
 
 	// Debugging
 	protected long rehashTime, numRehashes;

--- a/application/org.openjdk.jmc.joverflow/src/main/java/org/openjdk/jmc/joverflow/util/ValueWitIntIdMap.java
+++ b/application/org.openjdk.jmc.joverflow/src/main/java/org/openjdk/jmc/joverflow/util/ValueWitIntIdMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -55,7 +55,7 @@ public class ValueWitIntIdMap<V extends ValueWithIntId> {
 	private V[] values;
 	private int size, capacity, threshold;
 
-	volatile Collection<V> valuesCollectionView = null;
+	volatile Collection<V> valuesCollectionView;
 
 	private long rehashTime; // Debugging
 

--- a/application/org.openjdk.jmc.rjmx/src/main/java/org/openjdk/jmc/rjmx/subscription/internal/DefaultAttributeSubscriptionThread.java
+++ b/application/org.openjdk.jmc.rjmx/src/main/java/org/openjdk/jmc/rjmx/subscription/internal/DefaultAttributeSubscriptionThread.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -87,7 +87,7 @@ public class DefaultAttributeSubscriptionThread extends Thread {
 
 	private boolean sendNulls;
 
-	private volatile boolean collectDebugInfo = false;
+	private volatile boolean collectDebugInfo;
 	private Map<MRI, DefaultSubscriptionDebugInformation> subscriptionDebugInfo;
 
 	public static class SubscriptionStats {

--- a/application/org.openjdk.jmc.rjmx/src/main/java/org/openjdk/jmc/rjmx/subscription/internal/DefaultNotificationSubscriptionManager.java
+++ b/application/org.openjdk.jmc.rjmx/src/main/java/org/openjdk/jmc/rjmx/subscription/internal/DefaultNotificationSubscriptionManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -71,7 +71,7 @@ public final class DefaultNotificationSubscriptionManager {
 //	private final IMBeanHelperService service;
 	private final MBeanServerConnection mbeanServer;
 
-	private volatile boolean collectDebugInfo = false;
+	private volatile boolean collectDebugInfo;
 	private Map<MRI, DefaultSubscriptionDebugInformation> subscriptionDebugInfo;
 
 	/**

--- a/application/org.openjdk.jmc.ui.common/src/main/java/org/openjdk/jmc/ui/common/util/FilterMatcher.java
+++ b/application/org.openjdk.jmc.ui.common/src/main/java/org/openjdk/jmc/ui/common/util/FilterMatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -52,7 +52,7 @@ public class FilterMatcher {
 
 	private final static FilterMatcher instance = new FilterMatcher();
 
-	private static volatile Pattern lastPattern = null;
+	private static volatile Pattern lastPattern;
 
 	public static enum Where {
 		BEFORE, AFTER, BEFORE_AND_AFTER

--- a/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/polling/PollManager.java
+++ b/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/polling/PollManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -52,8 +52,8 @@ public class PollManager implements Runnable, IPropertyChangeListener {
 	}
 
 	private final Vector<Pollable> m_pollableObjects = new Vector<>();
-	volatile private int m_pollingInterval = 0;
-	volatile private boolean m_keepAlive = false;
+	volatile private int m_pollingInterval;
+	volatile private boolean m_keepAlive;
 	private final String m_propertyName;
 
 	public PollManager(int pollingInterval, String propertyName) {

--- a/application/tests/org.openjdk.jmc.rjmx.test/src/test/java/org/openjdk/jmc/rjmx/test/synthetic/SyntheticNotificationTest.java
+++ b/application/tests/org.openjdk.jmc.rjmx.test/src/test/java/org/openjdk/jmc/rjmx/test/synthetic/SyntheticNotificationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -60,7 +60,7 @@ public class SyntheticNotificationTest extends ServerHandleTestCase {
 
 	private IConnectionHandle handle;
 	private MBeanServerConnection connection;
-	private volatile boolean gotNotification = false;
+	private volatile boolean gotNotification;
 
 	private class SyntheticNotificationListener implements NotificationListener {
 		private Notification lastNotification;

--- a/core/org.openjdk.jmc.flightrecorder.writer/src/main/java/org/openjdk/jmc/flightrecorder/writer/MetadataImpl.java
+++ b/core/org.openjdk.jmc.flightrecorder.writer/src/main/java/org/openjdk/jmc/flightrecorder/writer/MetadataImpl.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2021, Datadog, Inc. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Datadog, Inc. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -74,7 +74,7 @@ final class MetadataImpl {
 	private final Map<Integer, String> reverseStringTable = new ConcurrentSkipListMap<>();
 	private final Set<ResolvableType> unresolvedTypes = new CopyOnWriteArraySet<>();
 
-	private volatile TypesImpl types = null;
+	private volatile TypesImpl types;
 
 	MetadataImpl(ConstantPools constantPools) {
 		this.constantPools = constantPools;

--- a/core/tests/org.openjdk.jmc.common.test/src/main/java/org/openjdk/jmc/common/util/BoundedListTest.java
+++ b/core/tests/org.openjdk.jmc.common.test/src/main/java/org/openjdk/jmc/common/util/BoundedListTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -48,7 +48,7 @@ public class BoundedListTest {
 
 	private static class ProducerThread implements Runnable {
 		private final BoundedList<Long> list;
-		private volatile boolean shouldStop = false;
+		private volatile boolean shouldStop;
 		private long counter;
 
 		public ProducerThread(BoundedList<Long> list) {
@@ -77,7 +77,7 @@ public class BoundedListTest {
 
 	private static class ValidationThread implements Runnable {
 		private final BoundedList<Long> list;
-		private volatile boolean shouldStop = false;
+		private volatile boolean shouldStop;
 		private volatile long countError = -1;
 		private volatile long sequenceError = -1;
 		private volatile long maxNum;


### PR DESCRIPTION
Hi,

this PR avoids some volatile writes similar to https://bugs.openjdk.org/browse/JMC-7414.

Since I can't create JIRA issues, I hope you can create this for me. Let me know if I can help in any other way, though. It has been a while since I contributed to JMC

Cheers,
Christoph

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JMC-7933](https://bugs.openjdk.org/browse/JMC-7933): Avoid volatile writes for default field values


### Reviewers
 * [Marcus Hirt](https://openjdk.org/census#hirt) (@thegreystone - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmc pull/435/head:pull/435` \
`$ git checkout pull/435`

Update a local copy of the PR: \
`$ git checkout pull/435` \
`$ git pull https://git.openjdk.org/jmc pull/435/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 435`

View PR using the GUI difftool: \
`$ git pr show -t 435`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmc/pull/435.diff">https://git.openjdk.org/jmc/pull/435.diff</a>

</details>
