### PR TITLE
7998: Upgrading spifly and jetty project version

### DIFF
--- a/releng/platform-definitions/platform-definition-2022-12/platform-definition-2022-12.target
+++ b/releng/platform-definitions/platform-definition-2022-12/platform-definition-2022-12.target
@@ -45,11 +45,11 @@
             <unit id="org.adoptopenjdk.jemmy-browser" version="2.0.0"/>
             <unit id="org.adoptopenjdk.jemmy-core" version="2.0.0"/>
             <unit id="org.adoptopenjdk.jemmy-swt" version="2.0.0"/>
-            <unit id="org.eclipse.jetty.websocket.api" version="10.0.11"/>
-            <unit id="org.eclipse.jetty.websocket.server" version="10.0.11"/>
-            <unit id="org.eclipse.jetty.websocket.servlet" version="10.0.11"/>
-            <unit id="org.eclipse.jetty.websocket.javax.server" version="10.0.11"/>
-            <unit id="org.apache.aries.spifly.dynamic.bundle" version="1.3.4"/>
+            <unit id="org.eclipse.jetty.websocket.api" version="10.0.12"/>
+            <unit id="org.eclipse.jetty.websocket.server" version="10.0.12"/>
+            <unit id="org.eclipse.jetty.websocket.servlet" version="10.0.12"/>
+            <unit id="org.eclipse.jetty.websocket.javax.server" version="10.0.12"/>
+            <unit id="org.apache.aries.spifly.dynamic.bundle" version="1.3.6"/>
             <repository location="http://localhost:8080/site"/>
         </location>
         <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">

--- a/releng/third-party/pom.xml
+++ b/releng/third-party/pom.xml
@@ -46,14 +46,14 @@
 		<jakarta.activation.version>2.0.1</jakarta.activation.version>
 		<jakarta.mail.version>2.0.1</jakarta.mail.version>
 		<javax.websocket.version>1.1</javax.websocket.version>
-		<jetty.version>10.0.11</jetty.version>
+		<jetty.version>10.0.12</jetty.version>
 		<jemmy.version>2.0.0</jemmy.version>
 		<jetty-maven-plugin.version>9.4.46.v20220331</jetty-maven-plugin.version>
 		<lz4.version>1.8.0</lz4.version>
 		<maven-enforcer-plugin.version>3.0.0</maven-enforcer-plugin.version>
 		<owasp.encoder.version>1.2.3</owasp.encoder.version>
 		<p2-maven-plugin.version>2.0.0</p2-maven-plugin.version>
-		<spifly.version>1.3.4</spifly.version>
+		<spifly.version>1.3.6</spifly.version>
 	</properties>
 
 	<build>


### PR DESCRIPTION
Eclipse 22-12 uses Jetty Project 10.0.12 and ASM 9.4. To keep the versions consistent with Eclipse 22-12, upgraded the third party libraries. I will update the **thirdpartyreadme.txt** file later.
Jetty Project from10.0.11 to 10.0.12.
Spifly from 1.3.4 to 1.3.6. (To match ASM 9.4)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JMC-7998](https://bugs.openjdk.org/browse/JMC-7998): Upgrading spifly and jetty project version


### Reviewers
 * [Marcus Hirt](https://openjdk.org/census#hirt) (@thegreystone - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmc pull/461/head:pull/461` \
`$ git checkout pull/461`

Update a local copy of the PR: \
`$ git checkout pull/461` \
`$ git pull https://git.openjdk.org/jmc pull/461/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 461`

View PR using the GUI difftool: \
`$ git pr show -t 461`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmc/pull/461.diff">https://git.openjdk.org/jmc/pull/461.diff</a>

</details>
