### PR TITLE
8083: Updates for releng projects

### DIFF
--- a/releng/platform-definitions/platform-definition-2022-09/platform-definition-2022-09.target
+++ b/releng/platform-definitions/platform-definition-2022-09/platform-definition-2022-09.target
@@ -56,7 +56,7 @@
             <unit id="org.eclipse.equinox.executable.feature.group" version="3.8.1800.v20220720-1949"/>
             <unit id="org.eclipse.pde.feature.group" version="3.14.1300.v20220831-1800"/>
             <unit id="org.eclipse.platform.sdk" version="4.25.0.I20220831-1800"/>
-            <repository location="http://download.eclipse.org/releases/2022-09/"/>
+            <repository location="https://download.eclipse.org/releases/2022-09/"/>
         </location>
         <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
             <unit id="org.eclipse.babel.nls_eclipse_ja.feature.group" version="4.25.0.v20230221050449"/>

--- a/releng/platform-definitions/platform-definition-2022-12/platform-definition-2022-12.target
+++ b/releng/platform-definitions/platform-definition-2022-12/platform-definition-2022-12.target
@@ -56,7 +56,7 @@
             <unit id="org.eclipse.equinox.executable.feature.group" version="3.8.1900.v20221108-1024"/>
             <unit id="org.eclipse.pde.feature.group" version="3.14.1400.v20221123-1800"/>
             <unit id="org.eclipse.platform.sdk" version="4.26.0.I20221123-1800"/>
-            <repository location="http://download.eclipse.org/releases/2022-12/"/>
+            <repository location="https://download.eclipse.org/releases/2022-12/"/>
         </location>
         <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
             <unit id="org.eclipse.babel.nls_eclipse_ja.feature.group" version="4.26.0.v20230220105658"/>

--- a/releng/platform-definitions/platform-definition-2023-03/platform-definition-2023-03.target
+++ b/releng/platform-definitions/platform-definition-2023-03/platform-definition-2023-03.target
@@ -56,7 +56,7 @@
             <unit id="org.eclipse.equinox.executable.feature.group" version="3.8.2000.v20221201-0912"/>
             <unit id="org.eclipse.pde.feature.group" version="3.14.1500.v20230302-0300"/>
             <unit id="org.eclipse.platform.sdk" version="4.27.0.I20230302-0300"/>
-            <repository location="http://download.eclipse.org/releases/2023-03/"/>
+            <repository location="https://download.eclipse.org/releases/2023-03/"/>
         </location>
         <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
             <unit id="org.eclipse.babel.nls_eclipse_ja.feature.group" version="4.26.0.v20230220105658"/>

--- a/releng/third-party/.classpath
+++ b/releng/third-party/.classpath
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="src" output="target/classes" path="src/main/java">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" output="target/test-classes" path="src/test/java">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.m2e.MAVEN2_CLASSPATH_CONTAINER">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="output" path="target/classes"/>
+</classpath>

--- a/releng/third-party/pom.xml
+++ b/releng/third-party/pom.xml
@@ -40,21 +40,24 @@
 
 	<properties>
 		<!-- Config -->
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<maven.compiler.source>17</maven.compiler.source>
+		<maven.compiler.target>17</maven.compiler.target>
 		<spotless.config.path>${basedir}/../../configuration/ide/eclipse/formatting/formatting.xml</spotless.config.path>
+		<!-- Plugin Versions -->
+		<p2-maven-plugin.version>2.1.0</p2-maven-plugin.version>
+		<jetty-maven-plugin.version>11.0.15</jetty-maven-plugin.version>
+		<maven-enforcer-plugin.version>3.3.0</maven-enforcer-plugin.version>
 		<!-- Versions -->
-		<hdrhistogram.version>2.1.12</hdrhistogram.version>
 		<jakarta.mail.version>2.0.1</jakarta.mail.version>
 		<angus.activation.version>2.0.0</angus.activation.version>
 		<jakarta.activation.version>2.1.1</jakarta.activation.version>
 		<osgi-resource-locator.version>1.0.3</osgi-resource-locator.version>
-		<javax.websocket.version>1.1</javax.websocket.version>
-		<jetty.version>10.0.12</jetty.version>
-		<jemmy.version>2.0.0</jemmy.version>
-		<jetty-maven-plugin.version>9.4.46.v20220331</jetty-maven-plugin.version>
-		<lz4.version>1.8.0</lz4.version>
-		<maven-enforcer-plugin.version>3.0.0</maven-enforcer-plugin.version>
 		<owasp.encoder.version>1.2.3</owasp.encoder.version>
-		<p2-maven-plugin.version>2.0.0</p2-maven-plugin.version>
+		<lz4.version>1.8.0</lz4.version>
+		<hdrhistogram.version>2.1.12</hdrhistogram.version>
+		<jemmy.version>2.0.0</jemmy.version>
+		<jetty.version>10.0.12</jetty.version>
 		<spifly.version>1.3.6</spifly.version>
 	</properties>
 
@@ -140,7 +143,6 @@
 				<artifactId>jetty-maven-plugin</artifactId>
 				<version>${jetty-maven-plugin.version}</version>
 				<configuration>
-					<scanIntervalSeconds>60</scanIntervalSeconds>
 					<webAppSourceDirectory>${basedir}/target/repository/</webAppSourceDirectory>
 					<webApp>
 						<contextPath>/site</contextPath>
@@ -163,8 +165,8 @@
 						<configuration>
 							<rules>
 								<requireJavaVersion>
-									<version>[1.8.0-40,)</version>
-									<message>Building JMC requires Java 8 version JDK 1.8.0_40 or later</message>
+									<version>[17,)</version>
+									<message>Building JMC requires Java 17 or later</message>
 								</requireJavaVersion>
 							</rules>
 						</configuration>
@@ -177,8 +179,8 @@
 						<configuration>
 							<rules>
 								<requireMavenVersion>
-									<version>3.3.1</version>
-									<message>Building JMC requires at least Maven 3.3.1</message>
+									<version>3.5.0</version>
+									<message>Building JMC requires at least Maven 3.5.0</message>
 								</requireMavenVersion>
 							</rules>
 						</configuration>


### PR DESCRIPTION
The releng projects (Local update site for building/development and Eclipse platform definition files) need some TLC.

The releng/third-party project needs some version bumps. Furthermore, for importing it as maven project into eclipse, it should have a .classpath file.

In detail, I bumped versions of the used plugins. Most significantly I updated the used jetty-maven-plugin from 9.4.46.v20220331 to 11.0.15. Seems to work out of the box, no issues. The config parameter `scanIntervalSeconds` is not recognized in that version any more.
Furthermore, I changed the maven enforcer settings to require JDK 17 and Maven 3.5.0, as in other places.

Also, the Eclipse platform URL should use https rather than http nowadays. Spolier/Outlook: To be able to use Eclipse 2023-06 I believe that we will need to find a solution to run the jetty with https. Otherwise, importing into Eclipse will not work any longer.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JMC-8083](https://bugs.openjdk.org/browse/JMC-8083): Updates for releng projects (**Enhancement** - P4)


### Reviewers
 * [Marcus Hirt](https://openjdk.org/census#hirt) (@thegreystone - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmc.git pull/494/head:pull/494` \
`$ git checkout pull/494`

Update a local copy of the PR: \
`$ git checkout pull/494` \
`$ git pull https://git.openjdk.org/jmc.git pull/494/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 494`

View PR using the GUI difftool: \
`$ git pr show -t 494`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmc/pull/494.diff">https://git.openjdk.org/jmc/pull/494.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jmc/pull/494#issuecomment-1585242504)