### PR TITLE
8155 Upgrade to Eclipse 2023-12

### DIFF
--- a/application/org.openjdk.jmc.console.agent/META-INF/MANIFEST.MF
+++ b/application/org.openjdk.jmc.console.agent/META-INF/MANIFEST.MF
@@ -14,10 +14,10 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.e4.core.contexts,
  org.openjdk.jmc.console.ui,
  org.openjdk.jmc.flightrecorder.ui,
- org.openjdk.jmc.rjmx
+ org.openjdk.jmc.rjmx,
+ jakarta.inject.jakarta.inject-api
 Bundle-RequiredExecutionEnvironment: JavaSE-17
-Import-Package: javax.inject,
- org.eclipse.debug.core.sourcelookup.containers
+Import-Package: org.eclipse.debug.core.sourcelookup.containers
 Bundle-ActivationPolicy: lazy
 Bundle-Activator: org.openjdk.jmc.console.agent.AgentPlugin
 Automatic-Module-Name: org.openjdk.jmc.console.agent

--- a/application/org.openjdk.jmc.console.jconsole/META-INF/MANIFEST.MF
+++ b/application/org.openjdk.jmc.console.jconsole/META-INF/MANIFEST.MF
@@ -9,7 +9,8 @@ Bundle-Localization: plugin
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,
  org.openjdk.jmc.ui,
- org.openjdk.jmc.console.ui
+ org.openjdk.jmc.console.ui,
+ jakarta.inject.jakarta.inject-api
 Bundle-ActivationPolicy: lazy
 Export-Package: org.openjdk.jmc.console.jconsole
 Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/application/org.openjdk.jmc.console.jconsole/src/main/java/org/openjdk/jmc/console/jconsole/tabs/JConsoleTab.java
+++ b/application/org.openjdk.jmc.console.jconsole/src/main/java/org/openjdk/jmc/console/jconsole/tabs/JConsoleTab.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -37,7 +37,7 @@ import java.awt.EventQueue;
 import java.awt.Frame;
 import java.awt.Panel;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.awt.SWT_AWT;

--- a/application/org.openjdk.jmc.console.ui.diagnostic/META-INF/MANIFEST.MF
+++ b/application/org.openjdk.jmc.console.ui.diagnostic/META-INF/MANIFEST.MF
@@ -8,7 +8,8 @@ Bundle-Activator: org.openjdk.jmc.console.ui.diagnostic.DiagnosticPlugin
 Bundle-Vendor: Oracle Corporation
 Bundle-Localization: plugin
 Require-Bundle: org.openjdk.jmc.console.ui,
- org.openjdk.jmc.rjmx.ui
+ org.openjdk.jmc.rjmx.ui,
+ jakarta.inject.jakarta.inject-api
 Bundle-ActivationPolicy: lazy
 Export-Package: org.openjdk.jmc.console.ui.diagnostic.form,
  org.openjdk.jmc.console.ui.diagnostic.preferences

--- a/application/org.openjdk.jmc.console.ui.diagnostic/src/main/java/org/openjdk/jmc/console/ui/diagnostic/form/DiagnosticTab.java
+++ b/application/org.openjdk.jmc.console.ui.diagnostic/src/main/java/org/openjdk/jmc/console/ui/diagnostic/form/DiagnosticTab.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -35,7 +35,7 @@ package org.openjdk.jmc.console.ui.diagnostic.form;
 import java.util.Collection;
 import java.util.Collections;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.SashForm;

--- a/application/org.openjdk.jmc.console.ui.mbeanbrowser/META-INF/MANIFEST.MF
+++ b/application/org.openjdk.jmc.console.ui.mbeanbrowser/META-INF/MANIFEST.MF
@@ -10,7 +10,8 @@ Require-Bundle: org.openjdk.jmc.console.ui,
  org.openjdk.jmc.ui.common,
  org.openjdk.jmc.ui,
  org.openjdk.jmc.rjmx,
- org.openjdk.jmc.rjmx.ui
+ org.openjdk.jmc.rjmx.ui,
+ jakarta.inject.jakarta.inject-api
 Bundle-ActivationPolicy: lazy
 Bundle-Activator: org.openjdk.jmc.console.ui.mbeanbrowser.MBeanBrowserPlugin
 Export-Package: org.openjdk.jmc.console.ui.mbeanbrowser.notifications;x-friends:="org.openjdk.jmc.test.jemmy",

--- a/application/org.openjdk.jmc.console.ui.mbeanbrowser/src/main/java/org/openjdk/jmc/console/ui/mbeanbrowser/tab/MBeanTab.java
+++ b/application/org.openjdk.jmc.console.ui.mbeanbrowser/src/main/java/org/openjdk/jmc/console/ui/mbeanbrowser/tab/MBeanTab.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -32,7 +32,7 @@
  */
 package org.openjdk.jmc.console.ui.mbeanbrowser.tab;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 import javax.management.MBeanServerConnection;
 
 import org.eclipse.swt.SWT;

--- a/application/org.openjdk.jmc.console.ui.notification/META-INF/MANIFEST.MF
+++ b/application/org.openjdk.jmc.console.ui.notification/META-INF/MANIFEST.MF
@@ -17,7 +17,8 @@ Require-Bundle: org.openjdk.jmc.ui.common,
  org.openjdk.jmc.alert,
  org.openjdk.jmc.flightrecorder.controlpanel.ui,
  org.openjdk.jmc.flightrecorder.controlpanel.ui.configuration,
- org.openjdk.jmc.flightrecorder.configuration
+ org.openjdk.jmc.flightrecorder.configuration,
+ jakarta.inject.jakarta.inject-api
 Bundle-ActivationPolicy: lazy
 Bundle-Activator: org.openjdk.jmc.console.ui.notification.NotificationPlugin
 Export-Package: org.openjdk.jmc.console.ui.notification,

--- a/application/org.openjdk.jmc.console.ui.notification/src/main/java/org/openjdk/jmc/console/ui/notification/TriggerTab.java
+++ b/application/org.openjdk.jmc.console.ui.notification/src/main/java/org/openjdk/jmc/console/ui/notification/TriggerTab.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -32,7 +32,7 @@
  */
 package org.openjdk.jmc.console.ui.notification;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 
 import org.eclipse.jface.viewers.ISelectionChangedListener;
 import org.eclipse.jface.viewers.IStructuredSelection;

--- a/application/org.openjdk.jmc.console.ui.subscriptions/META-INF/MANIFEST.MF
+++ b/application/org.openjdk.jmc.console.ui.subscriptions/META-INF/MANIFEST.MF
@@ -9,6 +9,7 @@ Bundle-Vendor: Oracle Corporation
 Bundle-Localization: plugin
 Require-Bundle: org.openjdk.jmc.console.ui,
  org.eclipse.core.runtime,
- org.openjdk.jmc.rjmx.ui
+ org.openjdk.jmc.rjmx.ui,
+ jakarta.inject.jakarta.inject-api
 Bundle-ActivationPolicy: lazy
 Automatic-Module-Name: org.openjdk.jmc.console.ui.subscriptions

--- a/application/org.openjdk.jmc.console.ui.subscriptions/src/main/java/org/openjdk/jmc/console/ui/subscriptions/SubscriptionTab.java
+++ b/application/org.openjdk.jmc.console.ui.subscriptions/src/main/java/org/openjdk/jmc/console/ui/subscriptions/SubscriptionTab.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -32,7 +32,7 @@
  */
 package org.openjdk.jmc.console.ui.subscriptions;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 
 import org.eclipse.swt.layout.FillLayout;
 import org.eclipse.swt.widgets.Composite;

--- a/application/org.openjdk.jmc.console.ui/META-INF/MANIFEST.MF
+++ b/application/org.openjdk.jmc.console.ui/META-INF/MANIFEST.MF
@@ -10,8 +10,8 @@ Bundle-Localization: plugin
 Require-Bundle: org.openjdk.jmc.rjmx.ui;visibility:=reexport,
  org.eclipse.e4.core.contexts;bundle-version="1.3.0",
  org.eclipse.e4.core.di;bundle-version="1.3.0";visibility:=reexport,
- javax.inject;bundle-version="1.0.0";visibility:=reexport,
- org.openjdk.jmc.commands
+ org.openjdk.jmc.commands,
+ jakarta.inject.jakarta.inject-api
 Bundle-ActivationPolicy: lazy
 Export-Package: org.openjdk.jmc.console.ui.actions;
   x-friends:="org.openjdk.jmc.console.ext.coherence,
@@ -23,6 +23,5 @@ Export-Package: org.openjdk.jmc.console.ui.actions;
  org.openjdk.jmc.console.ui.messages.internal;x-friends:="org.openjdk.jmc.console.uitest",
  org.openjdk.jmc.console.ui.preferences;x-friends:="org.openjdk.jmc.console.uitest"
 Bundle-ClassPath: .
-Import-Package: javax.inject;version="1.0.0"
 Automatic-Module-Name: org.openjdk.jmc.console.ui
 

--- a/application/org.openjdk.jmc.console.ui/src/main/java/org/openjdk/jmc/console/ui/editor/internal/ConsoleEditor.java
+++ b/application/org.openjdk.jmc.console.ui/src/main/java/org/openjdk/jmc/console/ui/editor/internal/ConsoleEditor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -36,7 +36,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Level;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 import javax.management.MBeanServerConnection;
 
 import org.eclipse.core.runtime.IConfigurationElement;

--- a/application/org.openjdk.jmc.console.ui/src/main/java/org/openjdk/jmc/console/ui/editor/internal/ConsoleFormPage.java
+++ b/application/org.openjdk.jmc.console.ui/src/main/java/org/openjdk/jmc/console/ui/editor/internal/ConsoleFormPage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -35,7 +35,7 @@ package org.openjdk.jmc.console.ui.editor.internal;
 import java.io.StringReader;
 import java.util.logging.Level;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 
 import org.eclipse.core.runtime.IConfigurationElement;
 import org.eclipse.jface.action.GroupMarker;

--- a/application/org.openjdk.jmc.console.ui/src/main/java/org/openjdk/jmc/console/ui/tabs/memory/MemoryTab.java
+++ b/application/org.openjdk.jmc.console.ui/src/main/java/org/openjdk/jmc/console/ui/tabs/memory/MemoryTab.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -34,7 +34,7 @@ package org.openjdk.jmc.console.ui.tabs.memory;
 
 import java.util.logging.Level;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 import javax.management.MBeanServerConnection;
 import javax.management.ObjectName;
 

--- a/application/org.openjdk.jmc.console.ui/src/main/java/org/openjdk/jmc/console/ui/tabs/overview/OverviewTab.java
+++ b/application/org.openjdk.jmc.console.ui/src/main/java/org/openjdk/jmc/console/ui/tabs/overview/OverviewTab.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -32,7 +32,7 @@
  */
 package org.openjdk.jmc.console.ui.tabs.overview;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 import javax.management.MBeanServerConnection;
 import javax.management.ObjectName;
 

--- a/application/org.openjdk.jmc.console.ui/src/main/java/org/openjdk/jmc/console/ui/tabs/system/SystemTab.java
+++ b/application/org.openjdk.jmc.console.ui/src/main/java/org/openjdk/jmc/console/ui/tabs/system/SystemTab.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -32,7 +32,7 @@
  */
 package org.openjdk.jmc.console.ui.tabs.system;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 import javax.management.MBeanServerConnection;
 import javax.management.ObjectName;
 

--- a/application/org.openjdk.jmc.console.ui/src/main/java/org/openjdk/jmc/console/ui/tabs/threads/ThreadTab.java
+++ b/application/org.openjdk.jmc.console.ui/src/main/java/org/openjdk/jmc/console/ui/tabs/threads/ThreadTab.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -32,7 +32,7 @@
  */
 package org.openjdk.jmc.console.ui.tabs.threads;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 import javax.management.MBeanServerConnection;
 import javax.management.ObjectName;
 

--- a/application/pom.xml
+++ b/application/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-   Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+   Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
 
    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-   Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+   Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
 
    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
@@ -51,7 +51,7 @@
 			<name>Universal Permissive License Version 1.0</name>
 			<url>http://oss.oracle.com/licenses/upl</url>
 			<distribution>repo</distribution>
-			<comments>Copyright (c) 2018, 2023, Oracle and/or its affiliates. Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.</comments>
+			<comments>Copyright (c) 2018, 2024, Oracle and/or its affiliates. Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.</comments>
 		</license>
 	</licenses>
 	<organization>
@@ -94,7 +94,7 @@
 		<maven.compiler.source>17</maven.compiler.source>
 		<maven.compiler.target>17</maven.compiler.target>
 		<!-- Plugin Versions -->
-		<tycho.version>3.0.4</tycho.version>
+		<tycho.version>3.0.5</tycho.version>
 		<maven.toolchains.version>3.1.0</maven.toolchains.version>
 		<maven.checkstyle.version>3.3.0</maven.checkstyle.version>
 		<!-- Seems like the currently latest spotless version 2.36.0 has some issue with libicu, so going for 2.34.0 now -->
@@ -125,10 +125,31 @@
 	</distributionManagement>
 	<profiles>
 		<profile>
-			<id>2023-09</id>
+			<id>2023-12</id>
 			<activation>
 				<activeByDefault>true</activeByDefault>
 			</activation>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.eclipse.tycho</groupId>
+						<artifactId>target-platform-configuration</artifactId>
+						<version>${tycho.version}</version>
+						<configuration>
+							<target>
+								<artifact>
+									<groupId>org.openjdk.jmc</groupId>
+									<artifactId>platform-definition-2023-12</artifactId>
+									<version>${revision}${changelist}</version>
+								</artifact>
+							</target>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+		<profile>
+			<id>2023-09</id>
 			<build>
 				<plugins>
 					<plugin>

--- a/releng/platform-definitions/platform-definition-2022-09/platform-definition-2022-09.target
+++ b/releng/platform-definitions/platform-definition-2022-09/platform-definition-2022-09.target
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
-   Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
-   Copyright (c) 2022, 2023, Datadog, Inc. All rights reserved.
+   Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
+   Copyright (c) 2022, 2024, Datadog, Inc. All rights reserved.
 
    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
@@ -45,10 +45,10 @@
             <unit id="org.adoptopenjdk.jemmy-browser" version="2.0.0"/>
             <unit id="org.adoptopenjdk.jemmy-core" version="2.0.0"/>
             <unit id="org.adoptopenjdk.jemmy-swt" version="2.0.0"/>
-            <unit id="org.eclipse.jetty.websocket.api" version="10.0.17"/>
-            <unit id="org.eclipse.jetty.websocket.server" version="10.0.17"/>
-            <unit id="org.eclipse.jetty.websocket.servlet" version="10.0.17"/>
-            <unit id="org.eclipse.jetty.websocket.javax.server" version="10.0.17"/>
+            <unit id="org.eclipse.jetty.websocket.api" version="10.0.18"/>
+            <unit id="org.eclipse.jetty.websocket.server" version="10.0.18"/>
+            <unit id="org.eclipse.jetty.websocket.servlet" version="10.0.18"/>
+            <unit id="org.eclipse.jetty.websocket.javax.server" version="10.0.18"/>
             <unit id="org.apache.aries.spifly.dynamic.bundle" version="1.3.6"/>
             <unit id="fireplace-swing" version="0.0.1.rc3"/>
             <unit id="fireplace-swt-awt-bridge" version="0.0.1.rc3"/>

--- a/releng/platform-definitions/platform-definition-2022-09/platform-definition-2022-09.target
+++ b/releng/platform-definitions/platform-definition-2022-09/platform-definition-2022-09.target
@@ -37,6 +37,7 @@
     <locations>
         <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
             <unit id="org.eclipse.angus.jakarta.mail" version="2.0.1"/>
+            <unit id="jakarta.inject.jakarta.inject-api" version="2.0.1"/>
             <unit id="angus-activation" version="2.0.0"/>
             <unit id="org.owasp.encoder" version="1.2.3"/>
             <unit id="lz4-java" version="1.8.0"/>

--- a/releng/platform-definitions/platform-definition-2022-12/platform-definition-2022-12.target
+++ b/releng/platform-definitions/platform-definition-2022-12/platform-definition-2022-12.target
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
-   Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
-   Copyright (c) 2022, 2023, Datadog, Inc. All rights reserved.
+   Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
+   Copyright (c) 2022, 2024, Datadog, Inc. All rights reserved.
 
    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
@@ -45,10 +45,10 @@
             <unit id="org.adoptopenjdk.jemmy-browser" version="2.0.0"/>
             <unit id="org.adoptopenjdk.jemmy-core" version="2.0.0"/>
             <unit id="org.adoptopenjdk.jemmy-swt" version="2.0.0"/>
-            <unit id="org.eclipse.jetty.websocket.api" version="10.0.17"/>
-            <unit id="org.eclipse.jetty.websocket.server" version="10.0.17"/>
-            <unit id="org.eclipse.jetty.websocket.servlet" version="10.0.17"/>
-            <unit id="org.eclipse.jetty.websocket.javax.server" version="10.0.17"/>
+            <unit id="org.eclipse.jetty.websocket.api" version="10.0.18"/>
+            <unit id="org.eclipse.jetty.websocket.server" version="10.0.18"/>
+            <unit id="org.eclipse.jetty.websocket.servlet" version="10.0.18"/>
+            <unit id="org.eclipse.jetty.websocket.javax.server" version="10.0.18"/>
             <unit id="org.apache.aries.spifly.dynamic.bundle" version="1.3.6"/>
             <unit id="fireplace-swing" version="0.0.1.rc3"/>
             <unit id="fireplace-swt-awt-bridge" version="0.0.1.rc3"/>

--- a/releng/platform-definitions/platform-definition-2022-12/platform-definition-2022-12.target
+++ b/releng/platform-definitions/platform-definition-2022-12/platform-definition-2022-12.target
@@ -37,6 +37,7 @@
     <locations>
         <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
             <unit id="org.eclipse.angus.jakarta.mail" version="2.0.1"/>
+            <unit id="jakarta.inject.jakarta.inject-api" version="2.0.1"/>
             <unit id="angus-activation" version="2.0.0"/>
             <unit id="org.owasp.encoder" version="1.2.3"/>
             <unit id="lz4-java" version="1.8.0"/>

--- a/releng/platform-definitions/platform-definition-2023-03/platform-definition-2023-03.target
+++ b/releng/platform-definitions/platform-definition-2023-03/platform-definition-2023-03.target
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
-   Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
-   Copyright (c) 2023, Datadog, Inc. All rights reserved.
+   Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
+   Copyright (c) 2023, 2024, Datadog, Inc. All rights reserved.
 
    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
@@ -45,10 +45,10 @@
             <unit id="org.adoptopenjdk.jemmy-browser" version="2.0.0"/>
             <unit id="org.adoptopenjdk.jemmy-core" version="2.0.0"/>
             <unit id="org.adoptopenjdk.jemmy-swt" version="2.0.0"/>
-            <unit id="org.eclipse.jetty.websocket.api" version="10.0.17"/>
-            <unit id="org.eclipse.jetty.websocket.server" version="10.0.17"/>
-            <unit id="org.eclipse.jetty.websocket.servlet" version="10.0.17"/>
-            <unit id="org.eclipse.jetty.websocket.javax.server" version="10.0.17"/>
+            <unit id="org.eclipse.jetty.websocket.api" version="10.0.18"/>
+            <unit id="org.eclipse.jetty.websocket.server" version="10.0.18"/>
+            <unit id="org.eclipse.jetty.websocket.servlet" version="10.0.18"/>
+            <unit id="org.eclipse.jetty.websocket.javax.server" version="10.0.18"/>
             <unit id="org.apache.aries.spifly.dynamic.bundle" version="1.3.6"/>
             <unit id="fireplace-swing" version="0.0.1.rc3"/>
             <unit id="fireplace-swt-awt-bridge" version="0.0.1.rc3"/>

--- a/releng/platform-definitions/platform-definition-2023-03/platform-definition-2023-03.target
+++ b/releng/platform-definitions/platform-definition-2023-03/platform-definition-2023-03.target
@@ -37,6 +37,7 @@
     <locations>
         <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
             <unit id="org.eclipse.angus.jakarta.mail" version="2.0.1"/>
+            <unit id="jakarta.inject.jakarta.inject-api" version="2.0.1"/>
             <unit id="angus-activation" version="2.0.0"/>
             <unit id="org.owasp.encoder" version="1.2.3"/>
             <unit id="lz4-java" version="1.8.0"/>

--- a/releng/platform-definitions/platform-definition-2023-09/platform-definition-2023-09.target
+++ b/releng/platform-definitions/platform-definition-2023-09/platform-definition-2023-09.target
@@ -60,6 +60,7 @@
             <unit id="org.eclipse.equinox.executable.feature.group" version="3.8.2200.v20230717-2134"/>
             <unit id="org.eclipse.pde.feature.group" version="3.15.100.v20230903-1000"/>
             <unit id="org.eclipse.platform.sdk" version="4.29.0.I20230903-1000"/>
+            <unit id="jakarta.inject.jakarta.inject-api" version="2.0.1"/>
             <repository location="https://download.eclipse.org/releases/2023-09/"/>
         </location>
         <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">

--- a/releng/platform-definitions/platform-definition-2023-09/platform-definition-2023-09.target
+++ b/releng/platform-definitions/platform-definition-2023-09/platform-definition-2023-09.target
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
-   Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
-   Copyright (c) 2023, Datadog, Inc. All rights reserved.
+   Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
+   Copyright (c) 2023, 2024, Datadog, Inc. All rights reserved.
 
    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
@@ -45,10 +45,10 @@
             <unit id="org.adoptopenjdk.jemmy-browser" version="2.0.0"/>
             <unit id="org.adoptopenjdk.jemmy-core" version="2.0.0"/>
             <unit id="org.adoptopenjdk.jemmy-swt" version="2.0.0"/>
-            <unit id="org.eclipse.jetty.websocket.api" version="10.0.17"/>
-            <unit id="org.eclipse.jetty.websocket.server" version="10.0.17"/>
-            <unit id="org.eclipse.jetty.websocket.servlet" version="10.0.17"/>
-            <unit id="org.eclipse.jetty.websocket.javax.server" version="10.0.17"/>
+            <unit id="org.eclipse.jetty.websocket.api" version="10.0.18"/>
+            <unit id="org.eclipse.jetty.websocket.server" version="10.0.18"/>
+            <unit id="org.eclipse.jetty.websocket.servlet" version="10.0.18"/>
+            <unit id="org.eclipse.jetty.websocket.javax.server" version="10.0.18"/>
             <unit id="org.apache.aries.spifly.dynamic.bundle" version="1.3.6"/>
             <unit id="fireplace-swing" version="0.0.1.rc3"/>
             <unit id="fireplace-swt-awt-bridge" version="0.0.1.rc3"/>

--- a/releng/platform-definitions/platform-definition-2023-12/platform-definition-2023-12.target
+++ b/releng/platform-definitions/platform-definition-2023-12/platform-definition-2023-12.target
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+   Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
+   Copyright (c) 2023, 2024, Datadog, Inc. All rights reserved.
+
+   DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+
+   The contents of this file are subject to the terms of either the Universal Permissive License
+   v 1.0 as shown at http://oss.oracle.com/licenses/upl
+
+   or the following license:
+
+   Redistribution and use in source and binary forms, with or without modification, are permitted
+   provided that the following conditions are met:
+
+   1. Redistributions of source code must retain the above copyright notice, this list of conditions
+   and the following disclaimer.
+
+   2. Redistributions in binary form must reproduce the above copyright notice, this list of
+   conditions and the following disclaimer in the documentation and/or other materials provided with
+   the distribution.
+
+   3. Neither the name of the copyright holder nor the names of its contributors may be used to
+   endorse or promote products derived from this software without specific prior written permission.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+   IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+   FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+   DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+   DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+   WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+   WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+-->
+<?pde version="3.8"?>
+<target name="jmc-target-2023-12" sequenceNumber="47">
+    <locations>
+        <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+            <unit id="org.eclipse.angus.jakarta.mail" version="2.0.1"/>
+            <unit id="angus-activation" version="2.0.0"/>
+            <unit id="org.owasp.encoder" version="1.2.3"/>
+            <unit id="lz4-java" version="1.8.0"/>
+            <unit id="org.hdrhistogram.HdrHistogram" version="2.1.12"/>
+            <unit id="org.adoptopenjdk.jemmy-awt-input" version="2.0.0"/>
+            <unit id="org.adoptopenjdk.jemmy-browser" version="2.0.0"/>
+            <unit id="org.adoptopenjdk.jemmy-core" version="2.0.0"/>
+            <unit id="org.adoptopenjdk.jemmy-swt" version="2.0.0"/>
+            <unit id="org.eclipse.jetty.websocket.api" version="10.0.18"/>
+            <unit id="org.eclipse.jetty.websocket.server" version="10.0.18"/>
+            <unit id="org.eclipse.jetty.websocket.servlet" version="10.0.18"/>
+            <unit id="org.eclipse.jetty.websocket.javax.server" version="10.0.18"/>
+            <unit id="org.apache.aries.spifly.dynamic.bundle" version="1.3.6"/>
+            <unit id="fireplace-swing" version="0.0.1.rc3"/>
+            <unit id="fireplace-swt-awt-bridge" version="0.0.1.rc3"/>
+            <unit id="fireplace-swing-animation" version="0.0.1.rc3"/>
+            <unit id="radiance-animation" version="6.0.0"/>
+            <repository location="http://localhost:8080/site"/>
+        </location>
+        <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+            <unit id="org.eclipse.equinox.executable.feature.group" version="3.8.2300.v20231106-1826"/>
+            <unit id="org.eclipse.pde.feature.group" version="3.15.200.v20231201-0110"/>
+	    <unit id="jakarta.servlet-api" version="4.0.0"/>
+	    <unit id="org.eclipse.equinox.p2.ui.sdk.scheduler" version="1.6.100.v20230630-1506"/>
+	    <unit id="org.eclipse.equinox.p2.updatechecker" version="1.4.100.v20230630-1506"/>
+	    <unit id="org.eclipse.update.configurator" version="3.5.200.v20231102-0934"/>
+	    <unit id="org.eclipse.equinox.p2.reconciler.dropins" version="1.5.200.v20230921-2011"/>
+	    <unit id="org.eclipse.help.webapp" version="3.11.200.v20231108-0716"/>
+	    <unit id="org.apache.commons.codec" version="1.14.0.v20221112-0806"/>
+	    <unit id="org.eclipse.rcp.feature.group" version="4.30.0.v20231201-0512"/>
+	    <unit id="org.eclipse.help.feature.group" version="2.3.1600.v20231201-0110"/>
+	    <unit id="org.eclipse.equinox.p2.rcp.feature.feature.group" version="1.4.2200.v20231112-1314"/>
+	    <unit id="org.eclipse.ui.net" version="1.5.200.v20231106-1240"/>
+	    <unit id="org.eclipse.equinox.p2.director.app" version="1.3.200.v20231103-0929"/>
+            <unit id="org.eclipse.sdk" version="4.30.0.v20231201-0110"/>
+            <repository location="https://download.eclipse.org/releases/2023-12/"/>
+        </location>
+        <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+            <unit id="org.eclipse.babel.nls_eclipse_ja.feature.group" version="4.26.0.v20230220105658"/>
+            <unit id="org.eclipse.babel.nls_eclipse_zh.feature.group" version="4.26.0.v20230220105658"/>
+            <!-- No new release yet - using 2022-12 -->
+            <repository location="https://archive.eclipse.org/technology/babel/update-site/R0.20.0/2022-12/"/>
+        </location>
+    </locations>
+    <targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
+</target>

--- a/releng/platform-definitions/platform-definition-2023-12/platform-definition-2023-12.target
+++ b/releng/platform-definitions/platform-definition-2023-12/platform-definition-2023-12.target
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
-   Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
-   Copyright (c) 2023, 2024, Datadog, Inc. All rights reserved.
+   Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+   Copyright (c) 2024, Datadog, Inc. All rights reserved.
 
    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 

--- a/releng/platform-definitions/platform-definition-2023-12/platform-definition-2023-12.target
+++ b/releng/platform-definitions/platform-definition-2023-12/platform-definition-2023-12.target
@@ -59,18 +59,18 @@
         <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
             <unit id="org.eclipse.equinox.executable.feature.group" version="3.8.2300.v20231106-1826"/>
             <unit id="org.eclipse.pde.feature.group" version="3.15.200.v20231201-0110"/>
-	    <unit id="jakarta.servlet-api" version="4.0.0"/>
-	    <unit id="org.eclipse.equinox.p2.ui.sdk.scheduler" version="1.6.100.v20230630-1506"/>
-	    <unit id="org.eclipse.equinox.p2.updatechecker" version="1.4.100.v20230630-1506"/>
-	    <unit id="org.eclipse.update.configurator" version="3.5.200.v20231102-0934"/>
-	    <unit id="org.eclipse.equinox.p2.reconciler.dropins" version="1.5.200.v20230921-2011"/>
-	    <unit id="org.eclipse.help.webapp" version="3.11.200.v20231108-0716"/>
-	    <unit id="org.apache.commons.codec" version="1.14.0.v20221112-0806"/>
-	    <unit id="org.eclipse.rcp.feature.group" version="4.30.0.v20231201-0512"/>
-	    <unit id="org.eclipse.help.feature.group" version="2.3.1600.v20231201-0110"/>
-	    <unit id="org.eclipse.equinox.p2.rcp.feature.feature.group" version="1.4.2200.v20231112-1314"/>
-	    <unit id="org.eclipse.ui.net" version="1.5.200.v20231106-1240"/>
-	    <unit id="org.eclipse.equinox.p2.director.app" version="1.3.200.v20231103-0929"/>
+            <unit id="jakarta.servlet-api" version="4.0.0"/>
+            <unit id="org.eclipse.equinox.p2.ui.sdk.scheduler" version="1.6.100.v20230630-1506"/>
+            <unit id="org.eclipse.equinox.p2.updatechecker" version="1.4.100.v20230630-1506"/>
+            <unit id="org.eclipse.update.configurator" version="3.5.200.v20231102-0934"/>
+            <unit id="org.eclipse.equinox.p2.reconciler.dropins" version="1.5.200.v20230921-2011"/>
+            <unit id="org.eclipse.help.webapp" version="3.11.200.v20231108-0716"/>
+            <unit id="org.apache.commons.codec" version="1.14.0.v20221112-0806"/>
+            <unit id="org.eclipse.rcp.feature.group" version="4.30.0.v20231201-0512"/>
+            <unit id="org.eclipse.help.feature.group" version="2.3.1600.v20231201-0110"/>
+            <unit id="org.eclipse.equinox.p2.rcp.feature.feature.group" version="1.4.2200.v20231112-1314"/>
+            <unit id="org.eclipse.ui.net" version="1.5.200.v20231106-1240"/>
+            <unit id="org.eclipse.equinox.p2.director.app" version="1.3.200.v20231103-0929"/>
             <unit id="org.eclipse.sdk" version="4.30.0.v20231201-0110"/>
             <repository location="https://download.eclipse.org/releases/2023-12/"/>
         </location>

--- a/releng/platform-definitions/platform-definition-2023-12/pom.xml
+++ b/releng/platform-definitions/platform-definition-2023-12/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-   Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
-   Copyright (c) 2023, 2024, Datadog, Inc. All rights reserved.
+   Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+   Copyright (c) 2024, Datadog, Inc. All rights reserved.
 
    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 

--- a/releng/platform-definitions/platform-definition-2023-12/pom.xml
+++ b/releng/platform-definitions/platform-definition-2023-12/pom.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-   Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
+   Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
+   Copyright (c) 2023, 2024, Datadog, Inc. All rights reserved.
 
    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
@@ -35,19 +36,12 @@
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.openjdk.jmc</groupId>
-		<artifactId>missioncontrol.releng</artifactId>
+		<artifactId>platform-definitions</artifactId>
 		<version>${revision}${changelist}</version>
 	</parent>
-	<artifactId>platform-definitions</artifactId>
-	<packaging>pom</packaging>
+	<artifactId>platform-definition-2023-12</artifactId>
+	<packaging>eclipse-target-definition</packaging>
 	<properties>
-		<jmc.config.path>${project.basedir}/../../configuration</jmc.config.path>
+		<jmc.config.path>${project.basedir}/../../../configuration</jmc.config.path>
 	</properties>
-	<modules>
-		<module>platform-definition-2023-12</module>
-		<module>platform-definition-2023-09</module>
-		<module>platform-definition-2023-03</module>
-		<module>platform-definition-2022-12</module>
-		<module>platform-definition-2022-09</module>
-	</modules>
 </project>

--- a/releng/pom.xml
+++ b/releng/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-   Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+   Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
 
    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 

--- a/releng/third-party/pom.xml
+++ b/releng/third-party/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-   Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+   Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
 
    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
@@ -57,7 +57,7 @@
 		<lz4.version>1.8.0</lz4.version>
 		<hdrhistogram.version>2.1.12</hdrhistogram.version>
 		<jemmy.version>2.0.0</jemmy.version>
-		<jetty.version>10.0.17</jetty.version>
+		<jetty.version>10.0.18</jetty.version>
 		<spifly.version>1.3.6</spifly.version>
 		<fireplace.version>0.0.1-rc3</fireplace.version>
 		<radiance.version>6.0.0</radiance.version>

--- a/releng/third-party/pom.xml
+++ b/releng/third-party/pom.xml
@@ -61,6 +61,7 @@
 		<spifly.version>1.3.6</spifly.version>
 		<fireplace.version>0.0.1-rc3</fireplace.version>
 		<radiance.version>6.0.0</radiance.version>
+		<jakarta.inject.version>2.0.1</jakarta.inject.version>
 	</properties>
 
 	<build>
@@ -80,6 +81,9 @@
 								<!-- groupId:artifactId:version -->
 								<artifact>
 									<id>org.eclipse.angus:jakarta.mail:${jakarta.mail.version}</id>
+								</artifact>	
+								<artifact>
+									<id>jakarta.inject:jakarta.inject-api:${jakarta.inject.version}</id>
 								</artifact>	
 								<artifact>
 									<id>org.eclipse.angus:angus-activation:${angus.activation.version}</id>


### PR DESCRIPTION
Eclipse platform upgrade to 2023-12.

- javax.inject has been replaced with jakarta.inject.
- added missing features to target file.
- upgraded tycho to 3.0.5.
- upgraded jetty to 10.0.18.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JMC-8155](https://bugs.openjdk.org/browse/JMC-8155): Upgrade to Eclipse 2023-12 (**Task** - P2)


### Reviewers
 * [Alex Macdonald](https://openjdk.org/census#aptmac) (@aptmac - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmc.git pull/546/head:pull/546` \
`$ git checkout pull/546`

Update a local copy of the PR: \
`$ git checkout pull/546` \
`$ git pull https://git.openjdk.org/jmc.git pull/546/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 546`

View PR using the GUI difftool: \
`$ git pr show -t 546`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmc/pull/546.diff">https://git.openjdk.org/jmc/pull/546.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jmc/pull/546#issuecomment-1898954131)