### PR TITLE
8050: JMC Automated Analysis should improve the messages when ignoring to evaluate some rules.

### DIFF
--- a/application/org.openjdk.jmc.flightrecorder.ui/defaultPages.xml
+++ b/application/org.openjdk.jmc.flightrecorder.ui/defaultPages.xml
@@ -45,6 +45,7 @@
 			</table>
 			<report>
 				<showOk value="false" />
+				<showIgnore value="false" />
 			</report>
 		</state>
 	</page>

--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/RuleManager.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/RuleManager.java
@@ -84,8 +84,6 @@ public class RuleManager {
 
 	public static final String RULE_CONFIGURATION_PREFERENCE_ID = "ruleConfiguration"; //$NON-NLS-1$
 	public static final String UNMAPPED_REMAINDER_TOPIC = ""; //$NON-NLS-1$
-	private static final String BULLET_CHARACTER = "\\u2022 "; //$NON-NLS-1$
-	private static final String NEW_LINE = "\n"; //$NON-NLS-1$
 
 	/**
 	 * A unique object to mark this editor's job family for rule evaluation
@@ -162,16 +160,10 @@ public class RuleManager {
 						Thread.sleep(100);
 					}
 				} else {
-					StringBuffer ignoreReason = new StringBuffer(NEW_LINE);
-					ignoreReason.append(NLS.bind(Messages.JFR_EDITOR_RULES_IGNORED_REASON, rule.getName()));
-					ignoreReason.append(NEW_LINE);
-					rule.getRequiredEvents().entrySet().forEach(entry -> {
-						ignoreReason.append(BULLET_CHARACTER + entry.getKey() + " - " + entry.getValue());
-						ignoreReason.append(NEW_LINE);
-					});
-					result = ResultBuilder.createFor(rule, config::getValue).setSeverity(Severity.NA)
-							.setSummary(Messages.JFR_EDITOR_RULES_IGNORED + NEW_LINE + ignoreReason).build();
-					evaluatedRules.put(rule.getClass(), Severity.NA);
+					String reason = RulesToolkit.getIgnoreReason(items.getItems(), rule);
+					result = ResultBuilder.createFor(rule, config::getValue).setSeverity(Severity.IGNORE)
+							.setSummary(reason).build();
+					evaluatedRules.put(rule.getClass(), Severity.IGNORE);
 				}
 			} catch (Exception e) {
 				FlightRecorderUI.getDefault().getLogger().log(Level.WARNING, "Could not evaluate " + rule.getName(), e); //$NON-NLS-1$

--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/RuleManager.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/RuleManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023 Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -84,6 +84,8 @@ public class RuleManager {
 
 	public static final String RULE_CONFIGURATION_PREFERENCE_ID = "ruleConfiguration"; //$NON-NLS-1$
 	public static final String UNMAPPED_REMAINDER_TOPIC = ""; //$NON-NLS-1$
+	private static final String BULLET_CHARACTER = "\\u2022 "; //$NON-NLS-1$
+	private static final String NEW_LINE = "\n"; //$NON-NLS-1$
 
 	/**
 	 * A unique object to mark this editor's job family for rule evaluation
@@ -160,8 +162,15 @@ public class RuleManager {
 						Thread.sleep(100);
 					}
 				} else {
+					StringBuffer ignoreReason = new StringBuffer(NEW_LINE);
+					ignoreReason.append(NLS.bind(Messages.JFR_EDITOR_RULES_IGNORED_REASON, rule.getName()));
+					ignoreReason.append(NEW_LINE);
+					rule.getRequiredEvents().entrySet().forEach(entry -> {
+						ignoreReason.append(BULLET_CHARACTER + entry.getKey() + " - " + entry.getValue());
+						ignoreReason.append(NEW_LINE);
+					});
 					result = ResultBuilder.createFor(rule, config::getValue).setSeverity(Severity.NA)
-							.setSummary(Messages.JFR_EDITOR_RULES_IGNORED).build();
+							.setSummary(Messages.JFR_EDITOR_RULES_IGNORED + NEW_LINE + ignoreReason).build();
 					evaluatedRules.put(rule.getClass(), Severity.NA);
 				}
 			} catch (Exception e) {

--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/common/ImageConstants.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/common/ImageConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -80,6 +80,7 @@ public class ImageConstants {
 
 	public static final String ICON_OK = "ok.png"; //$NON-NLS-1$
 	public static final String ICON_NA = "na.png"; //$NON-NLS-1$
+	public static final String ICON_IGNORE = "na.png"; //$NON-NLS-1$
 	public static final String ICON_INFO = "info.png"; //$NON-NLS-1$
 	public static final String ICON_WARNING = "warning.png"; //$NON-NLS-1$
 	public static final String ICON_ERROR = "Erreur-icon.png"; //$NON-NLS-1$

--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/messages/internal/Messages.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/messages/internal/Messages.java
@@ -472,6 +472,7 @@ public class Messages extends NLS {
 	public static String RESULT_VIEW_ANALYSIS_DISABLED;
 	public static String RESULT_VIEW_NO_EDITOR_SELECTED;
 	public static String RULESPAGE_SHOW_OK_RESULTS_ACTION;
+	public static String RULESPAGE_SHOW_IGNORE_RESULTS_ACTION;
 	public static String RULES_SHOW_RESULTS_ACTION;
 	public static String RULES_STATISTICS;
 	public static String RecordingPage_CONCURRENT_RECORDINGS_SELECTION;

--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/messages/internal/Messages.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/messages/internal/Messages.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -298,6 +298,7 @@ public class Messages extends NLS {
 	public static String JFR_EDITOR_RULES_CANCELLED;
 	public static String JFR_EDITOR_RULES_EVALUATING;
 	public static String JFR_EDITOR_RULES_IGNORED;
+	public static String JFR_EDITOR_RULES_IGNORED_REASON;
 	public static String JFR_EDITOR_RULES_SCHEDULED;
 	public static String JFR_EDITOR_RULES_TASK_NAME;
 	public static String JFR_EDITOR_RULES_WAITING;

--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/overview/ResultOverview.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/overview/ResultOverview.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -151,6 +151,18 @@ public class ResultOverview extends AbstractDataPage implements IPageUI {
 		}
 	}
 
+	class ShowIgnoreAction extends Action {
+		public ShowIgnoreAction(String text) {
+			super(text, IAction.AS_CHECK_BOX);
+			super.setImageDescriptor(ResultOverview.ICON_IGNORE);
+		}
+
+		@Override
+		public void run() {
+			report.setShowIgnore(this.isChecked());
+		}
+	}
+
 	class BrowserAction extends Action {
 		public BrowserAction(String text) {
 			super(text, IAction.AS_CHECK_BOX);
@@ -198,6 +210,8 @@ public class ResultOverview extends AbstractDataPage implements IPageUI {
 			.getMCImageDescriptor(ImageConstants.ICON_OK);
 	public static final ImageDescriptor ICON_NA = FlightRecorderUI.getDefault()
 			.getMCImageDescriptor(ImageConstants.ICON_NA);
+	public static final ImageDescriptor ICON_IGNORE = FlightRecorderUI.getDefault()
+			.getMCImageDescriptor(ImageConstants.ICON_IGNORE);
 
 	private static final ImageDescriptor ICON_OVERVIEW = FlightRecorderUI.getDefault()
 			.getMCImageDescriptor(ImageConstants.ICON_OVERVIEW);
@@ -214,6 +228,7 @@ public class ResultOverview extends AbstractDataPage implements IPageUI {
 	private IState loadedState;
 	private ExportAction exportAction;
 	private ShowOkAction showOkAction;
+	private ShowIgnoreAction showIgnoreAction;
 	private Separator separator;
 	private BrowserAction browserAction;
 
@@ -234,6 +249,9 @@ public class ResultOverview extends AbstractDataPage implements IPageUI {
 		showOkAction = new ShowOkAction(Messages.RULESPAGE_SHOW_OK_RESULTS_ACTION);
 		showOkAction.setId("showOk"); //$NON-NLS-1$
 		form.getToolBarManager().add(showOkAction);
+		showIgnoreAction = new ShowIgnoreAction(Messages.RULESPAGE_SHOW_IGNORE_RESULTS_ACTION);
+		showIgnoreAction.setId("showIgnore"); //$NON-NLS-1$
+		form.getToolBarManager().add(showIgnoreAction);
 		exportAction = new ExportAction(Messages.ResultOverview_EXPORT_ACTION, ICON_EXPORT, editor);
 		exportAction.setId("exportAction"); //$NON-NLS-1$
 		form.getToolBarManager().add(exportAction);
@@ -261,6 +279,7 @@ public class ResultOverview extends AbstractDataPage implements IPageUI {
 
 	private void setVisibleActions(boolean visible) {
 		form.getToolBarManager().find(showOkAction.getId()).setVisible(visible);
+		form.getToolBarManager().find(showIgnoreAction.getId()).setVisible(visible);
 		form.getToolBarManager().find(exportAction.getId()).setVisible(visible);
 		form.getToolBarManager().find(separator.getId()).setVisible(visible);
 		form.getToolBarManager().find(browserAction.getId()).setVisible(false);
@@ -295,6 +314,7 @@ public class ResultOverview extends AbstractDataPage implements IPageUI {
 					report = null;
 				} else {
 					showOkAction.setChecked(report.getShowOk());
+					showIgnoreAction.setChecked(report.getShowIgnore());
 				}
 			} catch (SWTException | SWTError e) {
 				reportAction.setEnabled(false);
@@ -360,6 +380,7 @@ public class ResultOverview extends AbstractDataPage implements IPageUI {
 	 */
 	public void enableBrowserAction() {
 		form.getToolBarManager().find(showOkAction.getId()).setVisible(false);
+		form.getToolBarManager().find(showIgnoreAction.getId()).setVisible(false);
 		form.getToolBarManager().find(exportAction.getId()).setVisible(false);
 		form.getToolBarManager().find(separator.getId()).setVisible(false);
 		form.getToolBarManager().find(browserAction.getId()).setVisible(true);

--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/overview/ResultReportUi.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/overview/ResultReportUi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -244,6 +244,7 @@ public class ResultReportUi {
 
 	private final HashMap<String, Boolean> resultExpandedStates = new HashMap<>();
 	private Boolean showOk = false;
+	private Boolean showIgnore = false;
 	private Boolean isLoaded = false;
 
 	private Browser browser;
@@ -330,8 +331,27 @@ public class ResultReportUi {
 		}
 	}
 
+	public void setShowIgnore(boolean showIgnore) {
+		this.showIgnore = showIgnore;
+		if (!isSinglePage) {
+			try {
+				// FIXME: Avoid implicit dependency on HTML/javascript template. Generate script in RulesHtmlToolkit instead
+				browser.evaluate(String.format("overview.showIgnore(%b);", showIgnore)); //$NON-NLS-1$
+			} catch (SWTException swte) {
+				String html = RulesHtmlToolkit.generateStructuredHtml(new PageContainerResultProvider(editor),
+						descriptors, resultExpandedStates, false);
+				String adjustedHtml = adjustAnchorFollowAction(html);
+				browser.setText(adjustedHtml);
+			}
+		}
+	}
+
 	boolean getShowOk() {
 		return showOk;
+	}
+
+	boolean getShowIgnore() {
+		return showIgnore;
 	}
 
 	private ConcurrentLinkedQueue<String> commandQueue = new ConcurrentLinkedQueue<>();
@@ -415,6 +435,11 @@ public class ResultReportUi {
 		} catch (NullPointerException npe) {
 			// ignore NPE when there is no state value is available 
 		}
+		try {
+			this.showIgnore = Boolean.valueOf(state.getChild("report").getChild("showIgnore").getAttribute("value")); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+		} catch (NullPointerException npe) {
+			// ignore NPE when there is no state value is available 
+		}
 		browser.addListener(SWT.MenuDetect, new Listener() {
 			@Override
 			public void handleEvent(Event event) {
@@ -435,6 +460,7 @@ public class ResultReportUi {
 					new Linker(browser, "linker", descriptors, editor); //$NON-NLS-1$
 					new Expander(browser, "expander"); //$NON-NLS-1$
 					browser.execute(String.format("overview.showOk(%b);", showOk)); //$NON-NLS-1$
+					browser.execute(String.format("overview.showIgnore(%b);", showIgnore)); //$NON-NLS-1$
 					if (isSinglePage) {
 						browser.execute(OVERVIEW_MAKE_SCALABLE);
 					}
@@ -458,6 +484,7 @@ public class ResultReportUi {
 
 	public void saveTo(IWritableState state) {
 		state.createChild("report").createChild("showOk").putString("value", showOk.toString()); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+		state.createChild("report").createChild("showIgnore").putString("value", showIgnore.toString()); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
 	}
 
 }

--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/resources/org/openjdk/jmc/flightrecorder/ui/messages/internal/messages.properties
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/resources/org/openjdk/jmc/flightrecorder/ui/messages/internal/messages.properties
@@ -449,6 +449,7 @@ RULES_SHOW_RESULTS_ACTION=Show Results
 # {0} is a localized severity string (e.g. Warning), {1} is a number, {2} is a number
 RULES_STATISTICS=Max severity: {0}\nInteresting results: {1} (of {2})
 RULESPAGE_SHOW_OK_RESULTS_ACTION=Show OK Results
+RULESPAGE_SHOW_IGNORE_RESULTS_ACTION=Show IGNORED Results
 
 SAVE_AS_TITLE=Save As
 SAVE_AS_JFR_DESCRIPTION=Save a copy of your recording

--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/resources/org/openjdk/jmc/flightrecorder/ui/messages/internal/messages.properties
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/resources/org/openjdk/jmc/flightrecorder/ui/messages/internal/messages.properties
@@ -1,5 +1,5 @@
 #
-#  Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+#  Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
 #
 #  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
@@ -183,6 +183,7 @@ JFR_EDITOR_RULE_EVALUATION_ERROR_DESCRIPTION=Could not evaluate this rule: {0}
 JFR_EDITOR_RULES_CANCELLED=Cancelled by user.
 JFR_EDITOR_RULES_EVALUATING=Evaluating...
 JFR_EDITOR_RULES_IGNORED=Ignored
+JFR_EDITOR_RULES_IGNORED_REASON=Rule "{0}" is IGNORED because one / more of the following event availability criteria is not met.
 JFR_EDITOR_RULES_SCHEDULED=Scheduled...
 JFR_EDITOR_RULES_TASK_NAME=Rule Evaluation
 JFR_EDITOR_RULES_WAITING=Waiting for scheduling...

--- a/core/org.openjdk.jmc.flightrecorder.rules/src/main/java/org/openjdk/jmc/flightrecorder/rules/Severity.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules/src/main/java/org/openjdk/jmc/flightrecorder/rules/Severity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -52,7 +52,9 @@ public enum Severity {
 	/**
 	 * Results with this severity score should be presented as warnings.
 	 */
-	WARNING(75, Messages.getString(Messages.Severity_WARNING));
+	WARNING(75, Messages.getString(Messages.Severity_WARNING)),
+
+	IGNORE(-3, Messages.getString(Messages.Severity_IGNORE));
 
 	private final double score;
 	private final String localizedName;
@@ -70,7 +72,7 @@ public enum Severity {
 		return score;
 	}
 
-	private static final Severity[] VALUES = {WARNING, INFO, OK, NA};
+	private static final Severity[] VALUES = {WARNING, INFO, OK, NA, IGNORE};
 
 	public static Severity get(double score) {
 		for (Severity s : VALUES) {

--- a/core/org.openjdk.jmc.flightrecorder.rules/src/main/java/org/openjdk/jmc/flightrecorder/rules/messages/internal/Messages.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules/src/main/java/org/openjdk/jmc/flightrecorder/rules/messages/internal/Messages.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -49,6 +49,9 @@ public class Messages {
 	public static final String RulesToolkit_EVALUATION_ERROR_DESCRIPTION = "RulesToolkit_EVALUATION_ERROR_DESCRIPTION"; //$NON-NLS-1$
 	public static final String RulesToolkit_EVERY_CHUNK = "RulesToolkit_EVERY_CHUNK"; //$NON-NLS-1$
 	public static final String RulesToolkit_RULE_IGNORED = "RulesToolkit_RULE_IGNORED"; //$NON-NLS-1$
+	public static final String RulesToolkit_RULE_IGNORED_REASON = "RulesToolkit_RULE_IGNORED_REASON"; //$NON-NLS-1$
+	public static final String RulesToolkit_RULES_IGNORED_REASON = "RulesToolkit_RULES_IGNORED_REASON"; //$NON-NLS-1$
+	public static final String RulesToolkit_RULES_IGNORED_EVENT_AVAILABILITY = "RulesToolkit_RULES_IGNORED_EVENT_AVAILABILITY"; //$NON-NLS-1$
 	public static final String RulesToolkit_RULE_RECOMMENDS_EVENTS = "RulesToolkit_RULE_RECOMMENDS_EVENTS"; //$NON-NLS-1$
 	public static final String RulesToolkit_RULE_REQUIRES_EVENTS = "RulesToolkit_RULE_REQUIRES_EVENTS"; //$NON-NLS-1$
 	public static final String RulesToolkit_RULE_REQUIRES_EVENTS_LONG = "RulesToolkit_RULE_REQUIRES_EVENTS_LONG"; //$NON-NLS-1$
@@ -65,6 +68,7 @@ public class Messages {
 	public static final String Severity_NOT_APPLICABLE = "Severity_NOT_APPLICABLE"; //$NON-NLS-1$
 	public static final String Severity_OK = "Severity_OK"; //$NON-NLS-1$
 	public static final String Severity_WARNING = "Severity_WARNING"; //$NON-NLS-1$
+	public static final String Severity_IGNORE = "Severity_IGNORE";
 	public static final String TypedResult_SCORE_NAME = "TypedResult_SCORE_NAME"; //$NON-NLS-1$
 	public static final String TypedResult_SCORE_DESCRIPTION = "TypedResult_SCORE_DESCRIPTION"; //$NON-NLS-1$
 

--- a/core/org.openjdk.jmc.flightrecorder.rules/src/main/java/org/openjdk/jmc/flightrecorder/rules/report/JfrRulesReport.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules/src/main/java/org/openjdk/jmc/flightrecorder/rules/report/JfrRulesReport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -154,6 +154,8 @@ public class JfrRulesReport {
 					minSeverity = Severity.INFO;
 				} else if (minString.equalsIgnoreCase("warning")) { //$NON-NLS-1$
 					minSeverity = Severity.WARNING;
+				} else if (minString.equalsIgnoreCase("ignore")) { //$NON-NLS-1$
+					minSeverity = Severity.IGNORE;
 				} else {
 					System.out.println("Unrecognized value of -min"); //$NON-NLS-1$
 					return;

--- a/core/org.openjdk.jmc.flightrecorder.rules/src/main/java/org/openjdk/jmc/flightrecorder/rules/report/html/internal/Messages.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules/src/main/java/org/openjdk/jmc/flightrecorder/rules/report/html/internal/Messages.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -41,6 +41,7 @@ public class Messages {
 	private static final ResourceBundle RESOURCE_BUNDLE = ResourceBundle.getBundle(BUNDLE_NAME);
 
 	public static final String RULESPAGE_SHOW_OK_RESULTS_ACTION = "RULESPAGE_SHOW_OK_RESULTS_ACTION"; //$NON-NLS-1$
+	public static final String RULESPAGE_SHOW_IGNORE_RESULTS_ACTION = "RULESPAGE_SHOW_IGNORE_RESULTS_ACTION"; //$NON-NLS-1$
 	public static final String RULES_ALL_IGNORED_MESSAGE = "RULES_ALL_IGNORED_MESSAGE"; //$NON-NLS-1$
 	public static final String RULES_NO_PROBLEMS_FOUND = "RULES_NO_PROBLEMS_FOUND"; //$NON-NLS-1$
 	public static final String RULES_NO_PROBLEMS_FOUND_DETAILS = "RULES_NO_PROBLEMS_FOUND_DETAILS"; //$NON-NLS-1$

--- a/core/org.openjdk.jmc.flightrecorder.rules/src/main/java/org/openjdk/jmc/flightrecorder/rules/report/html/internal/RulesHtmlToolkit.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules/src/main/java/org/openjdk/jmc/flightrecorder/rules/report/html/internal/RulesHtmlToolkit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -85,13 +85,13 @@ public class RulesHtmlToolkit {
 			return "info"; //$NON-NLS-1$
 		} else if (result.getSeverity() == Severity.OK) {
 			return "ok"; //$NON-NLS-1$
+		} else if (result.getSeverity() == Severity.IGNORE) {
+			return "ignore"; //$NON-NLS-1$
 		} else if (result.getSeverity() == Severity.NA) {
 			if (Boolean.TRUE.equals(result.getResult(FAILED))) {
 				return "error"; //$NON-NLS-1$
 			} else if (Boolean.TRUE.equals(result.getResult(IN_PROGRESS))) {
 				return "progress"; //$NON-NLS-1$
-			} else if (Boolean.TRUE.equals(result.getResult(IGNORED))) {
-				return "ignore"; //$NON-NLS-1$
 			}
 			return "na"; //$NON-NLS-1$
 		}
@@ -135,6 +135,22 @@ public class RulesHtmlToolkit {
 		String template = PUSH_DIV;
 		template += END_DIV;
 		template += createShowOK();
+		template += END_DIV;
+		return template;
+	}
+
+	private static String createShowIgnore() {
+		String ignore = "<div class=\"okbox\"><label class=\"showIgnoreText\" for=\"showIgnore\">"; //$NON-NLS-1$
+		ignore += Messages.getString(Messages.RULESPAGE_SHOW_IGNORE_RESULTS_ACTION);
+		ignore += "</label>&nbsp;<input type=\"checkbox\" onclick='overview.showIgnore(this.checked);' id=\"showIgnore\">&nbsp;&nbsp;&nbsp;</div>"; //$NON-NLS-1$
+		ignore += "<script>window.onload = function() {overview.showIgnore(false)}</script>"; //$NON-NLS-1$
+		return ignore;
+	}
+
+	private static String buildShowIgnoreCheckBox() {
+		String template = PUSH_DIV;
+		template += END_DIV;
+		template += createShowIgnore();
 		template += END_DIV;
 		return template;
 	}
@@ -197,7 +213,17 @@ public class RulesHtmlToolkit {
 		boolean isInProgress = Boolean.TRUE.equals(result.getResult(IN_PROGRESS));
 		String displayScore = isInProgress ? "none" : "inline block"; //$NON-NLS-1$ //$NON-NLS-2$
 		String displayProgress = isInProgress ? "inline block" : "none"; //$NON-NLS-1$ //$NON-NLS-2$
-		return MessageFormat.format(sb.toString(), Encode.forHtml(id + uuid), (value == -1) ? "N/A" : value, //$NON-NLS-1$
+		Object scoreLabel;
+		if (value == -1) {
+			scoreLabel = "N/A";
+		} else if (value == -3) {
+			scoreLabel = "Ignored";
+			description = description.replaceAll("\n", "</br>"); //$NON-NLS-1$ //$NON-NLS-2$
+		} else {
+			scoreLabel = value;
+		}
+
+		return MessageFormat.format(sb.toString(), Encode.forHtml(id + uuid), scoreLabel, //$NON-NLS-1$
 				Encode.forHtml(title), description, getType(result), margin, clazz, button, displayScore,
 				displayProgress, id);
 	}
@@ -285,6 +311,7 @@ public class RulesHtmlToolkit {
 		StringBuilder div = new StringBuilder(getHtmlTemplate());
 		if (addShowOkCheckBox) {
 			div.append(buildShowOkCheckBox());
+			div.append(buildShowIgnoreCheckBox());
 		}
 		div.append(getAllOkTemplate());
 		div.append(getAllIgnoredTemplate());

--- a/core/org.openjdk.jmc.flightrecorder.rules/src/main/resources/org/openjdk/jmc/flightrecorder/rules/messages/internal/messages.properties
+++ b/core/org.openjdk.jmc.flightrecorder.rules/src/main/resources/org/openjdk/jmc/flightrecorder/rules/messages/internal/messages.properties
@@ -1,5 +1,5 @@
 #
-#  Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+#  Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
 #
 #  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
@@ -59,13 +59,16 @@ RulesToolkit_RULE_REQUIRES_SOME_EVENTS=The {0} rule requires events to be availa
 RulesToolkit_RULE_RECOMMENDS_EVENTS=To improve rule accuracy and/or get more details for further investigation, it is recommended to enable the following event types: {0}.
 RulesToolkit_RULE_RESULT_RETRIEVAL_ERROR=Unexpected problem retrieving rule result.
 RulesToolkit_TOO_FEW_EVENTS=Too few events to calculate the result.
-
+RulesToolkit_RULE_IGNORED_REASON=The rule is not evaluated because of this {0} issue :
+RulesToolkit_RULES_IGNORED_REASON=The rule is not evaluated because of these {0} issues :
+RulesToolkit_RULES_IGNORED_EVENT_AVAILABILITY={0} is {1} but the expected status is {2}
 Result_SHORT_RECORDING=This recording is only {0} long, consider creating a recording longer than {1} for improved rule accuracy.
 
 Severity_INFORMATION=Information
 Severity_NOT_APPLICABLE=Not Applicable
 Severity_OK=OK
 Severity_WARNING=Warning
+Severity_IGNORE=Ignore
 
 ItemTreeToolkit_BREAKDOWN_HEADER_LAYERS=\n\u2023\u2023 Breakdown (layers):\n
 ItemTreeToolkit_BREAKDOWN_HEADER_MAX_DURATION_EVENT_CHAIN=\u2043\u2043 Breakdown (max duration event chain):\n

--- a/core/org.openjdk.jmc.flightrecorder.rules/src/main/resources/org/openjdk/jmc/flightrecorder/rules/report/html/internal/messages.properties
+++ b/core/org.openjdk.jmc.flightrecorder.rules/src/main/resources/org/openjdk/jmc/flightrecorder/rules/report/html/internal/messages.properties
@@ -1,5 +1,5 @@
 #
-#  Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+#  Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
 #
 #  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
@@ -32,6 +32,7 @@
 #
 ResultOverview_NO_RESULTS_FOR_PAGE=There are no results associated with this page.
 RULESPAGE_SHOW_OK_RESULTS_ACTION=Show OK Results
+RULESPAGE_SHOW_IGNORE_RESULTS_ACTION=Show IGNORED Results
 RULES_ALL_IGNORED_MESSAGE=No rules were enabled in the configuration.
 RULES_NO_PROBLEMS_FOUND=The automated analysis did not find any problems with this recording
 RULES_NO_PROBLEMS_FOUND_DETAILS=Press the 'Show OK Results' button to see more details

--- a/core/org.openjdk.jmc.flightrecorder.rules/src/main/resources/org/openjdk/jmc/flightrecorder/rules/report/html/internal/rules_overview.html
+++ b/core/org.openjdk.jmc.flightrecorder.rules/src/main/resources/org/openjdk/jmc/flightrecorder/rules/report/html/internal/rules_overview.html
@@ -1,5 +1,5 @@
 <!--
-   Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+   Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
    Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
 -->
 <html lang="en">
@@ -137,6 +137,10 @@ section {
 	background-color: gray;
 }
 
+.rule_score.ignore {
+	background-color: lightblue;
+}
+
 .rule_score.error {
     background-color: #FF0000;
 }
@@ -159,6 +163,10 @@ section {
 
 .rule_bar.na {
 	background-color: gray;
+}
+
+.rule_bar.ignore {
+	background-color: lightblue;
 }
 
 .rule_bar.error {
@@ -242,6 +250,12 @@ section {
 	font-family: sans-serif;
 	font-size: 85%;
 }
+
+.showIgnoreText {
+	font-family: sans-serif;
+	font-size: 85%;
+}
+
 .anchorTag {
 	cursor:pointer;
 	color:blue;
@@ -260,6 +274,7 @@ section {
 	});
 	
 	var showOk = false;
+	var showIgnore = false;
 	
 	var overview = {
 		initializeRuleOverview : function() {
@@ -305,6 +320,20 @@ section {
 			showOk = ok;
 		},
 		
+		showIgnore : function(ignore) {
+			var newDisplay = ignore ? "block" : "none";
+			var css = document.all ? 'rules' : 'cssRules';
+			var rule = document.styleSheets[0][css];
+			for (var i = 0; i < rule.length; i++) {
+				if (rule[i].selectorText == ".ignore") {
+					rule[i].style.display = newDisplay;
+				}
+			}
+			overview.updateElementsDisplay("ignore", newDisplay);
+			overview.updatePageHeadersVisibility();
+			showIgnore = ignore;
+		},
+
 		updatePageHeadersVisibility : function() {
 			var headers = document.getElementsByClassName("page_heading");
 			for (var i = 0; i < headers.length; i++) {
@@ -400,7 +429,7 @@ section {
 				score = 'N/A';
 			} else if (score == -3) {
 				severity = 'ignore';
-				score = 'I';
+				score = 'Ignored';
 			} else if (score == -2) {
 				severity = 'error';
 				score = '';
@@ -423,7 +452,7 @@ section {
 			for (var i = 0; i < elements.length; i++)  {
 				elements[i].className = 'rule ' + severity;
 				if (showOk) {
-					if (severity !== 'ignore') {
+					if (severity === 'ok' || severity === 'na') {
 						elements[i].style.display = 'block';
 					} else {
 						elements[i].style.display = 'none';
@@ -436,6 +465,19 @@ section {
 					}
 				}
 			}
+
+			for (var i = 0; i < elements.length; i++)  {
+				elements[i].className = 'rule ' + severity;
+				if (showIgnore) {
+					if (severity === 'ignore') {
+						elements[i].style.display = 'block';
+					} else {
+						elements[i].style.display = 'none';
+					}
+				}
+
+			}
+
 			var scoreBarElements = document.getElementsByName(id + '_score_bar');
 			for (var i = 0; i < scoreBarElements.length; i++) {
 				var scoreBar = scoreBarElements[i];


### PR DESCRIPTION
One of our customers requested to see a detailed _Ignore Reason_ whenever we ignore any rule in JMC. Rather than just saying Ignored. As part of this PR, we have added a new field Ignored Reason which will be displayed for all the Ignored Rules. It will give a clear idea about the missing event availability requirement.

The Automated Analysis screen will look like this:
![image](https://user-images.githubusercontent.com/11155712/233875905-f70cf844-e9b3-405d-a9be-12a169abfaf1.png)

In the above screenshot, there are few rules which are Ignored and the corresponding reasons are mentioned.

Please review the PR and let me know your review comments.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JMC-8050](https://bugs.openjdk.org/browse/JMC-8050): JMC Automated Analysis should improve the messages when ignoring to evaluate some rules.


### Reviewers
 * [Marcus Hirt](https://openjdk.org/census#hirt) (@thegreystone - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmc.git pull/481/head:pull/481` \
`$ git checkout pull/481`

Update a local copy of the PR: \
`$ git checkout pull/481` \
`$ git pull https://git.openjdk.org/jmc.git pull/481/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 481`

View PR using the GUI difftool: \
`$ git pr show -t 481`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmc/pull/481.diff">https://git.openjdk.org/jmc/pull/481.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jmc/pull/481#issuecomment-1519224270)