### PR TITLE
8102: Automated analysis page does not expand the results for Windows

### DIFF
--- a/core/org.openjdk.jmc.flightrecorder.rules/src/main/resources/org/openjdk/jmc/flightrecorder/rules/report/html/internal/rules_overview.html
+++ b/core/org.openjdk.jmc.flightrecorder.rules/src/main/resources/org/openjdk/jmc/flightrecorder/rules/report/html/internal/rules_overview.html
@@ -282,10 +282,10 @@ section {
 				e = window.event ? event.srcElement : e.target;
 				if (e.className && e.className.indexOf("rule_") != -1
 						&& e.className.indexOf("text") == -1) {
-					var loc = (e.id.includes("_score_value")) ? e.id.indexOf("_score_value") :
-						((e.id.includes("_name")) ? e.id.indexOf("_name") :
-						((e.id.includes("_heading")) ? e.id.indexOf("_heading") :
-					 	((e.id.includes("_text_hide")) ? e.id.indexOf("_text_hide") : null)));
+					var loc = (e.id.indexOf("_score_value") !== -1) ? e.id.indexOf("_score_value") :
+						((e.id.indexOf("_name") !== -1) ? e.id.indexOf("_name") :
+						((e.id.indexOf("_heading") !== -1) ? e.id.indexOf("_heading") :
+					 	((e.id.indexOf("_text_hide") !== -1) ? e.id.indexOf("_text_hide") : null)));
 					if (loc != null) {
 						id_to_toggle = e.id.slice(0, loc) + "_text";
 						overview.toggleVisibility(id_to_toggle, document


### PR DESCRIPTION
To fix the bug https://bugs.openjdk.org/browse/JMC-8073, **rules_overview.html** had been modified and **.includes()** method was added. But this method does not work with all browsers e.g IE.  On windows Automated analysis page does not expand the results. 

Fix: I have replaced all **.includes()** with widely supported **.indexOf()**.
e.g ` e.id.includes("_name") `has been replaced with` e.id.indexOf("_name") !== -1`

With this change it works in all platforms.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JMC-8102](https://bugs.openjdk.org/browse/JMC-8102): Automated analysis page does not expand the results for Windows (**Bug** - P2)


### Reviewers
 * [Alex Macdonald](https://openjdk.org/census#aptmac) (@aptmac - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmc.git pull/507/head:pull/507` \
`$ git checkout pull/507`

Update a local copy of the PR: \
`$ git checkout pull/507` \
`$ git pull https://git.openjdk.org/jmc.git pull/507/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 507`

View PR using the GUI difftool: \
`$ git pr show -t 507`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmc/pull/507.diff">https://git.openjdk.org/jmc/pull/507.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jmc/pull/507#issuecomment-1640579040)