### PR TITLE
8118: Add user configuration for delay between JVM discovery and attachment

### DIFF
--- a/application/org.openjdk.jmc.browser.attach/src/main/java/org/openjdk/jmc/browser/attach/LocalJVMToolkit.java
+++ b/application/org.openjdk.jmc.browser.attach/src/main/java/org/openjdk/jmc/browser/attach/LocalJVMToolkit.java
@@ -38,6 +38,7 @@ import static org.openjdk.jmc.common.jvm.Connectable.NO;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.lang.Thread.State;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -109,10 +110,13 @@ public class LocalJVMToolkit {
 
 	private static long SEQ_NUMBER = 0;
 	private static boolean isErrorMessageSent = false;
+	private static boolean isPreferenceStoreListenerEnabled;
 	private static boolean m_unconnectableInited = false;
 	private static AtomicBoolean m_showUnconnectable = new AtomicBoolean();
 
 	private static Map<Object, DiscoveryEntry> last = new WeakHashMap<>();
+
+	private static Thread sleeperThread;
 
 	static final String LOCAL_CONNECTOR_ADDRESS_PROP = "com.sun.management.jmxremote.localConnectorAddress"; //$NON-NLS-1$
 	static final String JVM_ARGS_PROP = "sun.jvm.args"; //$NON-NLS-1$
@@ -319,6 +323,27 @@ public class LocalJVMToolkit {
 		return stringValue.toUpperCase().contains("DEBUG"); //$NON-NLS-1$
 	}
 
+	private static void addPreferenceStoreListener() {
+		if (!isPreferenceStoreListenerEnabled) {
+			BrowserAttachPlugin.getDefault().getPreferenceStore()
+					.addPropertyChangeListener(new IPropertyChangeListener() {
+						@Override
+						public void propertyChange(PropertyChangeEvent event) {
+							if (event.getProperty().equals(PreferenceConstants.P_JVM_ATTACH_DELAY)) {
+								if (sleeperThread.getState().equals(State.TIMED_WAITING)) {
+									sleeperThread.interrupt();
+								}
+							}
+						}
+					});
+			isPreferenceStoreListenerEnabled = true;
+		}
+	}
+
+	private static final int getJvmAttachDelay() {
+		return BrowserAttachPlugin.getDefault().getPreferenceStore().getInt(PreferenceConstants.P_JVM_ATTACH_DELAY);
+	}
+
 	private static void populateAttachableVMs(Map<Object, DiscoveryEntry> map) {
 		// This used to leak \BaseNamedObjects\hsperfdata_* Section handles on Windows
 		List<VirtualMachineDescriptor> vms = VirtualMachine.list();
@@ -334,6 +359,22 @@ public class LocalJVMToolkit {
 					// Check if we already have a descriptor *first* to avoid unnecessary attach which may leak handles
 					DiscoveryEntry connDesc = last.get(vmid);
 					if (connDesc == null) {
+						if (getJvmAttachDelay() > 0) {
+							addPreferenceStoreListener();
+							sleeperThread = new Thread(() -> {
+								try {
+									Thread.sleep(getJvmAttachDelay());
+								} catch (InterruptedException e) {
+									// Interrupted if delay setting is changed while sleeping.
+								}
+							});
+							try {
+								sleeperThread.start();
+								sleeperThread.join();
+							} catch (InterruptedException e) {
+								// ignore
+							}
+						}
 						connDesc = createAttachableJvmDescriptor(vmd);
 					}
 

--- a/application/org.openjdk.jmc.browser.attach/src/main/java/org/openjdk/jmc/browser/attach/preferences/AttachPreferencePage.java
+++ b/application/org.openjdk.jmc.browser.attach/src/main/java/org/openjdk/jmc/browser/attach/preferences/AttachPreferencePage.java
@@ -32,6 +32,8 @@
  */
 package org.openjdk.jmc.browser.attach.preferences;
 
+import java.time.Duration;
+
 import org.eclipse.jface.preference.BooleanFieldEditor;
 import org.eclipse.jface.preference.FieldEditorPreferencePage;
 import org.eclipse.jface.preference.IntegerFieldEditor;
@@ -69,6 +71,10 @@ public class AttachPreferencePage extends FieldEditorPreferencePage implements I
 				Messages.AttachPreferencePage_BROWSER_REFRESH_INTERVAL, getFieldEditorParent());
 		browserScanInterval.setValidRange(1000, Integer.MAX_VALUE);
 		addField(browserScanInterval);
+		IntegerFieldEditor jvmAttachOffset = new IntegerFieldEditor(PreferenceConstants.P_JVM_ATTACH_DELAY,
+				Messages.AttachPreferencePage_JVM_ATTACH_DELAY, getFieldEditorParent());
+		jvmAttachOffset.setValidRange(0, (int) Duration.ofMinutes(1).toMillis());
+		addField(jvmAttachOffset);
 		PreferencesToolkit.fillNoteControl(getFieldEditorParent(),
 				Messages.AttachPreferencePage_NOTE_SHOW_UNCONNECTABLE);
 	}

--- a/application/org.openjdk.jmc.browser.attach/src/main/java/org/openjdk/jmc/browser/attach/preferences/Messages.java
+++ b/application/org.openjdk.jmc.browser.attach/src/main/java/org/openjdk/jmc/browser/attach/preferences/Messages.java
@@ -41,6 +41,7 @@ public class Messages extends NLS {
 	public static String AttachPreferencePage_BROWSER_REFRESH_INTERVAL;
 	public static String AttachPreferencePage_CAPTION_AUTO_START;
 	public static String AttachPreferencePage_CAPTION_SHOW_UNCONNECTABLE;
+	public static String AttachPreferencePage_JVM_ATTACH_DELAY;
 	public static String AttachPreferencePage_NOTE_SHOW_UNCONNECTABLE;
 
 	static {

--- a/application/org.openjdk.jmc.browser.attach/src/main/java/org/openjdk/jmc/browser/attach/preferences/PreferenceConstants.java
+++ b/application/org.openjdk.jmc.browser.attach/src/main/java/org/openjdk/jmc/browser/attach/preferences/PreferenceConstants.java
@@ -42,6 +42,11 @@ public class PreferenceConstants {
 	public static final String P_REFRESH_INTERVAL = "refreshInterval"; //$NON-NLS-1$
 
 	/**
+	 * Preference key for setting a delay when creating the attachable JVM Descriptor
+	 */
+	public static final String P_JVM_ATTACH_DELAY = "jvmAttachDelay"; //$NON-NLS-1$
+
+	/**
 	 * Preferences key for automatically starting the agent.
 	 */
 	public static final String P_AUTO_START_AGENT = "autoStartPreference"; //$NON-NLS-1$

--- a/application/org.openjdk.jmc.browser.attach/src/main/java/org/openjdk/jmc/browser/attach/preferences/PreferenceInitializer.java
+++ b/application/org.openjdk.jmc.browser.attach/src/main/java/org/openjdk/jmc/browser/attach/preferences/PreferenceInitializer.java
@@ -46,6 +46,7 @@ public class PreferenceInitializer extends AbstractPreferenceInitializer {
 		// See http://visualvm.sourcearchive.com/documentation/1.2.1-0ubuntu3/MainClassApplicationTypeFactory_8java-source.html
 		IPreferenceStore store = BrowserAttachPlugin.getDefault().getPreferenceStore();
 		store.setDefault(PreferenceConstants.P_REFRESH_INTERVAL, 5000);
+		store.setDefault(PreferenceConstants.P_JVM_ATTACH_DELAY, 0);
 		store.setDefault(PreferenceConstants.P_AUTO_START_AGENT, true);
 		store.setDefault(PreferenceConstants.P_SHOW_UNCONNECTABLE, true);
 	}

--- a/application/org.openjdk.jmc.browser.attach/src/main/resources/org/openjdk/jmc/browser/attach/preferences/messages.properties
+++ b/application/org.openjdk.jmc.browser.attach/src/main/resources/org/openjdk/jmc/browser/attach/preferences/messages.properties
@@ -34,4 +34,5 @@ AttachPreferencePage_ATTACH_PREFERENCES_DESCRIPTION=These are the preferences fo
 AttachPreferencePage_BROWSER_REFRESH_INTERVAL=JVM Browser Refresh Interval [ms]:
 AttachPreferencePage_CAPTION_AUTO_START=Automatically &start the local management agent if not already started
 AttachPreferencePage_CAPTION_SHOW_UNCONNECTABLE=Show unconnectable JVMs
+AttachPreferencePage_JVM_ATTACH_DELAY=Delay between discovering a new JVM and attachment [ms]:
 AttachPreferencePage_NOTE_SHOW_UNCONNECTABLE=In order to connect to a JVM that can't be attached to (e.g. connecting to a 32-bit JVM from a 64-bit Mission Control), the management agent has to be started manually by using the JVM flag -Dcom.sun.management.jmxremote\nIf this option is unchecked then the JVM browser will hide local JVMs that can't be attached to and that do not have the management agent started.


### PR DESCRIPTION
This PR addresses JMC-8118 [0], in which it'd be nice to be able to specify a time delay between when a JVM is discovered and when JVM is attached to (for the JvmDescriptor creation). I've placed this option into the Preferences menu at Preferences > JDK Mission Control > JVM Browser > Local, with a maximum delay time of 1 minute and a default time of 0ms (current).

There is currently an issue where if a newly launched JVM is not fully set-up by the time JMC discovers and attaches to it (via JvmDescriptor creation), then the target JVM could through an error and/or crash on startup. For example, if an application uses a custom logging manager that hasn't been fully initialized prior to JvmDescriptor creation, it may/will just crash.

Example:
![8118](https://github.com/openjdk/jmc/assets/10425301/d199cf50-2dba-4577-86fb-1dd65973d67a)

[0] https://bugs.openjdk.org/browse/JMC-8118

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JMC-8118](https://bugs.openjdk.org/browse/JMC-8118): Add user configuration for delay between JVM discovery and attachment (**Bug** - P3)


### Reviewers
 * [Marcus Hirt](https://openjdk.org/census#hirt) (@thegreystone - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmc.git pull/513/head:pull/513` \
`$ git checkout pull/513`

Update a local copy of the PR: \
`$ git checkout pull/513` \
`$ git pull https://git.openjdk.org/jmc.git pull/513/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 513`

View PR using the GUI difftool: \
`$ git pr show -t 513`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmc/pull/513.diff">https://git.openjdk.org/jmc/pull/513.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jmc/pull/513#issuecomment-1696272454)