### PR TITLE
8156: JfrRulesReport.printReport does not respect verbosity for text and json

### DIFF
--- a/core/org.openjdk.jmc.flightrecorder.rules/src/main/resources/org/openjdk/jmc/flightrecorder/rules/report/html.xslt
+++ b/core/org.openjdk.jmc.flightrecorder.rules/src/main/resources/org/openjdk/jmc/flightrecorder/rules/report/html.xslt
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!--   
-   Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+   Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
    
    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
    

--- a/core/org.openjdk.jmc.flightrecorder.rules/src/main/resources/org/openjdk/jmc/flightrecorder/rules/report/html.xslt
+++ b/core/org.openjdk.jmc.flightrecorder.rules/src/main/resources/org/openjdk/jmc/flightrecorder/rules/report/html.xslt
@@ -54,8 +54,9 @@
 	<xsl:apply-templates select="name" />
 	<xsl:apply-templates select="severity" />
 	<xsl:apply-templates select="score" />
-	<xsl:apply-templates select="message" />
-	<xsl:apply-templates select="detailedmessage" />
+	<xsl:apply-templates select="summary" />
+	<xsl:apply-templates select="explanation" />
+	<xsl:apply-templates select="solution" />
 	<xsl:apply-templates select="itemset" />
 </xsl:template>
 
@@ -71,12 +72,16 @@
 	<p><b>Score:</b> <xsl:value-of select="format-number(.,'0.#')"/></p>
 </xsl:template>
 
-<xsl:template match="rule/message">
-	<p><b>Message:</b> <xsl:value-of select="."/></p>
+<xsl:template match="rule/summary">
+	<p><b>Summary:</b> <xsl:value-of select="."/></p>
 </xsl:template>
 
-<xsl:template match="rule/detailedmessage">
-	<p><b>Detailed message:</b> <xsl:value-of select="."/></p>
+<xsl:template match="rule/explanation">
+	<p><b>Explanation:</b> <xsl:value-of select="."/></p>
+</xsl:template>
+
+<xsl:template match="rule/solution">
+	<p><b>Solution:</b> <xsl:value-of select="."/></p>
 </xsl:template>
 
 <xsl:template match="itemset">

--- a/core/org.openjdk.jmc.flightrecorder.rules/src/main/resources/org/openjdk/jmc/flightrecorder/rules/report/json.xslt
+++ b/core/org.openjdk.jmc.flightrecorder.rules/src/main/resources/org/openjdk/jmc/flightrecorder/rules/report/json.xslt
@@ -136,9 +136,9 @@
                "name": "<xsl:apply-templates select="name" />", <xsl:choose><xsl:when test="count(error)>0"><xsl:text>&#xa;               </xsl:text>"error": "<xsl:apply-templates select="error" />"</xsl:when><xsl:otherwise>
                "severity": "<xsl:apply-templates select="severity" />",
                "score": <xsl:apply-templates select="score" />,
-               "message": "<xsl:apply-templates select="summary" />",
-               "detailedMessage": "<xsl:apply-templates select="explanation" />"<xsl:apply-templates select="itemset" />
-             	</xsl:otherwise>
+               "summary": "<xsl:apply-templates select="summary" />",
+               "explanation": "<xsl:apply-templates select="explanation" />",
+               "solution": "<xsl:apply-templates select="solution" />"<xsl:apply-templates select="itemset" /></xsl:otherwise>
              </xsl:choose>
               }<xsl:if test="following-sibling::*">,</xsl:if></xsl:template>
 

--- a/core/org.openjdk.jmc.flightrecorder.rules/src/main/resources/org/openjdk/jmc/flightrecorder/rules/report/text.xslt
+++ b/core/org.openjdk.jmc.flightrecorder.rules/src/main/resources/org/openjdk/jmc/flightrecorder/rules/report/text.xslt
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!--   
-   Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+   Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
    
    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
    

--- a/core/org.openjdk.jmc.flightrecorder.rules/src/main/resources/org/openjdk/jmc/flightrecorder/rules/report/text.xslt
+++ b/core/org.openjdk.jmc.flightrecorder.rules/src/main/resources/org/openjdk/jmc/flightrecorder/rules/report/text.xslt
@@ -51,8 +51,9 @@
 	<xsl:apply-templates select="name" />
 	<xsl:apply-templates select="severity" />
 	<xsl:apply-templates select="score" />
-	<xsl:apply-templates select="message" />
-	<xsl:apply-templates select="detailedmessage" />
+	<xsl:apply-templates select="summary" />
+	<xsl:apply-templates select="explanation" />
+	<xsl:apply-templates select="solution" />
 	<xsl:apply-templates select="itemset" />
 	<xsl:text>&#xa;</xsl:text>
 </xsl:template>
@@ -75,26 +76,33 @@
 	<xsl:text>&#xa;</xsl:text>
 </xsl:template>
 
-<xsl:template match="rule/message">
-	<xsl:text>Message: </xsl:text>
+<xsl:template match="rule/summary">
+	<xsl:text>Summary: </xsl:text>
 	<xsl:value-of select="."/>
 	<xsl:text>&#xa;</xsl:text>
 </xsl:template>
 
-<xsl:template match="rule/detailedmessage">
-	<xsl:text>Detailed message: </xsl:text>
+<xsl:template match="rule/explanation">
+	<xsl:text>Explanation: </xsl:text>
+	<xsl:value-of select="."/>
+	<xsl:text>&#xa;</xsl:text>
+</xsl:template>
+
+<xsl:template match="rule/solution">
+	<xsl:text>Solution: </xsl:text>
 	<xsl:value-of select="."/>
 	<xsl:text>&#xa;</xsl:text>
 </xsl:template>
 
 <xsl:template match="itemset">
+	<xsl:text>Result item set: </xsl:text>
 	<xsl:apply-templates select="name"/>
 	<xsl:apply-templates select="fields"/>
 	<xsl:apply-templates select="items"/>
 </xsl:template>
 
 <xsl:template match="itemset/name">
-	<xsl:text>Result item set: </xsl:text>
+	<xsl:text>Name: </xsl:text>
 	<xsl:value-of select="."/>
 	<xsl:text>&#xa;</xsl:text>
 </xsl:template>


### PR DESCRIPTION
The xslt files had not been updated to conform with the updated xml format.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JMC-8156](https://bugs.openjdk.org/browse/JMC-8156): JfrRulesReport.printReport does not respect verbosity for text and json (**Bug** - P2)


### Reviewers
 * [Henrik Dafgård](https://openjdk.org/census#hdafgard) (@Gunde - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmc.git pull/540/head:pull/540` \
`$ git checkout pull/540`

Update a local copy of the PR: \
`$ git checkout pull/540` \
`$ git pull https://git.openjdk.org/jmc.git pull/540/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 540`

View PR using the GUI difftool: \
`$ git pr show -t 540`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmc/pull/540.diff">https://git.openjdk.org/jmc/pull/540.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jmc/pull/540#issuecomment-1854863612)