### PR TITLE
7449: Add GitHub action to verify copyright year

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -41,6 +41,18 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  check_copyright_year:
+    runs-on: 'ubuntu-latest'
+    defaults:
+      run:
+       shell: bash
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - name : Check latest copyright year
+      run: ./scripts/checkcopyrightyear.sh
   build_and_test:
     name: Build and Test on ${{ matrix.os }}
     strategy:

--- a/scripts/checkcopyrightyear.sh
+++ b/scripts/checkcopyrightyear.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+CURRENT_YEAR=$(date +'%Y')
+MODIFIED_FILES=$(git diff --name-only origin/master)
+counter=0
+
+for fileToCheck in $MODIFIED_FILES
+do
+    if [[ ($fileToCheck =~ .*\.java) || ($fileToCheck =~ .*\.htm) || ($fileToCheck =~ pom.xml) || ($fileToCheck =~ .*\.properties) ]]
+    then
+        LATEST=$(sed -n "s/^.*Copyright (c).\+\(20[[:digit:]]\{2\}\).*$/\1/p" $fileToCheck)
+        for year in $LATEST; do
+            if [ $year -ne $CURRENT_YEAR ]
+            then
+                counter=$((counter + 1))
+                echo "Requires update: $fileToCheck"
+            fi
+        done
+    fi
+done
+if [ $counter -ne 0 ]
+then
+    echo "There is a total of $counter copyright year(s) that require updating."
+    exit 1
+else
+    exit 0
+fi


### PR DESCRIPTION
This PR looks to address JMC-7449 [[0]](https://bugs.openjdk.org/browse/JMC-7449), in which it'd be nice to have a GitHub action that checks the copyright year of changed files (useful for PR reviews).

I've added a `check_copyright_year` job to the github workflow, that checks out the repository  and then runs a bash script. This bash script lives alongside the `updatecopyrightyear.sh` script and other build-related scripts in `/scripts`. By using `fetch-depth: 0` on the workflow job, we're able to do a git diff against origin/master to get a list of all files that have been altered in a given PR. From there it does a similar file extension check to what `updatecopyrightyear.sh` does, and then uses sed to get the "latest" copyright years (there can be multiple if the header has multiple company names). It compares those years to the current year, and if there is not a match then it prints out the filename to the console and increases a counter that gets printed out when the script returns 1.

I made a quick test commit ([link](https://github.com/aptmac/jmc/commit/d854e14109d775a8228d729c099463ac8b3a6b8a)) that changed a handful of files without updating their headers, the GH workflow can be found here: https://github.com/aptmac/jmc/actions/runs/6712104409/job/18240941002
Example of what the workflow looks like:
```
Run ./scripts/checkcopyrightyear.sh
Requires update: agent/src/main/java/org/openjdk/jmc/agent/impl/MalformedConverterException.java
Requires update: agent/src/main/java/org/openjdk/jmc/agent/jfr/impl/package-info.java
Requires update: agent/src/main/java/org/openjdk/jmc/agent/jfr/impl/package-info.java
Requires update: application/org.openjdk.jmc.browser/pom.xml
Requires update: application/org.openjdk.jmc.browser/src/main/java/org/openjdk/jmc/browser/JVMBrowserPlugin.java
Requires update: application/org.openjdk.jmc.docs/html/toc.htm
Requires update: application/org.openjdk.jmc.rjmx/build.properties
There is a total of 7 copyright year(s) that require updating.
Error: Process completed with exit code 1.

```

[0] https://bugs.openjdk.org/browse/JMC-7449

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JMC-7449](https://bugs.openjdk.org/browse/JMC-7449): Add GitHub action to verify copyright year (**Enhancement** - P3)


### Reviewers
 * [Marcus Hirt](https://openjdk.org/census#hirt) (@thegreystone - **Reviewer**)
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmc.git pull/530/head:pull/530` \
`$ git checkout pull/530`

Update a local copy of the PR: \
`$ git checkout pull/530` \
`$ git pull https://git.openjdk.org/jmc.git pull/530/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 530`

View PR using the GUI difftool: \
`$ git pr show -t 530`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmc/pull/530.diff">https://git.openjdk.org/jmc/pull/530.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jmc/pull/530#issuecomment-1788303719)