### PR TITLE
7192: Event browser should be able to search and show event type ids

### DIFF
--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/common/TypeFilterBuilder.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/common/TypeFilterBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -271,6 +271,9 @@ public class TypeFilterBuilder {
 
 		private boolean matches(Object element) {
 			String label = labelProvider.apply(element);
+			if (element instanceof EventTypeNode) {
+				label = label.concat(" " + ((EventTypeNode) element).getType().getIdentifier());
+			}
 			if (FilterMatcher.getInstance().match(label, filterString, true)) {
 				return true;
 			}

--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/EventBrowserPage.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/EventBrowserPage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -350,6 +350,8 @@ public class EventBrowserPage extends AbstractDataPage {
 					newColumns.add(0, new ColumnSettings(combinedId, false, null, null));
 				}
 			});
+			// add a column for the event type id, hidden by default
+			itemListBuilder.addColumn(JfrAttributes.EVENT_TYPE_ID);
 			listColumns.addAll(0, newColumns);
 
 			saveFilterActionStates();


### PR DESCRIPTION
This PR addresses JMC-7192 [[0]](https://bugs.openjdk.org/browse/JMC-7192), in which it'd be nice to be able to search by event type ids in the event browser.

At the moment, the filter is acting on the strings of each label in the event browser tree, which contains the name of the event and the number of entries it has. This PR updates `matches()` to include a check to see if it's of type `EventTypeNode`, and if so, include the event identifier as well.

JMC-7192 also mentions that there should be a column for type id (hidden by default), which now happens as well.  

Before:
![before](https://github.com/openjdk/jmc/assets/10425301/c5816504-3a22-4337-bc26-e4b46543bcc4)

After:
![after](https://github.com/openjdk/jmc/assets/10425301/3d1d1b59-4906-4029-a511-f40a32f1c9a6)

[0] https://bugs.openjdk.org/browse/JMC-7192

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JMC-7192](https://bugs.openjdk.org/browse/JMC-7192): Event browser should be able to search and show event type ids (**Enhancement** - P2)


### Reviewers
 * [Marcus Hirt](https://openjdk.org/census#hirt) (@thegreystone - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmc.git pull/527/head:pull/527` \
`$ git checkout pull/527`

Update a local copy of the PR: \
`$ git checkout pull/527` \
`$ git pull https://git.openjdk.org/jmc.git pull/527/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 527`

View PR using the GUI difftool: \
`$ git pr show -t 527`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmc/pull/527.diff">https://git.openjdk.org/jmc/pull/527.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jmc/pull/527#issuecomment-1785207148)