### PR TITLE
8123: Use StandardCharsets where possible

### DIFF
--- a/application/org.openjdk.jmc.browser.attach/src/main/java/org/openjdk/jmc/browser/attach/LocalJVMToolkit.java
+++ b/application/org.openjdk.jmc.browser.attach/src/main/java/org/openjdk/jmc/browser/attach/LocalJVMToolkit.java
@@ -39,6 +39,7 @@ import static org.openjdk.jmc.common.jvm.Connectable.NO;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -570,7 +571,7 @@ public class LocalJVMToolkit {
 		do {
 			n = in.read(b);
 			if (n > 0) {
-				String s = new String(b, 0, n, "UTF-8"); //$NON-NLS-1$
+				String s = new String(b, 0, n, StandardCharsets.UTF_8);
 				buf.append(s);
 			}
 		} while (n > 0);

--- a/application/org.openjdk.jmc.flightrecorder.controlpanel.ui.configuration/src/main/java/org/openjdk/jmc/flightrecorder/controlpanel/ui/configuration/model/xml/XMLModel.java
+++ b/application/org.openjdk.jmc.flightrecorder.controlpanel.ui.configuration/src/main/java/org/openjdk/jmc/flightrecorder/controlpanel/ui/configuration/model/xml/XMLModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/application/org.openjdk.jmc.flightrecorder.controlpanel.ui.configuration/src/main/java/org/openjdk/jmc/flightrecorder/controlpanel/ui/configuration/model/xml/XMLModel.java
+++ b/application/org.openjdk.jmc.flightrecorder.controlpanel.ui.configuration/src/main/java/org/openjdk/jmc/flightrecorder/controlpanel/ui/configuration/model/xml/XMLModel.java
@@ -42,6 +42,7 @@ import java.io.StringReader;
 import java.io.StringWriter;
 import java.io.Writer;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -259,7 +260,7 @@ public final class XMLModel extends Observable {
 	public void saveToFile(File file) throws IOException {
 		// NOTE: The pretty printer writes that the encoding is UTF-8, so we must make sure it is.
 		// Ensure charset exists before opening file for writing.
-		Charset charset = Charset.forName("UTF-8"); //$NON-NLS-1$
+		Charset charset = StandardCharsets.UTF_8;
 		try (Writer osw = new OutputStreamWriter(new FileOutputStream(file), charset)) {
 			if (writeTo(osw)) {
 				setDirty(false);

--- a/application/org.openjdk.jmc.rcp.application/src/main/java/org/openjdk/jmc/rcp/logging/LoggingToolkit.java
+++ b/application/org.openjdk.jmc.rcp.application/src/main/java/org/openjdk/jmc/rcp/logging/LoggingToolkit.java
@@ -38,6 +38,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.Properties;
 import java.util.logging.Level;
 import java.util.logging.LogManager;
@@ -153,7 +154,7 @@ public final class LoggingToolkit {
 		try (ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
 			props.store(baos, ""); //$NON-NLS-1$
 			String newProps = baos.toString();
-			return new ByteArrayInputStream(newProps.getBytes("UTF-8")); //$NON-NLS-1$
+			return new ByteArrayInputStream(newProps.getBytes(StandardCharsets.UTF_8));
 		}
 	}
 

--- a/application/org.openjdk.jmc.rjmx/src/main/java/org/openjdk/jmc/rjmx/persistence/internal/PersistenceReader.java
+++ b/application/org.openjdk.jmc.rjmx/src/main/java/org/openjdk/jmc/rjmx/persistence/internal/PersistenceReader.java
@@ -39,6 +39,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -251,10 +252,7 @@ public class PersistenceReader implements IMRIService, IAttributeStorageService 
 		}
 		MRI mri;
 		try {
-			mri = MRI.createFromQualifiedName(URLDecoder.decode(attributeDir.getName(), "UTF-8")); //$NON-NLS-1$
-		} catch (UnsupportedEncodingException e) {
-			// This should never happen
-			throw new RuntimeException(e);
+			mri = MRI.createFromQualifiedName(URLDecoder.decode(attributeDir.getName(), StandardCharsets.UTF_8));
 		} catch (IllegalArgumentException e) {
 			// Log warning and ignore directory
 			RJMXPlugin.getDefault().getLogger().log(Level.WARNING,

--- a/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/util/StringToolkit.java
+++ b/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/util/StringToolkit.java
@@ -36,8 +36,9 @@ import java.io.BufferedInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.Iterator;
 
@@ -45,7 +46,6 @@ import java.util.Iterator;
  * A toolkit for strings.
  */
 public final class StringToolkit {
-	private static final String UTF_8 = "UTF-8"; //$NON-NLS-1$
 
 	private StringToolkit() {
 		throw new AssertionError("This is not the constructor you are looking for!"); //$NON-NLS-1$
@@ -61,7 +61,23 @@ public final class StringToolkit {
 	 *             if something went wrong
 	 */
 	public static String readString(InputStream in) throws IOException {
-		return readString(in, UTF_8);
+		return readString(in, StandardCharsets.UTF_8);
+	}
+
+	/**
+	 * Reads the contents of a stream with specified character encoding to a string.
+	 *
+	 * @param in
+	 *            the stream to read from
+	 * @param charset
+	 *            the {@link java.nio.charset.Charset charset}
+	 * @return a string with the contents available from the stream
+	 * @throws IOException
+	 *             if something went wrong
+	 */
+	public static String readString(InputStream in, Charset charset) throws IOException {
+		ByteArrayOutputStream buf = read(in);
+		return buf.toString(charset);
 	}
 
 	/**
@@ -76,6 +92,11 @@ public final class StringToolkit {
 	 *             if something went wrong
 	 */
 	public static String readString(InputStream in, String charsetName) throws IOException {
+		ByteArrayOutputStream buf = read(in);
+		return buf.toString(charsetName);
+	}
+
+	private static ByteArrayOutputStream read(InputStream in) throws IOException {
 		BufferedInputStream bis = new BufferedInputStream(in);
 		ByteArrayOutputStream buf = new ByteArrayOutputStream();
 		int result = bis.read();
@@ -83,7 +104,7 @@ public final class StringToolkit {
 			buf.write((byte) result);
 			result = bis.read();
 		}
-		return buf.toString(charsetName);
+		return buf;
 	}
 
 	/**
@@ -94,11 +115,7 @@ public final class StringToolkit {
 	 * @return a string usable as a file name
 	 */
 	public static String encodeFilename(String string) {
-		try {
-			return URLEncoder.encode(string, UTF_8);
-		} catch (UnsupportedEncodingException e) {
-			return string.replaceAll("\\W+", "-"); //$NON-NLS-1$ //$NON-NLS-2$
-		}
+		return URLEncoder.encode(string, StandardCharsets.UTF_8);
 	}
 
 	/**

--- a/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/util/StringToolkit.java
+++ b/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/util/StringToolkit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/util/XmlToolkit.java
+++ b/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/util/XmlToolkit.java
@@ -41,6 +41,7 @@ import java.io.PrintWriter;
 import java.io.StringReader;
 import java.io.StringWriter;
 import java.io.Writer;
+import java.nio.charset.StandardCharsets;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.logging.Level;
@@ -450,7 +451,7 @@ public final class XmlToolkit {
 	 *             if the file could not written
 	 */
 	public static void storeDocumentToFile(Document doc, File file) throws IOException {
-		try (PrintWriter pw = new PrintWriter(file, "UTF-8")) { //$NON-NLS-1$
+		try (PrintWriter pw = new PrintWriter(file, StandardCharsets.UTF_8)) {
 			prettyPrint(doc.getDocumentElement(), pw);
 		}
 	}

--- a/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/util/XmlToolkit.java
+++ b/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/util/XmlToolkit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/internal/parser/v0/UTFStringParser.java
+++ b/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/internal/parser/v0/UTFStringParser.java
@@ -33,6 +33,8 @@
 package org.openjdk.jmc.flightrecorder.internal.parser.v0;
 
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 import org.openjdk.jmc.common.unit.ContentType;
 import org.openjdk.jmc.common.unit.UnitLookup;
@@ -42,7 +44,7 @@ import org.openjdk.jmc.flightrecorder.internal.InvalidJfrFileException;
  * Reads a UTF-8 string.
  */
 final class UTFStringParser implements IArrayElementParser<String>, IValueReader {
-	private static final String CHARSET = "UTF-8"; //$NON-NLS-1$
+	private static final Charset CHARSET = StandardCharsets.UTF_8;
 	public static final UTFStringParser INSTANCE = new UTFStringParser();
 
 	@Override

--- a/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/internal/parser/v0/UTFStringParser.java
+++ b/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/internal/parser/v0/UTFStringParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/core/org.openjdk.jmc.jdp/src/main/java/org/openjdk/jmc/jdp/common/JDPPacket.java
+++ b/core/org.openjdk.jmc.jdp/src/main/java/org/openjdk/jmc/jdp/common/JDPPacket.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/core/org.openjdk.jmc.jdp/src/main/java/org/openjdk/jmc/jdp/common/JDPPacket.java
+++ b/core/org.openjdk.jmc.jdp/src/main/java/org/openjdk/jmc/jdp/common/JDPPacket.java
@@ -38,6 +38,7 @@ import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.EOFException;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -170,7 +171,7 @@ public final class JDPPacket implements Discoverable {
 		if (dis.read(buf) != length) {
 			throw new IOException("Problem decoding string!"); //$NON-NLS-1$
 		}
-		return new String(buf, "UTF-8"); //$NON-NLS-1$
+		return new String(buf, StandardCharsets.UTF_8);
 
 	}
 

--- a/core/org.openjdk.jmc.testlib/src/main/java/org/openjdk/jmc/test/TestToolkit.java
+++ b/core/org.openjdk.jmc.testlib/src/main/java/org/openjdk/jmc/test/TestToolkit.java
@@ -40,6 +40,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -116,8 +117,8 @@ public final class TestToolkit {
 		BufferedReader readerExp = null;
 		BufferedReader readerAct = null;
 		try {
-			readerExp = new BufferedReader(new InputStreamReader(expected.open(), "UTF-8"));
-			readerAct = new BufferedReader(new InputStreamReader(actual.open(), "UTF-8"));
+			readerExp = new BufferedReader(new InputStreamReader(expected.open(), StandardCharsets.UTF_8));
+			readerAct = new BufferedReader(new InputStreamReader(actual.open(), StandardCharsets.UTF_8));
 			int lineNumber = 0;
 			String expLine = null;
 			while ((expLine = readerExp.readLine()) != null) {

--- a/core/org.openjdk.jmc.testlib/src/main/java/org/openjdk/jmc/test/TestToolkit.java
+++ b/core/org.openjdk.jmc.testlib/src/main/java/org/openjdk/jmc/test/TestToolkit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/core/tests/org.openjdk.jmc.jdp.test/src/main/java/org/openjdk/jmc/jdp/client/TestToolkit.java
+++ b/core/tests/org.openjdk.jmc.jdp.test/src/main/java/org/openjdk/jmc/jdp/client/TestToolkit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/core/tests/org.openjdk.jmc.jdp.test/src/main/java/org/openjdk/jmc/jdp/client/TestToolkit.java
+++ b/core/tests/org.openjdk.jmc.jdp.test/src/main/java/org/openjdk/jmc/jdp/client/TestToolkit.java
@@ -33,12 +33,12 @@
 package org.openjdk.jmc.jdp.client;
 
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
 import java.net.DatagramPacket;
 import java.net.InetAddress;
 import java.net.MalformedURLException;
 import java.net.MulticastSocket;
 import java.net.UnknownHostException;
+import java.nio.charset.StandardCharsets;
 import java.security.SecureRandom;
 import java.util.logging.Level;
 
@@ -107,11 +107,7 @@ public final class TestToolkit {
 	public static String parseCommaSeparatedByteString(String str) {
 		String[] tmp = str.split(", ");
 		byte[] bytes = toBytes(tmp);
-		try {
-			return new String(bytes, "UTF-8");
-		} catch (UnsupportedEncodingException e) {
-			return null;
-		}
+		return new String(bytes, StandardCharsets.UTF_8);
 	}
 
 	public static Configuration createConfiguration() {


### PR DESCRIPTION
Hi,

this PR replaces `UTF-8` String usages with `StandardCharsets.UTF_8` where possible.

I'd appreciate if this is sponsored including a ticket etc.

Cheers,
Christoph

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JMC-8123](https://bugs.openjdk.org/browse/JMC-8123): Use StandardCharsets where possible (**Enhancement** - P4)


### Reviewers
 * [Marcus Hirt](https://openjdk.org/census#hirt) (@thegreystone - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmc.git pull/518/head:pull/518` \
`$ git checkout pull/518`

Update a local copy of the PR: \
`$ git checkout pull/518` \
`$ git pull https://git.openjdk.org/jmc.git pull/518/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 518`

View PR using the GUI difftool: \
`$ git pr show -t 518`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmc/pull/518.diff">https://git.openjdk.org/jmc/pull/518.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jmc/pull/518#issuecomment-1751338429)