### PR TITLE
8073: Rule result visibility not always toggleable in Results Page

### DIFF
--- a/core/org.openjdk.jmc.flightrecorder.rules/src/main/resources/org/openjdk/jmc/flightrecorder/rules/report/html/internal/rules_overview.html
+++ b/core/org.openjdk.jmc.flightrecorder.rules/src/main/resources/org/openjdk/jmc/flightrecorder/rules/report/html/internal/rules_overview.html
@@ -282,9 +282,15 @@ section {
 				e = window.event ? event.srcElement : e.target;
 				if (e.className && e.className.indexOf("rule_") != -1
 						&& e.className.indexOf("text") == -1) {
-					id_to_toggle = e.id.slice(0, e.id.indexOf("_")) + "_text";
-					overview.toggleVisibility(id_to_toggle, document
-							.getElementById(id_to_toggle + "_hide"));
+					var loc = (e.id.includes("_score_value")) ? e.id.indexOf("_score_value") :
+						((e.id.includes("_name")) ? e.id.indexOf("_name") :
+						((e.id.includes("_heading")) ? e.id.indexOf("_heading") :
+					 	((e.id.includes("_text_hide")) ? e.id.indexOf("_text_hide") : null)));
+					if (loc != null) {
+						id_to_toggle = e.id.slice(0, loc) + "_text";
+						overview.toggleVisibility(id_to_toggle, document
+								.getElementById(id_to_toggle + "_hide"));
+					}
 				}
 			}
 		},


### PR DESCRIPTION
This PR addresses JMC-8073 [[0]](https://bugs.openjdk.org/browse/JMC-8073), in which not all single page rule result html pages allow for the expansion and collapsing of individual rule results. These are the rule results found in the "Results" ui when viewing a jfr page (such as Garbage Collections).

The problem here is a premature slicing of the result id in the rules_overview.html when toggling the visibility [[1]](https://github.com/openjdk/jmc/blob/master/core/org.openjdk.jmc.flightrecorder.rules/src/main/resources/org/openjdk/jmc/flightrecorder/rules/report/html/internal/rules_overview.html#L285).

On the main automated analysis result page, the id can be in a format like `CompareCpu757108857_text_hide`, where we have the rule name plus a uuid, and  some html tag to identify it. In this case, `toggleVisiblity()` currently slices the first underscore, we end up with `CompareCpu757108857`, and the html is happy.

When viewing a single page result page, the uuid is instead replaced with a rule topic [[2]](https://github.com/openjdk/jmc/blob/master/core/org.openjdk.jmc.flightrecorder.rules/src/main/java/org/openjdk/jmc/flightrecorder/rules/report/html/internal/RulesHtmlToolkit.java#L177), which could be a string containing underscores itself, such as "garbage_collection" [[3]](https://github.com/openjdk/jmc/blob/master/core/org.openjdk.jmc.flightrecorder.rules/src/main/resources/org/openjdk/jmc/flightrecorder/rules/report/html/resultgroups.xml#L62). In this case, the id gets prematurely sliced into something like `GcPauseRatiogarbage_text`, which won't match a corresponding result button in the html.

The idea here is to trim the tail end of the id instead, given that there are only four possible combinations of `_score_value`, `_name`, `_heading`, and `_text_hide` that can be clicked on.

[0] https://bugs.openjdk.org/browse/JMC-8073
[1] https://github.com/openjdk/jmc/blob/master/core/org.openjdk.jmc.flightrecorder.rules/src/main/resources/org/openjdk/jmc/flightrecorder/rules/report/html/internal/rules_overview.html#L285
[2] https://github.com/openjdk/jmc/blob/master/core/org.openjdk.jmc.flightrecorder.rules/src/main/java/org/openjdk/jmc/flightrecorder/rules/report/html/internal/RulesHtmlToolkit.java#L178
[3] https://github.com/openjdk/jmc/blob/master/core/org.openjdk.jmc.flightrecorder.rules/src/main/resources/org/openjdk/jmc/flightrecorder/rules/report/html/resultgroups.xml#L62
