### PR TITLE
7978: Add new metric prefixes

### DIFF
--- a/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/unit/DecimalPrefix.java
+++ b/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/unit/DecimalPrefix.java
@@ -49,6 +49,8 @@ import org.openjdk.jmc.common.unit.LinearKindOfQuantity.LinearUnitSelector;
 // Localization is delegated to the Messages class. Warnings here would still not catch the cases that matter.
 @SuppressWarnings("nls")
 public enum DecimalPrefix implements IPrefix<DecimalPrefix> {
+	QUECTO(-30, 'q'),
+	RONTO(-27, 'r'),
 	YOCTO(-24, 'y'),
 	ZEPTO(-21, 'z'),
 	ATTO(-18, 'a'),
@@ -69,7 +71,9 @@ public enum DecimalPrefix implements IPrefix<DecimalPrefix> {
 	PETA(15, 'P'),
 	EXA(18, 'E'),
 	ZETTA(21, 'Z'),
-	YOTTA(24, 'Y');
+	YOTTA(24, 'Y'),
+	RONNA(27, 'R'),
+	QUETTA(30, 'Q');
 
 	private DecimalPrefix(int powerOf10, char prefixChar) {
 		this(powerOf10, "" + prefixChar, null);
@@ -92,8 +96,8 @@ public enum DecimalPrefix implements IPrefix<DecimalPrefix> {
 		doubleMult = StrictMath.pow(10, powerOf10);
 	}
 
-	private final static DecimalPrefix[] THOUSANDS = {YOCTO, ZEPTO, ATTO, FEMTO, PICO, NANO, MICRO, MILLI, NONE, KILO,
-			MEGA, GIGA, TERA, EXA, PETA, ZETTA, YOTTA};
+	private final static DecimalPrefix[] THOUSANDS = {QUECTO, RONTO, YOCTO, ZEPTO, ATTO, FEMTO, PICO, NANO, MICRO,
+			MILLI, NONE, KILO, MEGA, GIGA, TERA, EXA, PETA, ZETTA, YOTTA, RONNA, QUETTA};
 
 	private final static Map<String, DecimalPrefix> PREFIX_BY_SYMBOL;
 
@@ -131,7 +135,7 @@ public enum DecimalPrefix implements IPrefix<DecimalPrefix> {
 	}
 
 	public static DecimalPrefix getEngFloorPrefix(double value) {
-		int idx = Math.max(0, getFloorLog1000(value) - (YOCTO.powerOfTen / 3));
+		int idx = Math.max(0, getFloorLog1000(value) - (QUECTO.powerOfTen / 3));
 		return THOUSANDS[Math.min(idx, THOUSANDS.length - 1)];
 	}
 

--- a/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/unit/DecimalUnitSelector.java
+++ b/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/unit/DecimalUnitSelector.java
@@ -157,7 +157,7 @@ public class DecimalUnitSelector implements LinearUnitSelector {
 		int log10 = DecimalPrefix.getFloorLog1000(absVal) * 3;
 
 		// FIXME: Iterate over a collection of specified units/prefixes instead (capped by absVal).
-		final int minLog10 = DecimalPrefix.YOCTO.powerOf10();
+		final int minLog10 = DecimalPrefix.QUECTO.powerOf10();
 
 		while (log10 >= minLog10) {
 			DecimalScaleFactor inverseFactor = DecimalScaleFactor.get(-log10);

--- a/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/unit/UnitLookup.java
+++ b/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/unit/UnitLookup.java
@@ -43,8 +43,8 @@ import static org.openjdk.jmc.common.unit.DecimalPrefix.NANO;
 import static org.openjdk.jmc.common.unit.DecimalPrefix.NONE;
 import static org.openjdk.jmc.common.unit.DecimalPrefix.PICO;
 import static org.openjdk.jmc.common.unit.DecimalPrefix.TERA;
-import static org.openjdk.jmc.common.unit.DecimalPrefix.YOCTO;
-import static org.openjdk.jmc.common.unit.DecimalPrefix.YOTTA;
+import static org.openjdk.jmc.common.unit.DecimalPrefix.QUECTO;
+import static org.openjdk.jmc.common.unit.DecimalPrefix.QUETTA;
 
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
@@ -452,7 +452,7 @@ final public class UnitLookup {
 
 	private static LinearKindOfQuantity createFrequency() {
 		LinearKindOfQuantity frequency = new LinearKindOfQuantity("frequency", "Hz", EnumSet.range(NONE, TERA),
-				EnumSet.range(YOCTO, YOTTA));
+				EnumSet.range(QUECTO, QUETTA));
 
 		frequency.addFormatter(new LinearKindOfQuantity.AutoFormatter(frequency, "Dynamic"));
 		frequency.addFormatter(new KindOfQuantity.ExactFormatter<>(frequency));
@@ -472,7 +472,7 @@ final public class UnitLookup {
 		EnumSet<DecimalPrefix> commonPrefixes = EnumSet.range(PICO, MILLI);
 		commonPrefixes.add(NONE);
 		LinearKindOfQuantity timeSpan = new LinearKindOfQuantity("timespan", "s", commonPrefixes,
-				EnumSet.range(YOCTO, YOTTA));
+				EnumSet.range(QUECTO, QUETTA));
 		LinearUnit second = timeSpan.atomUnit;
 		LinearUnit minute = timeSpan.makeUnit("min", second.quantity(60));
 		LinearUnit hour = timeSpan.makeUnit("h", minute.quantity(60));

--- a/core/tests/org.openjdk.jmc.common.test/src/main/java/org/openjdk/jmc/common/test/unit/AdHocQuantityTest.java
+++ b/core/tests/org.openjdk.jmc.common.test/src/main/java/org/openjdk/jmc/common/test/unit/AdHocQuantityTest.java
@@ -42,8 +42,8 @@ import static org.openjdk.jmc.common.unit.DecimalPrefix.KILO;
 import static org.openjdk.jmc.common.unit.DecimalPrefix.MICRO;
 import static org.openjdk.jmc.common.unit.DecimalPrefix.MILLI;
 import static org.openjdk.jmc.common.unit.DecimalPrefix.NONE;
-import static org.openjdk.jmc.common.unit.DecimalPrefix.YOCTO;
-import static org.openjdk.jmc.common.unit.DecimalPrefix.YOTTA;
+import static org.openjdk.jmc.common.unit.DecimalPrefix.QUECTO;
+import static org.openjdk.jmc.common.unit.DecimalPrefix.QUETTA;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -85,7 +85,7 @@ public class AdHocQuantityTest extends MCTestCase {
 		// Only needed when this suite is run on its own.
 		@SuppressWarnings("unused")
 		Object classInitWorkaround = UnitLookup.RAW_NUMBER;
-		length = new LinearKindOfQuantity("length", "m", YOCTO, YOTTA);
+		length = new LinearKindOfQuantity("length", "m", QUECTO, QUETTA);
 		um = length.getUnit(MICRO);
 		mm = length.getUnit(MILLI);
 		cm = length.getUnit(CENTI);

--- a/core/tests/org.openjdk.jmc.common.test/src/main/java/org/openjdk/jmc/common/test/unit/DecimalPrefixTest.java
+++ b/core/tests/org.openjdk.jmc.common.test/src/main/java/org/openjdk/jmc/common/test/unit/DecimalPrefixTest.java
@@ -37,6 +37,10 @@ import static org.openjdk.jmc.common.unit.DecimalPrefix.YOCTO;
 import static org.openjdk.jmc.common.unit.DecimalPrefix.YOTTA;
 import static org.openjdk.jmc.common.unit.DecimalPrefix.ZEPTO;
 import static org.openjdk.jmc.common.unit.DecimalPrefix.ZETTA;
+import static org.openjdk.jmc.common.unit.DecimalPrefix.QUECTO;
+import static org.openjdk.jmc.common.unit.DecimalPrefix.QUETTA;
+import static org.openjdk.jmc.common.unit.DecimalPrefix.RONTO;
+import static org.openjdk.jmc.common.unit.DecimalPrefix.RONNA;
 import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
@@ -48,6 +52,24 @@ public class DecimalPrefixTest extends MCTestCase {
 	public void testZero() {
 		assertEquals(0, DecimalPrefix.getFloorLog1000(0));
 		assertEquals(NONE, DecimalPrefix.getEngFloorPrefix(0));
+	}
+
+	@Test
+	public void testQuecto() {
+		double quectos = 2 * Math.pow(10, -30);
+		assertEquals(-10, DecimalPrefix.getFloorLog1000(quectos));
+		assertEquals(QUECTO, DecimalPrefix.getEngFloorPrefix(quectos));
+		assertEquals(-10, DecimalPrefix.getFloorLog1000(-quectos));
+		assertEquals(QUECTO, DecimalPrefix.getEngFloorPrefix(-quectos));
+	}
+
+	@Test
+	public void testRonto() {
+		double rontos = 2 * Math.pow(10, -27);
+		assertEquals(-9, DecimalPrefix.getFloorLog1000(rontos));
+		assertEquals(RONTO, DecimalPrefix.getEngFloorPrefix(rontos));
+		assertEquals(-9, DecimalPrefix.getFloorLog1000(-rontos));
+		assertEquals(RONTO, DecimalPrefix.getEngFloorPrefix(-rontos));
 	}
 
 	@Test
@@ -66,6 +88,24 @@ public class DecimalPrefixTest extends MCTestCase {
 		assertEquals(ZEPTO, DecimalPrefix.getEngFloorPrefix(zeptos));
 		assertEquals(-7, DecimalPrefix.getFloorLog1000(-zeptos));
 		assertEquals(ZEPTO, DecimalPrefix.getEngFloorPrefix(-zeptos));
+	}
+
+	@Test
+	public void testQuetta() {
+		double quettas = 2 * Math.pow(10, 30);
+		assertEquals(10, DecimalPrefix.getFloorLog1000(quettas));
+		assertEquals(QUETTA, DecimalPrefix.getEngFloorPrefix(quettas));
+		assertEquals(10, DecimalPrefix.getFloorLog1000(-quettas));
+		assertEquals(QUETTA, DecimalPrefix.getEngFloorPrefix(-quettas));
+	}
+
+	@Test
+	public void testRonna() {
+		double ronnas = 2 * Math.pow(10, 27);
+		assertEquals(9, DecimalPrefix.getFloorLog1000(ronnas));
+		assertEquals(RONNA, DecimalPrefix.getEngFloorPrefix(ronnas));
+		assertEquals(9, DecimalPrefix.getFloorLog1000(-ronnas));
+		assertEquals(RONNA, DecimalPrefix.getEngFloorPrefix(-ronnas));
 	}
 
 	@Test


### PR DESCRIPTION
This PR adds the new metric prefixes quecto, ronto, ronna & quetta.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JMC-7978](https://bugs.openjdk.org/browse/JMC-7978): Add new metric prefixes


### Reviewers
 * [Marcus Hirt](https://openjdk.org/census#hirt) (@thegreystone - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmc pull/454/head:pull/454` \
`$ git checkout pull/454`

Update a local copy of the PR: \
`$ git checkout pull/454` \
`$ git pull https://git.openjdk.org/jmc pull/454/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 454`

View PR using the GUI difftool: \
`$ git pr show -t 454`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmc/pull/454.diff">https://git.openjdk.org/jmc/pull/454.diff</a>

</details>
