### PR TITLE
8070: Move to JDK 17 leftovers

### DIFF
--- a/application/org.openjdk.jmc.flightrecorder.configuration/src/main/java/org/openjdk/jmc/flightrecorder/configuration/internal/DefaultValueMap.java
+++ b/application/org.openjdk.jmc.flightrecorder.configuration/src/main/java/org/openjdk/jmc/flightrecorder/configuration/internal/DefaultValueMap.java
@@ -59,7 +59,6 @@ public class DefaultValueMap<K> implements IDescribedMap<K> {
 		this(knownOptions, null);
 	}
 
-	@SuppressWarnings("unchecked")
 	public DefaultValueMap(IMapper<K, IOptionDescriptor<?>> fallbacks) {
 		this(Collections.emptyMap(), fallbacks);
 	}

--- a/application/org.openjdk.jmc.flightrecorder.configuration/src/main/java/org/openjdk/jmc/flightrecorder/configuration/internal/DefaultValueMap.java
+++ b/application/org.openjdk.jmc.flightrecorder.configuration/src/main/java/org/openjdk/jmc/flightrecorder/configuration/internal/DefaultValueMap.java
@@ -61,8 +61,7 @@ public class DefaultValueMap<K> implements IDescribedMap<K> {
 
 	@SuppressWarnings("unchecked")
 	public DefaultValueMap(IMapper<K, IOptionDescriptor<?>> fallbacks) {
-		// NOTE: Cast is just to circumvent issue in Eclipse 4.5.2 with JDK 7 compiler/libs.
-		this((Map<K, ? extends IOptionDescriptor<?>>) Collections.emptyMap(), fallbacks);
+		this(Collections.emptyMap(), fallbacks);
 	}
 
 	public DefaultValueMap(Map<K, ? extends IOptionDescriptor<?>> knownOptions,

--- a/application/org.openjdk.jmc.flightrecorder.configuration/src/main/java/org/openjdk/jmc/flightrecorder/configuration/internal/DefaultValueMap.java
+++ b/application/org.openjdk.jmc.flightrecorder.configuration/src/main/java/org/openjdk/jmc/flightrecorder/configuration/internal/DefaultValueMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/common/FilterEditor.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/common/FilterEditor.java
@@ -437,8 +437,12 @@ public class FilterEditor {
 		Transfer[] localTransfer = new Transfer[] {LocalSelectionTransfer.getTransfer()};
 		tree.addDragSupport(DND.DROP_MOVE | DND.DROP_COPY, localTransfer,
 				DndToolkit.createLocalDragSource(tree, this::deleteNodes));
-		ViewerDropAdapter dropTarget = DndToolkit.createLocalDropListTarget(tree, CompositeNode.class, FilterNode.class,
-				this::performDrop, this::validateDrop);
+		ViewerDropAdapter dropTarget = DndToolkit.createLocalDropListTarget(tree,
+				CompositeNode.class,
+				FilterNode.class,
+				this::performDrop,
+				this::validateDrop
+		);
 		dropTarget.setFeedbackEnabled(false);
 		tree.addDropSupport(DND.DROP_MOVE | DND.DROP_COPY, localTransfer, dropTarget);
 		ColumnViewerToolTipSupport.enableFor(tree);
@@ -562,7 +566,7 @@ public class FilterEditor {
 		notifyListener();
 	}
 
-	private int validateDrop(List<? extends FilterNode> src, CompositeNode target, int operation) {
+	private <N extends FilterNode> int validateDrop(List<N> src, CompositeNode target, int operation) {
 		if (target == null ? root.children.containsAll(src) : target.children.containsAll(src)) {
 			return DND.DROP_NONE;
 		} else if (find(target, src)) {
@@ -582,7 +586,7 @@ public class FilterEditor {
 		return false;
 	}
 
-	private boolean performDrop(List<? extends FilterNode> src, CompositeNode target, int operation, int location) {
+	private <N extends FilterNode> boolean performDrop(List<N> src, CompositeNode target, int operation, int location) {
 		if (target == null) {
 			target = root;
 		}

--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/common/FilterEditor.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/common/FilterEditor.java
@@ -437,12 +437,8 @@ public class FilterEditor {
 		Transfer[] localTransfer = new Transfer[] {LocalSelectionTransfer.getTransfer()};
 		tree.addDragSupport(DND.DROP_MOVE | DND.DROP_COPY, localTransfer,
 				DndToolkit.createLocalDragSource(tree, this::deleteNodes));
-		ViewerDropAdapter dropTarget = DndToolkit.createLocalDropListTarget(tree,
-				CompositeNode.class,
-				FilterNode.class,
-				this::performDrop,
-				this::validateDrop
-		);
+		ViewerDropAdapter dropTarget = DndToolkit.createLocalDropListTarget(tree, CompositeNode.class, FilterNode.class,
+				this::performDrop, this::validateDrop);
 		dropTarget.setFeedbackEnabled(false);
 		tree.addDropSupport(DND.DROP_MOVE | DND.DROP_COPY, localTransfer, dropTarget);
 		ColumnViewerToolTipSupport.enableFor(tree);

--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/common/FilterEditor.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/common/FilterEditor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/misc/DndToolkit.java
+++ b/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/misc/DndToolkit.java
@@ -112,8 +112,12 @@ public class DndToolkit {
 	}
 
 	public static <T, U> ViewerDropAdapter createLocalDropListTarget(
-		Viewer viewer, Class<T> targetType, Class<U> srcType, IDropAction<List<? extends U>, T> action,
-		IDropValidator<List<? extends U>, T> validator) {
+		Viewer viewer,
+		Class<T> targetType,
+		Class<U> srcType,
+		IDropAction<List<U>, T> action,
+		IDropValidator<List<U>, T> validator
+	) {
 		return createLocalDropTarget(viewer, targetType, new IDropAction<ISelection, T>() {
 
 			@SuppressWarnings("unchecked")

--- a/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/misc/DndToolkit.java
+++ b/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/misc/DndToolkit.java
@@ -112,12 +112,8 @@ public class DndToolkit {
 	}
 
 	public static <T, U> ViewerDropAdapter createLocalDropListTarget(
-		Viewer viewer,
-		Class<T> targetType,
-		Class<U> srcType,
-		IDropAction<List<U>, T> action,
-		IDropValidator<List<U>, T> validator
-	) {
+		Viewer viewer, Class<T> targetType, Class<U> srcType, IDropAction<List<U>, T> action,
+		IDropValidator<List<U>, T> validator) {
 		return createLocalDropTarget(viewer, targetType, new IDropAction<ISelection, T>() {
 
 			@SuppressWarnings("unchecked")

--- a/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/misc/DndToolkit.java
+++ b/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/misc/DndToolkit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/docker/Dockerfile-jmc
+++ b/docker/Dockerfile-jmc
@@ -1,4 +1,4 @@
-FROM azul/zulu-openjdk:17-latest AS builder
+FROM eclipse-temurin:17-jammy AS builder
 
 RUN apt-get update && apt-get install -y maven
 

--- a/docker/Dockerfile-jmc
+++ b/docker/Dockerfile-jmc
@@ -1,3 +1,35 @@
+#
+#  Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+#  
+#  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+#  
+#  The contents of this file are subject to the terms of either the Universal Permissive License 
+#  v 1.0 as shown at http://oss.oracle.com/licenses/upl
+#  
+#  or the following license:
+#  
+#  Redistribution and use in source and binary forms, with or without modification, are permitted
+#  provided that the following conditions are met:
+#  
+#  1. Redistributions of source code must retain the above copyright notice, this list of conditions
+#  and the following disclaimer.
+#  
+#  2. Redistributions in binary form must reproduce the above copyright notice, this list of
+#  conditions and the following disclaimer in the documentation and/or other materials provided with
+#  the distribution.
+#  
+#  3. Neither the name of the copyright holder nor the names of its contributors may be used to
+#  endorse or promote products derived from this software without specific prior written permission.
+#  
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+#  IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+#  FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+#  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+#  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+#  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+#  WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
 FROM eclipse-temurin:17-jammy AS builder
 
 RUN apt-get update && apt-get install -y maven

--- a/docker/Dockerfile-jmc
+++ b/docker/Dockerfile-jmc
@@ -1,6 +1,8 @@
-FROM openjdk:11-jdk-buster AS builder
+FROM azul/zulu-openjdk:17-latest AS builder
 
 RUN apt-get update && apt-get install -y maven
+
+VOLUME [ "/root/.m2", "/target" ]
 
 WORKDIR /jmc
 COPY core core/
@@ -9,7 +11,10 @@ COPY configuration configuration/
 COPY license license/
 COPY releng releng/
 COPY pom.xml ./
+COPY docker/docker-toolchains.xml .mvn/toolchains.xml
 RUN grep -rl localhost:8080 releng | xargs sed -i s/localhost:8080/p2:8080/
 ENV MAVEN_OPTS="-Xmx1G"
 
-CMD cd /jmc/core && mvn clean install && cd /jmc && mvn package && cp -a /jmc/target/* /target
+CMD mvn clean install --file core/pom.xml --toolchains .mvn/toolchains.xml \
+  && mvn package --toolchains .mvn/toolchains.xml \
+  && cp -a /jmc/target/* /target

--- a/docker/Dockerfile-jmc
+++ b/docker/Dockerfile-jmc
@@ -1,5 +1,5 @@
 #
-#  Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+#  Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
 #  
 #  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #  

--- a/docker/Dockerfile-p2
+++ b/docker/Dockerfile-p2
@@ -1,4 +1,4 @@
-FROM openjdk:11-jdk-buster
+FROM azul/zulu-openjdk:17-latest
 
 RUN apt-get update && apt-get install -y maven
 

--- a/docker/Dockerfile-p2
+++ b/docker/Dockerfile-p2
@@ -1,3 +1,35 @@
+#
+#  Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+#  
+#  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+#  
+#  The contents of this file are subject to the terms of either the Universal Permissive License 
+#  v 1.0 as shown at http://oss.oracle.com/licenses/upl
+#  
+#  or the following license:
+#  
+#  Redistribution and use in source and binary forms, with or without modification, are permitted
+#  provided that the following conditions are met:
+#  
+#  1. Redistributions of source code must retain the above copyright notice, this list of conditions
+#  and the following disclaimer.
+#  
+#  2. Redistributions in binary form must reproduce the above copyright notice, this list of
+#  conditions and the following disclaimer in the documentation and/or other materials provided with
+#  the distribution.
+#  
+#  3. Neither the name of the copyright holder nor the names of its contributors may be used to
+#  endorse or promote products derived from this software without specific prior written permission.
+#  
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+#  IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+#  FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+#  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+#  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+#  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+#  WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
 FROM eclipse-temurin:17-jammy
 
 RUN apt-get update && apt-get install -y maven

--- a/docker/Dockerfile-p2
+++ b/docker/Dockerfile-p2
@@ -1,5 +1,5 @@
 #
-#  Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+#  Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
 #  
 #  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #  

--- a/docker/Dockerfile-p2
+++ b/docker/Dockerfile-p2
@@ -1,4 +1,4 @@
-FROM azul/zulu-openjdk:17-latest
+FROM eclipse-temurin:17-jammy
 
 RUN apt-get update && apt-get install -y maven
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -4,8 +4,6 @@ services:
     build:
       context: ..
       dockerfile: docker/Dockerfile-p2
-    ports:
-      - "8080:8080"
   jmc:
     build:
       context: ..

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,5 +1,5 @@
 #
-#  Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+#  Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
 #  
 #  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #  

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,3 +1,35 @@
+#
+#  Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+#  
+#  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+#  
+#  The contents of this file are subject to the terms of either the Universal Permissive License 
+#  v 1.0 as shown at http://oss.oracle.com/licenses/upl
+#  
+#  or the following license:
+#  
+#  Redistribution and use in source and binary forms, with or without modification, are permitted
+#  provided that the following conditions are met:
+#  
+#  1. Redistributions of source code must retain the above copyright notice, this list of conditions
+#  and the following disclaimer.
+#  
+#  2. Redistributions in binary form must reproduce the above copyright notice, this list of
+#  conditions and the following disclaimer in the documentation and/or other materials provided with
+#  the distribution.
+#  
+#  3. Neither the name of the copyright holder nor the names of its contributors may be used to
+#  endorse or promote products derived from this software without specific prior written permission.
+#  
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+#  IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+#  FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+#  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+#  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+#  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+#  WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
 version: '3'
 services:
   p2:

--- a/docker/docker-toolchains.xml
+++ b/docker/docker-toolchains.xml
@@ -4,11 +4,11 @@
     <type>jdk</type>
     <provides>
       <version>17</version>
-      <vendor>azul</vendor>
+      <vendor>temurin</vendor>
       <id>JavaSE-17</id>
     </provides>
     <configuration>
-      <jdkHome>/usr/lib/jvm/zulu17</jdkHome>
+      <jdkHome>/opt/java/openjdk/</jdkHome>
     </configuration>
   </toolchain>
 </toolchains>

--- a/docker/docker-toolchains.xml
+++ b/docker/docker-toolchains.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-   Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+   Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
    
    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
    

--- a/docker/docker-toolchains.xml
+++ b/docker/docker-toolchains.xml
@@ -1,4 +1,36 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+   
+   DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+   
+   The contents of this file are subject to the terms of either the Universal Permissive License 
+   v 1.0 as shown at http://oss.oracle.com/licenses/upl
+   
+   or the following license:
+   
+   Redistribution and use in source and binary forms, with or without modification, are permitted
+   provided that the following conditions are met:
+   
+   1. Redistributions of source code must retain the above copyright notice, this list of conditions
+   and the following disclaimer.
+   
+   2. Redistributions in binary form must reproduce the above copyright notice, this list of
+   conditions and the following disclaimer in the documentation and/or other materials provided with
+   the distribution.
+   
+   3. Neither the name of the copyright holder nor the names of its contributors may be used to
+   endorse or promote products derived from this software without specific prior written permission.
+   
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+   IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+   FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+   DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+   DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+   WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+   WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+-->
 <toolchains>
   <toolchain>
     <type>jdk</type>

--- a/docker/docker-toolchains.xml
+++ b/docker/docker-toolchains.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<toolchains>
+  <toolchain>
+    <type>jdk</type>
+    <provides>
+      <version>17</version>
+      <vendor>azul</vendor>
+      <id>JavaSE-17</id>
+    </provides>
+    <configuration>
+      <jdkHome>/usr/lib/jvm/zulu17</jdkHome>
+    </configuration>
+  </toolchain>
+</toolchains>

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--   
+<!--
    Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
    
    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.

--- a/pom.xml
+++ b/pom.xml
@@ -178,69 +178,6 @@
 				</plugins>
 			</build>
 		</profile>
-		<profile>
-			<id>2022-06</id>
-			<build>
-				<plugins>
-					<plugin>
-						<groupId>org.eclipse.tycho</groupId>
-						<artifactId>target-platform-configuration</artifactId>
-						<version>${tycho.version}</version>
-						<configuration>
-							<target>
-								<artifact>
-									<groupId>org.openjdk.jmc</groupId>
-									<artifactId>platform-definition-2022-06</artifactId>
-									<version>${revision}${changelist}</version>
-								</artifact>
-							</target>
-						</configuration>
-					</plugin>
-				</plugins>
-			</build>
-		</profile>
-		<profile>
-			<id>2022-03</id>
-			<build>
-				<plugins>
-					<plugin>
-						<groupId>org.eclipse.tycho</groupId>
-						<artifactId>target-platform-configuration</artifactId>
-						<version>${tycho.version}</version>
-						<configuration>
-							<target>
-								<artifact>
-									<groupId>org.openjdk.jmc</groupId>
-									<artifactId>platform-definition-2022-03</artifactId>
-									<version>${revision}${changelist}</version>
-								</artifact>
-							</target>
-						</configuration>
-					</plugin>
-				</plugins>
-			</build>
-		</profile>
-		<profile>
-			<id>2021-12</id>
-			<build>
-				<plugins>
-					<plugin>
-						<groupId>org.eclipse.tycho</groupId>
-						<artifactId>target-platform-configuration</artifactId>
-						<version>${tycho.version}</version>
-						<configuration>
-							<target>
-								<artifact>
-									<groupId>org.openjdk.jmc</groupId>
-									<artifactId>platform-definition-2021-12</artifactId>
-									<version>${revision}${changelist}</version>
-								</artifact>
-							</target>
-						</configuration>
-					</plugin>
-				</plugins>
-			</build>
-		</profile>		
 	</profiles>
 	<build>
 		<plugins>


### PR DESCRIPTION
In #482 I forgot to update the Docker build, as well as remove some old profiles in the parent pom. This PR, fixes that. Also I noticed a few quirks around ECJ compiler that I think should be removed as they are not working when using a regular OpenJDK compiler.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JMC-8070](https://bugs.openjdk.org/browse/JMC-8070): Move to JDK 17 leftovers


### Reviewers
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmc.git pull/483/head:pull/483` \
`$ git checkout pull/483`

Update a local copy of the PR: \
`$ git checkout pull/483` \
`$ git pull https://git.openjdk.org/jmc.git pull/483/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 483`

View PR using the GUI difftool: \
`$ git pr show -t 483`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmc/pull/483.diff">https://git.openjdk.org/jmc/pull/483.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jmc/pull/483#issuecomment-1551670000)