### PR TITLE
8096: EventTemplateTest fails for JDKs with custom jfr profiles

### DIFF
--- a/application/tests/org.openjdk.jmc.rjmx.services.jfr.test/src/test/java/org/openjdk/jmc/rjmx/services/jfr/test/EventTemplateTest.java
+++ b/application/tests/org.openjdk.jmc.rjmx.services.jfr.test/src/test/java/org/openjdk/jmc/rjmx/services/jfr/test/EventTemplateTest.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
- * 
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * The contents of this file are subject to the terms of either the Universal Permissive License
@@ -10,17 +10,17 @@
  *
  * Redistribution and use in source and binary forms, with or without modification, are permitted
  * provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice, this list of conditions
  * and the following disclaimer.
- * 
+ *
  * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
  * conditions and the following disclaimer in the documentation and/or other materials provided with
  * the distribution.
- * 
+ *
  * 3. Neither the name of the copyright holder nor the names of its contributors may be used to
  * endorse or promote products derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
  * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
@@ -32,16 +32,15 @@
  */
 package org.openjdk.jmc.rjmx.services.jfr.test;
 
-import static org.junit.Assert.assertNotNull;
-
 import java.util.Collection;
 import java.util.List;
 
 import org.junit.Assert;
 import org.junit.Test;
-
 import org.openjdk.jmc.flightrecorder.configuration.events.IEventTypeID;
 import org.openjdk.jmc.rjmx.services.jfr.IFlightRecorderService;
+
+import static org.junit.Assert.assertNotNull;
 
 @SuppressWarnings("nls")
 public class EventTemplateTest extends JfrTestCase {
@@ -59,7 +58,8 @@ public class EventTemplateTest extends JfrTestCase {
 		assumeHotSpot7u12OrLater(getConnectionHandle());
 
 		IFlightRecorderService service = getFlightRecorderService();
-		List<String> templates = service.getServerTemplates();
+		List<String> templates = service.getServerTemplates().stream().filter(t -> t.contains("provider=\"Oracle\""))
+				.toList();
 
 		Collection<? extends IEventTypeID> allEventTypes = service.getEventTypeInfoMapByID().keySet();
 		for (IEventTypeID eventTypeId : allEventTypes) {


### PR DESCRIPTION
EventTemplateTest could be made more robust to not fail for VMs that deliver custom JFR profiles, such as SapMachine does.

The test currently expects that every JFR profile contains all available events which might not be true. The generic idea to fix this is to only assume this for profiles that are tagged with `provider="Oracle"`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JMC-8096](https://bugs.openjdk.org/browse/JMC-8096): EventTemplateTest fails for JDKs with custom jfr profiles (**Bug** - P3)


### Reviewers
 * [Alex Macdonald](https://openjdk.org/census#aptmac) (@aptmac - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmc.git pull/501/head:pull/501` \
`$ git checkout pull/501`

Update a local copy of the PR: \
`$ git checkout pull/501` \
`$ git pull https://git.openjdk.org/jmc.git pull/501/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 501`

View PR using the GUI difftool: \
`$ git pr show -t 501`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmc/pull/501.diff">https://git.openjdk.org/jmc/pull/501.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jmc/pull/501#issuecomment-1599635757)