### PR TITLE
8117: mvn clean install on JMC Core fails if path contains space

### DIFF
--- a/core/tests/org.openjdk.jmc.flightrecorder.test/src/main/java/org/openjdk/jmc/flightrecorder/test/CharAttributeTest.java
+++ b/core/tests/org.openjdk.jmc.flightrecorder.test/src/main/java/org/openjdk/jmc/flightrecorder/test/CharAttributeTest.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2022, Red Hat, Inc. All rights reserved.
+ * Copyright (c) 2022, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2023 Red Hat, Inc. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -35,6 +35,7 @@ package org.openjdk.jmc.flightrecorder.test;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.URISyntaxException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
@@ -60,9 +61,10 @@ import jdk.jfr.Recording;
 public class CharAttributeTest {
 
 	@Test
-	public void shouldParseEventWithCharAttribute() throws IOException, CouldNotLoadRecordingException {
+	public void shouldParseEventWithCharAttribute()
+			throws IOException, CouldNotLoadRecordingException, URISyntaxException {
 		File recordingFile = new File(
-				CharAttributeTest.class.getClassLoader().getResource("recordings/char_attribute.jfr").getFile());
+				CharAttributeTest.class.getClassLoader().getResource("recordings/char_attribute.jfr").toURI());
 		IItemCollection items = JfrLoaderToolkit.loadEvents(Arrays.asList(recordingFile))
 				.apply(ItemFilters.type("jmc.CharTestEvent"));
 

--- a/core/tests/org.openjdk.jmc.flightrecorder.test/src/main/java/org/openjdk/jmc/flightrecorder/test/ConstantPoolExtensionTest.java
+++ b/core/tests/org.openjdk.jmc.flightrecorder.test/src/main/java/org/openjdk/jmc/flightrecorder/test/ConstantPoolExtensionTest.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2021, Datadog, Inc. All rights reserved.
+ * Copyright (c) 2021, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2023 Datadog, Inc. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -35,6 +35,7 @@ package org.openjdk.jmc.flightrecorder.test;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -112,11 +113,11 @@ public class ConstantPoolExtensionTest {
 			"java.lang.Class", "jdk.types.Package", "jdk.types.OldObject",};
 
 	@Test
-	public void constantResolution() throws IOException, CouldNotLoadRecordingException {
+	public void constantResolution() throws IOException, CouldNotLoadRecordingException, URISyntaxException {
 		List<IParserExtension> extensions = new ArrayList<>(ParserExtensionRegistry.getParserExtensions());
 		extensions.add(new MyParserExtension());
 		File recordingFile = new File(
-				ConstantPoolExtensionTest.class.getClassLoader().getResource("recordings/metadata_new.jfr").getFile());
+				ConstantPoolExtensionTest.class.getClassLoader().getResource("recordings/metadata_new.jfr").toURI());
 		IItemCollection items = JfrLoaderToolkit.loadEvents(Arrays.asList(recordingFile), extensions);
 		Assert.assertTrue(items.hasItems());
 		IConstantPoolExtension ext = ((IParserStats) items).getConstantPoolExtensions()


### PR DESCRIPTION
mvn clean install on JMC Core fails if path contains space. 

If there is a space in path, mvn clean install fails. Space has been replaced by %20 and it makes the path incorrect. To fix this issue URI has to be used in place of URL.
Please refer the below screen shot for error.
<img width="1776" alt="8117" src="https://github.com/openjdk/jmc/assets/97600378/83657740-3731-46a6-8b94-a1a092f0cf08">

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JMC-8117](https://bugs.openjdk.org/browse/JMC-8117): mvn clean install on JMC Core fails if path contains space (**Bug** - P3)


### Reviewers
 * [Alex Macdonald](https://openjdk.org/census#aptmac) (@aptmac - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmc.git pull/512/head:pull/512` \
`$ git checkout pull/512`

Update a local copy of the PR: \
`$ git checkout pull/512` \
`$ git pull https://git.openjdk.org/jmc.git pull/512/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 512`

View PR using the GUI difftool: \
`$ git pr show -t 512`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmc/pull/512.diff">https://git.openjdk.org/jmc/pull/512.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jmc/pull/512#issuecomment-1682655454)