### PR TITLE
8173: 2023-12 target platform needs update to take org.eclipse.ui.themes

### DIFF
--- a/releng/platform-definitions/platform-definition-2023-12/platform-definition-2023-12.target
+++ b/releng/platform-definitions/platform-definition-2023-12/platform-definition-2023-12.target
@@ -71,6 +71,7 @@
             <unit id="org.eclipse.equinox.p2.rcp.feature.feature.group" version="1.4.2200.v20231112-1314"/>
             <unit id="org.eclipse.ui.net" version="1.5.200.v20231106-1240"/>
             <unit id="org.eclipse.equinox.p2.director.app" version="1.3.200.v20231103-0929"/>
+            <unit id="org.eclipse.ui.themes" version="1.2.2300.v20230807-1354"/>
             <unit id="org.eclipse.sdk" version="4.30.0.v20231201-0110"/>
             <repository location="https://download.eclipse.org/releases/2023-12/"/>
         </location>


### PR DESCRIPTION
Reviewed-by: aptmac

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JMC-8173](https://bugs.openjdk.org/browse/JMC-8173): 2023-12 target platform needs update to take org.eclipse.ui.themes (**Task** - P2) ⚠️ Issue is already resolved. Consider making this a "backport pull request" by setting the PR title to `Backport <hash>` with the hash of the original commit. See [Backports](https://wiki.openjdk.org/display/SKARA/Backports).


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmc.git pull/551/head:pull/551` \
`$ git checkout pull/551`

Update a local copy of the PR: \
`$ git checkout pull/551` \
`$ git pull https://git.openjdk.org/jmc.git pull/551/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 551`

View PR using the GUI difftool: \
`$ git pr show -t 551`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmc/pull/551.diff">https://git.openjdk.org/jmc/pull/551.diff</a>

</details>
