### PR TITLE
8041: JfrRulesReport -format json produce incomplete results

### DIFF
--- a/core/org.openjdk.jmc.flightrecorder.rules/src/main/resources/org/openjdk/jmc/flightrecorder/rules/report/json.xslt
+++ b/core/org.openjdk.jmc.flightrecorder.rules/src/main/resources/org/openjdk/jmc/flightrecorder/rules/report/json.xslt
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!--   
-   Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+   Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
    
    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
    
@@ -136,8 +136,8 @@
                "name": "<xsl:apply-templates select="name" />", <xsl:choose><xsl:when test="count(error)>0"><xsl:text>&#xa;               </xsl:text>"error": "<xsl:apply-templates select="error" />"</xsl:when><xsl:otherwise>
                "severity": "<xsl:apply-templates select="severity" />",
                "score": <xsl:apply-templates select="score" />,
-               "message": "<xsl:apply-templates select="message" />",
-               "detailedMessage": "<xsl:apply-templates select="detailedmessage" />"<xsl:apply-templates select="itemset" />
+               "message": "<xsl:apply-templates select="summary" />",
+               "detailedMessage": "<xsl:apply-templates select="explanation" />"<xsl:apply-templates select="itemset" />
              	</xsl:otherwise>
              </xsl:choose>
               }<xsl:if test="following-sibling::*">,</xsl:if></xsl:template>


### PR DESCRIPTION
The output of JSON report contains blank placeholders like below:
"message": "",
"detailedMessage": ""

After the fix:

"message": "No long socket write pauses were found in this recording (the longest was 26.678 ms).",
 "detailedMessage": "Note that there are some socket write patterns with high duration writes that we consider to be normal and are therefore excluded. Such patterns include JMX RMI communication."

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JMC-8041](https://bugs.openjdk.org/browse/JMC-8041): JfrRulesReport -format json produce incomplete results


### Reviewers
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - Committer)
 * [Marcus Hirt](https://openjdk.org/census#hirt) (@thegreystone - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmc pull/468/head:pull/468` \
`$ git checkout pull/468`

Update a local copy of the PR: \
`$ git checkout pull/468` \
`$ git pull https://git.openjdk.org/jmc pull/468/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 468`

View PR using the GUI difftool: \
`$ git pr show -t 468`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmc/pull/468.diff">https://git.openjdk.org/jmc/pull/468.diff</a>

</details>
