### PR TITLE
5994: Ensure dropins folder works

### DIFF
--- a/application/org.openjdk.jmc.feature.rcp/feature.xml
+++ b/application/org.openjdk.jmc.feature.rcp/feature.xml
@@ -191,4 +191,18 @@
          version="0.0.0"
          unpack="false"/>
 
+   <plugin
+         id="org.eclipse.ui.ide"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.ui.editors"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
 </feature>


### PR DESCRIPTION
This short PR looks to address JMC-5994 [[0]](https://bugs.openjdk.org/browse/JMC-5994), in which the plugin dropins folder does not work for JMC.

The idea behind the dropins folder is that you can place an external Eclipse plugin directly into the folder and it'll be loaded by Eclipse into JMC during application start. Taking a look at the debug logs, it looks like there are a couple of features that are missing that are required for running UI related plugins (`org.eclipse.ui.ide` & `org.eclipse.ui.editors`). The issue description [0] mentions checking if the dropins functionality worked in JMC 6, as it was also not working in JMC 7, so this looks to be a long-running issue.

I've created a very basic plugin that can be found here for testing purposes: https://github.com/aptmac/5994-dummy-plugin

To test this PR you can place the dummy folder into the dropins folder and verify the installation using the dialog at `Help -> About JDK Mission Control -> Installation Details -> Plug-ins`. You can also place the `.option` file into the same directory as your build jmc application and then run jmc using the debug console: `./jmc -debug -console -consoleLog`

**Before:**
Log:
```
!ENTRY org.eclipse.equinox.p2.director 2 0 2023-12-08 09:21:45.417
!MESSAGE Problems resolving provisioning plan.
!SUBENTRY 1 org.eclipse.equinox.p2.director 2 0 2023-12-08 09:21:45.417
!MESSAGE Unable to satisfy dependency from dummy 1.0.0.qualifier to osgi.bundle; org.eclipse.ui.editors 0.0.0.
!SUBENTRY 1 org.eclipse.equinox.p2.director 2 0 2023-12-08 09:21:45.417
!MESSAGE Unable to satisfy dependency from dummy 1.0.0.qualifier to osgi.bundle; org.eclipse.ui.ide 0.0.0.

```
Installation Details:
![before](https://github.com/openjdk/jmc/assets/10425301/c1c7f5f6-5fa4-4a9f-a8f4-2d9f26d76431)

**After:**
Log:
```
[p2] Fri Dec 08 09:49:29 EST 2023 - [Start Level: Equinox Container: f14ff445-7fe9-4e0a-8b62-619cfa6b1b24] [reconciler] Cached timestamp file empty.
[p2] Fri Dec 08 09:49:29 EST 2023 - [Start Level: Equinox Container: f14ff445-7fe9-4e0a-8b62-619cfa6b1b24] [reconciler] Performing reconciliation.
[p2] Fri Dec 08 09:49:29 EST 2023 - [Start Level: Equinox Container: f14ff445-7fe9-4e0a-8b62-619cfa6b1b24] [reconciler] [dropins] Interesting feature or bundle added: /home/aptmac/workspace/jmc/target/products/org.openjdk.jmc/linux/gtk/x86_64/JDK Mission Control/dropins/dummy
[p2] Fri Dec 08 09:49:29 EST 2023 - [Start Level: Equinox Container: f14ff445-7fe9-4e0a-8b62-619cfa6b1b24] [reconciler] Timestamp file does not exist.
[p2] Fri Dec 08 09:49:29 EST 2023 - [Start Level: Equinox Container: f14ff445-7fe9-4e0a-8b62-619cfa6b1b24] [reconciler] Performing reconciliation.
[p2] Fri Dec 08 09:49:29 EST 2023 - [Start Level: Equinox Container: f14ff445-7fe9-4e0a-8b62-619cfa6b1b24] [reconciler] Profile timestamp not found in cache.
[p2] Fri Dec 08 09:49:29 EST 2023 - [Start Level: Equinox Container: f14ff445-7fe9-4e0a-8b62-619cfa6b1b24] [reconciler] Performing reconciliation.
[p2] Fri Dec 08 09:49:29 EST 2023 - [Start Level: Equinox Container: f14ff445-7fe9-4e0a-8b62-619cfa6b1b24] [reconciler] Adding IU: dummy 1.0.0.qualifier
[p2] Fri Dec 08 09:49:29 EST 2023 - [Start Level: Equinox Container: f14ff445-7fe9-4e0a-8b62-619cfa6b1b24] [reconciler] Adding IU property: dummy 1.0.0.qualifier->{org.eclipse.equinox.p2.type.lock=1, org.eclipse.equinox.p2.internal.inclusion.rules=OPTIONAL, org.eclipse.equinox.p2.reconciler.dropins=true}
```
Installation Details:
![after](https://github.com/openjdk/jmc/assets/10425301/1633255e-1f7e-4842-9994-750dee962711)

Additions to the features directory:
![features](https://github.com/openjdk/jmc/assets/10425301/6d5cce1b-3701-4e90-94d6-6023c0ef65e9)

[0] https://bugs.openjdk.org/browse/JMC-5994

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JMC-5994](https://bugs.openjdk.org/browse/JMC-5994): Ensure dropins folder works (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmc.git pull/537/head:pull/537` \
`$ git checkout pull/537`

Update a local copy of the PR: \
`$ git checkout pull/537` \
`$ git pull https://git.openjdk.org/jmc.git pull/537/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 537`

View PR using the GUI difftool: \
`$ git pr show -t 537`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmc/pull/537.diff">https://git.openjdk.org/jmc/pull/537.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jmc/pull/537#issuecomment-1847456166)