### PR TITLE
8093: Rules dependant on GarbageCollectionInfoRule throw NPE if there is no gcInfo

### DIFF
--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/memory/GcLockerRule.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/memory/GcLockerRule.java
@@ -79,7 +79,7 @@ public class GcLockerRule implements IRule {
 			.<TypedResult<?>> asList(TypedResult.SCORE, GC_LOCKER_RATIO);
 
 	private static final Map<String, EventAvailability> REQUIRED_EVENTS = RequiredEventsBuilder.create()
-			.addEventType(JdkTypeIDs.GARBAGE_COLLECTION, EventAvailability.ENABLED).build();
+			.addEventType(JdkTypeIDs.GARBAGE_COLLECTION, EventAvailability.AVAILABLE).build();
 
 	private IResult getResult(
 		IItemCollection items, IPreferenceValueProvider valueProvider, IResultValueProvider resultProvider) {

--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/memory/GcLockerRule.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/memory/GcLockerRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/memory/GcStallRule.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/memory/GcStallRule.java
@@ -65,7 +65,7 @@ public class GcStallRule implements IRule {
 	private static final String GC_STALL_RESULT_ID = "GcStall"; //$NON-NLS-1$
 
 	private static final Map<String, EventAvailability> REQUIRED_EVENTS = RequiredEventsBuilder.create()
-			.addEventType(JdkTypeIDs.GARBAGE_COLLECTION, EventAvailability.ENABLED)
+			.addEventType(JdkTypeIDs.GARBAGE_COLLECTION, EventAvailability.AVAILABLE)
 			.addEventType(JdkTypeIDs.GC_CONF, EventAvailability.ENABLED).build();
 
 	@Override

--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/memory/GcStallRule.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/memory/GcStallRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/memory/HeapInspectionRule.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/memory/HeapInspectionRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/memory/HeapInspectionRule.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/memory/HeapInspectionRule.java
@@ -80,7 +80,7 @@ public class HeapInspectionRule implements IRule {
 			.<TypedResult<?>> asList(TypedResult.SCORE, OBJECT_COUNT_GCS);
 
 	private static final Map<String, EventAvailability> REQUIRED_EVENTS = RequiredEventsBuilder.create()
-			.addEventType(JdkTypeIDs.GARBAGE_COLLECTION, EventAvailability.ENABLED).build();
+			.addEventType(JdkTypeIDs.GARBAGE_COLLECTION, EventAvailability.AVAILABLE).build();
 
 	@Override
 	public RunnableFuture<IResult> createEvaluation(

--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/memory/SystemGcRule.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/memory/SystemGcRule.java
@@ -79,7 +79,7 @@ public class SystemGcRule implements IRule {
 			.<TypedResult<?>> asList(TypedResult.SCORE, SYSTEM_GC_RATIO);
 
 	private static final Map<String, EventAvailability> REQUIRED_EVENTS = RequiredEventsBuilder.create()
-			.addEventType(JdkTypeIDs.GARBAGE_COLLECTION, EventAvailability.ENABLED).build();
+			.addEventType(JdkTypeIDs.GARBAGE_COLLECTION, EventAvailability.AVAILABLE).build();
 
 	@Override
 	public RunnableFuture<IResult> createEvaluation(

--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/memory/SystemGcRule.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/memory/SystemGcRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *


### PR DESCRIPTION
This short PR addresses a bug where the four gc rules that depend on GarbageCollectionInfoRule will throw a NPE when evaluating in the case there is no GC information.

This (probably?) won't happen too often, as it requires the jdk.GarbageCollection event to be enabled but never recorded. I was interacting with a handful of short recordings when I ran into this. 
![event-browser](https://github.com/openjdk/jmc/assets/10425301/cac8ceaa-34b6-46b3-8a42-14af375a7c51)

The GarbageCollectionInfoRule has it's jdk.GarbageCollection EventAvailability set to AVAILABLE, which means it's looking for the event to be both enabled and have data before evaluating.

The four rules that depend on it have their EventAvailability set to ENABLED, so these rules will run if the event is enabled but even if there's no data. Because GarbageCollectionInfoRule never runs, the aggregate object in the dependant rules is null ([[example]](https://github.com/openjdk/jmc/blob/master/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/memory/HeapInspectionRule.java#L102) [0]), so a NPE is thrown when trying to evaluate it.

The fix here is to make these rules require the gc events to be available in order to proceed, similar to how GarbageCollectionInfoRule does.

Before:
![before](https://github.com/openjdk/jmc/assets/10425301/e4eb6b7f-4055-491c-a5b3-ded5608644d7)

After:
![after](https://github.com/openjdk/jmc/assets/10425301/3caf81ac-b8a8-4b8b-a87f-4bc11f14c8c2)

[0] https://github.com/openjdk/jmc/blob/master/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/memory/HeapInspectionRule.java#L102

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JMC-8093](https://bugs.openjdk.org/browse/JMC-8093): Rules dependant on GarbageCollectionInfoRule throw NPE if there is no gcInfo (**Bug** - P5)


### Reviewers
 * [Marcus Hirt](https://openjdk.org/census#hirt) (@thegreystone - **Reviewer**) ⚠️ Review applies to [5fa1f3e9](https://git.openjdk.org/jmc/pull/498/files/5fa1f3e917959295fb44f9dac2b3d23ffd2e9549)
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmc.git pull/498/head:pull/498` \
`$ git checkout pull/498`

Update a local copy of the PR: \
`$ git checkout pull/498` \
`$ git pull https://git.openjdk.org/jmc.git pull/498/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 498`

View PR using the GUI difftool: \
`$ git pr show -t 498`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmc/pull/498.diff">https://git.openjdk.org/jmc/pull/498.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jmc/pull/498#issuecomment-1595292865)