### PR TITLE
8125: Update the developer guide for latest Eclipse

### DIFF
--- a/docs/devguide/README.md
+++ b/docs/devguide/README.md
@@ -12,7 +12,13 @@ There are various Eclipse bundles out there. Get (at least) the Eclipse IDE for 
 
 To get to the screen where you can select another packaging than the standard, click on the [Download Packages](https://www.eclipse.org/downloads/eclipse-packages) link on the Eclipse download page.
 
-Install it, start it and create a new workspace for your JMC work. Creating a new workspace is as easy as picking a new name when starting up your Eclipse in the dialog asking for a directory for the workspace:
+Install Eclipse, and before starting it, add the following two lines to the eclipse.ini file:
+   ```
+   -Dp2.httpRule=allow
+   -Dp2.trustedAuthorities=https://download.eclipse.org,https://archive.eclipse.org,http://localhost
+   ```
+
+Next start Eclipse and create a new workspace for your JMC work. Creating a new workspace is as easy as picking a new name when starting up your Eclipse in the dialog asking for a directory for the workspace:
 
 ![Workspace Selection](images/workspace.png)
 


### PR DESCRIPTION
Updating the dev guide with a workaround for Eclipse currently redirecting to https for http URLs by default, which doesn't work well with our locally running jetty.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JMC-8125](https://bugs.openjdk.org/browse/JMC-8125): Update the developer guide for latest Eclipse (**Task** - P3)


### Reviewers
 * [Virag Purnam](https://openjdk.org/census#vpurnam) (@viragpurnam - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmc.git pull/521/head:pull/521` \
`$ git checkout pull/521`

Update a local copy of the PR: \
`$ git checkout pull/521` \
`$ git pull https://git.openjdk.org/jmc.git pull/521/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 521`

View PR using the GUI difftool: \
`$ git pr show -t 521`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmc/pull/521.diff">https://git.openjdk.org/jmc/pull/521.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jmc/pull/521#issuecomment-1751499324)