### PR TITLE
8174: Check license year script may check files not changed by a PR

### DIFF
--- a/scripts/checkcopyrightyear.sh
+++ b/scripts/checkcopyrightyear.sh
@@ -1,7 +1,11 @@
 #!/usr/bin/env bash
 
+# set remote for upstream repository
+git remote -v | grep -w upstream || git remote add upstream https://github.com/openjdk/jmc.git
+git fetch upstream
+
 CURRENT_YEAR=$(date +'%Y')
-MODIFIED_FILES=$(git diff --name-only origin/master)
+MODIFIED_FILES=$(git diff --name-only upstream/master)
 counter=0
 
 for fileToCheck in $MODIFIED_FILES


### PR DESCRIPTION
This short PR addresses JMC-8174 [[0]](https://bugs.openjdk.org/browse/JMC-8174), in which the check license year script may fail when checking files not modified by the PR it's running against.

The issue is that I originally had `origin/master` as the branch the PR would be checked against, forgetting that these checks are run on our own forks and not openjdk/jmc. As a result, if the PR owner's `origin/master` is out of date, then the check license script may incorrectly error even if the PR is okay against `upstream/master`. To amend this I've added a line that greps the result of `git remote -v` and looks for `upstream`, and if it doesn't exist then it adds a new remote and fetches it. Now we can compare the PR commits against `upstream/master`

[0] https://bugs.openjdk.org/browse/JMC-8174

Examples:

Current (checks out own fork of jmc): https://github.com/aptmac/jmc/actions/runs/7904023625/job/21573338057#step:2:463

8174 (checks out openjdk/jmc): https://github.com/aptmac/jmc/actions/runs/7875363437/job/21487103607#step:3:5

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JMC-8174](https://bugs.openjdk.org/browse/JMC-8174): Check license year script may check files not changed by a PR (**Bug** - P4)


### Reviewers
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)
 * [Brice Dutheil](https://openjdk.org/census#bdutheil) (@bric3 - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmc.git pull/552/head:pull/552` \
`$ git checkout pull/552`

Update a local copy of the PR: \
`$ git checkout pull/552` \
`$ git pull https://git.openjdk.org/jmc.git pull/552/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 552`

View PR using the GUI difftool: \
`$ git pr show -t 552`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmc/pull/552.diff">https://git.openjdk.org/jmc/pull/552.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jmc/pull/552#issuecomment-1939140207)