### PR TITLE
7944: Reduce allocations of Double during chunk loading

### DIFF
--- a/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/unit/BinaryScaleFactor.java
+++ b/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/unit/BinaryScaleFactor.java
@@ -86,11 +86,7 @@ public class BinaryScaleFactor extends ScaleFactor {
 				return get(powerOf2 + ((BinaryScaleFactor) innerFactor).powerOf2);
 			}
 			long longMultiplier = 1L << powerOf2;
-			Number multiplier = innerFactor.targetNumber(longMultiplier);
-			if (multiplier instanceof Long) {
-				return new LongScaleFactor(multiplier.longValue());
-			}
-			return new ImpreciseScaleFactor(multiplier);
+			return innerFactor.scale(longMultiplier);
 		}
 
 		@Override

--- a/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/unit/DecimalScaleFactor.java
+++ b/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/unit/DecimalScaleFactor.java
@@ -124,11 +124,7 @@ public class DecimalScaleFactor extends ScaleFactor {
 			if (innerFactor instanceof DecimalScaleFactor) {
 				return get(powerOf10 + ((DecimalScaleFactor) innerFactor).powerOf10);
 			}
-			Number multiplier = innerFactor.targetNumber(longMultiplier);
-			if (multiplier instanceof Long) {
-				return new LongScaleFactor(multiplier.longValue());
-			}
-			return new ImpreciseScaleFactor(multiplier);
+			return innerFactor.scale(longMultiplier);
 		}
 
 		@Override

--- a/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/unit/IScalarAffineTransform.java
+++ b/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/unit/IScalarAffineTransform.java
@@ -49,7 +49,7 @@ public interface IScalarAffineTransform {
 	 * @return the offset to be added (after the source value has been multiplied with the
 	 *         {@link #getMultiplier() multiplier})
 	 */
-	Number getOffset();
+	double getOffset();
 
 	/**
 	 * @return the multiplier which source values should be multiplied with (before the

--- a/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/unit/ImpreciseScaleFactor.java
+++ b/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/unit/ImpreciseScaleFactor.java
@@ -37,9 +37,9 @@ package org.openjdk.jmc.common.unit;
  * (rational) converters.
  */
 public class ImpreciseScaleFactor extends ScaleFactor {
-	private final Number numberFactor;
+	private final double numberFactor;
 
-	public ImpreciseScaleFactor(Number factor) {
+	public ImpreciseScaleFactor(double factor) {
 		numberFactor = factor;
 	}
 
@@ -48,17 +48,17 @@ public class ImpreciseScaleFactor extends ScaleFactor {
 		if (innerFactor.isUnity()) {
 			return this;
 		}
-		return new ImpreciseScaleFactor(innerFactor.targetValue(numberFactor.doubleValue()));
+		return new ImpreciseScaleFactor(innerFactor.targetValue(numberFactor));
 	}
 
 	@Override
 	public ScaleFactor invert() {
-		return new ImpreciseScaleFactor(1.0 / numberFactor.doubleValue());
+		return new ImpreciseScaleFactor(1.0 / numberFactor);
 	}
 
 	@Override
 	public boolean targetOutOfRange(long srcNumericalValue, long maxAbsValue) {
-		if (numberFactor.doubleValue() >= 1.0) {
+		if (numberFactor >= 1.0) {
 			if (srcNumericalValue >= 0) {
 				return srcNumericalValue > (maxAbsValue / getMultiplier());
 			} else {
@@ -75,7 +75,7 @@ public class ImpreciseScaleFactor extends ScaleFactor {
 
 	@Override
 	public boolean targetOutOfRange(double srcNumericalValue, long maxAbsValue) {
-		if (numberFactor.doubleValue() >= 1.0) {
+		if (numberFactor >= 1.0) {
 			if (srcNumericalValue >= 0) {
 				return srcNumericalValue > (maxAbsValue / getMultiplier());
 			} else {
@@ -92,17 +92,17 @@ public class ImpreciseScaleFactor extends ScaleFactor {
 
 	@Override
 	public double targetValue(double srcNumericalValue) {
-		return srcNumericalValue * numberFactor.doubleValue();
+		return srcNumericalValue * numberFactor;
 	}
 
 	@Override
 	public long targetValue(long srcNumericalValue) {
-		return Math.round(srcNumericalValue * numberFactor.doubleValue());
+		return Math.round(srcNumericalValue * numberFactor);
 	}
 
 	@Override
 	public long targetFloor(long srcNumericalValue) {
-		return (long) Math.floor(srcNumericalValue * numberFactor.doubleValue());
+		return (long) Math.floor(srcNumericalValue * numberFactor);
 	}
 
 	@Override
@@ -130,21 +130,21 @@ public class ImpreciseScaleFactor extends ScaleFactor {
 	@Override
 	public boolean equals(Object other) {
 		return (other instanceof ImpreciseScaleFactor)
-				&& numberFactor.equals(((ImpreciseScaleFactor) other).numberFactor);
+				&& Double.compare(numberFactor, ((ImpreciseScaleFactor) other).numberFactor) == 0;
 	}
 
 	@Override
 	public int hashCode() {
-		return numberFactor.hashCode();
+		return Double.hashCode(numberFactor);
 	}
 
 	@Override
 	public String toString() {
-		return numberFactor.toString();
+		return Double.toString(numberFactor);
 	}
 
 	@Override
 	public double getMultiplier() {
-		return numberFactor.doubleValue();
+		return numberFactor;
 	}
 }

--- a/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/unit/LongPostOffsetTransform.java
+++ b/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/unit/LongPostOffsetTransform.java
@@ -46,7 +46,7 @@ public class LongPostOffsetTransform implements IScalarAffineTransform {
 	}
 
 	@Override
-	public Number getOffset() {
+	public double getOffset() {
 		return offset;
 	}
 
@@ -154,7 +154,7 @@ public class LongPostOffsetTransform implements IScalarAffineTransform {
 			return new LongPostOffsetTransform(multiplier * innerTransform.getMultiplier(), offset);
 		}
 		return SimpleAffineTransform.createWithPostOffset(multiplier * innerTransform.getMultiplier(),
-				targetNumber(innerTransform.getOffset()));
+				targetValue(innerTransform.getOffset()));
 	}
 
 	@Override
@@ -166,7 +166,7 @@ public class LongPostOffsetTransform implements IScalarAffineTransform {
 			return invert();
 		}
 		double invertedMultiplier = 1.0 / multiplier;
-		double otherOffset = innerTransform.getOffset().doubleValue();
+		double otherOffset = innerTransform.getOffset();
 		return new SimpleAffineTransform(innerTransform.getMultiplier() * invertedMultiplier,
 				(otherOffset - offset) * invertedMultiplier);
 	}

--- a/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/unit/LongPreOffsetTransform.java
+++ b/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/unit/LongPreOffsetTransform.java
@@ -49,7 +49,7 @@ public class LongPreOffsetTransform implements IScalarAffineTransform {
 	}
 
 	@Override
-	public Number getOffset() {
+	public double getOffset() {
 		return preOffset * multiplier;
 	}
 
@@ -156,7 +156,7 @@ public class LongPreOffsetTransform implements IScalarAffineTransform {
 			return this;
 		}
 		return SimpleAffineTransform.createWithPostOffset(multiplier * innerTransform.getMultiplier(),
-				targetNumber(innerTransform.getOffset()));
+				targetValue(innerTransform.getOffset()));
 	}
 
 	@Override
@@ -168,7 +168,7 @@ public class LongPreOffsetTransform implements IScalarAffineTransform {
 			return invert();
 		}
 		double invertedMultiplier = 1.0 / multiplier;
-		double otherOffset = innerTransform.getOffset().doubleValue();
+		double otherOffset = innerTransform.getOffset();
 		return new SimpleAffineTransform(innerTransform.getMultiplier() * invertedMultiplier,
 				(otherOffset * invertedMultiplier) - preOffset);
 	}

--- a/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/unit/LongScaleFactor.java
+++ b/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/unit/LongScaleFactor.java
@@ -47,11 +47,7 @@ public class LongScaleFactor extends ScaleFactor {
 		if (innerFactor.isUnity()) {
 			return this;
 		}
-		Number multiplier = innerFactor.targetNumber(longMultiplier);
-		if (multiplier instanceof Long) {
-			return new LongScaleFactor(multiplier.longValue());
-		}
-		return new ImpreciseScaleFactor(multiplier);
+		return innerFactor.scale(longMultiplier);
 	}
 
 	@Override

--- a/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/unit/ScalarQuantity.java
+++ b/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/unit/ScalarQuantity.java
@@ -84,22 +84,6 @@ abstract class ScalarQuantity<U extends TypedUnit<U>> extends Number implements 
 	public abstract int hashCode();
 
 	@Override
-	public IQuantity in(IUnit targetUnit) {
-		if (targetUnit == unit) {
-			return this;
-		}
-		return targetUnit.quantity(numberValueIn(targetUnit));
-	}
-
-	@Override
-	public ITypedQuantity<U> in(U targetUnit) {
-		if (targetUnit == unit) {
-			return this;
-		}
-		return targetUnit.quantity(numberValueIn(targetUnit));
-	}
-
-	@Override
 	public long longValueIn(IUnit targetUnit) throws QuantityConversionException {
 		return longValueIn(targetUnit, Long.MAX_VALUE);
 	}
@@ -190,6 +174,30 @@ abstract class ScalarQuantity<U extends TypedUnit<U>> extends Number implements 
 		@Override
 		public Number numberValue() {
 			return numericalValue;
+		}
+
+		@Override
+		public IQuantity in(IUnit targetUnit) {
+			if (unit == targetUnit) {
+				return this;
+			}
+			IScalarAffineTransform transform = unit.valueTransformTo(targetUnit);
+			if (transform.targetOutOfRange(numericalValue, Long.MAX_VALUE)) {
+				return targetUnit.quantity(doubleValueIn(targetUnit));
+			}
+			return targetUnit.quantity(clampedLongValueIn(targetUnit));
+		}
+
+		@Override
+		public ITypedQuantity<U> in(U targetUnit) {
+			if (unit == targetUnit) {
+				return this;
+			}
+			IScalarAffineTransform transform = unit.valueTransformTo(targetUnit);
+			if (transform.targetOutOfRange(numericalValue, Long.MAX_VALUE)) {
+				return targetUnit.quantity(doubleValueIn(targetUnit));
+			}
+			return targetUnit.quantity(clampedLongValueIn(targetUnit));
 		}
 
 		@Override
@@ -372,6 +380,22 @@ abstract class ScalarQuantity<U extends TypedUnit<U>> extends Number implements 
 		@Override
 		public Number numberValue() {
 			return numericalValue;
+		}
+
+		@Override
+		public IQuantity in(IUnit targetUnit) {
+			if (targetUnit == unit) {
+				return this;
+			}
+			return targetUnit.quantity(doubleValueIn(targetUnit));
+		}
+
+		@Override
+		public ITypedQuantity<U> in(U targetUnit) {
+			if (targetUnit == unit) {
+				return this;
+			}
+			return targetUnit.quantity(doubleValueIn(targetUnit));
 		}
 
 		@Override

--- a/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/unit/ScaleFactor.java
+++ b/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/unit/ScaleFactor.java
@@ -58,7 +58,7 @@ public abstract class ScaleFactor implements IScalarAffineTransform, Comparable<
 			return new LongPreOffsetTransform(preOT.preOffset, preOT.getMultiplier() * getMultiplier());
 		}
 		return SimpleAffineTransform.createWithPostOffset(innerTransform.getMultiplier() * getMultiplier(),
-				targetNumber(innerTransform.getOffset()));
+				targetValue(innerTransform.getOffset()));
 	}
 
 	/**
@@ -96,7 +96,7 @@ public abstract class ScaleFactor implements IScalarAffineTransform, Comparable<
 	public abstract ScaleFactor invert();
 
 	@Override
-	public final Number getOffset() {
+	public final double getOffset() {
 		return 0;
 	}
 
@@ -125,6 +125,13 @@ public abstract class ScaleFactor implements IScalarAffineTransform, Comparable<
 			return targetValue(srcNumericalValue);
 		}
 		return targetValue((double) srcNumericalValue);
+	}
+
+	public ScaleFactor scale(long multiplier) {
+		if (isInteger() && !targetOutOfRange(multiplier, Long.MAX_VALUE)) {
+			return new LongScaleFactor(targetValue(multiplier));
+		}
+		return new ImpreciseScaleFactor(targetValue((double) multiplier));
 	}
 
 	@Override

--- a/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/unit/SimpleAffineTransform.java
+++ b/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/unit/SimpleAffineTransform.java
@@ -64,7 +64,7 @@ public class SimpleAffineTransform implements IScalarAffineTransform {
 	}
 
 	@Override
-	public Number getOffset() {
+	public double getOffset() {
 		return offset;
 	}
 
@@ -161,7 +161,7 @@ public class SimpleAffineTransform implements IScalarAffineTransform {
 	@Override
 	public IScalarAffineTransform concat(IScalarAffineTransform innerTransform) {
 		return SimpleAffineTransform.createWithPostOffset(multiplier * innerTransform.getMultiplier(),
-				targetNumber(innerTransform.getOffset()));
+				targetValue(innerTransform.getOffset()));
 	}
 
 	@Override
@@ -170,7 +170,7 @@ public class SimpleAffineTransform implements IScalarAffineTransform {
 			return DecimalScaleFactor.get(0);
 		}
 		double invertedMultiplier = 1.0 / multiplier;
-		double otherOffset = innerTransform.getOffset().doubleValue();
+		double otherOffset = innerTransform.getOffset();
 		return new SimpleAffineTransform(innerTransform.getMultiplier() * invertedMultiplier,
 				(otherOffset - offset) * invertedMultiplier);
 	}


### PR DESCRIPTION
Using jmc-common as a library in a backend process we see high allocation rates of `Double` and have observed moderate performance improvements from this simple refactoring:
* Use primitive `double` in `ImpreciseScaleFactor`
* Use primitive `double` in `IScalarAffineTransformation.getOffset`
* Push multiplication of a scale factor down to a new method `ScaleFactor.scale(long multiplier)`
* Push `ScalarQuantity.in` down to `LongStored`/`DoubleStored` to avoid generalising over primitive types, when the `IQuantity` type can be varied instead.
---------
### Progress
- [ ] Commit message must refer to an issue
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmc pull/436/head:pull/436` \
`$ git checkout pull/436`

Update a local copy of the PR: \
`$ git checkout pull/436` \
`$ git pull https://git.openjdk.org/jmc pull/436/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 436`

View PR using the GUI difftool: \
`$ git pr show -t 436`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmc/pull/436.diff">https://git.openjdk.org/jmc/pull/436.diff</a>

</details>

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JMC-7944](https://bugs.openjdk.org/browse/JMC-7944): Reduce allocations of Double during chunk loading


### Reviewers
 * [Henrik Dafgård](https://openjdk.org/census#hdafgard) (@Gunde - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmc pull/436/head:pull/436` \
`$ git checkout pull/436`

Update a local copy of the PR: \
`$ git checkout pull/436` \
`$ git pull https://git.openjdk.org/jmc pull/436/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 436`

View PR using the GUI difftool: \
`$ git pr show -t 436`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmc/pull/436.diff">https://git.openjdk.org/jmc/pull/436.diff</a>

</details>
