### PR TITLE
8063: IMCFrame Type cache not synchronized

### DIFF
--- a/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/IMCFrame.java
+++ b/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/IMCFrame.java
@@ -33,6 +33,7 @@
  */
 package org.openjdk.jmc.common;
 
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -104,14 +105,15 @@ public interface IMCFrame {
 		 * instances. The expectation is that the number of unrecognized frame types will be very
 		 * small, usually zero, so the memory overhead of the cache stays negligible.
 		 */
-		private static final Map<String, Type> TYPE_CACHE = new LinkedHashMap<String, Type>() {
-			private static final long serialVersionUID = 6330800425284157773L;
+		private static final Map<String, Type> TYPE_CACHE = Collections
+				.synchronizedMap(new LinkedHashMap<String, Type>() {
+					private static final long serialVersionUID = 6330800425284157773L;
 
-			@Override
-			protected boolean removeEldestEntry(Map.Entry<String, Type> eldest) {
-				return size() > TYPE_CACHE_MAX_SIZE;
-			}
-		};
+					@Override
+					protected boolean removeEldestEntry(Map.Entry<String, Type> eldest) {
+						return size() > TYPE_CACHE_MAX_SIZE;
+					}
+				});
 
 		private final String id;
 		private final String name;


### PR DESCRIPTION
The type cache used in the IMCFrame Type inner class isn't synchronized and can thus cause a concurrent modification exception during e.g. JFR parsing.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JMC-8063](https://bugs.openjdk.org/browse/JMC-8063): IMCFrame Type cache not synchronized


### Reviewers
 * [Henrik Dafgård](https://openjdk.org/census#hdafgard) (@Gunde - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmc.git pull/476/head:pull/476` \
`$ git checkout pull/476`

Update a local copy of the PR: \
`$ git checkout pull/476` \
`$ git pull https://git.openjdk.org/jmc.git pull/476/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 476`

View PR using the GUI difftool: \
`$ git pr show -t 476`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmc/pull/476.diff">https://git.openjdk.org/jmc/pull/476.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jmc/pull/476#issuecomment-1498749731)