### PR TITLE
8067: JMC Automated Analysis Page shows blank

### DIFF
--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/META-INF/MANIFEST.MF
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/META-INF/MANIFEST.MF
@@ -12,6 +12,20 @@ Export-Package: org.openjdk.jmc.flightrecorder.rules.jdk.cpu;x-friends:="org.ope
  org.openjdk.jmc.flightrecorder.rules.jdk.io;x-friends:="org.openjdk.jmc.flightrecorder.ui",
  org.openjdk.jmc.flightrecorder.rules.jdk.latency;x-friends:="org.openjdk.jmc.flightrecorder.ui",
  org.openjdk.jmc.flightrecorder.rules.jdk.memory;x-friends:="org.openjdk.jmc.flightrecorder.ui"
+Import-Package: org.openjdk.jmc.common,
+ org.openjdk.jmc.common.collection,
+ org.openjdk.jmc.common.item,
+ org.openjdk.jmc.common.unit,
+ org.openjdk.jmc.common.util,
+ org.openjdk.jmc.common.version,
+ org.openjdk.jmc.flightrecorder,
+ org.openjdk.jmc.flightrecorder.jdk,
+ org.openjdk.jmc.flightrecorder.memleak,
+ org.openjdk.jmc.flightrecorder.rules,
+ org.openjdk.jmc.flightrecorder.rules.tree,
+ org.openjdk.jmc.flightrecorder.rules.util,
+ org.openjdk.jmc.flightrecorder.stacktrace,
+ org.owasp.encoder
 Require-Bundle: org.openjdk.jmc.flightrecorder,
  org.openjdk.jmc.flightrecorder.rules
 Automatic-Module-Name: org.openjdk.jmc.flightrecorder.rules.jdk

--- a/core/org.openjdk.jmc.flightrecorder.rules/META-INF/MANIFEST.MF
+++ b/core/org.openjdk.jmc.flightrecorder.rules/META-INF/MANIFEST.MF
@@ -12,5 +12,6 @@ Export-Package: org.openjdk.jmc.flightrecorder.rules,
  org.openjdk.jmc.flightrecorder.rules.tree,
  org.openjdk.jmc.flightrecorder.rules.util
 Require-Bundle: org.openjdk.jmc.common;visibility:=reexport,
- org.openjdk.jmc.flightrecorder
+  org.openjdk.jmc.flightrecorder
+Import-Package: org.owasp.encoder
 Automatic-Module-Name: org.openjdk.jmc.flightrecorder.rules


### PR DESCRIPTION
Automated analysis page was showing blank. Log was showing error "**java.lang.NoClassDefFoundError: org/owasp/encoder/Encode**". 
Imported missing packages in "org.openjdk.jmc.flightrecorder.rules.jdk" and "org.openjdk.jmc.flightrecorder.rules".

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JMC-8067](https://bugs.openjdk.org/browse/JMC-8067): JMC Automated Analysis Page shows blank


### Reviewers
 * [Marcus Hirt](https://openjdk.org/census#hirt) (@thegreystone - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmc.git pull/479/head:pull/479` \
`$ git checkout pull/479`

Update a local copy of the PR: \
`$ git checkout pull/479` \
`$ git pull https://git.openjdk.org/jmc.git pull/479/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 479`

View PR using the GUI difftool: \
`$ git pr show -t 479`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmc/pull/479.diff">https://git.openjdk.org/jmc/pull/479.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jmc/pull/479#issuecomment-1516690078)