### PR TITLE
7977: Maximum Young Gen Size is displaying the min in GC config Page

### DIFF
--- a/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/jdk/JdkAggregators.java
+++ b/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/jdk/JdkAggregators.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/jdk/JdkAggregators.java
+++ b/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/jdk/JdkAggregators.java
@@ -177,7 +177,7 @@ public final class JdkAggregators {
 			JdkAttributes.YOUNG_GENERATION_MIN_SIZE);
 	public static final IAggregator<IQuantity, ?> YOUNG_GENERATION_MAX_SIZE = min(
 			JdkAttributes.YOUNG_GENERATION_MAX_SIZE.getName(), null, GC_CONF_YOUNG_GENERATION,
-			JdkAttributes.YOUNG_GENERATION_MIN_SIZE);
+			JdkAttributes.YOUNG_GENERATION_MAX_SIZE);
 	public static final IAggregator<IQuantity, ?> NEW_RATIO_MIN = min(NEW_RATIO.getName(), null,
 			GC_CONF_YOUNG_GENERATION, NEW_RATIO);
 	public static final IAggregator<IQuantity, ?> TENURING_THRESHOLD_INITIAL_MIN = min(


### PR DESCRIPTION
Change min to max attribute

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JMC-7977](https://bugs.openjdk.org/browse/JMC-7977): Maximum Young Gen Size is displaying the min in GC config Page


### Reviewers
 * [Alex Macdonald](https://openjdk.org/census#aptmac) (@aptmac - **Reviewer**) ⚠️ Review applies to [6450acdc](https://git.openjdk.org/jmc/pull/452/files/6450acdce68a55884b168a329cb8ccad6e69ef42)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmc pull/452/head:pull/452` \
`$ git checkout pull/452`

Update a local copy of the PR: \
`$ git checkout pull/452` \
`$ git pull https://git.openjdk.org/jmc pull/452/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 452`

View PR using the GUI difftool: \
`$ git pr show -t 452`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmc/pull/452.diff">https://git.openjdk.org/jmc/pull/452.diff</a>

</details>
