### PR TITLE
8160: Fix test failure in core due to missing new File Force rule in newly added JFRs

### DIFF
--- a/core/tests/org.openjdk.jmc.flightrecorder.rules.jdk.test/src/main/resources/baseline/JfrRuleBaseline.xml
+++ b/core/tests/org.openjdk.jmc.flightrecorder.rules.jdk.test/src/main/resources/baseline/JfrRuleBaseline.xml
@@ -4685,6 +4685,10 @@ Events of the following types have truncated stack traces: &#x3C;ul&#x3E;&#x3C;l
             <id>FileWrite</id>
             <severity>Not Applicable</severity>
         </rule>
+		<rule>
+            <id>FileForce</id>
+            <severity>Not Applicable</severity>
+        </rule>
         <rule>
             <id>FinalizersRun</id>
             <severity>Not Applicable</severity>
@@ -4939,6 +4943,10 @@ Events of the following types have truncated stack traces: &#x3C;ul&#x3E;&#x3C;l
             <id>FileWrite</id>
             <severity>OK</severity>
             <summary>There are no file write events in this recording.</summary>
+        </rule>
+		<rule>
+            <id>FileForce</id>
+            <severity>Not Applicable</severity>
         </rule>
         <rule>
             <id>FinalizersRun</id>


### PR DESCRIPTION
This PR fixes core test failure.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JMC-8160](https://bugs.openjdk.org/browse/JMC-8160): Fix test failure in core due to missing new File Force rule in newly added JFRs (**Bug** - P4)


### Reviewers
 * [Henrik Dafgård](https://openjdk.org/census#hdafgard) (@Gunde - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmc.git pull/541/head:pull/541` \
`$ git checkout pull/541`

Update a local copy of the PR: \
`$ git checkout pull/541` \
`$ git pull https://git.openjdk.org/jmc.git pull/541/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 541`

View PR using the GUI difftool: \
`$ git pr show -t 541`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmc/pull/541.diff">https://git.openjdk.org/jmc/pull/541.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jmc/pull/541#issuecomment-1859037307)