### PR TITLE
8175: Flightrecorder UI-tests are failing

### DIFF
--- a/application/uitests/org.openjdk.jmc.flightrecorder.uitest/src/test/java/org/openjdk/jmc/flightrecorder/uitest/ControlRecordingsTest.java
+++ b/application/uitests/org.openjdk.jmc.flightrecorder.uitest/src/test/java/org/openjdk/jmc/flightrecorder/uitest/ControlRecordingsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -35,6 +35,7 @@ package org.openjdk.jmc.flightrecorder.uitest;
 import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.openjdk.jmc.test.jemmy.MCJemmyTestBase;
@@ -247,6 +248,7 @@ public class ControlRecordingsTest extends MCJemmyTestBase {
 	/**
 	 * Verifies that recording events can be added/removed on the fly
 	 */
+	@Ignore("Requires a jdk17 backport of JDK-8286740")
 	@Test
 	public void modifyRecordingEvents() {
 		// Dump the test recording to get the current event settings (combined from, possibly multiple recordings)
@@ -292,6 +294,7 @@ public class ControlRecordingsTest extends MCJemmyTestBase {
 	/**
 	 * Verifies that recording event threshold settings can be modified on the fly
 	 */
+	@Ignore("Requires a jdk17 backport of JDK-8286740")
 	@Test
 	public void modifyEventThreshold() {
 		// Dump the test recording to get the current event settings (combined from, possibly multiple recordings)
@@ -330,6 +333,7 @@ public class ControlRecordingsTest extends MCJemmyTestBase {
 	/**
 	 * Verifies that recording event period settings can be modified on the fly
 	 */
+	@Ignore("Requires a jdk17 backport of JDK-8286740")
 	@Test
 	public void modifyEventPeriod() {
 		// FIXME: JMC-5207 - Remove the assume call once the GTK3 related bug has been fixed


### PR DESCRIPTION
This PR addresses JMC-8175 [[0]](https://bugs.openjdk.org/browse/JMC-8175), in which there are three uitests in ControlRecordingsTest that have sporadic failures.

The root cause looks to be https://bugs.openjdk.org/browse/JDK-8286740, which affects the jdk.ActiveSetting event in JDK 17. This issue, among other things, can lead to Active Setting events sharing the same timestamp due to the event object being cached (which you can see in my screenshots below).

The failing uitests operate by dumping a recording, finding an event that can have it's threshold/enablement/period changed, changing said value, and then verifying the result of the latest timestamp in the Event Settings table in the Recording Page. Because these events in jdk17 can share the same timestamp, we may end up in a situation where the uitest is trying to filter the table based on timestamp and verifying that the enabled setting is true, but there is a false & true for the same timestamp (or a 1s and 5ms in the case of `modifyEventPeriod()`).

I've attached two images below, one using jdk17 and one using jdk21. I dumped a recording of the jvm running jmc, enabled the allocation gc event, and then re-dumped the recording. The left jfr page shows the results for the initial recording, and the page on the right for the one with allocation gc enabled.

In jdk17 we can see events sharing the same timestamp, and in jdk21 they're unique. Based on Marcus' comment on the issue [[2]](https://bugs.openjdk.org/browse/JMC-8175?focusedId=14648937&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-14648937) I've ignored these tests with a comment mentioning they'll require a backport of JDK-8286740 to jdk17.

JDK 17 (duplicated timestamps)
![jdk17](https://github.com/openjdk/jmc/assets/10425301/2bd1278b-775b-476b-a801-9ae121ac4529)

JDK 21 (expected)
![jdk21](https://github.com/openjdk/jmc/assets/10425301/55b9c47f-225d-4d25-83c2-0d71a7d045a5)

[0] https://bugs.openjdk.org/browse/JMC-8175
[1] https://bugs.openjdk.org/browse/JDK-8286740
[2] https://bugs.openjdk.org/browse/JMC-8175?focusedId=14648937&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-14648937

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JMC-8175](https://bugs.openjdk.org/browse/JMC-8175): Flightrecorder UI-tests are failing (**Bug** - P2)


### Reviewers
 * [Virag Purnam](https://openjdk.org/census#vpurnam) (@viragpurnam - Committer)
 * [Marcus Hirt](https://openjdk.org/census#hirt) (@thegreystone - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmc.git pull/553/head:pull/553` \
`$ git checkout pull/553`

Update a local copy of the PR: \
`$ git checkout pull/553` \
`$ git pull https://git.openjdk.org/jmc.git pull/553/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 553`

View PR using the GUI difftool: \
`$ git pr show -t 553`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmc/pull/553.diff">https://git.openjdk.org/jmc/pull/553.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jmc/pull/553#issuecomment-1944181732)