### PR TITLE
8121: JMC should fail properly when executed with <17 JDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ If maven reports a toolchain error, e.g. :
 [ERROR] Please make sure you define the required toolchains in your ~/.m2/toolchains.xml file.
 ```
 
-Create or amend the local maven toolchain file by pointing to the right JDK (here any JDK 17).
+Create or amend the local maven toolchain file by pointing to the right/any JDK 17.
 
 <details><summary><code>~/.m2/toolchains.xml</code></summary>
 
@@ -259,18 +259,6 @@ Create or amend the local maven toolchain file by pointing to the right JDK (her
 <?xml version="1.0" encoding="UTF-8"?>
 <toolchains>
   <!-- JDK toolchains -->
-  <toolchain>
-    <type>jdk</type>
-    <provides>
-      <id>JavaSE-11</id>
-      <version>11</version>
-      <vendor>amazon</vendor>
-    </provides>
-    <configuration>
-	    <jdkHome>/Library/Java/JavaVirtualMachines/corretto-11.jdk/Contents/Home</jdkHome>
-    </configuration>
-  </toolchain>
-
   <!-- 
     Declare the JDK 17 toolchain installed on the local machine, 
     make sure the id is : JavaSE-17

--- a/application/org.openjdk.jmc.rcp.product/jmc.product
+++ b/application/org.openjdk.jmc.rcp.product/jmc.product
@@ -109,6 +109,7 @@
       <property name="eclipse.product" value="org.openjdk.jmc.rcp.application.product" />
       <property name="osgi.instance.area.default" value="@user.home/.jmc/9.0.0" />
       <property name="osgi.bundles.defaultStartLevel" value="4" />
+      <property name="osgi.requiredJavaVersion" value="17" />
    </configurations>
 
    <preferencesInfo>


### PR DESCRIPTION
Set `osgi.requireJavaVersion` property for in `jmc.product`, so that JMC fails directly with an understandable error message when it started on a <17 JDK.

The new error message looks like the follows when running JMC on JDK 1.8:

<img width="297" alt="MicrosoftTeams-image" src="https://github.com/openjdk/jmc/assets/490655/141132a7-fcde-486b-bbe0-d78633f5a659">

I tested it with various supported and unsupported JDK versions and it worked as expected.