### PR TITLE
8116: build{.sh,.bat} fail to detect started p2 jetty process

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -66,7 +66,7 @@ start "%1" cmd /C "mvn -f releng\third-party\pom.xml jetty:run --log-file %JETTY
 :wait_jetty
 echo Waiting for jetty server to start
 timeout /t 1
-findstr "[INFO] Started Jetty Server" %JETTY_LOG%
+findstr "[INFO] Started Server@" %JETTY_LOG%
 if not %ERRORLEVEL% == 0 goto :wait_jetty
 echo %time% jetty server up and running
 call :installCore

--- a/build.sh
+++ b/build.sh
@@ -60,7 +60,7 @@ function startJetty() {
     mvn jetty:run --log-file "${jettyLog}" &
     JETTY_PID=$!
 
-    while ! grep -q "^\[INFO\] Started Jetty Server$" "${jettyLog}"; do
+    while ! grep -q "^\[INFO\] Started Server@" "${jettyLog}"; do
         echo "$(date +%T) waiting for jetty server to start"
         sleep 1
     done


### PR DESCRIPTION
This pull request fixes the detection of the started jetty p2 instance needed for the build to succeed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JMC-8116](https://bugs.openjdk.org/browse/JMC-8116): build{.sh,.bat} fail to detect started p2 jetty process (**Bug** - P4)


### Reviewers
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - Committer)
 * [Virag Purnam](https://openjdk.org/census#vpurnam) (@viragpurnam - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmc.git pull/510/head:pull/510` \
`$ git checkout pull/510`

Update a local copy of the PR: \
`$ git checkout pull/510` \
`$ git pull https://git.openjdk.org/jmc.git pull/510/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 510`

View PR using the GUI difftool: \
`$ git pr show -t 510`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmc/pull/510.diff">https://git.openjdk.org/jmc/pull/510.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jmc/pull/510#issuecomment-1659849076)