### PR TITLE
7945: Avoid throwing NoSuchFieldException in ValueReaders$ReflectiveReader

### DIFF
--- a/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/internal/parser/v1/ValueReaders.java
+++ b/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/internal/parser/v1/ValueReaders.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -35,7 +35,10 @@ package org.openjdk.jmc.flightrecorder.internal.parser.v1;
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -506,6 +509,7 @@ class ValueReaders {
 	static class ReflectiveReader extends AbstractStructReader {
 		// FIXME: Change the reflective setting of fields to avoid the conversion workarounds that some classes have to make. See JMC-5966
 
+		private final Map<String, Field> identifiersToFields;
 		// String to prefix reserved java keywords with when looking for a class field
 		private static final String RESERVED_IDENTIFIER_PREFIX = "_"; //$NON-NLS-1$
 		private final List<Field> fields;
@@ -515,6 +519,7 @@ class ValueReaders {
 		<T> ReflectiveReader(Class<T> klass, int fieldCount, ContentType<? super T> ct) {
 			super(fieldCount);
 			this.klass = klass;
+			this.identifiersToFields = IdentifierFieldCache.INSTANCE.get(klass);
 			this.ct = ct;
 			fields = new ArrayList<>(fieldCount);
 		}
@@ -562,18 +567,31 @@ class ValueReaders {
 		void addField(String identifier, String name, String description, IValueReader reader)
 				throws InvalidJfrFileException {
 			valueReaders.add(reader);
-			try {
-				try {
-					fields.add(klass.getField(identifier));
-				} catch (NoSuchFieldException e) {
-					fields.add(klass.getField(RESERVED_IDENTIFIER_PREFIX + identifier));
-				}
-			} catch (NoSuchFieldException e) {
+			Field field = identifiersToFields.get(identifier);
+			if (field == null) {
+				field = identifiersToFields.get(RESERVED_IDENTIFIER_PREFIX + identifier);
+			}
+			if (field == null) {
 				Logger.getLogger(ReflectiveReader.class.getName()).log(Level.WARNING,
 						"Could not find field with name '" + identifier + "' in reader for '" + ct.getIdentifier() //$NON-NLS-1$ //$NON-NLS-2$
 								+ "'"); //$NON-NLS-1$
-				fields.add(null);
 			}
+			fields.add(field);
+		}
+	}
+
+	static class IdentifierFieldCache extends ClassValue<Map<String, Field>> {
+
+		public static final IdentifierFieldCache INSTANCE = new IdentifierFieldCache();
+
+		@Override
+		protected Map<String, Field> computeValue(Class<?> type) {
+			Field[] fields = type.getFields();
+			Map<String, Field> map = new HashMap<>(fields.length);
+			for (Field field : fields) {
+				map.put(field.getName(), field);
+			}
+			return Collections.unmodifiableMap(map);
 		}
 	}
 }


### PR DESCRIPTION
When using jmc-common in a backend process we throw the following swallowed exception millions of times a day:

```
java.lang.NoSuchFieldException: package
	at java.base/java.lang.Class.getField(Class.java:2149)
	at org.openjdk.jmc.flightrecorder.internal.parser.v1.ValueReaders$ReflectiveReader.addField(ValueReaders.java:593)
	at org.openjdk.jmc.flightrecorder.internal.parser.v1.TypeManager$TypeEntry.getReader(TypeManager.java:200)
	at org.openjdk.jmc.flightrecorder.internal.parser.v1.TypeManager.createFieldReader(TypeManager.java:493)
	at org.openjdk.jmc.flightrecorder.internal.parser.v1.TypeManager.access$000(TypeManager.java:86)
	at org.openjdk.jmc.flightrecorder.internal.parser.v1.TypeManager$TypeEntry.getReader(TypeManager.java:198)
	at org.openjdk.jmc.flightrecorder.internal.parser.v1.TypeManager.createFieldReader(TypeManager.java:493)
	at org.openjdk.jmc.flightrecorder.internal.parser.v1.TypeManager.access$000(TypeManager.java:86)
	at org.openjdk.jmc.flightrecorder.internal.parser.v1.TypeManager$TypeEntry.getReader(TypeManager.java:198)
	at org.openjdk.jmc.flightrecorder.internal.parser.v1.TypeManager.createFieldReader(TypeManager.java:493)
	at org.openjdk.jmc.flightrecorder.internal.parser.v1.TypeManager.access$000(TypeManager.java:86)
	at org.openjdk.jmc.flightrecorder.internal.parser.v1.TypeManager$TypeEntry.getReader(TypeManager.java:198)
	at org.openjdk.jmc.flightrecorder.internal.parser.v1.TypeManager.createFieldReader(TypeManager.java:493)
	at org.openjdk.jmc.flightrecorder.internal.parser.v1.TypeManager.access$000(TypeManager.java:86)
	at org.openjdk.jmc.flightrecorder.internal.parser.v1.TypeManager$EventTypeEntry.init(TypeManager.java:357)
	at org.openjdk.jmc.flightrecorder.internal.parser.v1.TypeManager.<init>(TypeManager.java:432)
	at org.openjdk.jmc.flightrecorder.internal.parser.v1.ChunkLoaderV1.call(ChunkLoaderV1.java:70)
	at org.openjdk.jmc.flightrecorder.internal.parser.v1.ChunkLoaderV1.call(ChunkLoaderV1.java:48)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:539)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	at java.base/java.lang.Thread.run(Thread.java:833)
```

This adds a simple memoization to store the identifier to field mapping, with size bounded by the number of classes used in JFR events.

---------
### Progress
- [ ] Commit message must refer to an issue
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Error
&nbsp;⚠️ The pull request body must not be empty.

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmc pull/447/head:pull/447` \
`$ git checkout pull/447`

Update a local copy of the PR: \
`$ git checkout pull/447` \
`$ git pull https://git.openjdk.org/jmc pull/447/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 447`

View PR using the GUI difftool: \
`$ git pr show -t 447`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmc/pull/447.diff">https://git.openjdk.org/jmc/pull/447.diff</a>

</details>

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JMC-7945](https://bugs.openjdk.org/browse/JMC-7945): Avoid throwing NoSuchFieldException in ValueReaders$ReflectiveReader


### Reviewers
 * [Marcus Hirt](https://openjdk.org/census#hirt) (@thegreystone - **Reviewer**) ⚠️ Review applies to [058a3a30](https://git.openjdk.org/jmc/pull/447/files/058a3a30be7ea5593ca8be1b2009112bf83166cf)
 * [Jaroslav Bachorik](https://openjdk.org/census#jbachorik) (@jbachorik - Author)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmc pull/447/head:pull/447` \
`$ git checkout pull/447`

Update a local copy of the PR: \
`$ git checkout pull/447` \
`$ git pull https://git.openjdk.org/jmc pull/447/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 447`

View PR using the GUI difftool: \
`$ git pr show -t 447`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmc/pull/447.diff">https://git.openjdk.org/jmc/pull/447.diff</a>

</details>
