### PR TITLE
8204 : Keyboard traps in flamegraph view for search option

### DIFF
--- a/application/org.openjdk.jmc.console.agent/src/main/java/org/openjdk/jmc/console/agent/manager/wizards/PresetManagerPage.java
+++ b/application/org.openjdk.jmc.console.agent/src/main/java/org/openjdk/jmc/console/agent/manager/wizards/PresetManagerPage.java
@@ -206,7 +206,7 @@ public class PresetManagerPage extends BaseWizardPage {
 				}
 
 				tableInspector.getViewer().refresh();
-				tableInspector.setFocus();
+				setFocusOnTableInspector();
 			}
 
 			@Override
@@ -214,7 +214,7 @@ public class PresetManagerPage extends BaseWizardPage {
 				String[] files = openFileDialog(Messages.PresetManagerPage_MESSAGE_EXPORT_PRESET_TO_A_FILE,
 						new String[] {PRESET_XML_EXTENSION}, SWT.SAVE | SWT.SINGLE);
 				if (files.length == 0) {
-					tableInspector.setFocus();
+					setFocusOnTableInspector();
 					return;
 				}
 
@@ -229,7 +229,7 @@ public class PresetManagerPage extends BaseWizardPage {
 			}
 		};
 		tableInspector.setContentProvider(new PresetTableContentProvider());
-		tableInspector.setFocus();
+		setFocusOnTableInspector();
 
 		return container;
 	}
@@ -255,5 +255,10 @@ public class PresetManagerPage extends BaseWizardPage {
 			PresetRepository repository = (PresetRepository) inputElement;
 			return repository.listPresets();
 		}
+	}
+
+	// 8204: This set focus is required in order to set the focus back to wizard instead of main screen
+	private void setFocusOnTableInspector() {
+		tableInspector.setFocus();
 	}
 }

--- a/application/org.openjdk.jmc.console.agent/src/main/java/org/openjdk/jmc/console/agent/manager/wizards/PresetManagerPage.java
+++ b/application/org.openjdk.jmc.console.agent/src/main/java/org/openjdk/jmc/console/agent/manager/wizards/PresetManagerPage.java
@@ -214,6 +214,7 @@ public class PresetManagerPage extends BaseWizardPage {
 				String[] files = openFileDialog(Messages.PresetManagerPage_MESSAGE_EXPORT_PRESET_TO_A_FILE,
 						new String[] {PRESET_XML_EXTENSION}, SWT.SAVE | SWT.SINGLE);
 				if (files.length == 0) {
+					tableInspector.setFocus();
 					return;
 				}
 
@@ -228,6 +229,7 @@ public class PresetManagerPage extends BaseWizardPage {
 			}
 		};
 		tableInspector.setContentProvider(new PresetTableContentProvider());
+		tableInspector.setFocus();
 
 		return container;
 	}

--- a/application/org.openjdk.jmc.console.agent/src/main/java/org/openjdk/jmc/console/agent/manager/wizards/PresetManagerPage.java
+++ b/application/org.openjdk.jmc.console.agent/src/main/java/org/openjdk/jmc/console/agent/manager/wizards/PresetManagerPage.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2020, 2021 Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2020, 2021 Red Hat Inc. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Red Hat Inc. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -206,6 +206,7 @@ public class PresetManagerPage extends BaseWizardPage {
 				}
 
 				tableInspector.getViewer().refresh();
+				tableInspector.setFocus();
 			}
 
 			@Override

--- a/application/org.openjdk.jmc.flightrecorder.controlpanel.ui/src/main/java/org/openjdk/jmc/flightrecorder/controlpanel/ui/wizards/TemplateEditPage.java
+++ b/application/org.openjdk.jmc.flightrecorder.controlpanel.ui/src/main/java/org/openjdk/jmc/flightrecorder/controlpanel/ui/wizards/TemplateEditPage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -38,6 +38,8 @@ import org.eclipse.jface.wizard.WizardPage;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.ModifyEvent;
 import org.eclipse.swt.events.ModifyListener;
+import org.eclipse.swt.events.TraverseEvent;
+import org.eclipse.swt.events.TraverseListener;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Composite;
@@ -182,6 +184,14 @@ public abstract class TemplateEditPage extends WizardPage implements IPerformFin
 			@Override
 			public void modifyText(ModifyEvent e) {
 				model.getConfiguration().setDescription(descriptionControl.getText());
+			}
+		});
+		descriptionControl.addTraverseListener(new TraverseListener() {
+			@Override
+			public void keyTraversed(TraverseEvent e) {
+				if (e.detail == SWT.TRAVERSE_TAB_NEXT || e.detail == SWT.TRAVERSE_TAB_PREVIOUS) {
+					e.doit = true;
+				}
 			}
 		});
 		GridData gd = new GridData(SWT.FILL, SWT.FILL, true, true, 2, 1);

--- a/application/org.openjdk.jmc.flightrecorder.flamegraph/src/main/java/org/openjdk/jmc/flightrecorder/flamegraph/views/FlamegraphSwingView.java
+++ b/application/org.openjdk.jmc.flightrecorder.flamegraph/src/main/java/org/openjdk/jmc/flightrecorder/flamegraph/views/FlamegraphSwingView.java
@@ -525,7 +525,7 @@ public class FlamegraphSwingView extends ViewPart implements ISelectionListener 
 							} else {
 								Display.getDefault().syncExec(new Runnable() {
 									public void run() {
-										traverseAlready = !traverseAlready;
+										setTraverseAlready(!traverseAlready);
 										if (traverseAlready) {
 											IWorkbenchPage activePage = PlatformUI.getWorkbench()
 													.getWorkbenchWindows()[0].getActivePage();
@@ -567,7 +567,7 @@ public class FlamegraphSwingView extends ViewPart implements ISelectionListener 
 						if (e.getModifiersEx() > 0) {
 							Display.getDefault().syncExec(new Runnable() {
 								public void run() {
-									traverseAlready = !traverseAlready;
+									setTraverseAlready(!traverseAlready);
 									if (traverseAlready) {
 										IWorkbenchPage activePage = PlatformUI.getWorkbench().getWorkbenchWindows()[0]
 												.getActivePage();
@@ -599,6 +599,10 @@ public class FlamegraphSwingView extends ViewPart implements ISelectionListener 
 			});
 			return panel;
 		});
+	}
+
+	private static void setTraverseAlready(boolean isTraverseAlready) {
+		traverseAlready = isTraverseAlready;
 	}
 
 	@Override

--- a/application/org.openjdk.jmc.flightrecorder.flamegraph/src/main/java/org/openjdk/jmc/flightrecorder/flamegraph/views/FlamegraphSwingView.java
+++ b/application/org.openjdk.jmc.flightrecorder.flamegraph/src/main/java/org/openjdk/jmc/flightrecorder/flamegraph/views/FlamegraphSwingView.java
@@ -51,6 +51,7 @@ import static org.openjdk.jmc.flightrecorder.flamegraph.MessagesUtils.getFlamegr
 import java.awt.BorderLayout;
 import java.awt.FlowLayout;
 import java.awt.KeyboardFocusManager;
+import java.awt.event.InputEvent;
 import java.awt.event.KeyAdapter;
 import java.awt.event.KeyEvent;
 import java.awt.image.BufferedImage;
@@ -520,7 +521,7 @@ public class FlamegraphSwingView extends ViewPart implements ISelectionListener 
 
 			// Adding focus traversal and key listener for main panel
 			setFocusTraversalProperties(panel);
-			addKeyListenerForBkwdFocustoSWT(panel);
+			addKeyListenerForBkwdFocusToSWT(panel);
 
 			return panel;
 		});
@@ -625,8 +626,7 @@ public class FlamegraphSwingView extends ViewPart implements ISelectionListener 
 			@Override
 			public void keyPressed(KeyEvent e) {
 				if (e.getKeyCode() == KeyEvent.VK_TAB) {
-					// Shift + TAB
-					if (e.getModifiersEx() > 0) {
+					if ((e.getModifiersEx() & InputEvent.SHIFT_DOWN_MASK) != 0) {
 						e.getComponent().transferFocusBackward();
 					} else {
 						e.getComponent().transferFocus();
@@ -648,8 +648,7 @@ public class FlamegraphSwingView extends ViewPart implements ISelectionListener 
 			@Override
 			public void keyPressed(KeyEvent e) {
 				if (e.getKeyCode() == KeyEvent.VK_TAB) {
-					// Shift + TAB
-					if (e.getModifiersEx() > 0) {
+					if ((e.getModifiersEx() & InputEvent.SHIFT_DOWN_MASK) != 0) {
 						e.getComponent().transferFocusBackward();
 					} else {
 						traverseAlready = !traverseAlready;
@@ -672,13 +671,12 @@ public class FlamegraphSwingView extends ViewPart implements ISelectionListener 
 	 * 
 	 * @param comp
 	 */
-	private void addKeyListenerForBkwdFocustoSWT(JComponent comp) {
+	private void addKeyListenerForBkwdFocusToSWT(JComponent comp) {
 		comp.addKeyListener(new KeyAdapter() {
 			@Override
 			public void keyPressed(KeyEvent e) {
 				if (e.getKeyCode() == KeyEvent.VK_TAB) {
-					// Shift + TAB
-					if (e.getModifiersEx() > 0) {
+					if ((e.getModifiersEx() & InputEvent.SHIFT_DOWN_MASK) != 0) {
 						traverseAlready = !traverseAlready;
 						// If already cycled (Bkwd) within swing component then transfer the focus back to SWT
 						if (traverseAlready) {

--- a/application/org.openjdk.jmc.flightrecorder.flamegraph/src/main/java/org/openjdk/jmc/flightrecorder/flamegraph/views/FlamegraphSwingView.java
+++ b/application/org.openjdk.jmc.flightrecorder.flamegraph/src/main/java/org/openjdk/jmc/flightrecorder/flamegraph/views/FlamegraphSwingView.java
@@ -600,7 +600,7 @@ public class FlamegraphSwingView extends ViewPart implements ISelectionListener 
 	private void setFocusBackToSWT() {
 		Display.getDefault().syncExec(new Runnable() {
 			public void run() {
-				IWorkbenchPage activePage = PlatformUI.getWorkbench().getWorkbenchWindows()[0].getActivePage();
+				IWorkbenchPage activePage = PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage();
 				try {
 					IViewPart outlineView = activePage.showView(OUTLINE_VIEW_ID);
 					if (activePage.getActiveEditor() != null) {
@@ -618,8 +618,6 @@ public class FlamegraphSwingView extends ViewPart implements ISelectionListener 
 
 	/**
 	 * Adding key listener to transfer focus forward or backward based on 'TAB' or 'Shift + TAB'
-	 * 
-	 * @param comp
 	 */
 	private void addKeyListener(JComponent comp) {
 		comp.addKeyListener(new KeyAdapter() {
@@ -640,8 +638,6 @@ public class FlamegraphSwingView extends ViewPart implements ISelectionListener 
 	/**
 	 * Adding key listener and checking if all the swing components are already cycled (Fwd) once.
 	 * On completion of swing component cycle transferring focus back to SWT.
-	 * 
-	 * @param comp
 	 */
 	private void addKeyListenerForFwdFocusToSWT(JComponent comp) {
 		comp.addKeyListener(new KeyAdapter() {
@@ -668,8 +664,6 @@ public class FlamegraphSwingView extends ViewPart implements ISelectionListener 
 	/**
 	 * Adding key listener and checking if all the swing components are already cycled (Bkwd) once.
 	 * On completion of swing component cycle transferring focus back to SWT.
-	 * 
-	 * @param comp
 	 */
 	private void addKeyListenerForBkwdFocusToSWT(JComponent comp) {
 		comp.addKeyListener(new KeyAdapter() {
@@ -695,8 +689,6 @@ public class FlamegraphSwingView extends ViewPart implements ISelectionListener 
 
 	/**
 	 * Setting the focus traversal properties.
-	 * 
-	 * @param comp
 	 */
 	private void setFocusTraversalProperties(JComponent comp) {
 		comp.setFocusTraversalKeys(KeyboardFocusManager.FORWARD_TRAVERSAL_KEYS, Collections.emptySet());


### PR DESCRIPTION
Focus Trapped Issue. Keyboard focus is trapped in three specific scenarios mentioned below:

1. Focus is trapped in JMC Agent Preset Manager

Select Window -> JMC Agent Preset Manager
Click on "Import Fils..."/ "Export File" button
Press Esc button when dialog is displayed
Press "Tab" button for multi times

2. Focus is trapped in Description of Template Manager

Select JVM Browser
Start Flight Recording
Template Manager
Click New
Click Edit
Focus to Description

3. Focus is trapped in search tool in Flame Graph  (Mostly on Windows)

Launch JDK Mission Control
Open any JFR file
Navigate to "Outline" tab
In Java Application, choose "Threads"
Move focus to search tool in Flame Graph

Solution:
1. PresetManagerPage.java : Setting the focus back to tableInspector.
2. TemplateEditPage.java : Added TraverseListener() for description field.
3. FlamegraphSwingView.java : Fix is not straight forward as SWT to Swing and back to SWT traversal is creating issue here. I have just implemented work around for this. I have added KeyListener() to all the swing components. Once it traverse through all the components, I am setting the Focus back to SWT.  With this there is no keyboard focus trap. 
 
These issues are kind of blocker with respect to accessibility. Could someone please review the changes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JMC-8204](https://bugs.openjdk.org/browse/JMC-8204): Keyboard traps in flamegraph view for search option (**Bug** - P2)


### Reviewers
 * [Alex Macdonald](https://openjdk.org/census#aptmac) (@aptmac - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmc.git pull/554/head:pull/554` \
`$ git checkout pull/554`

Update a local copy of the PR: \
`$ git checkout pull/554` \
`$ git pull https://git.openjdk.org/jmc.git pull/554/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 554`

View PR using the GUI difftool: \
`$ git pr show -t 554`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmc/pull/554.diff">https://git.openjdk.org/jmc/pull/554.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jmc/pull/554#issuecomment-1961134374)