### PR TITLE
8173: 2023-12 target platform needs update to take org.eclipse.ui.themes

### DIFF
--- a/releng/platform-definitions/platform-definition-2023-12/platform-definition-2023-12.target
+++ b/releng/platform-definitions/platform-definition-2023-12/platform-definition-2023-12.target
@@ -71,6 +71,7 @@
             <unit id="org.eclipse.equinox.p2.rcp.feature.feature.group" version="1.4.2200.v20231112-1314"/>
             <unit id="org.eclipse.ui.net" version="1.5.200.v20231106-1240"/>
             <unit id="org.eclipse.equinox.p2.director.app" version="1.3.200.v20231103-0929"/>
+            <unit id="org.eclipse.ui.themes" version="1.2.2300.v20230807-1354"/>
             <unit id="org.eclipse.sdk" version="4.30.0.v20231201-0110"/>
             <repository location="https://download.eclipse.org/releases/2023-12/"/>
         </location>


### PR DESCRIPTION
2023-12 target platform needs update to take org.eclipse.ui.themes.
org.eclipse.ui.themes has been added as part for Dark Mode Fix. Build on master has failed because of this.