### PR TITLE
8036: Upgrading Jakarta Mail in JMC

### DIFF
--- a/application/org.openjdk.jmc.feature.core/feature.xml
+++ b/application/org.openjdk.jmc.feature.core/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--   
-   Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+   Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
    
    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
    
@@ -175,14 +175,22 @@
          unpack="false"/>
 
    <plugin
-         id="com.sun.mail.jakarta.mail"
+         id="angus-activation"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   
+   <plugin
+         id="jakarta.activation-api"
          download-size="0"
          install-size="0"
          version="0.0.0"
          unpack="false"/>
 
    <plugin
-         id="com.sun.activation.jakarta.activation"
+         id="org.eclipse.angus.jakarta.mail"
          download-size="0"
          install-size="0"
          version="0.0.0"

--- a/license/THIRDPARTYREADME.txt
+++ b/license/THIRDPARTYREADME.txt
@@ -2371,759 +2371,6 @@ STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
 OF THE POSSIBILITY OF SUCH DAMAGE.
 
-%% The following notice is provided with respect to Jakarta Mail v2.0.1,
-which may be included with this product.
-
-					Eclipse Public License - v 2.0
-
-        THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS ECLIPSE
-        PUBLIC LICENSE ("AGREEMENT"). ANY USE, REPRODUCTION OR DISTRIBUTION
-        OF THE PROGRAM CONSTITUTES RECIPIENT'S ACCEPTANCE OF THIS AGREEMENT.
-
-    1. DEFINITIONS
-
-    "Contribution" means:
-
-      a) in the case of the initial Contributor, the initial content
-         Distributed under this Agreement, and
-
-      b) in the case of each subsequent Contributor: 
-         i) changes to the Program, and 
-         ii) additions to the Program;
-      where such changes and/or additions to the Program originate from
-      and are Distributed by that particular Contributor. A Contribution
-      "originates" from a Contributor if it was added to the Program by
-      such Contributor itself or anyone acting on such Contributor's behalf.
-      Contributions do not include changes or additions to the Program that
-      are not Modified Works.
-
-    "Contributor" means any person or entity that Distributes the Program.
-
-    "Licensed Patents" mean patent claims licensable by a Contributor which
-    are necessarily infringed by the use or sale of its Contribution alone
-    or when combined with the Program.
-
-    "Program" means the Contributions Distributed in accordance with this
-    Agreement.
-
-    "Recipient" means anyone who receives the Program under this Agreement
-    or any Secondary License (as applicable), including Contributors.
-
-    "Derivative Works" shall mean any work, whether in Source Code or other
-    form, that is based on (or derived from) the Program and for which the
-    editorial revisions, annotations, elaborations, or other modifications
-    represent, as a whole, an original work of authorship.
-
-    "Modified Works" shall mean any work in Source Code or other form that
-    results from an addition to, deletion from, or modification of the
-    contents of the Program, including, for purposes of clarity any new file
-    in Source Code form that contains any contents of the Program. Modified
-    Works shall not include works that contain only declarations,
-    interfaces, types, classes, structures, or files of the Program solely
-    in each case in order to link to, bind by name, or subclass the Program
-    or Modified Works thereof.
-
-    "Distribute" means the acts of a) distributing or b) making available
-    in any manner that enables the transfer of a copy.
-
-    "Source Code" means the form of a Program preferred for making
-    modifications, including but not limited to software source code,
-    documentation source, and configuration files.
-
-    "Secondary License" means either the GNU General Public License,
-    Version 2.0, or any later versions of that license, including any
-    exceptions or additional permissions as identified by the initial
-    Contributor.
-
-    2. GRANT OF RIGHTS
-
-      a) Subject to the terms of this Agreement, each Contributor hereby
-      grants Recipient a non-exclusive, worldwide, royalty-free copyright
-      license to reproduce, prepare Derivative Works of, publicly display,
-      publicly perform, Distribute and sublicense the Contribution of such
-      Contributor, if any, and such Derivative Works.
-
-      b) Subject to the terms of this Agreement, each Contributor hereby
-      grants Recipient a non-exclusive, worldwide, royalty-free patent
-      license under Licensed Patents to make, use, sell, offer to sell,
-      import and otherwise transfer the Contribution of such Contributor,
-      if any, in Source Code or other form. This patent license shall
-      apply to the combination of the Contribution and the Program if, at
-      the time the Contribution is added by the Contributor, such addition
-      of the Contribution causes such combination to be covered by the
-      Licensed Patents. The patent license shall not apply to any other
-      combinations which include the Contribution. No hardware per se is
-      licensed hereunder.
-
-      c) Recipient understands that although each Contributor grants the
-      licenses to its Contributions set forth herein, no assurances are
-      provided by any Contributor that the Program does not infringe the
-      patent or other intellectual property rights of any other entity.
-      Each Contributor disclaims any liability to Recipient for claims
-      brought by any other entity based on infringement of intellectual
-      property rights or otherwise. As a condition to exercising the
-      rights and licenses granted hereunder, each Recipient hereby
-      assumes sole responsibility to secure any other intellectual
-      property rights needed, if any. For example, if a third party
-      patent license is required to allow Recipient to Distribute the
-      Program, it is Recipient's responsibility to acquire that license
-      before distributing the Program.
-
-      d) Each Contributor represents that to its knowledge it has
-      sufficient copyright rights in its Contribution, if any, to grant
-      the copyright license set forth in this Agreement.
-
-      e) Notwithstanding the terms of any Secondary License, no
-      Contributor makes additional grants to any Recipient (other than
-      those set forth in this Agreement) as a result of such Recipient's
-      receipt of the Program under the terms of a Secondary License
-      (if permitted under the terms of Section 3).
-
-    3. REQUIREMENTS
-
-    3.1 If a Contributor Distributes the Program in any form, then:
-
-      a) the Program must also be made available as Source Code, in
-      accordance with section 3.2, and the Contributor must accompany
-      the Program with a statement that the Source Code for the Program
-      is available under this Agreement, and informs Recipients how to
-      obtain it in a reasonable manner on or through a medium customarily
-      used for software exchange; and
-
-      b) the Contributor may Distribute the Program under a license
-      different than this Agreement, provided that such license:
-         i) effectively disclaims on behalf of all other Contributors all
-         warranties and conditions, express and implied, including
-         warranties or conditions of title and non-infringement, and
-         implied warranties or conditions of merchantability and fitness
-         for a particular purpose;
-
-         ii) effectively excludes on behalf of all other Contributors all
-         liability for damages, including direct, indirect, special,
-         incidental and consequential damages, such as lost profits;
-
-         iii) does not attempt to limit or alter the recipients' rights
-         in the Source Code under section 3.2; and
-
-         iv) requires any subsequent distribution of the Program by any
-         party to be under a license that satisfies the requirements
-         of this section 3.
-
-    3.2 When the Program is Distributed as Source Code:
-
-      a) it must be made available under this Agreement, or if the
-      Program (i) is combined with other material in a separate file or
-      files made available under a Secondary License, and (ii) the initial
-      Contributor attached to the Source Code the notice described in
-      Exhibit A of this Agreement, then the Program may be made available
-      under the terms of such Secondary Licenses, and
-
-      b) a copy of this Agreement must be included with each copy of
-      the Program.
-
-    3.3 Contributors may not remove or alter any copyright, patent,
-    trademark, attribution notices, disclaimers of warranty, or limitations
-    of liability ("notices") contained within the Program from any copy of
-    the Program which they Distribute, provided that Contributors may add
-    their own appropriate notices.
-
-    4. COMMERCIAL DISTRIBUTION
-
-    Commercial distributors of software may accept certain responsibilities
-    with respect to end users, business partners and the like. While this
-    license is intended to facilitate the commercial use of the Program,
-    the Contributor who includes the Program in a commercial product
-    offering should do so in a manner which does not create potential
-    liability for other Contributors. Therefore, if a Contributor includes
-    the Program in a commercial product offering, such Contributor
-    ("Commercial Contributor") hereby agrees to defend and indemnify every
-    other Contributor ("Indemnified Contributor") against any losses,
-    damages and costs (collectively "Losses") arising from claims, lawsuits
-    and other legal actions brought by a third party against the Indemnified
-    Contributor to the extent caused by the acts or omissions of such
-    Commercial Contributor in connection with its distribution of the Program
-    in a commercial product offering. The obligations in this section do not
-    apply to any claims or Losses relating to any actual or alleged
-    intellectual property infringement. In order to qualify, an Indemnified
-    Contributor must: a) promptly notify the Commercial Contributor in
-    writing of such claim, and b) allow the Commercial Contributor to control,
-    and cooperate with the Commercial Contributor in, the defense and any
-    related settlement negotiations. The Indemnified Contributor may
-    participate in any such claim at its own expense.
-
-    For example, a Contributor might include the Program in a commercial
-    product offering, Product X. That Contributor is then a Commercial
-    Contributor. If that Commercial Contributor then makes performance
-    claims, or offers warranties related to Product X, those performance
-    claims and warranties are such Commercial Contributor's responsibility
-    alone. Under this section, the Commercial Contributor would have to
-    defend claims against the other Contributors related to those performance
-    claims and warranties, and if a court requires any other Contributor to
-    pay any damages as a result, the Commercial Contributor must pay
-    those damages.
-
-    5. NO WARRANTY
-
-    EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, AND TO THE EXTENT
-    PERMITTED BY APPLICABLE LAW, THE PROGRAM IS PROVIDED ON AN "AS IS"
-    BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
-    IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS OF
-    TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A PARTICULAR
-    PURPOSE. Each Recipient is solely responsible for determining the
-    appropriateness of using and distributing the Program and assumes all
-    risks associated with its exercise of rights under this Agreement,
-    including but not limited to the risks and costs of program errors,
-    compliance with applicable laws, damage to or loss of data, programs
-    or equipment, and unavailability or interruption of operations.
-
-    6. DISCLAIMER OF LIABILITY
-
-    EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, AND TO THE EXTENT
-    PERMITTED BY APPLICABLE LAW, NEITHER RECIPIENT NOR ANY CONTRIBUTORS
-    SHALL HAVE ANY LIABILITY FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
-    EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING WITHOUT LIMITATION LOST
-    PROFITS), HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-    ARISING IN ANY WAY OUT OF THE USE OR DISTRIBUTION OF THE PROGRAM OR THE
-    EXERCISE OF ANY RIGHTS GRANTED HEREUNDER, EVEN IF ADVISED OF THE
-    POSSIBILITY OF SUCH DAMAGES.
-
-    7. GENERAL
-
-    If any provision of this Agreement is invalid or unenforceable under
-    applicable law, it shall not affect the validity or enforceability of
-    the remainder of the terms of this Agreement, and without further
-    action by the parties hereto, such provision shall be reformed to the
-    minimum extent necessary to make such provision valid and enforceable.
-
-    If Recipient institutes patent litigation against any entity
-    (including a cross-claim or counterclaim in a lawsuit) alleging that the
-    Program itself (excluding combinations of the Program with other software
-    or hardware) infringes such Recipient's patent(s), then such Recipient's
-    rights granted under Section 2(b) shall terminate as of the date such
-    litigation is filed.
-
-    All Recipient's rights under this Agreement shall terminate if it
-    fails to comply with any of the material terms or conditions of this
-    Agreement and does not cure such failure in a reasonable period of
-    time after becoming aware of such noncompliance. If all Recipient's
-    rights under this Agreement terminate, Recipient agrees to cease use
-    and distribution of the Program as soon as reasonably practicable.
-    However, Recipient's obligations under this Agreement and any licenses
-    granted by Recipient relating to the Program shall continue and survive.
-
-    Everyone is permitted to copy and distribute copies of this Agreement,
-    but in order to avoid inconsistency the Agreement is copyrighted and
-    may only be modified in the following manner. The Agreement Steward
-    reserves the right to publish new versions (including revisions) of
-    this Agreement from time to time. No one other than the Agreement
-    Steward has the right to modify this Agreement. The Eclipse Foundation
-    is the initial Agreement Steward. The Eclipse Foundation may assign the
-    responsibility to serve as the Agreement Steward to a suitable separate
-    entity. Each new version of the Agreement will be given a distinguishing
-    version number. The Program (including Contributions) may always be
-    Distributed subject to the version of the Agreement under which it was
-    received. In addition, after a new version of the Agreement is published,
-    Contributor may elect to Distribute the Program (including its
-    Contributions) under the new version.
-
-    Except as expressly stated in Sections 2(a) and 2(b) above, Recipient
-    receives no rights or licenses to the intellectual property of any
-    Contributor under this Agreement, whether expressly, by implication,
-    estoppel or otherwise. All rights in the Program not expressly granted
-    under this Agreement are reserved. Nothing in this Agreement is intended
-    to be enforceable by any entity that is not a Contributor or Recipient.
-    No third-party beneficiary rights are created under this Agreement.
-
-    Exhibit A - Form of Secondary Licenses Notice
-
-    "This Source Code may also be made available under the following 
-    Secondary Licenses when the conditions for such availability set forth 
-    in the Eclipse Public License, v. 2.0 are satisfied: {name license(s),
-    version(s), and exceptions or additional permissions here}."
-
-      Simply including a copy of this Agreement, including this Exhibit A
-      is not sufficient to license the Source Code under Secondary Licenses.
-
-      If it is not possible or desirable to put the notice in a particular
-      file, then You may include the notice in a location (such as a LICENSE
-      file in a relevant directory) where a recipient would be likely to
-      look for such a notice.
-
-      You may add additional accurate notices of copyright ownership.
-
----
-
-##    The GNU General Public License (GPL) Version 2, June 1991
-
-    Copyright (C) 1989, 1991 Free Software Foundation, Inc.
-    51 Franklin Street, Fifth Floor
-    Boston, MA 02110-1335
-    USA
-
-    Everyone is permitted to copy and distribute verbatim copies
-    of this license document, but changing it is not allowed.
-
-    Preamble
-
-    The licenses for most software are designed to take away your freedom to
-    share and change it. By contrast, the GNU General Public License is
-    intended to guarantee your freedom to share and change free software--to
-    make sure the software is free for all its users. This General Public
-    License applies to most of the Free Software Foundation's software and
-    to any other program whose authors commit to using it. (Some other Free
-    Software Foundation software is covered by the GNU Library General
-    Public License instead.) You can apply it to your programs, too.
-
-    When we speak of free software, we are referring to freedom, not price.
-    Our General Public Licenses are designed to make sure that you have the
-    freedom to distribute copies of free software (and charge for this
-    service if you wish), that you receive source code or can get it if you
-    want it, that you can change the software or use pieces of it in new
-    free programs; and that you know you can do these things.
-
-    To protect your rights, we need to make restrictions that forbid anyone
-    to deny you these rights or to ask you to surrender the rights. These
-    restrictions translate to certain responsibilities for you if you
-    distribute copies of the software, or if you modify it.
-
-    For example, if you distribute copies of such a program, whether gratis
-    or for a fee, you must give the recipients all the rights that you have.
-    You must make sure that they, too, receive or can get the source code.
-    And you must show them these terms so they know their rights.
-
-    We protect your rights with two steps: (1) copyright the software, and
-    (2) offer you this license which gives you legal permission to copy,
-    distribute and/or modify the software.
-
-    Also, for each author's protection and ours, we want to make certain
-    that everyone understands that there is no warranty for this free
-    software. If the software is modified by someone else and passed on, we
-    want its recipients to know that what they have is not the original, so
-    that any problems introduced by others will not reflect on the original
-    authors' reputations.
-
-    Finally, any free program is threatened constantly by software patents.
-    We wish to avoid the danger that redistributors of a free program will
-    individually obtain patent licenses, in effect making the program
-    proprietary. To prevent this, we have made it clear that any patent must
-    be licensed for everyone's free use or not licensed at all.
-
-    The precise terms and conditions for copying, distribution and
-    modification follow.
-
-    TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
-
-    0. This License applies to any program or other work which contains a
-    notice placed by the copyright holder saying it may be distributed under
-    the terms of this General Public License. The "Program", below, refers
-    to any such program or work, and a "work based on the Program" means
-    either the Program or any derivative work under copyright law: that is
-    to say, a work containing the Program or a portion of it, either
-    verbatim or with modifications and/or translated into another language.
-    (Hereinafter, translation is included without limitation in the term
-    "modification".) Each licensee is addressed as "you".
-
-    Activities other than copying, distribution and modification are not
-    covered by this License; they are outside its scope. The act of running
-    the Program is not restricted, and the output from the Program is
-    covered only if its contents constitute a work based on the Program
-    (independent of having been made by running the Program). Whether that
-    is true depends on what the Program does.
-
-    1. You may copy and distribute verbatim copies of the Program's source
-    code as you receive it, in any medium, provided that you conspicuously
-    and appropriately publish on each copy an appropriate copyright notice
-    and disclaimer of warranty; keep intact all the notices that refer to
-    this License and to the absence of any warranty; and give any other
-    recipients of the Program a copy of this License along with the Program.
-
-    You may charge a fee for the physical act of transferring a copy, and
-    you may at your option offer warranty protection in exchange for a fee.
-
-    2. You may modify your copy or copies of the Program or any portion of
-    it, thus forming a work based on the Program, and copy and distribute
-    such modifications or work under the terms of Section 1 above, provided
-    that you also meet all of these conditions:
-
-        a) You must cause the modified files to carry prominent notices
-        stating that you changed the files and the date of any change.
-
-        b) You must cause any work that you distribute or publish, that in
-        whole or in part contains or is derived from the Program or any part
-        thereof, to be licensed as a whole at no charge to all third parties
-        under the terms of this License.
-
-        c) If the modified program normally reads commands interactively
-        when run, you must cause it, when started running for such
-        interactive use in the most ordinary way, to print or display an
-        announcement including an appropriate copyright notice and a notice
-        that there is no warranty (or else, saying that you provide a
-        warranty) and that users may redistribute the program under these
-        conditions, and telling the user how to view a copy of this License.
-        (Exception: if the Program itself is interactive but does not
-        normally print such an announcement, your work based on the Program
-        is not required to print an announcement.)
-
-    These requirements apply to the modified work as a whole. If
-    identifiable sections of that work are not derived from the Program, and
-    can be reasonably considered independent and separate works in
-    themselves, then this License, and its terms, do not apply to those
-    sections when you distribute them as separate works. But when you
-    distribute the same sections as part of a whole which is a work based on
-    the Program, the distribution of the whole must be on the terms of this
-    License, whose permissions for other licensees extend to the entire
-    whole, and thus to each and every part regardless of who wrote it.
-
-    Thus, it is not the intent of this section to claim rights or contest
-    your rights to work written entirely by you; rather, the intent is to
-    exercise the right to control the distribution of derivative or
-    collective works based on the Program.
-
-    In addition, mere aggregation of another work not based on the Program
-    with the Program (or with a work based on the Program) on a volume of a
-    storage or distribution medium does not bring the other work under the
-    scope of this License.
-
-    3. You may copy and distribute the Program (or a work based on it,
-    under Section 2) in object code or executable form under the terms of
-    Sections 1 and 2 above provided that you also do one of the following:
-
-        a) Accompany it with the complete corresponding machine-readable
-        source code, which must be distributed under the terms of Sections 1
-        and 2 above on a medium customarily used for software interchange; or,
-
-        b) Accompany it with a written offer, valid for at least three
-        years, to give any third party, for a charge no more than your cost
-        of physically performing source distribution, a complete
-        machine-readable copy of the corresponding source code, to be
-        distributed under the terms of Sections 1 and 2 above on a medium
-        customarily used for software interchange; or,
-
-        c) Accompany it with the information you received as to the offer to
-        distribute corresponding source code. (This alternative is allowed
-        only for noncommercial distribution and only if you received the
-        program in object code or executable form with such an offer, in
-        accord with Subsection b above.)
-
-    The source code for a work means the preferred form of the work for
-    making modifications to it. For an executable work, complete source code
-    means all the source code for all modules it contains, plus any
-    associated interface definition files, plus the scripts used to control
-    compilation and installation of the executable. However, as a special
-    exception, the source code distributed need not include anything that is
-    normally distributed (in either source or binary form) with the major
-    components (compiler, kernel, and so on) of the operating system on
-    which the executable runs, unless that component itself accompanies the
-    executable.
-
-    If distribution of executable or object code is made by offering access
-    to copy from a designated place, then offering equivalent access to copy
-    the source code from the same place counts as distribution of the source
-    code, even though third parties are not compelled to copy the source
-    along with the object code.
-
-    4. You may not copy, modify, sublicense, or distribute the Program
-    except as expressly provided under this License. Any attempt otherwise
-    to copy, modify, sublicense or distribute the Program is void, and will
-    automatically terminate your rights under this License. However, parties
-    who have received copies, or rights, from you under this License will
-    not have their licenses terminated so long as such parties remain in
-    full compliance.
-
-    5. You are not required to accept this License, since you have not
-    signed it. However, nothing else grants you permission to modify or
-    distribute the Program or its derivative works. These actions are
-    prohibited by law if you do not accept this License. Therefore, by
-    modifying or distributing the Program (or any work based on the
-    Program), you indicate your acceptance of this License to do so, and all
-    its terms and conditions for copying, distributing or modifying the
-    Program or works based on it.
-
-    6. Each time you redistribute the Program (or any work based on the
-    Program), the recipient automatically receives a license from the
-    original licensor to copy, distribute or modify the Program subject to
-    these terms and conditions. You may not impose any further restrictions
-    on the recipients' exercise of the rights granted herein. You are not
-    responsible for enforcing compliance by third parties to this License.
-
-    7. If, as a consequence of a court judgment or allegation of patent
-    infringement or for any other reason (not limited to patent issues),
-    conditions are imposed on you (whether by court order, agreement or
-    otherwise) that contradict the conditions of this License, they do not
-    excuse you from the conditions of this License. If you cannot distribute
-    so as to satisfy simultaneously your obligations under this License and
-    any other pertinent obligations, then as a consequence you may not
-    distribute the Program at all. For example, if a patent license would
-    not permit royalty-free redistribution of the Program by all those who
-    receive copies directly or indirectly through you, then the only way you
-    could satisfy both it and this License would be to refrain entirely from
-    distribution of the Program.
-
-    If any portion of this section is held invalid or unenforceable under
-    any particular circumstance, the balance of the section is intended to
-    apply and the section as a whole is intended to apply in other
-    circumstances.
-
-    It is not the purpose of this section to induce you to infringe any
-    patents or other property right claims or to contest validity of any
-    such claims; this section has the sole purpose of protecting the
-    integrity of the free software distribution system, which is implemented
-    by public license practices. Many people have made generous
-    contributions to the wide range of software distributed through that
-    system in reliance on consistent application of that system; it is up to
-    the author/donor to decide if he or she is willing to distribute
-    software through any other system and a licensee cannot impose that choice.
-
-    This section is intended to make thoroughly clear what is believed to be
-    a consequence of the rest of this License.
-
-    8. If the distribution and/or use of the Program is restricted in
-    certain countries either by patents or by copyrighted interfaces, the
-    original copyright holder who places the Program under this License may
-    add an explicit geographical distribution limitation excluding those
-    countries, so that distribution is permitted only in or among countries
-    not thus excluded. In such case, this License incorporates the
-    limitation as if written in the body of this License.
-
-    9. The Free Software Foundation may publish revised and/or new
-    versions of the General Public License from time to time. Such new
-    versions will be similar in spirit to the present version, but may
-    differ in detail to address new problems or concerns.
-
-    Each version is given a distinguishing version number. If the Program
-    specifies a version number of this License which applies to it and "any
-    later version", you have the option of following the terms and
-    conditions either of that version or of any later version published by
-    the Free Software Foundation. If the Program does not specify a version
-    number of this License, you may choose any version ever published by the
-    Free Software Foundation.
-
-    10. If you wish to incorporate parts of the Program into other free
-    programs whose distribution conditions are different, write to the
-    author to ask for permission. For software which is copyrighted by the
-    Free Software Foundation, write to the Free Software Foundation; we
-    sometimes make exceptions for this. Our decision will be guided by the
-    two goals of preserving the free status of all derivatives of our free
-    software and of promoting the sharing and reuse of software generally.
-
-    NO WARRANTY
-
-    11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO
-    WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.
-    EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR
-    OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND,
-    EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE
-    ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH
-    YOU. SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL
-    NECESSARY SERVICING, REPAIR OR CORRECTION.
-
-    12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN
-    WRITING WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY
-    AND/OR REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR
-    DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL
-    DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE PROGRAM
-    (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING RENDERED
-    INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A FAILURE OF
-    THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS), EVEN IF SUCH HOLDER OR
-    OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
-
-    END OF TERMS AND CONDITIONS
-
-    How to Apply These Terms to Your New Programs
-
-    If you develop a new program, and you want it to be of the greatest
-    possible use to the public, the best way to achieve this is to make it
-    free software which everyone can redistribute and change under these terms.
-
-    To do so, attach the following notices to the program. It is safest to
-    attach them to the start of each source file to most effectively convey
-    the exclusion of warranty; and each file should have at least the
-    "copyright" line and a pointer to where the full notice is found.
-
-        One line to give the program's name and a brief idea of what it does.
-        Copyright (C) <year> <name of author>
-
-        This program is free software; you can redistribute it and/or modify
-        it under the terms of the GNU General Public License as published by
-        the Free Software Foundation; either version 2 of the License, or
-        (at your option) any later version.
-
-        This program is distributed in the hope that it will be useful, but
-        WITHOUT ANY WARRANTY; without even the implied warranty of
-        MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
-        General Public License for more details.
-
-        You should have received a copy of the GNU General Public License
-        along with this program; if not, write to the Free Software
-        Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335 USA
-
-    Also add information on how to contact you by electronic and paper mail.
-
-    If the program is interactive, make it output a short notice like this
-    when it starts in an interactive mode:
-
-        Gnomovision version 69, Copyright (C) year name of author
-        Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type
-        `show w'. This is free software, and you are welcome to redistribute
-        it under certain conditions; type `show c' for details.
-
-    The hypothetical commands `show w' and `show c' should show the
-    appropriate parts of the General Public License. Of course, the commands
-    you use may be called something other than `show w' and `show c'; they
-    could even be mouse-clicks or menu items--whatever suits your program.
-
-    You should also get your employer (if you work as a programmer) or your
-    school, if any, to sign a "copyright disclaimer" for the program, if
-    necessary. Here is a sample; alter the names:
-
-        Yoyodyne, Inc., hereby disclaims all copyright interest in the
-        program `Gnomovision' (which makes passes at compilers) written by
-        James Hacker.
-
-        signature of Ty Coon, 1 April 1989
-        Ty Coon, President of Vice
-
-    This General Public License does not permit incorporating your program
-    into proprietary programs. If your program is a subroutine library, you
-    may consider it more useful to permit linking proprietary applications
-    with the library. If this is what you want to do, use the GNU Library
-    General Public License instead of this License.
-
----
-
-## CLASSPATH EXCEPTION
-
-    Linking this library statically or dynamically with other modules is
-    making a combined work based on this library.  Thus, the terms and
-    conditions of the GNU General Public License version 2 cover the whole
-    combination.
-
-    As a special exception, the copyright holders of this library give you
-    permission to link this library with independent modules to produce an
-    executable, regardless of the license terms of these independent
-    modules, and to copy and distribute the resulting executable under
-    terms of your choice, provided that you also meet, for each linked
-    independent module, the terms and conditions of the license of that
-    module.  An independent module is a module which is not derived from or
-    based on this library.  If you modify this library, you may extend this
-    exception to your version of the library, but you are not obligated to
-    do so.  If you do not wish to do so, delete this exception statement
-    from your version.
-
-Notice File :
-# Notices for Jakarta Mail
-
-This content is produced and maintained by the Jakarta Mail project.
-
-* Project home: https://projects.eclipse.org/projects/ee4j.mail
-
-## Trademarks
-
-Jakarta Mail is a trademark of the Eclipse Foundation.
-
-## Copyright
-
-All content is the property of the respective authors or their employers. For
-more information regarding authorship of content, please consult the listed
-source code repository logs.
-
-## Declared Project Licenses
-
-This program and the accompanying materials are made available under the terms
-of the Eclipse Public License v. 2.0 which is available at
-http://www.eclipse.org/legal/epl-2.0. This Source Code may also be made
-available under the following Secondary Licenses when the conditions for such
-availability set forth in the Eclipse Public License v. 2.0 are satisfied: GNU
-General Public License, version 2 with the GNU Classpath Exception which is
-available at https://www.gnu.org/software/classpath/license.html.
-
-SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
-
-## Source Code
-
-The project maintains the following source code repositories:
-
-* https://github.com/eclipse-ee4j/mail
-
-
-Dependency:
------------
-com.sun.activation » jakarta.activation 2.0.1
-
-EDL 1.0 Eclipse Distribution License - v 1.0
-Copyright (c) 2007, Eclipse Foundation, Inc. and its licensors.
-
-All rights reserved.
-
-Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
-
-Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
-Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
-Neither the name of the Eclipse Foundation, Inc. nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-%% The following notice is provided with respect to JavaBeans Activation Framework (JAF) v2.0.1, 
-which may be included with this product.
-
-Jakarta Activation API jar (jakarta.activation:jakarta.activation-api)
-  Copyright (c) 1997,2021 Oracle and/or its affiliates. All rights reserved.
-
-# Notices for Jakarta Activation
-
-This content is produced and maintained by Jakarta Activation project.
-
-* Project home: https://projects.eclipse.org/projects/ee4j.jaf
-
-## Copyright
-
-All content is the property of the respective authors or their employers. For
-more information regarding authorship of content, please consult the listed
-source code repository logs.
-
-## Declared Project Licenses
-
-This program and the accompanying materials are made available under the terms
-of the Eclipse Distribution License v. 1.0,
-which is available at http://www.eclipse.org/org/documents/edl-v10.php.
-
-SPDX-License-Identifier: BSD-3-Clause
-
-## Source Code
-
-The project maintains the following source code repositories:
-
-* https://github.com/eclipse-ee4j/jaf
---------------------------------------------
-Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
-   
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions
-are met:
-   
-  - Redistributions of source code must retain the above copyright
-    notice, this list of conditions and the following disclaimer.
-   
-  - Redistributions in binary form must reproduce the above copyright
-    notice, this list of conditions and the following disclaimer in the
-    documentation and/or other materials provided with the distribution.
-
-  - Neither the name of the Eclipse Foundation, Inc. nor the names of its
-    contributors may be used to endorse or promote products derived
-    from this software without specific prior written permission.
-   
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
-IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
-THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
-PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
-CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
-EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
-PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
-PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
-LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
-NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 --------------------------------------------
 
 %% The following notice is provided with respect to HdrHistogram v2.1.12,
@@ -7241,3 +6488,1569 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+-------------------------------------------------------------------------------------------
+
+%% The following notice is provided with respect to Angus Mail v2.0.1, 
+which may be included with this product.
+
+Eclipse Public License - v 2.0
+============================================================
+THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS ECLIPSE
+    PUBLIC LICENSE ("AGREEMENT"). ANY USE, REPRODUCTION OR DISTRIBUTION
+    OF THE PROGRAM CONSTITUTES RECIPIENT'S ACCEPTANCE OF THIS AGREEMENT.
+
+1. DEFINITIONS
+
+"Contribution" means:
+
+  a) in the case of the initial Contributor, the initial content
+     Distributed under this Agreement, and
+
+  b) in the case of each subsequent Contributor: 
+     i) changes to the Program, and 
+     ii) additions to the Program;
+  where such changes and/or additions to the Program originate from
+  and are Distributed by that particular Contributor. A Contribution
+  "originates" from a Contributor if it was added to the Program by
+  such Contributor itself or anyone acting on such Contributor's behalf.
+  Contributions do not include changes or additions to the Program that
+  are not Modified Works.
+
+"Contributor" means any person or entity that Distributes the Program.
+
+"Licensed Patents" mean patent claims licensable by a Contributor which
+are necessarily infringed by the use or sale of its Contribution alone
+or when combined with the Program.
+
+"Program" means the Contributions Distributed in accordance with this
+Agreement.
+
+"Recipient" means anyone who receives the Program under this Agreement
+or any Secondary License (as applicable), including Contributors.
+
+"Derivative Works" shall mean any work, whether in Source Code or other
+form, that is based on (or derived from) the Program and for which the
+editorial revisions, annotations, elaborations, or other modifications
+represent, as a whole, an original work of authorship.
+
+"Modified Works" shall mean any work in Source Code or other form that
+results from an addition to, deletion from, or modification of the
+contents of the Program, including, for purposes of clarity any new file
+in Source Code form that contains any contents of the Program. Modified
+Works shall not include works that contain only declarations,
+interfaces, types, classes, structures, or files of the Program solely
+in each case in order to link to, bind by name, or subclass the Program
+or Modified Works thereof.
+
+"Distribute" means the acts of a) distributing or b) making available
+in any manner that enables the transfer of a copy.
+
+"Source Code" means the form of a Program preferred for making
+modifications, including but not limited to software source code,
+documentation source, and configuration files.
+
+"Secondary License" means either the GNU General Public License,
+Version 2.0, or any later versions of that license, including any
+exceptions or additional permissions as identified by the initial
+Contributor.
+
+2. GRANT OF RIGHTS
+
+  a) Subject to the terms of this Agreement, each Contributor hereby
+  grants Recipient a non-exclusive, worldwide, royalty-free copyright
+  license to reproduce, prepare Derivative Works of, publicly display,
+  publicly perform, Distribute and sublicense the Contribution of such
+  Contributor, if any, and such Derivative Works.
+
+  b) Subject to the terms of this Agreement, each Contributor hereby
+  grants Recipient a non-exclusive, worldwide, royalty-free patent
+  license under Licensed Patents to make, use, sell, offer to sell,
+  import and otherwise transfer the Contribution of such Contributor,
+  if any, in Source Code or other form. This patent license shall
+  apply to the combination of the Contribution and the Program if, at
+  the time the Contribution is added by the Contributor, such addition
+  of the Contribution causes such combination to be covered by the
+  Licensed Patents. The patent license shall not apply to any other
+  combinations which include the Contribution. No hardware per se is
+  licensed hereunder.
+
+  c) Recipient understands that although each Contributor grants the
+  licenses to its Contributions set forth herein, no assurances are
+  provided by any Contributor that the Program does not infringe the
+  patent or other intellectual property rights of any other entity.
+  Each Contributor disclaims any liability to Recipient for claims
+  brought by any other entity based on infringement of intellectual
+  property rights or otherwise. As a condition to exercising the
+  rights and licenses granted hereunder, each Recipient hereby
+  assumes sole responsibility to secure any other intellectual
+  property rights needed, if any. For example, if a third party
+  patent license is required to allow Recipient to Distribute the
+  Program, it is Recipient's responsibility to acquire that license
+  before distributing the Program.
+
+  d) Each Contributor represents that to its knowledge it has
+  sufficient copyright rights in its Contribution, if any, to grant
+  the copyright license set forth in this Agreement.
+
+  e) Notwithstanding the terms of any Secondary License, no
+  Contributor makes additional grants to any Recipient (other than
+  those set forth in this Agreement) as a result of such Recipient's
+  receipt of the Program under the terms of a Secondary License
+  (if permitted under the terms of Section 3).
+
+3. REQUIREMENTS
+
+3.1 If a Contributor Distributes the Program in any form, then:
+
+  a) the Program must also be made available as Source Code, in
+  accordance with section 3.2, and the Contributor must accompany
+  the Program with a statement that the Source Code for the Program
+  is available under this Agreement, and informs Recipients how to
+  obtain it in a reasonable manner on or through a medium customarily
+  used for software exchange; and
+
+  b) the Contributor may Distribute the Program under a license
+  different than this Agreement, provided that such license:
+     i) effectively disclaims on behalf of all other Contributors all
+     warranties and conditions, express and implied, including
+     warranties or conditions of title and non-infringement, and
+     implied warranties or conditions of merchantability and fitness
+     for a particular purpose;
+
+     ii) effectively excludes on behalf of all other Contributors all
+     liability for damages, including direct, indirect, special,
+     incidental and consequential damages, such as lost profits;
+
+     iii) does not attempt to limit or alter the recipients' rights
+     in the Source Code under section 3.2; and
+
+     iv) requires any subsequent distribution of the Program by any
+     party to be under a license that satisfies the requirements
+     of this section 3.
+
+3.2 When the Program is Distributed as Source Code:
+
+  a) it must be made available under this Agreement, or if the
+  Program (i) is combined with other material in a separate file or
+  files made available under a Secondary License, and (ii) the initial
+  Contributor attached to the Source Code the notice described in
+  Exhibit A of this Agreement, then the Program may be made available
+  under the terms of such Secondary Licenses, and
+
+  b) a copy of this Agreement must be included with each copy of
+  the Program.
+
+3.3 Contributors may not remove or alter any copyright, patent,
+trademark, attribution notices, disclaimers of warranty, or limitations
+of liability ("notices") contained within the Program from any copy of
+the Program which they Distribute, provided that Contributors may add
+their own appropriate notices.
+
+4. COMMERCIAL DISTRIBUTION
+
+Commercial distributors of software may accept certain responsibilities
+with respect to end users, business partners and the like. While this
+license is intended to facilitate the commercial use of the Program,
+the Contributor who includes the Program in a commercial product
+offering should do so in a manner which does not create potential
+liability for other Contributors. Therefore, if a Contributor includes
+the Program in a commercial product offering, such Contributor
+("Commercial Contributor") hereby agrees to defend and indemnify every
+other Contributor ("Indemnified Contributor") against any losses,
+damages and costs (collectively "Losses") arising from claims, lawsuits
+and other legal actions brought by a third party against the Indemnified
+Contributor to the extent caused by the acts or omissions of such
+Commercial Contributor in connection with its distribution of the Program
+in a commercial product offering. The obligations in this section do not
+apply to any claims or Losses relating to any actual or alleged
+intellectual property infringement. In order to qualify, an Indemnified
+Contributor must: a) promptly notify the Commercial Contributor in
+writing of such claim, and b) allow the Commercial Contributor to control,
+and cooperate with the Commercial Contributor in, the defense and any
+related settlement negotiations. The Indemnified Contributor may
+participate in any such claim at its own expense.
+
+For example, a Contributor might include the Program in a commercial
+product offering, Product X. That Contributor is then a Commercial
+Contributor. If that Commercial Contributor then makes performance
+claims, or offers warranties related to Product X, those performance
+claims and warranties are such Commercial Contributor's responsibility
+alone. Under this section, the Commercial Contributor would have to
+defend claims against the other Contributors related to those performance
+claims and warranties, and if a court requires any other Contributor to
+pay any damages as a result, the Commercial Contributor must pay
+those damages.
+
+5. NO WARRANTY
+
+EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, AND TO THE EXTENT
+PERMITTED BY APPLICABLE LAW, THE PROGRAM IS PROVIDED ON AN "AS IS"
+BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS OF
+TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A PARTICULAR
+PURPOSE. Each Recipient is solely responsible for determining the
+appropriateness of using and distributing the Program and assumes all
+risks associated with its exercise of rights under this Agreement,
+including but not limited to the risks and costs of program errors,
+compliance with applicable laws, damage to or loss of data, programs
+or equipment, and unavailability or interruption of operations.
+
+6. DISCLAIMER OF LIABILITY
+
+EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, AND TO THE EXTENT
+PERMITTED BY APPLICABLE LAW, NEITHER RECIPIENT NOR ANY CONTRIBUTORS
+SHALL HAVE ANY LIABILITY FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING WITHOUT LIMITATION LOST
+PROFITS), HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OR DISTRIBUTION OF THE PROGRAM OR THE
+EXERCISE OF ANY RIGHTS GRANTED HEREUNDER, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
+
+7. GENERAL
+
+If any provision of this Agreement is invalid or unenforceable under
+applicable law, it shall not affect the validity or enforceability of
+the remainder of the terms of this Agreement, and without further
+action by the parties hereto, such provision shall be reformed to the
+minimum extent necessary to make such provision valid and enforceable.
+
+If Recipient institutes patent litigation against any entity
+(including a cross-claim or counterclaim in a lawsuit) alleging that the
+Program itself (excluding combinations of the Program with other software
+or hardware) infringes such Recipient's patent(s), then such Recipient's
+rights granted under Section 2(b) shall terminate as of the date such
+litigation is filed.
+
+All Recipient's rights under this Agreement shall terminate if it
+fails to comply with any of the material terms or conditions of this
+Agreement and does not cure such failure in a reasonable period of
+time after becoming aware of such noncompliance. If all Recipient's
+rights under this Agreement terminate, Recipient agrees to cease use
+and distribution of the Program as soon as reasonably practicable.
+However, Recipient's obligations under this Agreement and any licenses
+granted by Recipient relating to the Program shall continue and survive.
+
+Everyone is permitted to copy and distribute copies of this Agreement,
+but in order to avoid inconsistency the Agreement is copyrighted and
+may only be modified in the following manner. The Agreement Steward
+reserves the right to publish new versions (including revisions) of
+this Agreement from time to time. No one other than the Agreement
+Steward has the right to modify this Agreement. The Eclipse Foundation
+is the initial Agreement Steward. The Eclipse Foundation may assign the
+responsibility to serve as the Agreement Steward to a suitable separate
+entity. Each new version of the Agreement will be given a distinguishing
+version number. The Program (including Contributions) may always be
+Distributed subject to the version of the Agreement under which it was
+received. In addition, after a new version of the Agreement is published,
+Contributor may elect to Distribute the Program (including its
+Contributions) under the new version.
+
+Except as expressly stated in Sections 2(a) and 2(b) above, Recipient
+receives no rights or licenses to the intellectual property of any
+Contributor under this Agreement, whether expressly, by implication,
+estoppel or otherwise. All rights in the Program not expressly granted
+under this Agreement are reserved. Nothing in this Agreement is intended
+to be enforceable by any entity that is not a Contributor or Recipient.
+No third-party beneficiary rights are created under this Agreement.
+
+Exhibit A - Form of Secondary Licenses Notice
+
+"This Source Code may also be made available under the following 
+Secondary Licenses when the conditions for such availability set forth 
+in the Eclipse Public License, v. 2.0 are satisfied: {name license(s),
+version(s), and exceptions or additional permissions here}."
+
+  Simply including a copy of this Agreement, including this Exhibit A
+  is not sufficient to license the Source Code under Secondary Licenses.
+
+  If it is not possible or desirable to put the notice in a particular
+  file, then You may include the notice in a location (such as a LICENSE
+  file in a relevant directory) where a recipient would be likely to
+  look for such a notice.
+
+  You may add additional accurate notices of copyright ownership.
+
+=================================================
+The GNU General Public License (GPL) Version 2, June 1991
+=================================================
+Copyright (C) 1989, 1991 Free Software Foundation, Inc.
+51 Franklin Street, Fifth Floor
+Boston, MA 02110-1335
+USA
+
+Everyone is permitted to copy and distribute verbatim copies
+of this license document, but changing it is not allowed.
+
+Preamble
+
+The licenses for most software are designed to take away your freedom to
+share and change it. By contrast, the GNU General Public License is
+intended to guarantee your freedom to share and change free software--to
+make sure the software is free for all its users. This General Public
+License applies to most of the Free Software Foundation's software and
+to any other program whose authors commit to using it. (Some other Free
+Software Foundation software is covered by the GNU Library General
+Public License instead.) You can apply it to your programs, too.
+
+When we speak of free software, we are referring to freedom, not price.
+Our General Public Licenses are designed to make sure that you have the
+freedom to distribute copies of free software (and charge for this
+service if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs; and that you know you can do these things.
+
+To protect your rights, we need to make restrictions that forbid anyone
+to deny you these rights or to ask you to surrender the rights. These
+restrictions translate to certain responsibilities for you if you
+distribute copies of the software, or if you modify it.
+
+For example, if you distribute copies of such a program, whether gratis
+or for a fee, you must give the recipients all the rights that you have.
+You must make sure that they, too, receive or can get the source code.
+And you must show them these terms so they know their rights.
+
+We protect your rights with two steps: (1) copyright the software, and
+(2) offer you this license which gives you legal permission to copy,
+distribute and/or modify the software.
+
+Also, for each author's protection and ours, we want to make certain
+that everyone understands that there is no warranty for this free
+software. If the software is modified by someone else and passed on, we
+want its recipients to know that what they have is not the original, so
+that any problems introduced by others will not reflect on the original
+authors' reputations.
+
+Finally, any free program is threatened constantly by software patents.
+We wish to avoid the danger that redistributors of a free program will
+individually obtain patent licenses, in effect making the program
+proprietary. To prevent this, we have made it clear that any patent must
+be licensed for everyone's free use or not licensed at all.
+
+The precise terms and conditions for copying, distribution and
+modification follow.
+
+TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+0. This License applies to any program or other work which contains a
+notice placed by the copyright holder saying it may be distributed under
+the terms of this General Public License. The "Program", below, refers
+to any such program or work, and a "work based on the Program" means
+either the Program or any derivative work under copyright law: that is
+to say, a work containing the Program or a portion of it, either
+verbatim or with modifications and/or translated into another language.
+(Hereinafter, translation is included without limitation in the term
+"modification".) Each licensee is addressed as "you".
+
+Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope. The act of running
+the Program is not restricted, and the output from the Program is
+covered only if its contents constitute a work based on the Program
+(independent of having been made by running the Program). Whether that
+is true depends on what the Program does.
+
+1. You may copy and distribute verbatim copies of the Program's source
+code as you receive it, in any medium, provided that you conspicuously
+and appropriately publish on each copy an appropriate copyright notice
+and disclaimer of warranty; keep intact all the notices that refer to
+this License and to the absence of any warranty; and give any other
+recipients of the Program a copy of this License along with the Program.
+
+You may charge a fee for the physical act of transferring a copy, and
+you may at your option offer warranty protection in exchange for a fee.
+
+2. You may modify your copy or copies of the Program or any portion of
+it, thus forming a work based on the Program, and copy and distribute
+such modifications or work under the terms of Section 1 above, provided
+that you also meet all of these conditions:
+
+    a) You must cause the modified files to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    b) You must cause any work that you distribute or publish, that in
+    whole or in part contains or is derived from the Program or any part
+    thereof, to be licensed as a whole at no charge to all third parties
+    under the terms of this License.
+
+    c) If the modified program normally reads commands interactively
+    when run, you must cause it, when started running for such
+    interactive use in the most ordinary way, to print or display an
+    announcement including an appropriate copyright notice and a notice
+    that there is no warranty (or else, saying that you provide a
+    warranty) and that users may redistribute the program under these
+    conditions, and telling the user how to view a copy of this License.
+    (Exception: if the Program itself is interactive but does not
+    normally print such an announcement, your work based on the Program
+    is not required to print an announcement.)
+
+These requirements apply to the modified work as a whole. If
+identifiable sections of that work are not derived from the Program, and
+can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works. But when you
+distribute the same sections as part of a whole which is a work based on
+the Program, the distribution of the whole must be on the terms of this
+License, whose permissions for other licensees extend to the entire
+whole, and thus to each and every part regardless of who wrote it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Program.
+
+In addition, mere aggregation of another work not based on the Program
+with the Program (or with a work based on the Program) on a volume of a
+storage or distribution medium does not bring the other work under the
+scope of this License.
+
+3. You may copy and distribute the Program (or a work based on it,
+under Section 2) in object code or executable form under the terms of
+Sections 1 and 2 above provided that you also do one of the following:
+
+    a) Accompany it with the complete corresponding machine-readable
+    source code, which must be distributed under the terms of Sections 1
+    and 2 above on a medium customarily used for software interchange; or,
+
+    b) Accompany it with a written offer, valid for at least three
+    years, to give any third party, for a charge no more than your cost
+    of physically performing source distribution, a complete
+    machine-readable copy of the corresponding source code, to be
+    distributed under the terms of Sections 1 and 2 above on a medium
+    customarily used for software interchange; or,
+
+    c) Accompany it with the information you received as to the offer to
+    distribute corresponding source code. (This alternative is allowed
+    only for noncommercial distribution and only if you received the
+    program in object code or executable form with such an offer, in
+    accord with Subsection b above.)
+
+The source code for a work means the preferred form of the work for
+making modifications to it. For an executable work, complete source code
+means all the source code for all modules it contains, plus any
+associated interface definition files, plus the scripts used to control
+compilation and installation of the executable. However, as a special
+exception, the source code distributed need not include anything that is
+normally distributed (in either source or binary form) with the major
+components (compiler, kernel, and so on) of the operating system on
+which the executable runs, unless that component itself accompanies the
+executable.
+
+If distribution of executable or object code is made by offering access
+to copy from a designated place, then offering equivalent access to copy
+the source code from the same place counts as distribution of the source
+code, even though third parties are not compelled to copy the source
+along with the object code.
+
+4. You may not copy, modify, sublicense, or distribute the Program
+except as expressly provided under this License. Any attempt otherwise
+to copy, modify, sublicense or distribute the Program is void, and will
+automatically terminate your rights under this License. However, parties
+who have received copies, or rights, from you under this License will
+not have their licenses terminated so long as such parties remain in
+full compliance.
+
+5. You are not required to accept this License, since you have not
+signed it. However, nothing else grants you permission to modify or
+distribute the Program or its derivative works. These actions are
+prohibited by law if you do not accept this License. Therefore, by
+modifying or distributing the Program (or any work based on the
+Program), you indicate your acceptance of this License to do so, and all
+its terms and conditions for copying, distributing or modifying the
+Program or works based on it.
+
+6. Each time you redistribute the Program (or any work based on the
+Program), the recipient automatically receives a license from the
+original licensor to copy, distribute or modify the Program subject to
+these terms and conditions. You may not impose any further restrictions
+on the recipients' exercise of the rights granted herein. You are not
+responsible for enforcing compliance by third parties to this License.
+
+7. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License. If you cannot distribute
+so as to satisfy simultaneously your obligations under this License and
+any other pertinent obligations, then as a consequence you may not
+distribute the Program at all. For example, if a patent license would
+not permit royalty-free redistribution of the Program by all those who
+receive copies directly or indirectly through you, then the only way you
+could satisfy both it and this License would be to refrain entirely from
+distribution of the Program.
+
+If any portion of this section is held invalid or unenforceable under
+any particular circumstance, the balance of the section is intended to
+apply and the section as a whole is intended to apply in other
+circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system, which is implemented
+by public license practices. Many people have made generous
+contributions to the wide range of software distributed through that
+system in reliance on consistent application of that system; it is up to
+the author/donor to decide if he or she is willing to distribute
+software through any other system and a licensee cannot impose that choice.
+
+This section is intended to make thoroughly clear what is believed to be
+a consequence of the rest of this License.
+
+8. If the distribution and/or use of the Program is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Program under this License may
+add an explicit geographical distribution limitation excluding those
+countries, so that distribution is permitted only in or among countries
+not thus excluded. In such case, this License incorporates the
+limitation as if written in the body of this License.
+
+9. The Free Software Foundation may publish revised and/or new
+versions of the General Public License from time to time. Such new
+versions will be similar in spirit to the present version, but may
+differ in detail to address new problems or concerns.
+
+Each version is given a distinguishing version number. If the Program
+specifies a version number of this License which applies to it and "any
+later version", you have the option of following the terms and
+conditions either of that version or of any later version published by
+the Free Software Foundation. If the Program does not specify a version
+number of this License, you may choose any version ever published by the
+Free Software Foundation.
+
+10. If you wish to incorporate parts of the Program into other free
+programs whose distribution conditions are different, write to the
+author to ask for permission. For software which is copyrighted by the
+Free Software Foundation, write to the Free Software Foundation; we
+sometimes make exceptions for this. Our decision will be guided by the
+two goals of preserving the free status of all derivatives of our free
+software and of promoting the sharing and reuse of software generally.
+
+NO WARRANTY
+
+11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO
+WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.
+EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR
+OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND,
+EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE
+ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH
+YOU. SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL
+NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN
+WRITING WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY
+AND/OR REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR
+DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL
+DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE PROGRAM
+(INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING RENDERED
+INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A FAILURE OF
+THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS), EVEN IF SUCH HOLDER OR
+OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+
+END OF TERMS AND CONDITIONS
+
+How to Apply These Terms to Your New Programs
+
+If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+To do so, attach the following notices to the program. It is safest to
+attach them to the start of each source file to most effectively convey
+the exclusion of warranty; and each file should have at least the
+"copyright" line and a pointer to where the full notice is found.
+
+    One line to give the program's name and a brief idea of what it does.
+    Copyright (C) <year> <name of author>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful, but
+    WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+    General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335 USA
+
+Also add information on how to contact you by electronic and paper mail.
+
+If the program is interactive, make it output a short notice like this
+when it starts in an interactive mode:
+
+    Gnomovision version 69, Copyright (C) year name of author
+    Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type
+    `show w'. This is free software, and you are welcome to redistribute
+    it under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the
+appropriate parts of the General Public License. Of course, the commands
+you use may be called something other than `show w' and `show c'; they
+could even be mouse-clicks or menu items--whatever suits your program.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the program, if
+necessary. Here is a sample; alter the names:
+
+    Yoyodyne, Inc., hereby disclaims all copyright interest in the
+    program `Gnomovision' (which makes passes at compilers) written by
+    James Hacker.
+
+    signature of Ty Coon, 1 April 1989
+    Ty Coon, President of Vice
+
+This General Public License does not permit incorporating your program
+into proprietary programs. If your program is a subroutine library, you
+may consider it more useful to permit linking proprietary applications
+with the library. If this is what you want to do, use the GNU Library
+General Public License instead of this License.
+
+================================
+CLASSPATH EXCEPTION
+===============================
+Linking this library statically or dynamically with other modules is
+making a combined work based on this library.  Thus, the terms and
+conditions of the GNU General Public License version 2 cover the whole
+combination.
+
+As a special exception, the copyright holders of this library give you
+permission to link this library with independent modules to produce an
+executable, regardless of the license terms of these independent
+modules, and to copy and distribute the resulting executable under
+terms of your choice, provided that you also meet, for each linked
+independent module, the terms and conditions of the license of that
+module.  An independent module is a module which is not derived from or
+based on this library.  If you modify this library, you may extend this
+exception to your version of the library, but you are not obligated to
+do so.  If you do not wish to do so, delete this exception statement
+from your version.
+
+==========================
+Notice.md
+==========================
+Notices for Jakarta Mail
+
+This content is produced and maintained by the Jakarta Mail project.
+
+    Project home: https://projects.eclipse.org/projects/ee4j.mail
+
+Trademarks
+
+Jakarta Mail is a trademark of the Eclipse Foundation.
+Copyright
+
+All content is the property of the respective authors or their employers. For more information regarding authorship of content, please consult the listed source code repository logs.
+Declared Project Licenses
+
+This program and the accompanying materials are made available under the terms of the Eclipse Public License v. 2.0 which is available at http://www.eclipse.org/legal/epl-2.0. This Source Code may also be made available under the following Secondary Licenses when the conditions for such availability set forth in the Eclipse Public License v. 2.0 are satisfied: GNU General Public License, version 2 with the GNU Classpath Exception which is available at https://www.gnu.org/software/classpath/license.html.
+
+SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+Source Code
+
+The project maintains the following source code repositories:
+
+    https://github.com/eclipse-ee4j/mail
+
+Third-party Content
+
+This project leverages the following third party content.
+
+None
+Cryptography
+
+Content may contain encryption software. The country in which you are currently may have restrictions on the import, possession, and use, and/or re-export to another country, of encryption software. BEFORE using any encryption software, please check the country's laws, regulations and policies concerning the import, possession, or use, and re-export of encryption software, to see if this is permitted.
+
+=================================
+Fourth Party Dependencies
+=================================
+jakarta.mail-api            
+jakarta.activation-api  
+angus-activation          
+
+
+================
+jakarta.mail-api
+================
+Eclipse Public License - v 2.0
+    THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS ECLIPSE
+    PUBLIC LICENSE ("AGREEMENT"). ANY USE, REPRODUCTION OR DISTRIBUTION
+    OF THE PROGRAM CONSTITUTES RECIPIENT'S ACCEPTANCE OF THIS AGREEMENT.
+
+1. DEFINITIONS
+
+"Contribution" means:
+
+  a) in the case of the initial Contributor, the initial content
+     Distributed under this Agreement, and
+
+  b) in the case of each subsequent Contributor: 
+     i) changes to the Program, and 
+     ii) additions to the Program;
+  where such changes and/or additions to the Program originate from
+  and are Distributed by that particular Contributor. A Contribution
+  "originates" from a Contributor if it was added to the Program by
+  such Contributor itself or anyone acting on such Contributor's behalf.
+  Contributions do not include changes or additions to the Program that
+  are not Modified Works.
+
+"Contributor" means any person or entity that Distributes the Program.
+
+"Licensed Patents" mean patent claims licensable by a Contributor which
+are necessarily infringed by the use or sale of its Contribution alone
+or when combined with the Program.
+
+"Program" means the Contributions Distributed in accordance with this
+Agreement.
+
+"Recipient" means anyone who receives the Program under this Agreement
+or any Secondary License (as applicable), including Contributors.
+
+"Derivative Works" shall mean any work, whether in Source Code or other
+form, that is based on (or derived from) the Program and for which the
+editorial revisions, annotations, elaborations, or other modifications
+represent, as a whole, an original work of authorship.
+
+"Modified Works" shall mean any work in Source Code or other form that
+results from an addition to, deletion from, or modification of the
+contents of the Program, including, for purposes of clarity any new file
+in Source Code form that contains any contents of the Program. Modified
+Works shall not include works that contain only declarations,
+interfaces, types, classes, structures, or files of the Program solely
+in each case in order to link to, bind by name, or subclass the Program
+or Modified Works thereof.
+
+"Distribute" means the acts of a) distributing or b) making available
+in any manner that enables the transfer of a copy.
+
+"Source Code" means the form of a Program preferred for making
+modifications, including but not limited to software source code,
+documentation source, and configuration files.
+
+"Secondary License" means either the GNU General Public License,
+Version 2.0, or any later versions of that license, including any
+exceptions or additional permissions as identified by the initial
+Contributor.
+
+2. GRANT OF RIGHTS
+
+  a) Subject to the terms of this Agreement, each Contributor hereby
+  grants Recipient a non-exclusive, worldwide, royalty-free copyright
+  license to reproduce, prepare Derivative Works of, publicly display,
+  publicly perform, Distribute and sublicense the Contribution of such
+  Contributor, if any, and such Derivative Works.
+
+  b) Subject to the terms of this Agreement, each Contributor hereby
+  grants Recipient a non-exclusive, worldwide, royalty-free patent
+  license under Licensed Patents to make, use, sell, offer to sell,
+  import and otherwise transfer the Contribution of such Contributor,
+  if any, in Source Code or other form. This patent license shall
+  apply to the combination of the Contribution and the Program if, at
+  the time the Contribution is added by the Contributor, such addition
+  of the Contribution causes such combination to be covered by the
+  Licensed Patents. The patent license shall not apply to any other
+  combinations which include the Contribution. No hardware per se is
+  licensed hereunder.
+
+  c) Recipient understands that although each Contributor grants the
+  licenses to its Contributions set forth herein, no assurances are
+  provided by any Contributor that the Program does not infringe the
+  patent or other intellectual property rights of any other entity.
+  Each Contributor disclaims any liability to Recipient for claims
+  brought by any other entity based on infringement of intellectual
+  property rights or otherwise. As a condition to exercising the
+  rights and licenses granted hereunder, each Recipient hereby
+  assumes sole responsibility to secure any other intellectual
+  property rights needed, if any. For example, if a third party
+  patent license is required to allow Recipient to Distribute the
+  Program, it is Recipient's responsibility to acquire that license
+  before distributing the Program.
+
+  d) Each Contributor represents that to its knowledge it has
+  sufficient copyright rights in its Contribution, if any, to grant
+  the copyright license set forth in this Agreement.
+
+  e) Notwithstanding the terms of any Secondary License, no
+  Contributor makes additional grants to any Recipient (other than
+  those set forth in this Agreement) as a result of such Recipient's
+  receipt of the Program under the terms of a Secondary License
+  (if permitted under the terms of Section 3).
+
+3. REQUIREMENTS
+
+3.1 If a Contributor Distributes the Program in any form, then:
+
+  a) the Program must also be made available as Source Code, in
+  accordance with section 3.2, and the Contributor must accompany
+  the Program with a statement that the Source Code for the Program
+  is available under this Agreement, and informs Recipients how to
+  obtain it in a reasonable manner on or through a medium customarily
+  used for software exchange; and
+
+  b) the Contributor may Distribute the Program under a license
+  different than this Agreement, provided that such license:
+     i) effectively disclaims on behalf of all other Contributors all
+     warranties and conditions, express and implied, including
+     warranties or conditions of title and non-infringement, and
+     implied warranties or conditions of merchantability and fitness
+     for a particular purpose;
+
+     ii) effectively excludes on behalf of all other Contributors all
+     liability for damages, including direct, indirect, special,
+     incidental and consequential damages, such as lost profits;
+
+     iii) does not attempt to limit or alter the recipients' rights
+     in the Source Code under section 3.2; and
+
+     iv) requires any subsequent distribution of the Program by any
+     party to be under a license that satisfies the requirements
+     of this section 3.
+
+3.2 When the Program is Distributed as Source Code:
+
+  a) it must be made available under this Agreement, or if the
+  Program (i) is combined with other material in a separate file or
+  files made available under a Secondary License, and (ii) the initial
+  Contributor attached to the Source Code the notice described in
+  Exhibit A of this Agreement, then the Program may be made available
+  under the terms of such Secondary Licenses, and
+
+  b) a copy of this Agreement must be included with each copy of
+  the Program.
+
+3.3 Contributors may not remove or alter any copyright, patent,
+trademark, attribution notices, disclaimers of warranty, or limitations
+of liability ("notices") contained within the Program from any copy of
+the Program which they Distribute, provided that Contributors may add
+their own appropriate notices.
+
+4. COMMERCIAL DISTRIBUTION
+
+Commercial distributors of software may accept certain responsibilities
+with respect to end users, business partners and the like. While this
+license is intended to facilitate the commercial use of the Program,
+the Contributor who includes the Program in a commercial product
+offering should do so in a manner which does not create potential
+liability for other Contributors. Therefore, if a Contributor includes
+the Program in a commercial product offering, such Contributor
+("Commercial Contributor") hereby agrees to defend and indemnify every
+other Contributor ("Indemnified Contributor") against any losses,
+damages and costs (collectively "Losses") arising from claims, lawsuits
+and other legal actions brought by a third party against the Indemnified
+Contributor to the extent caused by the acts or omissions of such
+Commercial Contributor in connection with its distribution of the Program
+in a commercial product offering. The obligations in this section do not
+apply to any claims or Losses relating to any actual or alleged
+intellectual property infringement. In order to qualify, an Indemnified
+Contributor must: a) promptly notify the Commercial Contributor in
+writing of such claim, and b) allow the Commercial Contributor to control,
+and cooperate with the Commercial Contributor in, the defense and any
+related settlement negotiations. The Indemnified Contributor may
+participate in any such claim at its own expense.
+
+For example, a Contributor might include the Program in a commercial
+product offering, Product X. That Contributor is then a Commercial
+Contributor. If that Commercial Contributor then makes performance
+claims, or offers warranties related to Product X, those performance
+claims and warranties are such Commercial Contributor's responsibility
+alone. Under this section, the Commercial Contributor would have to
+defend claims against the other Contributors related to those performance
+claims and warranties, and if a court requires any other Contributor to
+pay any damages as a result, the Commercial Contributor must pay
+those damages.
+
+5. NO WARRANTY
+
+EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, AND TO THE EXTENT
+PERMITTED BY APPLICABLE LAW, THE PROGRAM IS PROVIDED ON AN "AS IS"
+BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS OF
+TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A PARTICULAR
+PURPOSE. Each Recipient is solely responsible for determining the
+appropriateness of using and distributing the Program and assumes all
+risks associated with its exercise of rights under this Agreement,
+including but not limited to the risks and costs of program errors,
+compliance with applicable laws, damage to or loss of data, programs
+or equipment, and unavailability or interruption of operations.
+
+6. DISCLAIMER OF LIABILITY
+
+EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, AND TO THE EXTENT
+PERMITTED BY APPLICABLE LAW, NEITHER RECIPIENT NOR ANY CONTRIBUTORS
+SHALL HAVE ANY LIABILITY FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING WITHOUT LIMITATION LOST
+PROFITS), HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OR DISTRIBUTION OF THE PROGRAM OR THE
+EXERCISE OF ANY RIGHTS GRANTED HEREUNDER, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
+
+7. GENERAL
+
+If any provision of this Agreement is invalid or unenforceable under
+applicable law, it shall not affect the validity or enforceability of
+the remainder of the terms of this Agreement, and without further
+action by the parties hereto, such provision shall be reformed to the
+minimum extent necessary to make such provision valid and enforceable.
+
+If Recipient institutes patent litigation against any entity
+(including a cross-claim or counterclaim in a lawsuit) alleging that the
+Program itself (excluding combinations of the Program with other software
+or hardware) infringes such Recipient's patent(s), then such Recipient's
+rights granted under Section 2(b) shall terminate as of the date such
+litigation is filed.
+
+All Recipient's rights under this Agreement shall terminate if it
+fails to comply with any of the material terms or conditions of this
+Agreement and does not cure such failure in a reasonable period of
+time after becoming aware of such noncompliance. If all Recipient's
+rights under this Agreement terminate, Recipient agrees to cease use
+and distribution of the Program as soon as reasonably practicable.
+However, Recipient's obligations under this Agreement and any licenses
+granted by Recipient relating to the Program shall continue and survive.
+
+Everyone is permitted to copy and distribute copies of this Agreement,
+but in order to avoid inconsistency the Agreement is copyrighted and
+may only be modified in the following manner. The Agreement Steward
+reserves the right to publish new versions (including revisions) of
+this Agreement from time to time. No one other than the Agreement
+Steward has the right to modify this Agreement. The Eclipse Foundation
+is the initial Agreement Steward. The Eclipse Foundation may assign the
+responsibility to serve as the Agreement Steward to a suitable separate
+entity. Each new version of the Agreement will be given a distinguishing
+version number. The Program (including Contributions) may always be
+Distributed subject to the version of the Agreement under which it was
+received. In addition, after a new version of the Agreement is published,
+Contributor may elect to Distribute the Program (including its
+Contributions) under the new version.
+
+Except as expressly stated in Sections 2(a) and 2(b) above, Recipient
+receives no rights or licenses to the intellectual property of any
+Contributor under this Agreement, whether expressly, by implication,
+estoppel or otherwise. All rights in the Program not expressly granted
+under this Agreement are reserved. Nothing in this Agreement is intended
+to be enforceable by any entity that is not a Contributor or Recipient.
+No third-party beneficiary rights are created under this Agreement.
+
+Exhibit A - Form of Secondary Licenses Notice
+
+"This Source Code may also be made available under the following 
+Secondary Licenses when the conditions for such availability set forth 
+in the Eclipse Public License, v. 2.0 are satisfied: {name license(s),
+version(s), and exceptions or additional permissions here}."
+
+  Simply including a copy of this Agreement, including this Exhibit A
+  is not sufficient to license the Source Code under Secondary Licenses.
+
+  If it is not possible or desirable to put the notice in a particular
+  file, then You may include the notice in a location (such as a LICENSE
+  file in a relevant directory) where a recipient would be likely to
+  look for such a notice.
+
+  You may add additional accurate notices of copyright ownership.
+_______________________________________________________ 
+The GNU General Public License (GPL) Version 2, June 1991
+______________________________________________________
+Copyright (C) 1989, 1991 Free Software Foundation, Inc.
+51 Franklin Street, Fifth Floor
+Boston, MA 02110-1335
+USA
+
+Everyone is permitted to copy and distribute verbatim copies
+of this license document, but changing it is not allowed.
+
+Preamble
+
+The licenses for most software are designed to take away your freedom to
+share and change it. By contrast, the GNU General Public License is
+intended to guarantee your freedom to share and change free software--to
+make sure the software is free for all its users. This General Public
+License applies to most of the Free Software Foundation's software and
+to any other program whose authors commit to using it. (Some other Free
+Software Foundation software is covered by the GNU Library General
+Public License instead.) You can apply it to your programs, too.
+
+When we speak of free software, we are referring to freedom, not price.
+Our General Public Licenses are designed to make sure that you have the
+freedom to distribute copies of free software (and charge for this
+service if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs; and that you know you can do these things.
+
+To protect your rights, we need to make restrictions that forbid anyone
+to deny you these rights or to ask you to surrender the rights. These
+restrictions translate to certain responsibilities for you if you
+distribute copies of the software, or if you modify it.
+
+For example, if you distribute copies of such a program, whether gratis
+or for a fee, you must give the recipients all the rights that you have.
+You must make sure that they, too, receive or can get the source code.
+And you must show them these terms so they know their rights.
+
+We protect your rights with two steps: (1) copyright the software, and
+(2) offer you this license which gives you legal permission to copy,
+distribute and/or modify the software.
+
+Also, for each author's protection and ours, we want to make certain
+that everyone understands that there is no warranty for this free
+software. If the software is modified by someone else and passed on, we
+want its recipients to know that what they have is not the original, so
+that any problems introduced by others will not reflect on the original
+authors' reputations.
+
+Finally, any free program is threatened constantly by software patents.
+We wish to avoid the danger that redistributors of a free program will
+individually obtain patent licenses, in effect making the program
+proprietary. To prevent this, we have made it clear that any patent must
+be licensed for everyone's free use or not licensed at all.
+
+The precise terms and conditions for copying, distribution and
+modification follow.
+
+TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+0. This License applies to any program or other work which contains a
+notice placed by the copyright holder saying it may be distributed under
+the terms of this General Public License. The "Program", below, refers
+to any such program or work, and a "work based on the Program" means
+either the Program or any derivative work under copyright law: that is
+to say, a work containing the Program or a portion of it, either
+verbatim or with modifications and/or translated into another language.
+(Hereinafter, translation is included without limitation in the term
+"modification".) Each licensee is addressed as "you".
+
+Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope. The act of running
+the Program is not restricted, and the output from the Program is
+covered only if its contents constitute a work based on the Program
+(independent of having been made by running the Program). Whether that
+is true depends on what the Program does.
+
+1. You may copy and distribute verbatim copies of the Program's source
+code as you receive it, in any medium, provided that you conspicuously
+and appropriately publish on each copy an appropriate copyright notice
+and disclaimer of warranty; keep intact all the notices that refer to
+this License and to the absence of any warranty; and give any other
+recipients of the Program a copy of this License along with the Program.
+
+You may charge a fee for the physical act of transferring a copy, and
+you may at your option offer warranty protection in exchange for a fee.
+
+2. You may modify your copy or copies of the Program or any portion of
+it, thus forming a work based on the Program, and copy and distribute
+such modifications or work under the terms of Section 1 above, provided
+that you also meet all of these conditions:
+
+    a) You must cause the modified files to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    b) You must cause any work that you distribute or publish, that in
+    whole or in part contains or is derived from the Program or any part
+    thereof, to be licensed as a whole at no charge to all third parties
+    under the terms of this License.
+
+    c) If the modified program normally reads commands interactively
+    when run, you must cause it, when started running for such
+    interactive use in the most ordinary way, to print or display an
+    announcement including an appropriate copyright notice and a notice
+    that there is no warranty (or else, saying that you provide a
+    warranty) and that users may redistribute the program under these
+    conditions, and telling the user how to view a copy of this License.
+    (Exception: if the Program itself is interactive but does not
+    normally print such an announcement, your work based on the Program
+    is not required to print an announcement.)
+
+These requirements apply to the modified work as a whole. If
+identifiable sections of that work are not derived from the Program, and
+can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works. But when you
+distribute the same sections as part of a whole which is a work based on
+the Program, the distribution of the whole must be on the terms of this
+License, whose permissions for other licensees extend to the entire
+whole, and thus to each and every part regardless of who wrote it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Program.
+
+In addition, mere aggregation of another work not based on the Program
+with the Program (or with a work based on the Program) on a volume of a
+storage or distribution medium does not bring the other work under the
+scope of this License.
+
+3. You may copy and distribute the Program (or a work based on it,
+under Section 2) in object code or executable form under the terms of
+Sections 1 and 2 above provided that you also do one of the following:
+
+    a) Accompany it with the complete corresponding machine-readable
+    source code, which must be distributed under the terms of Sections 1
+    and 2 above on a medium customarily used for software interchange; or,
+
+    b) Accompany it with a written offer, valid for at least three
+    years, to give any third party, for a charge no more than your cost
+    of physically performing source distribution, a complete
+    machine-readable copy of the corresponding source code, to be
+    distributed under the terms of Sections 1 and 2 above on a medium
+    customarily used for software interchange; or,
+
+    c) Accompany it with the information you received as to the offer to
+    distribute corresponding source code. (This alternative is allowed
+    only for noncommercial distribution and only if you received the
+    program in object code or executable form with such an offer, in
+    accord with Subsection b above.)
+
+The source code for a work means the preferred form of the work for
+making modifications to it. For an executable work, complete source code
+means all the source code for all modules it contains, plus any
+associated interface definition files, plus the scripts used to control
+compilation and installation of the executable. However, as a special
+exception, the source code distributed need not include anything that is
+normally distributed (in either source or binary form) with the major
+components (compiler, kernel, and so on) of the operating system on
+which the executable runs, unless that component itself accompanies the
+executable.
+
+If distribution of executable or object code is made by offering access
+to copy from a designated place, then offering equivalent access to copy
+the source code from the same place counts as distribution of the source
+code, even though third parties are not compelled to copy the source
+along with the object code.
+
+4. You may not copy, modify, sublicense, or distribute the Program
+except as expressly provided under this License. Any attempt otherwise
+to copy, modify, sublicense or distribute the Program is void, and will
+automatically terminate your rights under this License. However, parties
+who have received copies, or rights, from you under this License will
+not have their licenses terminated so long as such parties remain in
+full compliance.
+
+5. You are not required to accept this License, since you have not
+signed it. However, nothing else grants you permission to modify or
+distribute the Program or its derivative works. These actions are
+prohibited by law if you do not accept this License. Therefore, by
+modifying or distributing the Program (or any work based on the
+Program), you indicate your acceptance of this License to do so, and all
+its terms and conditions for copying, distributing or modifying the
+Program or works based on it.
+
+6. Each time you redistribute the Program (or any work based on the
+Program), the recipient automatically receives a license from the
+original licensor to copy, distribute or modify the Program subject to
+these terms and conditions. You may not impose any further restrictions
+on the recipients' exercise of the rights granted herein. You are not
+responsible for enforcing compliance by third parties to this License.
+
+7. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License. If you cannot distribute
+so as to satisfy simultaneously your obligations under this License and
+any other pertinent obligations, then as a consequence you may not
+distribute the Program at all. For example, if a patent license would
+not permit royalty-free redistribution of the Program by all those who
+receive copies directly or indirectly through you, then the only way you
+could satisfy both it and this License would be to refrain entirely from
+distribution of the Program.
+
+If any portion of this section is held invalid or unenforceable under
+any particular circumstance, the balance of the section is intended to
+apply and the section as a whole is intended to apply in other
+circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system, which is implemented
+by public license practices. Many people have made generous
+contributions to the wide range of software distributed through that
+system in reliance on consistent application of that system; it is up to
+the author/donor to decide if he or she is willing to distribute
+software through any other system and a licensee cannot impose that choice.
+
+This section is intended to make thoroughly clear what is believed to be
+a consequence of the rest of this License.
+
+8. If the distribution and/or use of the Program is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Program under this License may
+add an explicit geographical distribution limitation excluding those
+countries, so that distribution is permitted only in or among countries
+not thus excluded. In such case, this License incorporates the
+limitation as if written in the body of this License.
+
+9. The Free Software Foundation may publish revised and/or new
+versions of the General Public License from time to time. Such new
+versions will be similar in spirit to the present version, but may
+differ in detail to address new problems or concerns.
+
+Each version is given a distinguishing version number. If the Program
+specifies a version number of this License which applies to it and "any
+later version", you have the option of following the terms and
+conditions either of that version or of any later version published by
+the Free Software Foundation. If the Program does not specify a version
+number of this License, you may choose any version ever published by the
+Free Software Foundation.
+
+10. If you wish to incorporate parts of the Program into other free
+programs whose distribution conditions are different, write to the
+author to ask for permission. For software which is copyrighted by the
+Free Software Foundation, write to the Free Software Foundation; we
+sometimes make exceptions for this. Our decision will be guided by the
+two goals of preserving the free status of all derivatives of our free
+software and of promoting the sharing and reuse of software generally.
+
+NO WARRANTY
+
+11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO
+WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.
+EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR
+OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND,
+EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE
+ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH
+YOU. SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL
+NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN
+WRITING WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY
+AND/OR REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR
+DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL
+DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE PROGRAM
+(INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING RENDERED
+INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A FAILURE OF
+THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS), EVEN IF SUCH HOLDER OR
+OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+
+END OF TERMS AND CONDITIONS
+
+How to Apply These Terms to Your New Programs
+
+If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+To do so, attach the following notices to the program. It is safest to
+attach them to the start of each source file to most effectively convey
+the exclusion of warranty; and each file should have at least the
+"copyright" line and a pointer to where the full notice is found.
+
+    One line to give the program's name and a brief idea of what it does.
+    Copyright (C) <year> <name of author>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful, but
+    WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+    General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335 USA
+
+Also add information on how to contact you by electronic and paper mail.
+
+If the program is interactive, make it output a short notice like this
+when it starts in an interactive mode:
+
+    Gnomovision version 69, Copyright (C) year name of author
+    Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type
+    `show w'. This is free software, and you are welcome to redistribute
+    it under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the
+appropriate parts of the General Public License. Of course, the commands
+you use may be called something other than `show w' and `show c'; they
+could even be mouse-clicks or menu items--whatever suits your program.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the program, if
+necessary. Here is a sample; alter the names:
+
+    Yoyodyne, Inc., hereby disclaims all copyright interest in the
+    program `Gnomovision' (which makes passes at compilers) written by
+    James Hacker.
+
+    signature of Ty Coon, 1 April 1989
+    Ty Coon, President of Vice
+
+This General Public License does not permit incorporating your program
+into proprietary programs. If your program is a subroutine library, you
+may consider it more useful to permit linking proprietary applications
+with the library. If this is what you want to do, use the GNU Library
+General Public License instead of this License.
+
+__________________________________________
+CLASSPATH EXCEPTION
+__________________________________________
+Linking this library statically or dynamically with other modules is
+making a combined work based on this library.  Thus, the terms and
+conditions of the GNU General Public License version 2 cover the whole
+combination.
+
+As a special exception, the copyright holders of this library give you
+permission to link this library with independent modules to produce an
+executable, regardless of the license terms of these independent
+modules, and to copy and distribute the resulting executable under
+terms of your choice, provided that you also meet, for each linked
+independent module, the terms and conditions of the license of that
+module.  An independent module is a module which is not derived from or
+based on this library.  If you modify this library, you may extend this
+exception to your version of the library, but you are not obligated to
+do so.  If you do not wish to do so, delete this exception statement
+from your version.
+
+__________________________
+Notice.md
+__________________________
+Notices for Jakarta Mail
+
+This content is produced and maintained by the Jakarta Mail project.
+
+    Project home: https://projects.eclipse.org/projects/ee4j.mail
+
+Trademarks
+
+Jakarta Mail is a trademark of the Eclipse Foundation.
+Copyright
+
+All content is the property of the respective authors or their employers. For more information regarding authorship of content, please consult the listed source code repository logs.
+Declared Project Licenses
+
+This program and the accompanying materials are made available under the terms of the Eclipse Public License v. 2.0 which is available at https://www.eclipse.org/legal/epl-2.0. This Source Code may also be made available under the following Secondary Licenses when the conditions for such availability set forth in the Eclipse Public License v. 2.0 are satisfied: (secondary) GPL-2.0 with Classpath-exception-2.0 which is available at https://openjdk.java.net/legal/gplv2+ce.html.
+
+SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0
+Source Code
+
+The project maintains the following source code repositories:
+
+    https://github.com/jakartaee/mail-api
+    https://github.com/jakartaee/mail-tck
+    https://github.com/jakartaee/mail-spec
+
+Third-party Content
+
+This project leverages the following third party content.
+
+Apache Ant (1.9.6)
+
+    License: Apache License, 2.0, W3C License, Public Domain
+
+commons-lang3 (3.5)
+
+    License: Apache-2.0
+
+font-awesome (4.7.0)
+
+    License: OFL-1.1 AND MIT
+
+jsoup (1.10.2)
+
+    License: MIT
+
+JTHarness (5.0)
+
+    License: GPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+normalize.css (3.0.2)
+
+    License: MIT
+
+SigTest (4.0)
+
+    License: (GPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0)
+    Project: https://wiki.openjdk.java.net/display/CodeTools/sigtest
+    Source: http://hg.openjdk.java.net/code-tools/sigtest/file/c57f97e2ac2f
+
+Cryptography
+
+Content may contain encryption software. The country in which you are currently may have restrictions on the import, possession, and use, and/or re-export to another country, of encryption software. BEFORE using any encryption software, please check the country's laws, regulations and policies concerning the import, possession, or use, and re-export of encryption software, to see if this is permitted.
+
+======================
+jakarta.activation-api 
+======================
+BSD 3-Clause "New" or "Revised" License
+Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+  - Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+
+  - Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+
+  - Neither the name of the Eclipse Foundation, Inc. nor the names of its
+    contributors may be used to endorse or promote products derived
+    from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+_______________________________
+Notice.md
+______________________________
+Notices for Jakarta Activation
+
+This content is produced and maintained by the Jakarta Activation project.
+
+    Project home: https://projects.eclipse.org/projects/ee4j.jaf
+
+Trademarks
+
+Jakarta Activation is a trademark of the Eclipse Foundation.
+Copyright
+
+All content is the property of the respective authors or their employers. For more information regarding authorship of content, please consult the listed source code repository logs.
+Declared Project Licenses
+
+This program and the accompanying materials are made available under the terms of the Eclipse Public License v. 2.0 which is available at https://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License v1.0 which is available at https://www.eclipse.org/org/documents/edl-v10.php. This Source Code may also be made available under the following Secondary Licenses when the conditions for such availability set forth in the Eclipse Public License v. 2.0 are satisfied: (secondary) GPL-2.0 with Classpath-exception-2.0 which is available at https://openjdk.java.net/legal/gplv2+ce.html.
+
+SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause OR GPL-2.0-only with Classpath-exception-2.0
+Source Code
+
+The project maintains the following source code repositories:
+
+    https://github.com/jakartaee/jaf-api
+    https://github.com/jakartaee/jaf-tck
+
+Third-party Content
+
+This project leverages the following third party content.
+
+Apache Ant (1.9.6)
+
+    License: Apache License, 2.0, W3C License, Public Domain
+
+Apache Ant (1.9.6)
+
+    License: Apache License, 2.0, W3C License, Public Domain
+
+Apache commons-lang (3.5)
+
+    License: Apache-2.0
+
+font-awesome (4.7.0)
+
+    License: OFL-1.1 AND MIT
+
+jsoup (1.10.2)
+
+    License: MIT
+
+JTHarness (5.0)
+
+    License: (GPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0)
+    Project: https://wiki.openjdk.java.net/display/CodeTools/JT+Harness
+    Source: http://hg.openjdk.java.net/code-tools/jtharness/
+
+JUnit (4.12)
+
+    License: Eclipse Public License
+
+normalize.css (3.0.2)
+
+    License: MIT
+    Project: http://necolas.github.io/normalize.css/
+    Source: http://necolas.github.io/normalize.css/
+
+SigTest (4.0)
+
+    License: GPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+    Project: https://wiki.openjdk.java.net/display/CodeTools/sigtest
+    Source: http://hg.openjdk.java.net/code-tools/sigtest/file/c57f97e2ac2f
+
+Cryptography
+
+Content may contain encryption software. The country in which you are currently may have restrictions on the import, possession, and use, and/or re-export to another country, of encryption software. BEFORE using any encryption software, please check the country's laws, regulations and policies concerning the import, possession, or use, and re-export of encryption software, to see if this is permitted.
+
+==========================
+angus-activation 
+==========================
+BSD 3-Clause "New" or "Revised" License
+Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+  - Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+
+  - Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+
+  - Neither the name of the Eclipse Foundation, Inc. nor the names of its
+    contributors may be used to endorse or promote products derived
+    from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+_____________________________
+Notice.md
+_____________________________
+Notices for Eclipse Angus
+
+This content is produced and maintained by the Eclipse Angus project.
+
+    Project home: https://projects.eclipse.org/projects/ee4j.angus
+
+Trademarks
+
+Eclipse Angus is a trademark of the Eclipse Foundation.
+Copyright
+
+All content is the property of the respective authors or their employers. For more information regarding authorship of content, please consult the listed source code repository logs.
+Declared Project Licenses
+
+This program and the accompanying materials are made available under the terms of the Eclipse Distribution License v1.0 which is available at https://www.eclipse.org/org/documents/edl-v10.php.
+
+SPDX-License-Identifier: BSD-3-Clause
+Source Code
+
+The project maintains the following source code repositories:
+
+    https://github.com/eclipse-ee4j/angus-activation
+    https://github.com/eclipse-ee4j/angus-mail
+
+Third-party Content
+
+This project leverages the following third party content.
+
+None
+Cryptography
+
+Content may contain encryption software. The country in which you are currently may have restrictions on the import, possession, and use, and/or re-export to another country, of encryption software. BEFORE using any encryption software, please check the country's laws, regulations and policies concerning the import, possession, or use, and re-export of encryption software, to see if this is permitted.

--- a/releng/platform-definitions/platform-definition-2021-12/platform-definition-2021-12.target
+++ b/releng/platform-definitions/platform-definition-2021-12/platform-definition-2021-12.target
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
-   Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
-   Copyright (c) 2022, Datadog, Inc. All rights reserved.
+   Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
+   Copyright (c) 2022, 2023, Datadog, Inc. All rights reserved.
 
    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
@@ -36,8 +36,8 @@
 <target name="jmc-target-2021-12" sequenceNumber="47">
     <locations>
         <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-            <unit id="com.sun.mail.jakarta.mail" version="2.0.1"/>
-            <unit id="com.sun.activation.jakarta.activation" version="2.0.1"/>
+            <unit id="org.eclipse.angus.jakarta.mail" version="2.0.1"/>
+            <unit id="angus-activation" version="2.0.0"/>
             <unit id="org.owasp.encoder" version="1.2.3"/>
             <unit id="lz4-java" version="1.8.0"/>
             <unit id="org.hdrhistogram.HdrHistogram" version="2.1.12"/>

--- a/releng/platform-definitions/platform-definition-2022-03/platform-definition-2022-03.target
+++ b/releng/platform-definitions/platform-definition-2022-03/platform-definition-2022-03.target
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
-   Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
-   Copyright (c) 2022, Datadog, Inc. All rights reserved.
+   Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
+   Copyright (c) 2022, 2023, Datadog, Inc. All rights reserved.
 
    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
@@ -36,8 +36,8 @@
 <target name="jmc-target-2022-03" sequenceNumber="47">
     <locations>
         <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-            <unit id="com.sun.mail.jakarta.mail" version="2.0.1"/>
-            <unit id="com.sun.activation.jakarta.activation" version="2.0.1"/>
+            <unit id="org.eclipse.angus.jakarta.mail" version="2.0.1"/>
+            <unit id="angus-activation" version="2.0.0"/>
             <unit id="org.owasp.encoder" version="1.2.3"/>
             <unit id="lz4-java" version="1.8.0"/>
             <unit id="org.hdrhistogram.HdrHistogram" version="2.1.12"/>

--- a/releng/platform-definitions/platform-definition-2022-06/platform-definition-2022-06.target
+++ b/releng/platform-definitions/platform-definition-2022-06/platform-definition-2022-06.target
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
-   Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
-   Copyright (c) 2022, Datadog, Inc. All rights reserved.
+   Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
+   Copyright (c) 2022, 2023, Datadog, Inc. All rights reserved.
 
    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
@@ -36,8 +36,8 @@
 <target name="jmc-target-2022-06" sequenceNumber="47">
     <locations>
         <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-            <unit id="com.sun.mail.jakarta.mail" version="2.0.1"/>
-            <unit id="com.sun.activation.jakarta.activation" version="2.0.1"/>
+            <unit id="org.eclipse.angus.jakarta.mail" version="2.0.1"/>
+            <unit id="angus-activation" version="2.0.0"/>
             <unit id="org.owasp.encoder" version="1.2.3"/>
             <unit id="lz4-java" version="1.8.0"/>
             <unit id="org.hdrhistogram.HdrHistogram" version="2.1.12"/>

--- a/releng/platform-definitions/platform-definition-2022-09/platform-definition-2022-09.target
+++ b/releng/platform-definitions/platform-definition-2022-09/platform-definition-2022-09.target
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
-   Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
-   Copyright (c) 2022, Datadog, Inc. All rights reserved.
+   Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
+   Copyright (c) 2022, 2023, Datadog, Inc. All rights reserved.
 
    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
@@ -36,8 +36,8 @@
 <target name="jmc-target-2022-09" sequenceNumber="47">
     <locations>
         <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-            <unit id="com.sun.mail.jakarta.mail" version="2.0.1"/>
-            <unit id="com.sun.activation.jakarta.activation" version="2.0.1"/>
+            <unit id="org.eclipse.angus.jakarta.mail" version="2.0.1"/>
+            <unit id="angus-activation" version="2.0.0"/>
             <unit id="org.owasp.encoder" version="1.2.3"/>
             <unit id="lz4-java" version="1.8.0"/>
             <unit id="org.hdrhistogram.HdrHistogram" version="2.1.12"/>

--- a/releng/platform-definitions/platform-definition-2022-12/platform-definition-2022-12.target
+++ b/releng/platform-definitions/platform-definition-2022-12/platform-definition-2022-12.target
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
-   Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
-   Copyright (c) 2022, Datadog, Inc. All rights reserved.
+   Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
+   Copyright (c) 2022, 2023, Datadog, Inc. All rights reserved.
 
    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
@@ -36,8 +36,8 @@
 <target name="jmc-target-2022-12" sequenceNumber="47">
     <locations>
         <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-            <unit id="com.sun.mail.jakarta.mail" version="2.0.1"/>
-            <unit id="com.sun.activation.jakarta.activation" version="2.0.1"/>
+            <unit id="org.eclipse.angus.jakarta.mail" version="2.0.1"/>
+            <unit id="angus-activation" version="2.0.0"/>
             <unit id="org.owasp.encoder" version="1.2.3"/>
             <unit id="lz4-java" version="1.8.0"/>
             <unit id="org.hdrhistogram.HdrHistogram" version="2.1.12"/>

--- a/releng/third-party/pom.xml
+++ b/releng/third-party/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-   Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+   Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
 
    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
@@ -43,8 +43,10 @@
 		<spotless.config.path>${basedir}/../../configuration/ide/eclipse/formatting/formatting.xml</spotless.config.path>
 		<!-- Versions -->
 		<hdrhistogram.version>2.1.12</hdrhistogram.version>
-		<jakarta.activation.version>2.0.1</jakarta.activation.version>
 		<jakarta.mail.version>2.0.1</jakarta.mail.version>
+		<angus.activation.version>2.0.0</angus.activation.version>
+		<jakarta.activation.version>2.1.1</jakarta.activation.version>
+		<osgi-resource-locator.version>1.0.3</osgi-resource-locator.version>
 		<javax.websocket.version>1.1</javax.websocket.version>
 		<jetty.version>10.0.12</jetty.version>
 		<jemmy.version>2.0.0</jemmy.version>
@@ -72,15 +74,16 @@
 								<!-- specify third party non-OSGi dependencies here -->
 								<!-- groupId:artifactId:version -->
 								<artifact>
-									<id>com.sun.mail:jakarta.mail:${jakarta.mail.version}</id>
-									<override>true</override>
-									<instructions>
-										<Import-Package>*;resolution:=optional</Import-Package>
-										<Export-Package>*</Export-Package>
-									</instructions>
+									<id>org.eclipse.angus:jakarta.mail:${jakarta.mail.version}</id>
+								</artifact>	
+								<artifact>
+									<id>org.eclipse.angus:angus-activation:${angus.activation.version}</id>
+								</artifact>	
+								<artifact>
+									<id>jakarta.activation:jakarta.activation-api:${jakarta.activation.version}</id>
 								</artifact>
 								<artifact>
-									<id>com.sun.activation:jakarta.activation:${jakarta.activation.version}</id>
+									<id>org.glassfish.hk2:osgi-resource-locator:${osgi-resource-locator.version}</id>
 								</artifact>
 								<artifact>
 									<id>org.owasp.encoder:encoder:${owasp.encoder.version}</id>


### PR DESCRIPTION
Upgrading Jakarta Mail in JMC as **Jakarta Mail implementation moved to Eclipse Angus**
[https://eclipse-ee4j.github.io/angus-mail/](https://eclipse-ee4j.github.io/angus-mail/)

**com.sun.mail.jakarta.mail** has been replaced by **org.eclipse.angus.jakarta.mail**. Future development will happen in Eclipse Angus. 

Dependencies of org.eclipse.angus.jakarta.mail 2.0.1 
- angus-activation 2.0.0
- jakarta.activation-api 2.1.1
- osgi-resource-locator 1.0.3

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JMC-8036](https://bugs.openjdk.org/browse/JMC-8036): Upgrading Jakarta Mail in JMC


### Reviewers
 * [Marcus Hirt](https://openjdk.org/census#hirt) (@thegreystone - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmc pull/467/head:pull/467` \
`$ git checkout pull/467`

Update a local copy of the PR: \
`$ git checkout pull/467` \
`$ git pull https://git.openjdk.org/jmc pull/467/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 467`

View PR using the GUI difftool: \
`$ git pr show -t 467`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmc/pull/467.diff">https://git.openjdk.org/jmc/pull/467.diff</a>

</details>
