### PR TITLE
8131: Fix UTFStringParser compile error

### DIFF
--- a/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/internal/parser/v0/UTFStringParser.java
+++ b/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/internal/parser/v0/UTFStringParser.java
@@ -32,7 +32,6 @@
  */
 package org.openjdk.jmc.flightrecorder.internal.parser.v0;
 
-import java.io.UnsupportedEncodingException;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 
@@ -62,11 +61,7 @@ final class UTFStringParser implements IArrayElementParser<String>, IValueReader
 		offset.increase(2);
 		int index = offset.get();
 		offset.increase(len);
-		try {
-			return new String(bytes, index, len, CHARSET);
-		} catch (UnsupportedEncodingException e) {
-			throw new RuntimeException(e);
-		}
+		return new String(bytes, index, len, CHARSET);
 	}
 
 	private static int readUnsignedShort(byte[] bytes, int offset) {


### PR DESCRIPTION
Removes no longer needed try catch block.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Error
&nbsp;⚠️ This PR only contains changes already present in the target

### Issue
 * [JMC-8131](https://bugs.openjdk.org/browse/JMC-8131): Fix UTFStringParser compile error (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmc.git pull/526/head:pull/526` \
`$ git checkout pull/526`

Update a local copy of the PR: \
`$ git checkout pull/526` \
`$ git pull https://git.openjdk.org/jmc.git pull/526/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 526`

View PR using the GUI difftool: \
`$ git pr show -t 526`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmc/pull/526.diff">https://git.openjdk.org/jmc/pull/526.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jmc/pull/526#issuecomment-1764434984)