### PR TITLE
8145: Upgrade Jetty to version 10.0.17

### DIFF
--- a/releng/platform-definitions/platform-definition-2022-09/platform-definition-2022-09.target
+++ b/releng/platform-definitions/platform-definition-2022-09/platform-definition-2022-09.target
@@ -45,11 +45,11 @@
             <unit id="org.adoptopenjdk.jemmy-browser" version="2.0.0"/>
             <unit id="org.adoptopenjdk.jemmy-core" version="2.0.0"/>
             <unit id="org.adoptopenjdk.jemmy-swt" version="2.0.0"/>
-            <unit id="org.eclipse.jetty.websocket.api" version="10.0.11"/>
-            <unit id="org.eclipse.jetty.websocket.server" version="10.0.11"/>
-            <unit id="org.eclipse.jetty.websocket.servlet" version="10.0.11"/>
-            <unit id="org.eclipse.jetty.websocket.javax.server" version="10.0.11"/>
-            <unit id="org.apache.aries.spifly.dynamic.bundle" version="1.3.4"/>
+            <unit id="org.eclipse.jetty.websocket.api" version="10.0.17"/>
+            <unit id="org.eclipse.jetty.websocket.server" version="10.0.17"/>
+            <unit id="org.eclipse.jetty.websocket.servlet" version="10.0.17"/>
+            <unit id="org.eclipse.jetty.websocket.javax.server" version="10.0.17"/>
+            <unit id="org.apache.aries.spifly.dynamic.bundle" version="1.3.6"/>
             <unit id="fireplace-swing" version="0.0.1.rc3"/>
             <unit id="fireplace-swt-awt-bridge" version="0.0.1.rc3"/>
             <unit id="fireplace-swing-animation" version="0.0.1.rc3"/>

--- a/releng/platform-definitions/platform-definition-2022-12/platform-definition-2022-12.target
+++ b/releng/platform-definitions/platform-definition-2022-12/platform-definition-2022-12.target
@@ -45,10 +45,10 @@
             <unit id="org.adoptopenjdk.jemmy-browser" version="2.0.0"/>
             <unit id="org.adoptopenjdk.jemmy-core" version="2.0.0"/>
             <unit id="org.adoptopenjdk.jemmy-swt" version="2.0.0"/>
-            <unit id="org.eclipse.jetty.websocket.api" version="10.0.12"/>
-            <unit id="org.eclipse.jetty.websocket.server" version="10.0.12"/>
-            <unit id="org.eclipse.jetty.websocket.servlet" version="10.0.12"/>
-            <unit id="org.eclipse.jetty.websocket.javax.server" version="10.0.12"/>
+            <unit id="org.eclipse.jetty.websocket.api" version="10.0.17"/>
+            <unit id="org.eclipse.jetty.websocket.server" version="10.0.17"/>
+            <unit id="org.eclipse.jetty.websocket.servlet" version="10.0.17"/>
+            <unit id="org.eclipse.jetty.websocket.javax.server" version="10.0.17"/>
             <unit id="org.apache.aries.spifly.dynamic.bundle" version="1.3.6"/>
             <unit id="fireplace-swing" version="0.0.1.rc3"/>
             <unit id="fireplace-swt-awt-bridge" version="0.0.1.rc3"/>

--- a/releng/platform-definitions/platform-definition-2023-03/platform-definition-2023-03.target
+++ b/releng/platform-definitions/platform-definition-2023-03/platform-definition-2023-03.target
@@ -45,10 +45,10 @@
             <unit id="org.adoptopenjdk.jemmy-browser" version="2.0.0"/>
             <unit id="org.adoptopenjdk.jemmy-core" version="2.0.0"/>
             <unit id="org.adoptopenjdk.jemmy-swt" version="2.0.0"/>
-            <unit id="org.eclipse.jetty.websocket.api" version="10.0.12"/>
-            <unit id="org.eclipse.jetty.websocket.server" version="10.0.12"/>
-            <unit id="org.eclipse.jetty.websocket.servlet" version="10.0.12"/>
-            <unit id="org.eclipse.jetty.websocket.javax.server" version="10.0.12"/>
+            <unit id="org.eclipse.jetty.websocket.api" version="10.0.17"/>
+            <unit id="org.eclipse.jetty.websocket.server" version="10.0.17"/>
+            <unit id="org.eclipse.jetty.websocket.servlet" version="10.0.17"/>
+            <unit id="org.eclipse.jetty.websocket.javax.server" version="10.0.17"/>
             <unit id="org.apache.aries.spifly.dynamic.bundle" version="1.3.6"/>
             <unit id="fireplace-swing" version="0.0.1.rc3"/>
             <unit id="fireplace-swt-awt-bridge" version="0.0.1.rc3"/>

--- a/releng/platform-definitions/platform-definition-2023-09/platform-definition-2023-09.target
+++ b/releng/platform-definitions/platform-definition-2023-09/platform-definition-2023-09.target
@@ -45,10 +45,10 @@
             <unit id="org.adoptopenjdk.jemmy-browser" version="2.0.0"/>
             <unit id="org.adoptopenjdk.jemmy-core" version="2.0.0"/>
             <unit id="org.adoptopenjdk.jemmy-swt" version="2.0.0"/>
-            <unit id="org.eclipse.jetty.websocket.api" version="10.0.12"/>
-            <unit id="org.eclipse.jetty.websocket.server" version="10.0.12"/>
-            <unit id="org.eclipse.jetty.websocket.servlet" version="10.0.12"/>
-            <unit id="org.eclipse.jetty.websocket.javax.server" version="10.0.12"/>
+            <unit id="org.eclipse.jetty.websocket.api" version="10.0.17"/>
+            <unit id="org.eclipse.jetty.websocket.server" version="10.0.17"/>
+            <unit id="org.eclipse.jetty.websocket.servlet" version="10.0.17"/>
+            <unit id="org.eclipse.jetty.websocket.javax.server" version="10.0.17"/>
             <unit id="org.apache.aries.spifly.dynamic.bundle" version="1.3.6"/>
             <unit id="fireplace-swing" version="0.0.1.rc3"/>
             <unit id="fireplace-swt-awt-bridge" version="0.0.1.rc3"/>

--- a/releng/third-party/pom.xml
+++ b/releng/third-party/pom.xml
@@ -57,7 +57,7 @@
 		<lz4.version>1.8.0</lz4.version>
 		<hdrhistogram.version>2.1.12</hdrhistogram.version>
 		<jemmy.version>2.0.0</jemmy.version>
-		<jetty.version>10.0.12</jetty.version>
+		<jetty.version>10.0.17</jetty.version>
 		<spifly.version>1.3.6</spifly.version>
 		<fireplace.version>0.0.1-rc3</fireplace.version>
 		<radiance.version>6.0.0</radiance.version>


### PR DESCRIPTION
Default jetty with Eclipse 4.29 is 10.0.15. But this version of jetty has some vulnerabilities mentioned below.

Vulnerabilities:  ([jetty-project_10.0.15](https://mvnrepository.com/artifact/org.eclipse.jetty/jetty-project/10.0.15))
[CVE-2023-42503](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-42503)
[CVE-2023-41900](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-41900)
[CVE-2023-40167](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-40167)
[CVE-2023-39410](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-39410)
[CVE-2023-36479](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-36479)
[CVE-2023-36478](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-36478)
[CVE-2023-2976](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-2976)
[CVE-2020-8908](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-8908)

Vulnerabilities have been fixed in 10.0.17. Currently JMC is using 10.0.12.
So, we should use the jetty 10.0.17.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JMC-8145](https://bugs.openjdk.org/browse/JMC-8145): Upgrade Jetty to version 10.0.17 (**Bug** - P3)


### Reviewers
 * [Alex Macdonald](https://openjdk.org/census#aptmac) (@aptmac - **Reviewer**)
 * [Brice Dutheil](https://openjdk.org/census#bdutheil) (@bric3 - Author)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmc.git pull/532/head:pull/532` \
`$ git checkout pull/532`

Update a local copy of the PR: \
`$ git checkout pull/532` \
`$ git pull https://git.openjdk.org/jmc.git pull/532/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 532`

View PR using the GUI difftool: \
`$ git pr show -t 532`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmc/pull/532.diff">https://git.openjdk.org/jmc/pull/532.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jmc/pull/532#issuecomment-1801140277)