### PR TITLE
8167: [Accessibility]: 'Click here to start using JDK Mission Control' button does not have any function to open JDK mission control

### DIFF
--- a/application/org.openjdk.jmc.rcp.intro/content/root.xhtml
+++ b/application/org.openjdk.jmc.rcp.intro/content/root.xhtml
@@ -10,6 +10,17 @@
   <title>Welcome to JDK Mission Control</title>
   <link rel="stylesheet" href="root.css" type="text/css" />
   </head>
+  
+<script>
+function enterKeyPressed(event) {
+      if (event.keyCode == 13) {
+         window.location.href="http://org.eclipse.ui.intro/runAction?class=org.openjdk.jmc.rcp.intro.CloseIntroAction&amp;pluginId=org.openjdk.jmc.rcp.intro";
+         return true;
+      } else {
+         return false;
+      }
+   }
+</script>
 
 <body> 
 <include path="pageparts/banner" />
@@ -115,7 +126,7 @@
 
 </td></tr></table>
 
-<table tabindex="0"><tr><td>
+<table tabindex="0" onkeypress="return enterKeyPressed(event)"><tr><td>
         <a href="http://org.eclipse.ui.intro/runAction?class=org.openjdk.jmc.rcp.intro.CloseIntroAction&amp;pluginId=org.openjdk.jmc.rcp.intro" aria-label="Click here to start using JDK Mission Control">
             <h2> <img src="images/mission_control_64.png"/><include path="strings/gettowork_title" /></h2>
         </a>


### PR DESCRIPTION
On Welcome page, User move focus to "Click here to start using JDK Mission Control" button and press Enter but it does not have any function to open JDK mission control.

This issue was reported as part of accessibility testing requirement. From the accessibility point of view, the user will be stuck on welcome page and won't be able to proceed further.

<img width="959" alt="image" src="https://github.com/openjdk/jmc/assets/11155712/605ba3a3-991d-4367-8f30-6bbf8a3db56f">

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JMC-8167](https://bugs.openjdk.org/browse/JMC-8167): [Accessibility]: 'Click here to start using JDK Mission Control' button does not have any function to open JDK mission control (**Bug** - P3)


### Reviewers
 * [Alex Macdonald](https://openjdk.org/census#aptmac) (@aptmac - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmc.git pull/547/head:pull/547` \
`$ git checkout pull/547`

Update a local copy of the PR: \
`$ git checkout pull/547` \
`$ git pull https://git.openjdk.org/jmc.git pull/547/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 547`

View PR using the GUI difftool: \
`$ git pr show -t 547`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmc/pull/547.diff">https://git.openjdk.org/jmc/pull/547.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jmc/pull/547#issuecomment-1909762101)