### PR TITLE
7514: Add rule for finalizers run

### DIFF
--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/general/FinalizersRunRule.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/general/FinalizersRunRule.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ *
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * The contents of this file are subject to the terms of either the Universal Permissive License
+ * v 1.0 as shown at http://oss.oracle.com/licenses/upl
+ *
+ * or the following license:
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted
+ * provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions
+ * and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other materials provided with
+ * the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to
+ * endorse or promote products derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+ * WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.openjdk.jmc.flightrecorder.rules.jdk.general;
+
+import static org.openjdk.jmc.common.unit.UnitLookup.NUMBER;
+import static org.openjdk.jmc.common.unit.UnitLookup.NUMBER_UNITY;
+import static org.openjdk.jmc.common.unit.UnitLookup.PLAIN_TEXT;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.RunnableFuture;
+
+import org.openjdk.jmc.common.IMCType;
+import org.openjdk.jmc.common.item.IItem;
+import org.openjdk.jmc.common.item.IItemCollection;
+import org.openjdk.jmc.common.item.IItemFilter;
+import org.openjdk.jmc.common.item.IItemIterable;
+import org.openjdk.jmc.common.item.IMemberAccessor;
+import org.openjdk.jmc.common.item.ItemFilters;
+import org.openjdk.jmc.common.unit.IQuantity;
+import org.openjdk.jmc.common.util.IPreferenceValueProvider;
+import org.openjdk.jmc.common.util.TypedPreference;
+import org.openjdk.jmc.flightrecorder.jdk.JdkAttributes;
+import org.openjdk.jmc.flightrecorder.jdk.JdkTypeIDs;
+import org.openjdk.jmc.flightrecorder.rules.IResult;
+import org.openjdk.jmc.flightrecorder.rules.IResultValueProvider;
+import org.openjdk.jmc.flightrecorder.rules.IRule;
+import org.openjdk.jmc.flightrecorder.rules.ResultBuilder;
+import org.openjdk.jmc.flightrecorder.rules.Severity;
+import org.openjdk.jmc.flightrecorder.rules.TypedCollectionResult;
+import org.openjdk.jmc.flightrecorder.rules.TypedResult;
+import org.openjdk.jmc.flightrecorder.rules.jdk.messages.internal.Messages;
+import org.openjdk.jmc.flightrecorder.rules.util.JfrRuleTopics;
+import org.openjdk.jmc.flightrecorder.rules.util.RulesToolkit.EventAvailability;
+import org.openjdk.jmc.flightrecorder.rules.util.RulesToolkit.RequiredEventsBuilder;
+
+public class FinalizersRunRule implements IRule {
+
+	private static final String FINALIZERS_RUN_RESULT_ID = "FinalizersRun"; //$NON-NLS-1$
+
+	private static final TypedResult<IQuantity> FINALIZERS_RUN_COUNT = new TypedResult<>("finalizersRunCount", //$NON-NLS-1$
+			Messages.getString(Messages.FinalizersRunRule_RESULT_FINALIZERS_RUN_COUNT),
+			Messages.getString(Messages.FinalizersRunRule_RESULT_FINALIZERS_RUN_COUNT_DESC), NUMBER, IQuantity.class);
+	private static final TypedCollectionResult<String> FINALIZERS_RUN_CLASSES = new TypedCollectionResult<>(
+			"finalizersRunClasses", Messages.getString(Messages.FinalizersRunRule_RESULT_FINALIZERS_RUN_CLASSES), //$NON-NLS-1$
+			Messages.getString(Messages.FinalizersRunRule_RESULT_FINALIZERS_RUN_CLASSES_DESC), PLAIN_TEXT,
+			String.class);
+	private static final Collection<TypedResult<?>> RESULT_ATTRIBUTES = Arrays
+			.<TypedResult<?>> asList(FINALIZERS_RUN_COUNT, FINALIZERS_RUN_CLASSES);
+
+	private static final Map<String, EventAvailability> REQUIRED_EVENTS = RequiredEventsBuilder.create()
+			.addEventType(JdkTypeIDs.FINALIZER_STATISTICS, EventAvailability.AVAILABLE).build();
+
+	private static final TypedPreference<String> FINALIZABLE_CLASSES_INCLUDE_REGEXP = new TypedPreference<>(
+			"finalizable.classes.include.regexp", //$NON-NLS-1$
+			Messages.getString(Messages.FinalizersRunRule_CONFIG_FINALIZABLE_CLASSES_INCLUDE_REGEXP),
+			Messages.getString(Messages.FinalizersRunRule_CONFIG_FINALIZABLE_CLASSES_INCLUDE_REGEXP_DESC),
+			PLAIN_TEXT.getPersister(),
+			// Exclude a number of common standard library prefixes.
+			"^(?!java\\.|javax\\.|sun\\.|com\\.sun\\.|jdk\\.|scala\\.|kotlin\\.|kotlinx\\.|groovy\\.|closure\\.).*$"); //$NON-NLS-1$
+	private static final List<TypedPreference<?>> CONFIG_ATTRIBUTES = Arrays
+			.<TypedPreference<?>> asList(FINALIZABLE_CLASSES_INCLUDE_REGEXP);
+
+	@Override
+	public RunnableFuture<IResult> createEvaluation(
+		IItemCollection items, IPreferenceValueProvider valueProvider, IResultValueProvider resultProvider) {
+		return new FutureTask<>(() -> getResult(items, valueProvider));
+	}
+
+	@Override
+	public Collection<TypedPreference<?>> getConfigurationAttributes() {
+		return CONFIG_ATTRIBUTES;
+	}
+
+	@Override
+	public Collection<TypedResult<?>> getResults() {
+		return RESULT_ATTRIBUTES;
+	}
+
+	@Override
+	public String getId() {
+		return FINALIZERS_RUN_RESULT_ID;
+	}
+
+	@Override
+	public String getName() {
+		return Messages.getString(Messages.FinalizersRunRule_RULE_NAME);
+	}
+
+	@Override
+	public Map<String, EventAvailability> getRequiredEvents() {
+		return REQUIRED_EVENTS;
+	}
+
+	@Override
+	public String getTopic() {
+		return JfrRuleTopics.JAVA_APPLICATION;
+	}
+
+	private IResult getResult(IItemCollection items, IPreferenceValueProvider valueProvider) {
+		String classesIncludeRegex = valueProvider.getPreferenceValue(FINALIZABLE_CLASSES_INCLUDE_REGEXP);
+		IItemFilter finalizerStatisticsEventsFilter = ItemFilters.and(ItemFilters.type(JdkTypeIDs.FINALIZER_STATISTICS),
+				ItemFilters.matches(JdkAttributes.FINALIZABLE_CLASS_NAME, classesIncludeRegex));
+		IItemCollection finalizerStatisticsEvents = items.apply(finalizerStatisticsEventsFilter);
+
+		long totalCount = 0;
+		Set<String> finalizableClasses = new HashSet<String>();
+		for (IItemIterable eventIterable : finalizerStatisticsEvents) {
+			IMemberAccessor<IMCType, IItem> finalizableClassAccessor = JdkAttributes.FINALIZABLE_CLASS
+					.getAccessor(eventIterable.getType());
+			IMemberAccessor<IQuantity, IItem> totalFinalizersRunAccessor = JdkAttributes.TOTAL_FINALIZERS_RUN
+					.getAccessor(eventIterable.getType());
+			for (IItem event : eventIterable) {
+				IMCType finalizableClass = finalizableClassAccessor.getMember(event);
+				IQuantity totalFinalizersRun = totalFinalizersRunAccessor.getMember(event);
+				if (finalizableClass != null && totalFinalizersRun != null) {
+					long countforEvent = totalFinalizersRun.clampedLongValueIn(NUMBER_UNITY);
+					if (countforEvent > 0) {
+						totalCount += countforEvent;
+						finalizableClasses.add(finalizableClass.getFullName());
+					}
+				}
+			}
+		}
+
+		if (totalCount <= 0) {
+			return ResultBuilder.createFor(this, valueProvider).setSeverity(Severity.OK)
+					.setSummary(Messages.getString(Messages.FinalizersRunRule_SUMMARY_OK)).build();
+		}
+
+		return ResultBuilder.createFor(this, valueProvider).setSeverity(Severity.INFO)
+				.setSummary(Messages.getString(Messages.FinalizersRunRule_SUMMARY_WARN))
+				.setExplanation(Messages.getString(Messages.FinalizersRunRule_EXPLANATION))
+				.setSolution(Messages.getString(Messages.FinalizersRunRule_SOLUTION))
+				.addResult(FINALIZERS_RUN_COUNT, NUMBER_UNITY.quantity(totalCount))
+				.addResult(FINALIZERS_RUN_CLASSES, finalizableClasses).build();
+	}
+}

--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/messages/internal/Messages.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/messages/internal/Messages.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -267,6 +267,17 @@ public class Messages {
 	public static final String FileWriteRuleFactory_TEXT_WARN_LONG = "FileWriteRuleFactory_TEXT_WARN_LONG"; //$NON-NLS-1$
 	public static final String FileWriteRule_CONFIG_WARNING_LIMIT = "FileWriteRule_CONFIG_WARNING_LIMIT"; //$NON-NLS-1$
 	public static final String FileWriteRule_CONFIG_WARNING_LIMIT_LONG = "FileWriteRule_CONFIG_WARNING_LIMIT_LONG"; //$NON-NLS-1$
+	public static final String FinalizersRunRule_CONFIG_FINALIZABLE_CLASSES_INCLUDE_REGEXP = "FinalizersRunRule_CONFIG_FINALIZABLE_CLASSES_INCLUDE_REGEXP"; //$NON-NLS-1$
+	public static final String FinalizersRunRule_CONFIG_FINALIZABLE_CLASSES_INCLUDE_REGEXP_DESC = "FinalizersRunRule_CONFIG_FINALIZABLE_CLASSES_INCLUDE_REGEXP_DESC"; //$NON-NLS-1$
+	public static final String FinalizersRunRule_EXPLANATION = "FinalizersRunRule_EXPLANATION"; //$NON-NLS-1$
+	public static final String FinalizersRunRule_RESULT_FINALIZERS_RUN_CLASSES = "FinalizersRunRule_RESULT_FINALIZERS_RUN_CLASSES"; //$NON-NLS-1$
+	public static final String FinalizersRunRule_RESULT_FINALIZERS_RUN_CLASSES_DESC = "FinalizersRunRule_RESULT_FINALIZERS_RUN_CLASSES_DESC"; //$NON-NLS-1$
+	public static final String FinalizersRunRule_RESULT_FINALIZERS_RUN_COUNT = "FinalizersRunRule_RESULT_FINALIZERS_RUN_COUNT"; //$NON-NLS-1$
+	public static final String FinalizersRunRule_RESULT_FINALIZERS_RUN_COUNT_DESC = "FinalizersRunRule_RESULT_FINALIZERS_RUN_COUNT_DESC"; //$NON-NLS-1$
+	public static final String FinalizersRunRule_RULE_NAME = "FinalizersRunRule_RULE_NAME"; //$NON-NLS-1$
+	public static final String FinalizersRunRule_SOLUTION = "FinalizersRunRule_SOLUTION"; //$NON-NLS-1$
+	public static final String FinalizersRunRule_SUMMARY_OK = "FinalizersRunRule_SUMMARY_OK"; //$NON-NLS-1$
+	public static final String FinalizersRunRule_SUMMARY_WARN = "FinalizersRunRule_SUMMARY_WARN"; //$NON-NLS-1$
 	public static final String FlightRecordingSupportRule_EA_TEXT_WARN_LONG = "FlightRecordingSupportRule_EA_TEXT_WARN_LONG"; //$NON-NLS-1$
 	public static final String FlightRecordingSupportRule_EA_TEXT_WARN_SHORT = "FlightRecordingSupportRule_EA_TEXT_WARN_SHORT"; //$NON-NLS-1$
 	public static final String FlightRecordingSupportRule_NO_JVM_VERSION_EVENTS_TEXT = "FlightRecordingSupportRule_NO_JVM_VERSION_EVENTS_TEXT"; //$NON-NLS-1$

--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/resources/META-INF/services/org.openjdk.jmc.flightrecorder.rules.IRule
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/resources/META-INF/services/org.openjdk.jmc.flightrecorder.rules.IRule
@@ -1,5 +1,5 @@
 #
-#  Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+#  Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
 #
 #  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
@@ -53,6 +53,7 @@ org.openjdk.jmc.flightrecorder.rules.jdk.general.DiscouragedGcOptionsRule
 org.openjdk.jmc.flightrecorder.rules.jdk.general.DiscouragedVmOptionsRule
 org.openjdk.jmc.flightrecorder.rules.jdk.general.DumpReasonRule
 org.openjdk.jmc.flightrecorder.rules.jdk.general.FewSampledThreadsRule
+org.openjdk.jmc.flightrecorder.rules.jdk.general.FinalizersRunRule
 org.openjdk.jmc.flightrecorder.rules.jdk.general.FlightRecordingSupportRule
 org.openjdk.jmc.flightrecorder.rules.jdk.general.JfrPeriodicEventsFixRule
 org.openjdk.jmc.flightrecorder.rules.jdk.general.ManagementAgentRule

--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/resources/org/openjdk/jmc/flightrecorder/rules/jdk/messages/internal/messages.properties
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/resources/org/openjdk/jmc/flightrecorder/rules/jdk/messages/internal/messages.properties
@@ -278,6 +278,19 @@ FileWriteRuleFactory_TEXT_NO_EVENTS=There are no file write events in this recor
 FileWriteRuleFactory_TEXT_WARN=There are long file write pauses in this recording (the longest is {longestWriteTime}).
 # {longestWriteTime} is a time period, {longestWritePath} is a file path, {longestWriteAmount} is a size in bytes
 FileWriteRuleFactory_TEXT_WARN_LONG=The longest recorded file write took {longestWriteTime} to write {longestWriteAmount} to {longestWritePath}. Average time of recorded IO: {averageFileWrite}. Total time of recorded IO: {totalFileWrite}. Total time of recorded IO for the file {longestWritePath}: {totalWriteForLongest}.
+FinalizersRunRule_CONFIG_FINALIZABLE_CLASSES_INCLUDE_REGEXP=Finalizable Classes Included
+FinalizersRunRule_CONFIG_FINALIZABLE_CLASSES_INCLUDE_REGEXP_DESC=The regular expression used to filter finalizable classes.
+# {finalizersRunClasses} is a list of strings
+FinalizersRunRule_EXPLANATION=Finalization can lead to performance issues, deadlocks, or hangs, and has been marked for removal in a future Java version. The following finalizable classes have been detected: {finalizersRunClasses}
+FinalizersRunRule_RESULT_FINALIZERS_RUN_CLASSES=Finalizer Classes
+FinalizersRunRule_RESULT_FINALIZERS_RUN_CLASSES_DESC=The classes for which finalizers were run.
+FinalizersRunRule_RESULT_FINALIZERS_RUN_COUNT=Finalizer Count
+FinalizersRunRule_RESULT_FINALIZERS_RUN_COUNT_DESC=The number of finalizers that were run.
+FinalizersRunRule_RULE_NAME=Finalizers Run
+FinalizersRunRule_SOLUTION=Remove finalize method implementations from your application, and consider making use of the [Cleaner API](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/ref/Cleaner.html) instead.
+FinalizersRunRule_SUMMARY_OK=No finalizer executions were detected.
+# {finalizersRunCount} is a number
+FinalizersRunRule_SUMMARY_WARN={finalizersRunCount} finalizers were run.
 FlightRecordingSupportRule_RULE_NAME=Flight Recording Support
 FlightRecordingSupportRule_TEXT_OK=The JVM version used for this recording has full Flight Recorder support.
 FlightRecordingSupportRule_EA_TEXT_WARN_SHORT=The recording is from an early access build.

--- a/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/jdk/JdkAttributes.java
+++ b/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/jdk/JdkAttributes.java
@@ -1289,4 +1289,26 @@ public final class JdkAttributes {
 			Messages.getString(Messages.ATTR_CONSTANT_VALUE), PLAIN_TEXT);
 	public static final IAttribute<IQuantity> SAMPLE_WEIGHT = attr("weight", //$NON-NLS-1$
 			Messages.getString(Messages.ATTR_SAMPLE_WEIGHT), MEMORY);
+
+	public static final IAttribute<IQuantity> TOTAL_FINALIZERS_RUN = attr("totalFinalizersRun", //$NON-NLS-1$
+			Messages.getString(Messages.ATTR_TOTAL_FINALIZERS_RUN),
+			Messages.getString(Messages.ATTR_TOTAL_FINALIZERS_RUN_DESC), NUMBER);
+	public static final IAttribute<IMCType> FINALIZABLE_CLASS = attr("finalizableClass", //$NON-NLS-1$
+			Messages.getString(Messages.ATTR_FINALIZABLE_CLASS),
+			Messages.getString(Messages.ATTR_FINALIZABLE_CLASS_DESC), CLASS);
+	public static final IAttribute<String> FINALIZABLE_CLASS_NAME = Attribute.canonicalize(
+			new Attribute<String>("finalizableClassName", Messages.getString(Messages.ATTR_FINALIZABLE_CLASS_NAME), //$NON-NLS-1$
+					Messages.getString(Messages.ATTR_FINALIZABLE_CLASS_NAME_DESC), PLAIN_TEXT) {
+				@Override
+				public <U> IMemberAccessor<String, U> customAccessor(IType<U> type) {
+					final IMemberAccessor<IMCType, U> accessor = FINALIZABLE_CLASS.getAccessor(type);
+					return accessor == null ? null : new IMemberAccessor<String, U>() {
+						@Override
+						public String getMember(U i) {
+							IMCType type = accessor.getMember(i);
+							return type == null ? null : type.getFullName();
+						}
+					};
+				}
+			});
 }

--- a/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/jdk/JdkTypeIDs.java
+++ b/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/jdk/JdkTypeIDs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -205,4 +205,7 @@ public final class JdkTypeIDs {
 	public static final String HEAP_DUMP = PREFIX + "HeapDump";
 
 	public static final String PROCESS_START = PREFIX + "ProcessStart";
+
+	public static final String FINALIZER_STATISTICS = PREFIX + "FinalizerStatistics";
+
 }

--- a/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/jdk/messages/internal/Messages.java
+++ b/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/jdk/messages/internal/Messages.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -281,6 +281,12 @@ public class Messages {
 	public static final String ATTR_EXPLICIT_GC_DISABLED_DESC = "ATTR_EXPLICIT_GC_DISABLED_DESC"; //$NON-NLS-1$
 	public static final String ATTR_EXPORTED_PACKAGE = "ATTR_EXPORTED_PACKAGE"; //$NON-NLS-1$
 	public static final String ATTR_EXPORTING_MODULE = "ATTR_EXPORTING_MODULE"; //$NON-NLS-1$
+	public static final String ATTR_FINALIZABLE_CLASS = "ATTR_FINALIZABLE_CLASS"; //$NON-NLS-1$
+	public static final String ATTR_FINALIZABLE_CLASS_DESC = "ATTR_FINALIZABLE_CLASS_DESC"; //$NON-NLS-1$
+	public static final String ATTR_FINALIZABLE_CLASS_NAME = "ATTR_FINALIZABLE_CLASS_NAME"; //$NON-NLS-1$
+	public static final String ATTR_FINALIZABLE_CLASS_NAME_DESC = "ATTR_FINALIZABLE_CLASS_NAME_DESC"; //$NON-NLS-1$
+	public static final String ATTR_TOTAL_FINALIZERS_RUN = "ATTR_TOTAL_FINALIZERS_RUN"; //$NON-NLS-1$
+	public static final String ATTR_TOTAL_FINALIZERS_RUN_DESC = "ATTR_TOTAL_FINALIZERS_RUN_DESC"; //$NON-NLS-1$
 	public static final String ATTR_FLAG_NAME = "ATTR_FLAG_NAME"; //$NON-NLS-1$
 	public static final String ATTR_FLAG_NEW_VALUE_BOOLEAN = "ATTR_FLAG_NEW_VALUE BOOLEAN"; //$NON-NLS-1$
 	public static final String ATTR_FLAG_NEW_VALUE_NUMBER = "ATTR_FLAG_NEW_VALUE_NUMBER"; //$NON-NLS-1$

--- a/core/org.openjdk.jmc.flightrecorder/src/main/resources/org/openjdk/jmc/flightrecorder/messages/internal/messages.properties
+++ b/core/org.openjdk.jmc.flightrecorder/src/main/resources/org/openjdk/jmc/flightrecorder/messages/internal/messages.properties
@@ -1,5 +1,5 @@
 #
-#  Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+#  Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
 #
 #  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
@@ -49,6 +49,12 @@ ATTR_EVENT_TYPE=Event Type
 ATTR_EVENT_TYPE_DESC=The type of the event
 ATTR_EVENT_TYPE_ID=Event Type Id
 ATTR_EVENT_TYPE_ID_DESC=The identifier for the event type of the event
+ATTR_FINALIZABLE_CLASS=Class
+ATTR_FINALIZABLE_CLASS_DESC=The finalizable class
+ATTR_FINALIZABLE_CLASS_NAME=Class Name
+ATTR_FINALIZABLE_CLASS_NAME=The finalizable class name
+ATTR_TOTAL_FINALIZERS_RUN=Finalizers Run
+ATTR_TOTAL_FINALIZERS_RUN_DESC=The number of finalizers that were run
 ATTR_FLR_DATA_LOST=Flight Recorder Data Lost
 ATTR_FLR_DATA_LOST_DESC=The amount of flight recorder data that was lost because it could not be written to disk fast enough
 ATTR_LIFETIME=Event


### PR DESCRIPTION
A new `jdk.FinalizerStatistics` JFR event was introduced in JDK 18. This pull requests adds a simple rule that makes use of it:
![Screenshot 2022-11-30 at 14 19 49](https://user-images.githubusercontent.com/10694593/204806915-0da90fe3-ccc0-430e-96f8-ebc529f8e7a1.png)
