### PR TITLE
8046: build.bat --packageAgent doesn't detect failed builds

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -140,13 +140,13 @@ set TIMESTAMP=%LOCALDATETIME:~0,14%
 set PACKAGE_LOG=%cd%\build_%TIMESTAMP%.5.package.log
 cd agent
 call mvn install --log-file "%PACKAGE_LOG%"
-cd ..
 if %ERRORLEVEL% == 0  (
 	echo Agent library build complete. You can now run an example with the agent using --runAgentExample or --runAgentConverterExample
 	echo See agent/README.md for more information
-) else {
+) else (
+	echo Building the agent library failed.
 	exit /B 1
-}
+)
 exit /B 0
 
 :runAgentExample


### PR DESCRIPTION
When running build.bat --packageAgent, the build.bat doesn't detect if the maven call fails, since the ERRORLEVEL variable is overridden by the "cd .." call before it is checked. Additionally the format of the if/else construct is wrong (uses curly braces in the else part).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JMC-8046](https://bugs.openjdk.org/browse/JMC-8046): build.bat --packageAgent doesn't detect failed builds


### Reviewers
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - Committer)
 * [Marcus Hirt](https://openjdk.org/census#hirt) (@thegreystone - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmc.git pull/472/head:pull/472` \
`$ git checkout pull/472`

Update a local copy of the PR: \
`$ git checkout pull/472` \
`$ git pull https://git.openjdk.org/jmc.git pull/472/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 472`

View PR using the GUI difftool: \
`$ git pr show -t 472`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmc/pull/472.diff">https://git.openjdk.org/jmc/pull/472.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jmc/pull/472#issuecomment-1446667666)