### PR TITLE
7441: JVM System information tables do not scroll horizontally

### DIFF
--- a/application/org.openjdk.jmc.console.ui/src/main/java/org/openjdk/jmc/console/ui/tabs/system/SystemPropertiesSectionPart.java
+++ b/application/org.openjdk.jmc.console.ui/src/main/java/org/openjdk/jmc/console/ui/tabs/system/SystemPropertiesSectionPart.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -75,8 +75,7 @@ public class SystemPropertiesSectionPart extends MCSectionPart {
 		Composite body = createSectionBody(MCLayoutFactory.createMarginFreeFormPageLayout());
 		Composite filterComposite = toolkit.createComposite(body);
 		filterComposite.setLayoutData(MCLayoutFactory.createFormPageLayoutData(SWT.DEFAULT, SWT.DEFAULT, true, false));
-		Table table = toolkit.createTable(body,
-				SWT.FULL_SELECTION | SWT.MULTI | SWT.VIRTUAL | SWT.H_SCROLL | SWT.V_SCROLL);
+		Table table = toolkit.createTable(body, SWT.FULL_SELECTION | SWT.MULTI | SWT.H_SCROLL | SWT.V_SCROLL);
 		table.setLayoutData(MCLayoutFactory.createFormPageLayoutData());
 		TableViewer viewer = new TableViewer(table);
 		viewer.setContentProvider(new TreeStructureContentProvider());
@@ -122,6 +121,7 @@ public class SystemPropertiesSectionPart extends MCSectionPart {
 		Object v = event.getValue();
 		if (v instanceof TabularData) {
 			columnManager.getViewer().setInput(((TabularData) v).values());
+			columnManager.packColumns();
 		}
 	}
 }

--- a/application/org.openjdk.jmc.console.ui/src/main/java/org/openjdk/jmc/console/ui/tabs/system/TableInformationSectionPart.java
+++ b/application/org.openjdk.jmc.console.ui/src/main/java/org/openjdk/jmc/console/ui/tabs/system/TableInformationSectionPart.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -65,8 +65,7 @@ public class TableInformationSectionPart extends MCSectionPart {
 		super(parent, toolkit, Messages.SECTION_SERVER_INFORMATION_TITLE);
 
 		Composite body = createSectionBody(MCLayoutFactory.createMarginFreeFormPageLayout());
-		Table table = toolkit.createTable(body,
-				SWT.FULL_SELECTION | SWT.MULTI | SWT.VIRTUAL | SWT.H_SCROLL | SWT.V_SCROLL);
+		Table table = toolkit.createTable(body, SWT.FULL_SELECTION | SWT.MULTI | SWT.H_SCROLL | SWT.V_SCROLL);
 		table.setLayoutData(MCLayoutFactory.createFormPageLayoutData());
 		TableViewer viewer = new TableViewer(table);
 		viewer.setContentProvider(new TreeStructureContentProvider());
@@ -81,6 +80,7 @@ public class TableInformationSectionPart extends MCSectionPart {
 		ColumnMenusFactory.addDefaultMenus(columnManager, MCContextMenuManager.create(table));
 
 		viewer.setInput(ServerInformationModelBuilder.build(connection));
+		columnManager.packColumns();
 	}
 
 	public void saveState(IMemento state) {

--- a/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/column/ColumnManager.java
+++ b/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/column/ColumnManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -65,6 +65,7 @@ import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Item;
 import org.eclipse.swt.widgets.Listener;
 import org.eclipse.swt.widgets.Table;
+import org.eclipse.swt.widgets.TableColumn;
 import org.eclipse.swt.widgets.Tree;
 import org.eclipse.swt.widgets.Widget;
 
@@ -600,4 +601,9 @@ public class ColumnManager {
 		table.setTopIndex(state.getScrollIndex());
 	}
 
+	public void packColumns() {
+		for (TableColumn column : ((Table) getViewer().getControl()).getColumns()) {
+			column.pack();
+		}
+	}
 }


### PR DESCRIPTION
This PR addresses JMC-7441 [[0]](https://bugs.openjdk.org/browse/JMC-7441), in which the tables on the System tab in the JVM Browser don't scroll horizontally (very well).

While looking into this I noticed it affects many more tables, potentially most notable would be the automated analysis report ui, but that should be taken care of in a separate ticket.

The problem is that the column sizes aren't being set appropriately to the contents of the table. This affects the tables initialized with `SWT.VIRTUAL`, because these are lazy loaded and are not always fully filled out when it's time for the table to paint. I was playing around with an idea of adding a listener on the `SWT.Paint` event and having the columns re-sized in an attempt to keep these as virtual tables, but the initial re-paint was jarring visually. Also it might not make sense for (some of) these tables to be virtual; they don't contain a large amount of information and/or aren't mutable.

For the sake of the JVM Browser System tab tables, I just made these tables non-virtual and added a column packing function to the ColumnManager. The result is now the entire contents can be viewed in the table.

[0] https://bugs.openjdk.org/browse/JMC-7441

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JMC-7441](https://bugs.openjdk.org/browse/JMC-7441): JVM System information tables do not scroll horizontally (**Bug** - P4)


### Reviewers
 * [Marcus Hirt](https://openjdk.org/census#hirt) (@thegreystone - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmc.git pull/505/head:pull/505` \
`$ git checkout pull/505`

Update a local copy of the PR: \
`$ git checkout pull/505` \
`$ git pull https://git.openjdk.org/jmc.git pull/505/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 505`

View PR using the GUI difftool: \
`$ git pr show -t 505`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmc/pull/505.diff">https://git.openjdk.org/jmc/pull/505.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jmc/pull/505#issuecomment-1635127550)