### PR TITLE
7940: Fix manifest making the Eclipse IDE unhappy

### DIFF
--- a/core/tests/org.openjdk.jmc.flightrecorder.writer.test/META-INF/MANIFEST.MF
+++ b/core/tests/org.openjdk.jmc.flightrecorder.writer.test/META-INF/MANIFEST.MF
@@ -7,7 +7,6 @@ Bundle-Vendor: Oracle Corporation
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: org.openjdk.jmc.flightrecorder.writer
 Require-Bundle: org.junit,
- org.junit.jupiter.api,
  org.openjdk.jmc.common,
  org.openjdk.jmc.flightrecorder.writer;visibility:=reexport
 Automatic-Module-Name: org.openjdk.jmc.flightrecorder.writer.test


### PR DESCRIPTION
...

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JMC-7940](https://bugs.openjdk.org/browse/JMC-7940): Fix manifest making the Eclipse IDE unhappy


### Reviewers
 * [Alex Macdonald](https://openjdk.org/census#aptmac) (@aptmac - **Reviewer**)
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmc pull/445/head:pull/445` \
`$ git checkout pull/445`

Update a local copy of the PR: \
`$ git checkout pull/445` \
`$ git pull https://git.openjdk.org/jmc pull/445/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 445`

View PR using the GUI difftool: \
`$ git pr show -t 445`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmc/pull/445.diff">https://git.openjdk.org/jmc/pull/445.diff</a>

</details>
