### PR TITLE
make JfrWizardTest.verifyMinimalRecordingEventSettings work again

### DIFF
--- a/application/uitests/org.openjdk.jmc.flightrecorder.uitest/src/test/java/org/openjdk/jmc/flightrecorder/uitest/JfrWizardTest.java
+++ b/application/uitests/org.openjdk.jmc.flightrecorder.uitest/src/test/java/org/openjdk/jmc/flightrecorder/uitest/JfrWizardTest.java
@@ -83,11 +83,7 @@ public class JfrWizardTest extends MCJemmyTestBase {
 		recordingWizard.setDurationText("1 s");
 
 		// Disable all events except "Flight Recorder|Recording Setting"
-		recordingWizard.disableEvent("Flight Recorder");
-		recordingWizard.disableEvent("Java Application");
-		recordingWizard.disableEvent("Java Virtual Machine");
-		recordingWizard.disableEvent("Operating System");
-		recordingWizard.enableEvent("Flight Recorder", "Recording Setting");
+		recordingWizard.enableEventDisableOthers("Flight Recorder", "Recording Setting");
 
 		// Get the current settings (in the wizard)
 		EventSettingsData wizardEventSettings = recordingWizard.getCurrentEventSettings();

--- a/application/uitests/org.openjdk.jmc.test.jemmy/src/main/java/org/openjdk/jmc/test/jemmy/misc/wrappers/JfrWizard.java
+++ b/application/uitests/org.openjdk.jmc.test.jemmy/src/main/java/org/openjdk/jmc/test/jemmy/misc/wrappers/JfrWizard.java
@@ -46,7 +46,6 @@ import org.jemmy.lookup.Any;
 import org.jemmy.resources.StringComparePolicy;
 import org.jemmy.swt.ComboWrap;
 import org.junit.Assert;
-
 import org.openjdk.jmc.common.unit.QuantityConversionException;
 import org.openjdk.jmc.test.jemmy.misc.base.wrappers.MCJemmyBase;
 import org.openjdk.jmc.test.jemmy.misc.helpers.EventSettingsData;
@@ -307,6 +306,16 @@ public class JfrWizard extends MCJemmyBase {
 	}
 
 	/**
+	 * Enable the recording of the event and disable all other events.
+	 *
+	 * @param path
+	 *            the path of the event
+	 */
+	public void enableEventDisableOthers(String ... path) {
+		setEventSettingInvertOthers(true, ENABLED_BUTTON_NAME, path);
+	}
+
+	/**
 	 * Disable the recording of the event
 	 * 
 	 * @param path
@@ -444,6 +453,22 @@ public class JfrWizard extends MCJemmyBase {
 			button.setState(desiredState);
 		}
 		return currentState;
+	}
+
+	public void setEventSettingInvertOthers(boolean desiredState, String settingName, String ... path) {
+		// invert everything
+		// the actual names are observed to always at least contain the roots of the tree
+		// and setting them also sets all their children
+		{
+			final var eventSettingsTree = getEventSettingsTree();
+			final var names = eventSettingsTree.getAllItemTexts();
+			for (var name : names) {
+				final var currentPath = name.toArray(String[]::new);
+				setEventSetting(!desiredState, settingName, currentPath);
+			}
+		}
+		// lastly reset the desired state for the event the caller wanted
+		setEventSetting(desiredState, settingName, path);
 	}
 
 	private EventSettings setEventTextSetting(String desiredText, String settingName, String ... path) {


### PR DESCRIPTION
One test I see failing all the time when I run the ui tests for my other pull requst is JfrWizardTest.verifyMinimalRecordingEventSettings.

It looks to my like the issue is that the event groups must have chaged from when the test was written.
Here is what that looks like currently for me on Windows with a jdk 17.0.7
![JDK Mission Control 21 07 2023 20_13_20](https://github.com/openjdk/jmc/assets/917408/faa65318-5dd6-492b-ae2a-b5f4936a1f9d)
The Java Development Kit group is not explicitly disabled by the test and so it always fails when it tries to assert that only the "Flight Recorder">"Recording Setting" Event is enabled.

I changed the test so that is does not need to explicitly disable other groups by name. I think even if for some reason this test failing is a result of my setup on this computer, this way is more robust to changes in the groups.