### PR TITLE
8072: Bump some maven plugins and fix warnings

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -60,6 +60,7 @@
 		<maven.compiler.target>17</maven.compiler.target>
 		<jacoco.plugin.version>0.8.10</jacoco.plugin.version>
 		<maven.jar.version>3.3.0</maven.jar.version>
+		<!-- Seems like the currently latest spotless version 2.36.0 has some issue with libicu, so going for 2.34.0 now -->
 		<spotless.version>2.34.0</spotless.version>
 		<maven.checkstyle.version>3.3.0</maven.checkstyle.version>
 		<maven.directory.version>1.0</maven.directory.version>


### PR DESCRIPTION
Current maven build of JMC core shows some warnings/validation errors that can be fixed by bumping plugin versions.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JMC-8072](https://bugs.openjdk.org/browse/JMC-8072): Bump some maven plugins and fix warnings


### Reviewers
 * [Brice Dutheil](https://openjdk.org/census#bdutheil) (@bric3 - Author) ⚠️ Review applies to [d14f2d75](https://git.openjdk.org/jmc/pull/486/files/d14f2d757a75c3b81271712190eb3c4de492c60e)
 * [Alex Macdonald](https://openjdk.org/census#aptmac) (@aptmac - **Reviewer**)
 * [Virag Purnam](https://openjdk.org/census#vpurnam) (@viragpurnam - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmc.git pull/486/head:pull/486` \
`$ git checkout pull/486`

Update a local copy of the PR: \
`$ git checkout pull/486` \
`$ git pull https://git.openjdk.org/jmc.git pull/486/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 486`

View PR using the GUI difftool: \
`$ git pr show -t 486`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmc/pull/486.diff">https://git.openjdk.org/jmc/pull/486.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jmc/pull/486#issuecomment-1560735891)