### PR TITLE
8071: Cleanup after latest refactorings

### DIFF
--- a/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/security/ISecurityManager.java
+++ b/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/security/ISecurityManager.java
@@ -191,7 +191,7 @@ public interface ISecurityManager {
 	 * @param encryptionCipher
 	 *            the encryption cipher to use.
 	 * @throws SecurityException
-	 *            for security problems, e.g. provided cipher is not available.
+	 *             for security problems, e.g. provided cipher is not available.
 	 */
 	void setEncryptionCipher(String encryptionCipher) throws SecurityException;
 
@@ -199,9 +199,9 @@ public interface ISecurityManager {
 	 * Triggers a change of the master password.
 	 *
 	 * @throws ActionNotGrantedException
-	 *            if the master password was not given.
+	 *             if the master password was not given.
 	 * @throws SecurityException
-	 *            for other security problems, e.g. provided cipher is not available.
+	 *             for other security problems, e.g. provided cipher is not available.
 	 */
 	void changeMasterPassword() throws SecurityException;
 }

--- a/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/security/ISecurityManager.java
+++ b/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/security/ISecurityManager.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
- * 
+ *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * The contents of this file are subject to the terms of either the Universal Permissive License
@@ -10,17 +10,17 @@
  *
  * Redistribution and use in source and binary forms, with or without modification, are permitted
  * provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice, this list of conditions
  * and the following disclaimer.
- * 
+ *
  * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
  * conditions and the following disclaimer in the documentation and/or other materials provided with
  * the distribution.
- * 
+ *
  * 3. Neither the name of the copyright holder nor the names of its contributors may be used to
  * endorse or promote products derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
  * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
@@ -190,25 +190,18 @@ public interface ISecurityManager {
 	 *
 	 * @param encryptionCipher
 	 *            the encryption cipher to use.
-	 * @throws CipherNotAvailableException
-	 *             if the provided cipher is not available.
-	 * @throws ActionNotGrantedException
-	 *             if the master password was not given.
 	 * @throws SecurityException
-	 *             for other security problems.
+	 *            for security problems, e.g. provided cipher is not available.
 	 */
 	void setEncryptionCipher(String encryptionCipher) throws SecurityException;
 
 	/**
 	 * Triggers a change of the master password.
 	 *
-	 * @throws CipherNotAvailableException
-	 *             if no cipher is available.
 	 * @throws ActionNotGrantedException
-	 *             if the master password was not given.
+	 *            if the master password was not given.
 	 * @throws SecurityException
-	 *             for other security problems.
+	 *            for other security problems, e.g. provided cipher is not available.
 	 */
 	void changeMasterPassword() throws SecurityException;
-
 }

--- a/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/util/Environment.java
+++ b/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/util/Environment.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
- * 
+ *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * The contents of this file are subject to the terms of either the Universal Permissive License
@@ -10,17 +10,17 @@
  *
  * Redistribution and use in source and binary forms, with or without modification, are permitted
  * provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice, this list of conditions
  * and the following disclaimer.
- * 
+ *
  * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
  * conditions and the following disclaimer in the documentation and/or other materials provided with
  * the distribution.
- * 
+ *
  * 3. Neither the name of the copyright holder nor the names of its contributors may be used to
  * endorse or promote products derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
  * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
@@ -90,7 +90,7 @@ public class Environment {
 	}
 
 	/**
-	 * @return the "normal" 100% scaled DPI setting of the OS, 96 for Windows & Linux and 72 for
+	 * @return the "normal" 100% scaled DPI setting of the OS, 96 for Windows/Linux and 72 for
 	 *         MacOS.
 	 */
 	public static double getNormalDPI() {

--- a/core/org.openjdk.jmc.flightrecorder.writer/src/main/java/org/openjdk/jmc/flightrecorder/writer/api/Annotation.java
+++ b/core/org.openjdk.jmc.flightrecorder.writer/src/main/java/org/openjdk/jmc/flightrecorder/writer/api/Annotation.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2021, Datadog, Inc. All rights reserved.
+ * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2023, Datadog, Inc. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -168,11 +168,10 @@ public final class Annotation {
 
 	/**
 	 * Check whether a particular {@linkplain Type} is an annotation type
-	 * 
+	 *
 	 * @param type
 	 *            {@linkplain Type} to check
-	 * @return {@linkplain true} if the type extends {@linkplain java.lang.annotation.Annotation}
-	 *         type
+	 * @return true if the type extends {@linkplain java.lang.annotation.Annotation} type
 	 */
 	public static boolean isAnnotationType(Type type) {
 		return ANNOTATION_SUPER_TYPE_NAME.equals(type.getSupertype());
@@ -180,7 +179,7 @@ public final class Annotation {
 
 	/**
 	 * Get the list of the associated {@link Annotation annotations}
-	 * 
+	 *
 	 * @return the associated {@link Annotation annotations}
 	 */
 	public List<Annotation> getAnnotations() {
@@ -203,7 +202,7 @@ public final class Annotation {
 
 	/**
 	 * Get the attribute value by its name and type
-	 * 
+	 *
 	 * @param valueType
 	 *            the expected value type
 	 * @param name

--- a/core/tests/org.openjdk.jmc.common.test/src/main/java/org/openjdk/jmc/common/test/jvm/JVMCommandLineToolkitTest.java
+++ b/core/tests/org.openjdk.jmc.common.test/src/main/java/org/openjdk/jmc/common/test/jvm/JVMCommandLineToolkitTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
- * 
+ *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * The contents of this file are subject to the terms of either the Universal Permissive License
@@ -10,17 +10,17 @@
  *
  * Redistribution and use in source and binary forms, with or without modification, are permitted
  * provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice, this list of conditions
  * and the following disclaimer.
- * 
+ *
  * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
  * conditions and the following disclaimer in the documentation and/or other materials provided with
  * the distribution.
- * 
+ *
  * 3. Neither the name of the copyright holder nor the names of its contributors may be used to
  * endorse or promote products derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
  * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
@@ -30,11 +30,12 @@
  * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
  * WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.openjdk.jmc.common.jvm;
-
-import static org.junit.Assert.assertEquals;
+package org.openjdk.jmc.common.test.jvm;
 
 import org.junit.Test;
+import org.openjdk.jmc.common.jvm.JVMCommandLineToolkit;
+
+import static org.junit.Assert.assertEquals;
 
 public class JVMCommandLineToolkitTest {
 


### PR DESCRIPTION
After JMC-7308, test JVMCommandLineToolkitTest.java should move into core/common.
Also, there are some Javadoc related warnings during core build which should be fixed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JMC-8071](https://bugs.openjdk.org/browse/JMC-8071): Cleanup after latest refactorings


### Reviewers
 * [Brice Dutheil](https://openjdk.org/census#bdutheil) (@bric3 - Author)
 * [Alex Macdonald](https://openjdk.org/census#aptmac) (@aptmac - **Reviewer**)
 * [Virag Purnam](https://openjdk.org/census#vpurnam) (@viragpurnam - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmc.git pull/485/head:pull/485` \
`$ git checkout pull/485`

Update a local copy of the PR: \
`$ git checkout pull/485` \
`$ git pull https://git.openjdk.org/jmc.git pull/485/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 485`

View PR using the GUI difftool: \
`$ git pr show -t 485`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmc/pull/485.diff">https://git.openjdk.org/jmc/pull/485.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jmc/pull/485#issuecomment-1560199516)