### PR TITLE
8082: Add ctrl+a keyboard shortcut to select all lanes on jfr threads page

### DIFF
--- a/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/charts/XYChart.java
+++ b/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/charts/XYChart.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -729,6 +729,10 @@ public class XYChart {
 		selectionStart = xStart;
 		selectionEnd = xEnd;
 		return (oldRows == null) || !oldRows.equals(selectedRows);
+	}
+
+	public void selectAll(int numItems, int laneHeight) {
+		select(0, 0, 0, numItems * laneHeight, true);
 	}
 
 	public boolean clearSelection() {

--- a/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/misc/ChartCanvas.java
+++ b/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/misc/ChartCanvas.java
@@ -465,9 +465,9 @@ public class ChartCanvas extends Canvas {
 		@Override
 		public void keyReleased(KeyEvent event) {
 			switch (event.keyCode) {
-				case SWT.CTRL:
-					isCtrlHeld = false;
-					break;
+			case SWT.CTRL:
+				isCtrlHeld = false;
+				break;
 			}
 		}
 	}

--- a/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/misc/ChartCanvas.java
+++ b/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/misc/ChartCanvas.java
@@ -407,6 +407,8 @@ public class ChartCanvas extends Canvas {
 		}
 	}
 
+	private boolean isCtrlHeld;
+
 	class KeyNavigator implements KeyListener {
 
 		@Override
@@ -428,6 +430,20 @@ public class ChartCanvas extends Canvas {
 					redrawChart();
 					redrawChartText();
 					break;
+				case SWT.CTRL:
+					isCtrlHeld = true;
+					break;
+				case 'a':
+					if (isCtrlHeld) {
+						awtChart.selectAll(numItems, laneHeight);
+						if (selectionListener != null) {
+							selectionListener.run();
+						}
+						redrawChart();
+						redrawChartText();
+						break;
+					}
+					break;
 				case SWT.ARROW_RIGHT:
 					pan(10);
 					break;
@@ -448,9 +464,12 @@ public class ChartCanvas extends Canvas {
 
 		@Override
 		public void keyReleased(KeyEvent event) {
-			// Ignore
+			switch (event.keyCode) {
+				case SWT.CTRL:
+					isCtrlHeld = false;
+					break;
+			}
 		}
-
 	}
 
 	private class AntiAliasingListener implements IPropertyChangeListener {

--- a/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/misc/ChartTextCanvas.java
+++ b/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/misc/ChartTextCanvas.java
@@ -274,6 +274,8 @@ public class ChartTextCanvas extends Canvas {
 		}
 	}
 
+	private boolean isCtrlHeld;
+
 	class KeyNavigator implements KeyListener {
 
 		@Override
@@ -289,6 +291,20 @@ public class ChartTextCanvas extends Canvas {
 					redrawChart();
 					redrawChartText();
 					break;
+				case SWT.CTRL:
+					isCtrlHeld = true;
+					break;
+				case 'a':
+					if (isCtrlHeld) {
+						awtChart.selectAll(numItems, laneHeight);
+						if (selectionListener != null) {
+							selectionListener.run();
+						}
+						redrawChart();
+						redrawChartText();
+						break;
+					}
+					break;
 				default:
 					// Ignore
 				}
@@ -297,9 +313,12 @@ public class ChartTextCanvas extends Canvas {
 
 		@Override
 		public void keyReleased(KeyEvent event) {
-			// Ignore
+			switch (event.keyCode) {
+				case SWT.CTRL:
+					isCtrlHeld = false;
+					break;
+			}
 		}
-
 	}
 
 	private class AntiAliasingListener implements IPropertyChangeListener {

--- a/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/misc/ChartTextCanvas.java
+++ b/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/misc/ChartTextCanvas.java
@@ -314,9 +314,9 @@ public class ChartTextCanvas extends Canvas {
 		@Override
 		public void keyReleased(KeyEvent event) {
 			switch (event.keyCode) {
-				case SWT.CTRL:
-					isCtrlHeld = false;
-					break;
+			case SWT.CTRL:
+				isCtrlHeld = false;
+				break;
 			}
 		}
 	}


### PR DESCRIPTION
This PR addresses JMC-8082 [[0]](https://bugs.openjdk.org/browse/JMC-8082), in which it'd be nice to easily select all the threads on the jfr threads page using a keyboard shortcut. Inspired by https://github.com/openjdk/jmc/pull/492, it would be nice to add more "table" behaviour to the jfr threads page text canvas. In this case, the keyboard shortcut ctrl+a will highlight all of the thread lanes and update the current selection.

[0] https://bugs.openjdk.org/browse/JMC-8082

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JMC-8082](https://bugs.openjdk.org/browse/JMC-8082): Add ctrl+a keyboard shortcut to select all lanes on jfr threads page (**Enhancement** - P5)


### Reviewers
 * [Marcus Hirt](https://openjdk.org/census#hirt) (@thegreystone - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmc.git pull/493/head:pull/493` \
`$ git checkout pull/493`

Update a local copy of the PR: \
`$ git checkout pull/493` \
`$ git pull https://git.openjdk.org/jmc.git pull/493/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 493`

View PR using the GUI difftool: \
`$ git pr show -t 493`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmc/pull/493.diff">https://git.openjdk.org/jmc/pull/493.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jmc/pull/493#issuecomment-1585242269)