### PR TITLE
8124: Fix the release notes generator

### DIFF
--- a/releng/tools/org.openjdk.jmc.util.releasenotes/src/org/openjdk/jmc/utils/releasenotes/Transform.java
+++ b/releng/tools/org.openjdk.jmc.util.releasenotes/src/org/openjdk/jmc/utils/releasenotes/Transform.java
@@ -45,6 +45,7 @@ import java.util.ArrayDeque;
 import java.util.Arrays;
 import java.util.Deque;
 
+import javax.xml.XMLConstants;
 import javax.xml.transform.TransformerException;
 import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.stream.StreamResult;
@@ -112,13 +113,8 @@ public class Transform {
 	private static void transform(Path inputFile, Path outputFile, Path sylesheetFile)
 			throws IOException, TransformerException {
 		TransformerFactory transformerFactory = TransformerFactory.newInstance();
-		try {
-			transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
-			transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
-		} catch (TransformerConfigurationException e) {
-			// This should not happen anyway
-			throw new RuntimeException(e);
-		}
+		transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+		transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
 		try (InputStream xslIn = newInputStream(sylesheetFile);
 				InputStream in = newInputStream(inputFile);
 				OutputStream out = newOutputStream(outputFile)) {


### PR DESCRIPTION
Not sure how this ever compiled and ran under JDK 17. Discovered when importing everything into Eclipse 2023-09.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JMC-8124](https://bugs.openjdk.org/browse/JMC-8124): Fix the release notes generator (**Bug** - P3)


### Reviewers
 * [Alex Macdonald](https://openjdk.org/census#aptmac) (@aptmac - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmc.git pull/520/head:pull/520` \
`$ git checkout pull/520`

Update a local copy of the PR: \
`$ git checkout pull/520` \
`$ git pull https://git.openjdk.org/jmc.git pull/520/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 520`

View PR using the GUI difftool: \
`$ git pr show -t 520`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmc/pull/520.diff">https://git.openjdk.org/jmc/pull/520.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jmc/pull/520#issuecomment-1751499413)