### PR TITLE
8048: Agent throws exceptions on missing or empty descriptions

### DIFF
--- a/agent/src/main/java/org/openjdk/jmc/agent/jfr/impl/JFREventClassGenerator.java
+++ b/agent/src/main/java/org/openjdk/jmc/agent/jfr/impl/JFREventClassGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/agent/src/main/java/org/openjdk/jmc/agent/jfr/impl/JFREventClassGenerator.java
+++ b/agent/src/main/java/org/openjdk/jmc/agent/jfr/impl/JFREventClassGenerator.java
@@ -124,9 +124,11 @@ public class JFREventClassGenerator {
 		av.visitEnd();
 
 		// Description
-		av = fv.visitAnnotation("Ljdk/jfr/Description;", true);
-		av.visit("value", attribute.getDescription());
-		av.visitEnd();
+		if (attribute.getDescription() != null) {
+			av = fv.visitAnnotation("Ljdk/jfr/Description;", true);
+			av.visit("value", attribute.getDescription());
+			av.visitEnd();
+		}
 
 		// "ContentType"
 		// We support the old JDK 7 style content types transparently.
@@ -224,9 +226,11 @@ public class JFREventClassGenerator {
 		av.visitEnd();
 
 		// Description
-		av = cw.visitAnnotation("Ljdk/jfr/Description;", true);
-		av.visit("value", td.getEventDescription());
-		av.visitEnd();
+		if (td.getEventDescription() != null) {
+			av = cw.visitAnnotation("Ljdk/jfr/Description;", true);
+			av.visit("value", td.getEventDescription());
+			av.visitEnd();
+		}
 
 		// Category (path)
 		String[] pathElements = td.getEventPath().split("/");


### PR DESCRIPTION
The agent throws exceptions when the description of an event or value is empty or missing. This change just omits the Description annotation for the generated event classes in this case.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JMC-8048](https://bugs.openjdk.org/browse/JMC-8048): Agent throws exceptions on missing or empty descriptions


### Reviewers
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - Committer) ⚠️ Review applies to [51e6aaf1](https://git.openjdk.org/jmc/pull/473/files/51e6aaf1cff4c2dcca9b620fe9af3e61a61693f2)
 * [Marcus Hirt](https://openjdk.org/census#hirt) (@thegreystone - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmc pull/473/head:pull/473` \
`$ git checkout pull/473`

Update a local copy of the PR: \
`$ git checkout pull/473` \
`$ git pull https://git.openjdk.org/jmc pull/473/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 473`

View PR using the GUI difftool: \
`$ git pr show -t 473`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmc/pull/473.diff">https://git.openjdk.org/jmc/pull/473.diff</a>

</details>
