### PR TITLE
8101: Add ignore icon to automated analysis table

### DIFF
--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/overview/ResultTableUi.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/overview/ResultTableUi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -98,6 +98,8 @@ class ResultTableUi {
 				return image(ResultOverview.ICON_INFO);
 			case OK:
 				return image(ResultOverview.ICON_OK);
+			case IGNORE:
+				return image(ResultOverview.ICON_IGNORE);
 			case NA:
 				return image(ResultOverview.ICON_NA);
 			}


### PR DESCRIPTION
This short PR addresses JMC-8108 [[0]](https://bugs.openjdk.org/browse/JMC-8101), in which there is no icon for "Ignore" rules in the automated analysis page table. Here there's just a new case added to the switch statement that assigns icons for the table.

Before:
![Screenshot from 2023-07-13 16-57-04](https://github.com/openjdk/jmc/assets/10425301/9bce381d-ee04-4b91-b5fb-4fb103828016)

After:
![Screenshot from 2023-07-13 23-03-55](https://github.com/openjdk/jmc/assets/10425301/62f0b2d4-5d0e-48a6-81ce-4b0c174cdd21)

[0] https://bugs.openjdk.org/browse/JMC-8101

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JMC-8101](https://bugs.openjdk.org/browse/JMC-8101): Add ignore icon to automated analysis table (**Enhancement** - P5)


### Reviewers
 * [Suchita Chaturvedi](https://openjdk.org/census#schaturvedi) (@Suchitainf - Committer)
 * [Virag Purnam](https://openjdk.org/census#vpurnam) (@viragpurnam - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmc.git pull/506/head:pull/506` \
`$ git checkout pull/506`

Update a local copy of the PR: \
`$ git checkout pull/506` \
`$ git pull https://git.openjdk.org/jmc.git pull/506/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 506`

View PR using the GUI difftool: \
`$ git pr show -t 506`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmc/pull/506.diff">https://git.openjdk.org/jmc/pull/506.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jmc/pull/506#issuecomment-1635933656)