### PR TITLE
8103: Add user configuration for local JVM refresh interval

### DIFF
--- a/application/org.openjdk.jmc.browser.attach/src/main/java/org/openjdk/jmc/browser/attach/preferences/AttachPreferencePage.java
+++ b/application/org.openjdk.jmc.browser.attach/src/main/java/org/openjdk/jmc/browser/attach/preferences/AttachPreferencePage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -34,6 +34,7 @@ package org.openjdk.jmc.browser.attach.preferences;
 
 import org.eclipse.jface.preference.BooleanFieldEditor;
 import org.eclipse.jface.preference.FieldEditorPreferencePage;
+import org.eclipse.jface.preference.IntegerFieldEditor;
 import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchPreferencePage;
 import org.openjdk.jmc.browser.attach.BrowserAttachPlugin;
@@ -64,6 +65,10 @@ public class AttachPreferencePage extends FieldEditorPreferencePage implements I
 				Messages.AttachPreferencePage_CAPTION_AUTO_START, getFieldEditorParent()));
 		addField(new BooleanFieldEditor(PreferenceConstants.P_SHOW_UNCONNECTABLE,
 				Messages.AttachPreferencePage_CAPTION_SHOW_UNCONNECTABLE, getFieldEditorParent()));
+		IntegerFieldEditor browserScanInterval = new IntegerFieldEditor(PreferenceConstants.P_REFRESH_INTERVAL,
+				Messages.AttachPreferencePage_BROWSER_REFRESH_INTERVAL, getFieldEditorParent());
+		browserScanInterval.setValidRange(1000, Integer.MAX_VALUE);
+		addField(browserScanInterval);
 		PreferencesToolkit.fillNoteControl(getFieldEditorParent(),
 				Messages.AttachPreferencePage_NOTE_SHOW_UNCONNECTABLE);
 	}

--- a/application/org.openjdk.jmc.browser.attach/src/main/java/org/openjdk/jmc/browser/attach/preferences/Messages.java
+++ b/application/org.openjdk.jmc.browser.attach/src/main/java/org/openjdk/jmc/browser/attach/preferences/Messages.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -38,6 +38,7 @@ public class Messages extends NLS {
 	private static final String BUNDLE_NAME = "org.openjdk.jmc.browser.attach.preferences.messages"; //$NON-NLS-1$
 
 	public static String AttachPreferencePage_ATTACH_PREFERENCES_DESCRIPTION;
+	public static String AttachPreferencePage_BROWSER_REFRESH_INTERVAL;
 	public static String AttachPreferencePage_CAPTION_AUTO_START;
 	public static String AttachPreferencePage_CAPTION_SHOW_UNCONNECTABLE;
 	public static String AttachPreferencePage_NOTE_SHOW_UNCONNECTABLE;

--- a/application/org.openjdk.jmc.browser.attach/src/main/java/org/openjdk/jmc/browser/attach/preferences/PreferenceConstants.java
+++ b/application/org.openjdk.jmc.browser.attach/src/main/java/org/openjdk/jmc/browser/attach/preferences/PreferenceConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -36,6 +36,11 @@ package org.openjdk.jmc.browser.attach.preferences;
  * Constant definitions for plug-in preferences
  */
 public class PreferenceConstants {
+	/**
+	 * Preference key for setting the refresh interval of the JVM Browser
+	 */
+	public static final String P_REFRESH_INTERVAL = "refreshInterval"; //$NON-NLS-1$
+
 	/**
 	 * Preferences key for automatically starting the agent.
 	 */

--- a/application/org.openjdk.jmc.browser.attach/src/main/java/org/openjdk/jmc/browser/attach/preferences/PreferenceInitializer.java
+++ b/application/org.openjdk.jmc.browser.attach/src/main/java/org/openjdk/jmc/browser/attach/preferences/PreferenceInitializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -45,6 +45,7 @@ public class PreferenceInitializer extends AbstractPreferenceInitializer {
 	public void initializeDefaultPreferences() {
 		// See http://visualvm.sourcearchive.com/documentation/1.2.1-0ubuntu3/MainClassApplicationTypeFactory_8java-source.html
 		IPreferenceStore store = BrowserAttachPlugin.getDefault().getPreferenceStore();
+		store.setDefault(PreferenceConstants.P_REFRESH_INTERVAL, 5000);
 		store.setDefault(PreferenceConstants.P_AUTO_START_AGENT, true);
 		store.setDefault(PreferenceConstants.P_SHOW_UNCONNECTABLE, true);
 	}

--- a/application/org.openjdk.jmc.browser.attach/src/main/resources/org/openjdk/jmc/browser/attach/preferences/messages.properties
+++ b/application/org.openjdk.jmc.browser.attach/src/main/resources/org/openjdk/jmc/browser/attach/preferences/messages.properties
@@ -1,5 +1,5 @@
 #
-#  Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+#  Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
 #
 #  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
@@ -31,6 +31,7 @@
 #  WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 AttachPreferencePage_ATTACH_PREFERENCES_DESCRIPTION=These are the preferences for the Local Connection Provider.\n\n
+AttachPreferencePage_BROWSER_REFRESH_INTERVAL=JVM Browser Refresh Interval [ms]:
 AttachPreferencePage_CAPTION_AUTO_START=Automatically &start the local management agent if not already started
 AttachPreferencePage_CAPTION_SHOW_UNCONNECTABLE=Show unconnectable JVMs
 AttachPreferencePage_NOTE_SHOW_UNCONNECTABLE=In order to connect to a JVM that can't be attached to (e.g. connecting to a 32-bit JVM from a 64-bit Mission Control), the management agent has to be started manually by using the JVM flag -Dcom.sun.management.jmxremote\nIf this option is unchecked then the JVM browser will hide local JVMs that can't be attached to and that do not have the management agent started.


### PR DESCRIPTION
This PR addresses JMC-8103 [[0]](https://bugs.openjdk.org/browse/JMC-8103), in which it would be nice to have a user control for adjusting the rate at which the JVM browser discovers JVMs.

At the moment, the `LocalDescriptorProvider` scans every 5s for differences in local JVMs, and then goes through the process of creating a local descriptor, attaching, populating the jvm browser, etc.

This PR adds an extra field to the Preferences under `Preferences -> JVM Browser -> Local` that lets the user specify how frequently (or infrequently) this scan should occur. As mentioned at the latest upstream community meeting, this value should probably have a lower-bound as to not scan too often, so I've selected 1000 ms to match similar refresh rates of the jvm browser.

![example](https://github.com/openjdk/jmc/assets/10425301/4dbe363f-a3d4-4513-9654-f99cfe71aaeb)


[0] https://bugs.openjdk.org/browse/JMC-8103

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JMC-8103](https://bugs.openjdk.org/browse/JMC-8103): Add user configuration for local JVM refresh interval (**Enhancement** - P3)


### Reviewers
 * [Marcus Hirt](https://openjdk.org/census#hirt) (@thegreystone - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmc.git pull/508/head:pull/508` \
`$ git checkout pull/508`

Update a local copy of the PR: \
`$ git checkout pull/508` \
`$ git pull https://git.openjdk.org/jmc.git pull/508/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 508`

View PR using the GUI difftool: \
`$ git pr show -t 508`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmc/pull/508.diff">https://git.openjdk.org/jmc/pull/508.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jmc/pull/508#issuecomment-1643987255)