### PR TITLE
8095: Update org.openjdk.jmc.flightrecorder.rules.test/.classpath after JMC-8086

### DIFF
--- a/core/tests/org.openjdk.jmc.flightrecorder.rules.test/.classpath
+++ b/core/tests/org.openjdk.jmc.flightrecorder.rules.test/.classpath
@@ -17,5 +17,10 @@
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>
 	</classpathentry>
+	<classpathentry excluding="**" kind="src" output="target/classes" path="src/main/resources">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>


### PR DESCRIPTION
JMC-8086 requires updating org.openjdk.jmc.flightrecorder.rules.test/.classpath after adding resource files. This was missed out in the original change.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JMC-8095](https://bugs.openjdk.org/browse/JMC-8095): Update org.openjdk.jmc.flightrecorder.rules.test/.classpath after JMC-8086 (**Bug** - P4)


### Reviewers
 * [Alex Macdonald](https://openjdk.org/census#aptmac) (@aptmac - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmc.git pull/500/head:pull/500` \
`$ git checkout pull/500`

Update a local copy of the PR: \
`$ git checkout pull/500` \
`$ git pull https://git.openjdk.org/jmc.git pull/500/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 500`

View PR using the GUI difftool: \
`$ git pr show -t 500`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmc/pull/500.diff">https://git.openjdk.org/jmc/pull/500.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jmc/pull/500#issuecomment-1599583072)