### PR TITLE
8159: openUncompressedStream supports compressed inputs on all streams

### DIFF
--- a/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/io/IOToolkit.java
+++ b/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/io/IOToolkit.java
@@ -147,30 +147,27 @@ public final class IOToolkit {
 	 *             on I/O error
 	 */
 	public static InputStream openUncompressedStream(InputStream stream) throws IOException {
-		InputStream in = stream;
-		if (in.markSupported()) {
-			in.mark(MAGIC_GZ.length + 1);
-			if (hasMagic(in, MAGIC_GZ)) {
-				in.reset();
-				return new GZIPInputStream(in);
-			}
+		InputStream in = new BufferedInputStream(stream);
+		in.mark(MAGIC_GZ.length + 1);
+		if (hasMagic(in, MAGIC_GZ)) {
 			in.reset();
-			in.mark(MAGIC_ZIP.length + 1);
-			if (hasMagic(in, MAGIC_ZIP)) {
-				in.reset();
-				ZipInputStream zin = new ZipInputStream(in);
-				zin.getNextEntry();
-				return zin;
-			}
-			in.reset();
-			in.mark(MAGIC_LZ4.length + 1);
-			if (hasMagic(in, MAGIC_LZ4)) {
-				in.reset();
-				return new LZ4FrameInputStream(in);
-			}
-			in.reset();
+			return new GZIPInputStream(in);
 		}
-		in = new BufferedInputStream(stream);
+		in.reset();
+		in.mark(MAGIC_ZIP.length + 1);
+		if (hasMagic(in, MAGIC_ZIP)) {
+			in.reset();
+			ZipInputStream zin = new ZipInputStream(in);
+			zin.getNextEntry();
+			return zin;
+		}
+		in.reset();
+		in.mark(MAGIC_LZ4.length + 1);
+		if (hasMagic(in, MAGIC_LZ4)) {
+			in.reset();
+			return new LZ4FrameInputStream(in);
+		}
+		in.reset();
 		return in;
 	}
 

--- a/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/io/IOToolkit.java
+++ b/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/io/IOToolkit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/core/tests/org.openjdk.jmc.common.test/src/main/java/org/openjdk/jmc/common/test/util/IOToolkitTest.java
+++ b/core/tests/org.openjdk.jmc.common.test/src/main/java/org/openjdk/jmc/common/test/util/IOToolkitTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/core/tests/org.openjdk.jmc.common.test/src/main/java/org/openjdk/jmc/common/test/util/IOToolkitTest.java
+++ b/core/tests/org.openjdk.jmc.common.test/src/main/java/org/openjdk/jmc/common/test/util/IOToolkitTest.java
@@ -32,6 +32,7 @@
  */
 package org.openjdk.jmc.common.test.util;
 
+import java.io.FilterInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 
@@ -64,8 +65,22 @@ public class IOToolkitTest {
 	}
 
 	@Test
+	public void testUncompressUncompressedWithoutMark() throws IOException {
+		InputStream uncompressedStream = IOToolkit.openUncompressedStream(withoutMark(getStream(UNCOMPRESSED)));
+		String string = readFromStream(uncompressedStream);
+		Assert.assertEquals("String should be " + GURKA, GURKA, string);
+	}
+
+	@Test
 	public void testUncompressZipped() throws IOException {
 		InputStream uncompressedStream = IOToolkit.openUncompressedStream(getStream(ZIP));
+		String string = readFromStream(uncompressedStream);
+		Assert.assertEquals("String should be " + GURKA, GURKA, string);
+	}
+
+	@Test
+	public void testUncompressZippedWithoutMark() throws IOException {
+		InputStream uncompressedStream = IOToolkit.openUncompressedStream(withoutMark(getStream(ZIP)));
 		String string = readFromStream(uncompressedStream);
 		Assert.assertEquals("String should be " + GURKA, GURKA, string);
 	}
@@ -78,8 +93,22 @@ public class IOToolkitTest {
 	}
 
 	@Test
+	public void testUncompressGZippedWithoutMark() throws IOException {
+		InputStream uncompressedStream = IOToolkit.openUncompressedStream(withoutMark(getStream(GZ)));
+		String string = readFromStream(uncompressedStream);
+		Assert.assertEquals("String should be " + GURKA, GURKA, string);
+	}
+
+	@Test
 	public void testUncompressLZ4() throws IOException {
 		InputStream uncompressedStream = IOToolkit.openUncompressedStream(getStream(LZ4));
+		String string = readFromStream(uncompressedStream);
+		Assert.assertEquals("String should be " + GURKA, GURKA, string);
+	}
+
+	@Test
+	public void testUncompressLZ4WithoutMark() throws IOException {
+		InputStream uncompressedStream = IOToolkit.openUncompressedStream(withoutMark(getStream(LZ4)));
 		String string = readFromStream(uncompressedStream);
 		Assert.assertEquals("String should be " + GURKA, GURKA, string);
 	}
@@ -99,5 +128,25 @@ public class IOToolkitTest {
 			builder.append((char) c);
 		}
 		return builder.toString();
+	}
+
+	/** Wraps the provided {@link InputStream} such that it doesn't allow mark/reset. */
+	private static InputStream withoutMark(InputStream stream) {
+		return new FilterInputStream(stream) {
+			@Override
+			public void reset() throws IOException {
+				throw new IOException("reset is not supported");
+			}
+
+			@Override
+			public void mark(int limit) {
+				// nop
+			}
+
+			@Override
+			public boolean markSupported() {
+				return false;
+			}
+		};
 	}
 }


### PR DESCRIPTION
Previously this function supported compressed inputs only when the provided stream supported mark/reset. By shifting the BufferedInputStream wrapper prior to compression checks, we can support consistent behavior regardless of the stream implementation.
The new tests in this commit fail without the accompanying change to `IOToolkit.java`.

I'd be grateful if anyone could help create a jmc issue for this, I lack perms to create a ticket as described in the [contributing docs](https://github.com/openjdk/jmc/blob/master/CONTRIBUTING.md#pull-requests).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JMC-8159](https://bugs.openjdk.org/browse/JMC-8159): openUncompressedStream supports compressed inputs on all streams (**Enhancement** - P4)


### Reviewers
 * [Brice Dutheil](https://openjdk.org/census#bdutheil) (@bric3 - Author)
 * [Marcus Hirt](https://openjdk.org/census#hirt) (@thegreystone - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmc.git pull/539/head:pull/539` \
`$ git checkout pull/539`

Update a local copy of the PR: \
`$ git checkout pull/539` \
`$ git pull https://git.openjdk.org/jmc.git pull/539/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 539`

View PR using the GUI difftool: \
`$ git pr show -t 539`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmc/pull/539.diff">https://git.openjdk.org/jmc/pull/539.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jmc/pull/539#issuecomment-1854172080)