### PR TITLE
407: Clean up the swing initialization code

### DIFF
--- a/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/UIPlugin.java
+++ b/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/UIPlugin.java
@@ -32,14 +32,9 @@
  */
 package org.openjdk.jmc.ui;
 
-import java.awt.GraphicsEnvironment;
-import java.util.logging.Level;
-
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.jface.resource.ImageRegistry;
 import org.openjdk.jmc.common.security.SecurityManagerFactory;
-import org.openjdk.jmc.common.util.Environment;
-import org.openjdk.jmc.common.util.Environment.OSType;
 import org.openjdk.jmc.ui.misc.TrayManager;
 import org.openjdk.jmc.ui.preferences.PreferenceConstants;
 import org.openjdk.jmc.ui.security.DialogSecurityManager;
@@ -213,7 +208,6 @@ public class UIPlugin extends MCAbstractUIPlugin {
 	@Override
 	public void start(BundleContext context) throws Exception {
 		super.start(context);
-		initSwingLookAndFeel();
 		// FIXME: Move to extension point
 		SecurityManagerFactory.setDefaultSecurityManager(new DialogSecurityManager());
 	}
@@ -377,20 +371,5 @@ public class UIPlugin extends MCAbstractUIPlugin {
 	 */
 	public void setTrayManager(TrayManager trayManager) {
 		m_trayManager = trayManager;
-	}
-
-	/**
-	 * Sets the Swing look and feel if needed.
-	 */
-	private static void initSwingLookAndFeel() {
-		// Avoid the possibly broken GTK look and feel on Linux
-		String laf = System.getProperty("swing.defaultlaf"); //$NON-NLS-1$
-		if (Environment.getOSType() == OSType.LINUX && laf == null && !GraphicsEnvironment.isHeadless()) {
-			laf = "javax.swing.plaf.metal.MetalLookAndFeel"; //$NON-NLS-1$
-			System.setProperty("swing.defaultlaf", laf); //$NON-NLS-1$
-			System.setProperty("swing.systemlaf", laf); //$NON-NLS-1$
-			UIPlugin.getDefault().getLogger().log(Level.INFO,
-					"On Linux, setting look and feel system properties to " + laf); //$NON-NLS-1$
-		}
 	}
 }


### PR DESCRIPTION
Removing the workaround, since it isn't necessary anymore.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JMC-407](https://bugs.openjdk.org/browse/JMC-407): Clean up the swing initialization code (**Bug** - P4)


### Reviewers
 * [Alex Macdonald](https://openjdk.org/census#aptmac) (@aptmac - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmc.git pull/519/head:pull/519` \
`$ git checkout pull/519`

Update a local copy of the PR: \
`$ git checkout pull/519` \
`$ git pull https://git.openjdk.org/jmc.git pull/519/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 519`

View PR using the GUI difftool: \
`$ git pr show -t 519`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmc/pull/519.diff">https://git.openjdk.org/jmc/pull/519.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jmc/pull/519#issuecomment-1751333614)