### PR TITLE
7993: Support checkpoint event sizes beyond u4 limit

### DIFF
--- a/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/internal/parser/v1/ChunkLoaderV1.java
+++ b/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/internal/parser/v1/ChunkLoaderV1.java
@@ -75,7 +75,7 @@ public class ChunkLoaderV1 implements IChunkLoader {
 		while (delta != 0) {
 			constantPoolOffset += delta;
 			input.seek(constantPoolOffset);
-			delta = readConstantPoolEvent(input, manager);
+			delta = readConstantPoolEvent(input, manager, header.isIntegersCompressed());
 		}
 		manager.resolveConstants();
 
@@ -98,9 +98,14 @@ public class ChunkLoaderV1 implements IChunkLoader {
 		return data;
 	}
 
-	private static long readConstantPoolEvent(IDataInput input, TypeManager manager)
+	private static long readConstantPoolEvent(IDataInput input, TypeManager manager, boolean compressedInts)
 			throws IOException, InvalidJfrFileException {
-		input.readInt(); // size
+		// size (see JMC-7993)
+		if (compressedInts) {
+			input.readLong();
+		} else {
+			input.readInt();
+		}
 		ParserToolkit.assertValue(input.readLong(), CONSTANT_POOL_EVENT_TYPE); // type;
 		input.readLong(); // start
 		input.readLong(); // duration


### PR DESCRIPTION
See https://bugs.openjdk.org/browse/JDK-8298129.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JMC-7993](https://bugs.openjdk.org/browse/JMC-7993): Support checkpoint event sizes beyond u4 limit


### Reviewers
 * [Alex Macdonald](https://openjdk.org/census#aptmac) (@aptmac - **Reviewer**)
 * [Erik Gahlin](https://openjdk.org/census#egahlin) (@egahlin - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmc.git pull/458/head:pull/458` \
`$ git checkout pull/458`

Update a local copy of the PR: \
`$ git checkout pull/458` \
`$ git pull https://git.openjdk.org/jmc.git pull/458/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 458`

View PR using the GUI difftool: \
`$ git pr show -t 458`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmc/pull/458.diff">https://git.openjdk.org/jmc/pull/458.diff</a>

</details>
