### PR TITLE
8065: Remove socket read illegal value

### DIFF
--- a/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/item/Aggregators.java
+++ b/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/item/Aggregators.java
@@ -768,7 +768,8 @@ public class Aggregators {
 	}
 
 	public static IAggregator<IQuantity, ?> sum(
-		String name, String description, final String typeId, final IAttribute<IQuantity> attribute, Predicate<Double> predicate) {
+		String name, String description, final String typeId, final IAttribute<IQuantity> attribute,
+		Predicate<Double> predicate) {
 		ContentType<IQuantity> contentType = attribute.getContentType();
 		if (contentType instanceof LinearKindOfQuantity) {
 			return new Sum(name, description, (LinearKindOfQuantity) contentType) {

--- a/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/item/Aggregators.java
+++ b/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/item/Aggregators.java
@@ -147,7 +147,7 @@ public class Aggregators {
 		}
 
 		SumConsumer(IMemberAccessor<? extends IQuantity, IItem> accessor, Predicate predicate) {
-			super(accessor);
+			this(accessor);
 			this.predicate = predicate;
 		}
 

--- a/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/item/Aggregators.java
+++ b/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/item/Aggregators.java
@@ -768,8 +768,7 @@ public class Aggregators {
 	}
 
 	public static IAggregator<IQuantity, ?> sum(
-			String name, String description, final String typeId, final IAttribute<IQuantity> attribute,
-			Predicate<Double> predicate) {
+		String name, String description, final String typeId, final IAttribute<IQuantity> attribute, Predicate<Double> predicate) {
 		ContentType<IQuantity> contentType = attribute.getContentType();
 		if (contentType instanceof LinearKindOfQuantity) {
 			return new Sum(name, description, (LinearKindOfQuantity) contentType) {

--- a/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/item/Aggregators.java
+++ b/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/item/Aggregators.java
@@ -140,8 +140,15 @@ public class Aggregators {
 		double sum = 0.0;
 		IUnit unit = null;
 
+		Predicate predicate;
+
 		SumConsumer(IMemberAccessor<? extends IQuantity, IItem> accessor) {
 			super(accessor);
+		}
+
+		SumConsumer(IMemberAccessor<? extends IQuantity, IItem> accessor, Predicate predicate) {
+			super(accessor);
+			this.predicate = predicate;
 		}
 
 		@Override
@@ -150,7 +157,10 @@ public class Aggregators {
 			if (unit == null) {
 				unit = fieldValue.getUnit();
 			}
-			sum += fieldValue.doubleValueIn(unit);
+			double value = fieldValue.doubleValueIn(unit);
+			if ((predicate != null && predicate.test(value)) || (predicate == null)) {
+				sum += value;
+			}
 		}
 
 		@Override
@@ -743,6 +753,31 @@ public class Aggregators {
 		ContentType<IQuantity> contentType = attribute.getContentType();
 		if (contentType instanceof LinearKindOfQuantity) {
 			return new Sum(name, description, (LinearKindOfQuantity) contentType) {
+
+				@Override
+				protected IMemberAccessor<IQuantity, IItem> doGetAccessor(IType<IItem> type) {
+					if (type.getIdentifier().equals(typeId)) {
+						return attribute.getAccessor(type);
+					}
+					return null;
+				}
+
+			};
+		}
+		throw new IllegalArgumentException("Can only use LinearKindOfQuantity"); //$NON-NLS-1$
+	}
+
+	public static IAggregator<IQuantity, ?> sum(
+			String name, String description, final String typeId, final IAttribute<IQuantity> attribute,
+			Predicate<Double> predicate) {
+		ContentType<IQuantity> contentType = attribute.getContentType();
+		if (contentType instanceof LinearKindOfQuantity) {
+			return new Sum(name, description, (LinearKindOfQuantity) contentType) {
+
+				@Override
+				public SumConsumer newItemConsumer(IType<IItem> type) {
+					return new SumConsumer(getAccessor(type), predicate);
+				}
 
 				@Override
 				protected IMemberAccessor<IQuantity, IItem> doGetAccessor(IType<IItem> type) {

--- a/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/jdk/JdkAggregators.java
+++ b/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/jdk/JdkAggregators.java
@@ -279,7 +279,7 @@ public final class JdkAggregators {
 			Messages.getString(Messages.AGGR_SOCKET_WRITE_SIZE_DESC), SOCKET_WRITE, IO_SOCKET_BYTES_WRITTEN);
 	public static final IAggregator<IQuantity, ?> SOCKET_READ_SIZE = Aggregators.sum(
 			Messages.getString(Messages.AGGR_SOCKET_READ_SIZE), Messages.getString(Messages.AGGR_SOCKET_READ_SIZE_DESC),
-			SOCKET_READ, IO_SOCKET_BYTES_READ);
+			SOCKET_READ, IO_SOCKET_BYTES_READ, (value -> value >= 0));
 	public static final IAggregator<IQuantity, ?> SOCKET_WRITE_COUNT = Aggregators.count(
 			Messages.getString(Messages.AGGR_SOCKET_WRITE_COUNT),
 			Messages.getString(Messages.AGGR_SOCKET_WRITE_COUNT_DESC), JdkFilters.SOCKET_WRITE);


### PR DESCRIPTION
<img width="647" alt="图片" src="https://user-images.githubusercontent.com/7837910/231723450-21839fe4-4454-4e25-bf59-308526ac0c10.png">


Socket read failure returns -1
Negative statistics affect accuracy

After modification
<img width="548" alt="图片" src="https://user-images.githubusercontent.com/7837910/231723666-e9dd7983-a8de-4a14-b1e3-3dfad3dc6572.png">

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JMC-8065](https://bugs.openjdk.org/browse/JMC-8065): Remove socket read illegal value


### Reviewers
 * [Marcus Hirt](https://openjdk.org/census#hirt) (@thegreystone - **Reviewer**) ⚠️ Review applies to [7cbf73cf](https://git.openjdk.org/jmc/pull/478/files/7cbf73cfde8fe12eb16d93f4dc0f1141b37fac8c)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmc.git pull/478/head:pull/478` \
`$ git checkout pull/478`

Update a local copy of the PR: \
`$ git checkout pull/478` \
`$ git pull https://git.openjdk.org/jmc.git pull/478/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 478`

View PR using the GUI difftool: \
`$ git pr show -t 478`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmc/pull/478.diff">https://git.openjdk.org/jmc/pull/478.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jmc/pull/478#issuecomment-1506681983)