### PR TITLE
8080: Add support for enabling jfr on native images

### DIFF
--- a/application/org.openjdk.jmc.rjmx/src/main/java/org/openjdk/jmc/rjmx/ConnectionToolkit.java
+++ b/application/org.openjdk.jmc.rjmx/src/main/java/org/openjdk/jmc/rjmx/ConnectionToolkit.java
@@ -366,6 +366,20 @@ public final class ConnectionToolkit {
 	}
 
 	/**
+	 * Returns {@code true} if the connection handle is connected to a Substrate VM, {@code false}
+	 * otherwise. This method requires the connection handle to be connected.
+	 *
+	 * @param connectionHandle
+	 *            the connection handle to check.
+	 * @return {@code true} if the connection handle is connected to a Substrate VM, {@code false}
+	 *         otherwise.
+	 */
+	public static boolean isSubstrateVM(IConnectionHandle connectionHandle) {
+		String vmName = getVMName(connectionHandle);
+		return vmName != null && JavaVMVersionToolkit.isSubstrateVMName(vmName);
+	}
+
+	/**
 	 * Returns {@code true} if the connection handle is associated with an Oracle built JVM,
 	 * {@code false} otherwise. If the information is already present in the {@link JVMDescriptor},
 	 * this method will not cause any JMXRMI calls. If the information is lacking, an attempt will

--- a/application/org.openjdk.jmc.rjmx/src/main/java/org/openjdk/jmc/rjmx/JVMSupportToolkit.java
+++ b/application/org.openjdk.jmc.rjmx/src/main/java/org/openjdk/jmc/rjmx/JVMSupportToolkit.java
@@ -33,6 +33,7 @@
 package org.openjdk.jmc.rjmx;
 
 import javax.management.MBeanServerConnection;
+import javax.management.ObjectName;
 
 import org.openjdk.jmc.common.jvm.JVMDescriptor;
 import org.openjdk.jmc.common.jvm.JVMType;
@@ -46,6 +47,8 @@ import org.openjdk.jmc.rjmx.services.internal.HotspotManagementToolkit;
  * Checks the JVM capabilities of a connection.
  */
 public final class JVMSupportToolkit {
+
+	private final static String JFR_MBEAN_OBJECT_NAME = "jdk.management.jfr:type=FlightRecorder"; //$NON-NLS-1$
 
 	private JVMSupportToolkit() {
 		throw new IllegalArgumentException("Don't instantiate this toolkit"); //$NON-NLS-1$
@@ -66,7 +69,7 @@ public final class JVMSupportToolkit {
 		if (ConnectionToolkit.isJRockit(connection)) {
 			title = Messages.JVMSupport_TITLE_JROCKIT_NOT_SUPPORTED;
 			message = Messages.JVMSupport_MESSAGE_JROCKIT_NOT_SUPPORTED;
-		} else if (!ConnectionToolkit.isHotSpot(connection)) {
+		} else if (!ConnectionToolkit.isHotSpot(connection) && !ConnectionToolkit.isSubstrateVM(connection)) {
 			title = Messages.JVMSupport_TITLE_UNKNOWN_JVM;
 			message = Messages.JVMSupport_MESSAGE_UNKNOWN_JVM;
 		} else if (!ConnectionToolkit.isJavaVersionAboveOrEqual(connection,
@@ -98,8 +101,12 @@ public final class JVMSupportToolkit {
 		}
 		MBeanServerConnection server = connection.getServiceOrNull(MBeanServerConnection.class);
 		try {
-			HotspotManagementToolkit.getVMOption(server, "FlightRecorder");
-			return true;
+			if (ConnectionToolkit.isSubstrateVM(connection)) {
+				return server.isRegistered(new ObjectName(JFR_MBEAN_OBJECT_NAME));
+			} else {
+				HotspotManagementToolkit.getVMOption(server, "FlightRecorder");
+				return true;
+			}
 		} catch (Exception e) { // RuntimeMBeanException thrown if FlightRecorder is not present
 			return false;
 		}
@@ -177,6 +184,9 @@ public final class JVMSupportToolkit {
 				return getJfrJRockitNotSupported(shortMessage);
 			}
 			if (jvmInfo.getJvmType() == JVMType.UNKNOWN) {
+				return null;
+			}
+			if (jvmInfo.getJvmType() == JVMType.SUBSTRATE) {
 				return null;
 			}
 			if (jvmInfo.getJvmType() != JVMType.HOTSPOT) {

--- a/application/tests/org.openjdk.jmc.rjmx.test/src/test/java/org/openjdk/jmc/rjmx/test/JVMSupportToolkitTest.java
+++ b/application/tests/org.openjdk.jmc.rjmx.test/src/test/java/org/openjdk/jmc/rjmx/test/JVMSupportToolkitTest.java
@@ -49,8 +49,10 @@ import org.openjdk.jmc.rjmx.messages.internal.Messages;
 public class JVMSupportToolkitTest {
 	private static final String NAME_OPEN_JDK = "OpenJDK 64-Bit Server VM";
 	private static final String NAME_ORACLE = "Java HotSpot(TM) 64-Bit Server VM";
+	private static final String NAME_SUBSTRATE = "Substrate VM";
 	private static final String VENDOR_OPEN_JDK = "Oracle Corporation";
 	private static final String VENDOR_ORACLE = "Oracle Corporation";
+	private static final String VENDOR_GRAAL = "GraalVM Community";
 	// FIXME: Add tests for the methods that take IConnectionHandle as a parameter.
 
 	private static final String SUPPORTED_MESSAGE = null;
@@ -160,5 +162,16 @@ public class JVMSupportToolkitTest {
 				new ConnectionDescriptorBuilder().hostName("localhost").port(0).build(), null);
 		String errorMessage = JVMSupportToolkit.checkFlightRecorderSupport(server, false);
 		assertNotNull(errorMessage);
+	}
+
+	@Test
+	public void testSubstrateVMSupported() {
+		ServerHandle server = new ServerHandle(
+				new ServerDescriptor(null, null,
+						new JVMDescriptor("20", JVMType.SUBSTRATE, JVMArch.UNKNOWN, null, null, NAME_SUBSTRATE,
+								VENDOR_GRAAL, null, false, null)),
+				new ConnectionDescriptorBuilder().hostName("localhost").port(0).build(), null);
+		String errorMessage = JVMSupportToolkit.checkFlightRecorderSupport(server, false);
+		assertEquals(SUPPORTED_MESSAGE, errorMessage);
 	}
 }

--- a/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/jvm/JVMType.java
+++ b/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/jvm/JVMType.java
@@ -47,6 +47,10 @@ public enum JVMType {
 	 */
 	HOTSPOT,
 	/**
+	 * The JVM is Substrate VM.
+	 */
+	SUBSTRATE,
+	/**
 	 * The JVM is unknown.
 	 */
 	UNKNOWN,
@@ -67,6 +71,8 @@ public enum JVMType {
 			return JVMType.JROCKIT;
 		} else if (JavaVMVersionToolkit.isHotspotJVMName(jvmName)) {
 			return JVMType.HOTSPOT;
+		} else if (JavaVMVersionToolkit.isSubstrateVMName(jvmName)) {
+			return JVMType.SUBSTRATE;
 		}
 		return JVMType.OTHER;
 	}

--- a/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/version/JavaVMVersionToolkit.java
+++ b/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/version/JavaVMVersionToolkit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -114,6 +114,21 @@ public class JavaVMVersionToolkit {
 			return false;
 		}
 		return vmName.startsWith("Java HotSpot") || isOpenJDKJVMName(vmName) || vmName.startsWith("SAP"); //$NON-NLS-1$ //$NON-NLS-2$;
+	}
+
+	/**
+	 * Returns whether this is a Substrate VM or not.
+	 *
+	 * @param vmName
+	 *            the VM name to check.
+	 * @return {@code true} if it is a Substrate VM, {@code false} if it isn't or if was not
+	 *         possible to tell.
+	 */
+	public static boolean isSubstrateVMName(String vmName) {
+		if (vmName == null) {
+			return false;
+		}
+		return vmName.startsWith("Substrate VM"); //$NON-NLS-1$
 	}
 
 	/**

--- a/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/version/JavaVMVersionToolkit.java
+++ b/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/version/JavaVMVersionToolkit.java
@@ -91,7 +91,7 @@ public class JavaVMVersionToolkit {
 	 *
 	 * @param vmName
 	 *            the JVM name to check.
-	 * @return {@code true} of it is a JRockit, {@code false} if it isn't or if was not possible to
+	 * @return {@code true} of it is a JRockit, {@code false} if it isn't or if it was not possible to
 	 *         tell.
 	 */
 	public static boolean isJRockitJVMName(String vmName) {
@@ -106,7 +106,7 @@ public class JavaVMVersionToolkit {
 	 *
 	 * @param vmName
 	 *            the JVM name to check.
-	 * @return {@code true} if it is a HotSpot, {@code false} if it isn't or if was not possible to
+	 * @return {@code true} if it is a HotSpot, {@code false} if it isn't or if it was not possible to
 	 *         tell.
 	 */
 	public static boolean isHotspotJVMName(String vmName) {
@@ -121,7 +121,7 @@ public class JavaVMVersionToolkit {
 	 *
 	 * @param vmName
 	 *            the VM name to check.
-	 * @return {@code true} if it is a Substrate VM, {@code false} if it isn't or if was not
+	 * @return {@code true} if it is a Substrate VM, {@code false} if it isn't or if if was not
 	 *         possible to tell.
 	 */
 	public static boolean isSubstrateVMName(String vmName) {
@@ -136,7 +136,7 @@ public class JavaVMVersionToolkit {
 	 *
 	 * @param vmName
 	 *            the JVM name to check.
-	 * @return {@code true} if it is a OpenJDK JVM, {@code false} if it isn't or if was not possible
+	 * @return {@code true} if it is a OpenJDK JVM, {@code false} if it isn't or if it was not possible
 	 *         to tell.
 	 */
 	public static boolean isOpenJDKJVMName(String vmName) {

--- a/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/version/JavaVMVersionToolkit.java
+++ b/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/version/JavaVMVersionToolkit.java
@@ -91,8 +91,8 @@ public class JavaVMVersionToolkit {
 	 *
 	 * @param vmName
 	 *            the JVM name to check.
-	 * @return {@code true} of it is a JRockit, {@code false} if it isn't or if it was not possible to
-	 *         tell.
+	 * @return {@code true} of it is a JRockit, {@code false} if it isn't or if it was not possible
+	 *         to tell.
 	 */
 	public static boolean isJRockitJVMName(String vmName) {
 		if (vmName == null) {
@@ -106,8 +106,8 @@ public class JavaVMVersionToolkit {
 	 *
 	 * @param vmName
 	 *            the JVM name to check.
-	 * @return {@code true} if it is a HotSpot, {@code false} if it isn't or if it was not possible to
-	 *         tell.
+	 * @return {@code true} if it is a HotSpot, {@code false} if it isn't or if it was not possible
+	 *         to tell.
 	 */
 	public static boolean isHotspotJVMName(String vmName) {
 		if (vmName == null) {
@@ -136,8 +136,8 @@ public class JavaVMVersionToolkit {
 	 *
 	 * @param vmName
 	 *            the JVM name to check.
-	 * @return {@code true} if it is a OpenJDK JVM, {@code false} if it isn't or if it was not possible
-	 *         to tell.
+	 * @return {@code true} if it is a OpenJDK JVM, {@code false} if it isn't or if it was not
+	 *         possible to tell.
 	 */
 	public static boolean isOpenJDKJVMName(String vmName) {
 		if (vmName == null) {

--- a/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/version/JavaVMVersionToolkit.java
+++ b/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/version/JavaVMVersionToolkit.java
@@ -91,7 +91,7 @@ public class JavaVMVersionToolkit {
 	 *
 	 * @param vmName
 	 *            the JVM name to check.
-	 * @return {@code true} of it is a JRockit, {@code false} if it isn't or if it was not possible
+	 * @return {@code true} if it is a JRockit, {@code false} if it isn't or if it was not possible
 	 *         to tell.
 	 */
 	public static boolean isJRockitJVMName(String vmName) {


### PR DESCRIPTION
This PR addresses JMC-8080 [[0]](https://bugs.openjdk.org/browse/JMC-8080), in which it would be nice to add support for enabling flight recorder on GraalVM native images.

Currently, trying to use the flight recording wizard on a connected native image ends up with an error dialog:
![native-image](https://github.com/openjdk/jmc/assets/10425301/a04b49db-922c-451e-89d8-0cc951e3bbda)

The proposed solution here adds checks to determine if the vm is of type Substrate VM, and check if there is a flightrecording mbean registered.

[0] https://bugs.openjdk.org/browse/JMC-8080

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JMC-8080](https://bugs.openjdk.org/browse/JMC-8080): Add support for enabling jfr on native images (**Enhancement** - P3)


### Reviewers
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - Committer)
 * [Brice Dutheil](https://openjdk.org/census#bdutheil) (@bric3 - Author)


### Contributors
 * Robert Toyonaga `<rtoyonaga@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmc.git pull/491/head:pull/491` \
`$ git checkout pull/491`

Update a local copy of the PR: \
`$ git checkout pull/491` \
`$ git pull https://git.openjdk.org/jmc.git pull/491/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 491`

View PR using the GUI difftool: \
`$ git pr show -t 491`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmc/pull/491.diff">https://git.openjdk.org/jmc/pull/491.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jmc/pull/491#issuecomment-1582644719)