### PR TITLE
7948: Update ASM version in the Agent

### DIFF
--- a/agent/pom.xml
+++ b/agent/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-   Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+   Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
 
    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 

--- a/agent/pom.xml
+++ b/agent/pom.xml
@@ -74,8 +74,8 @@
 		<changelist>-SNAPSHOT</changelist>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-		<maven.compiler.source>11</maven.compiler.source>
-		<maven.compiler.target>11</maven.compiler.target>
+		<maven.compiler.source>17</maven.compiler.source>
+		<maven.compiler.target>17</maven.compiler.target>
 		<jmc.config.path>${project.basedir}/../configuration</jmc.config.path>
 		<!-- Plugin Versions -->
 		<maven.checkstyle.version>3.3.0</maven.checkstyle.version>
@@ -91,7 +91,7 @@
 		<nexus.staging.plugin.version>1.6.13</nexus.staging.plugin.version>
 		<maven.gpg.version>3.1.0</maven.gpg.version>
 		<!-- Dependency Versions -->
-		<asm.version>8.0.1</asm.version>
+		<asm.version>9.7</asm.version>
 		<junit.version>4.13.2</junit.version>
 	</properties>
 	<scm>
@@ -220,7 +220,7 @@
 								<Agent-Class>org.openjdk.jmc.agent.Agent</Agent-Class>
 								<Premain-Class>org.openjdk.jmc.agent.Agent</Premain-Class>
 								<Can-Retransform-Classes>true</Can-Retransform-Classes>
-								<Bundle-RequiredExecutionEnvironment>JavaSE-11</Bundle-RequiredExecutionEnvironment>
+								<Bundle-RequiredExecutionEnvironment>JavaSE-17</Bundle-RequiredExecutionEnvironment>
 								<Built-By></Built-By>
 							</manifestEntries>
 						</transformer>

--- a/agent/pom.xml
+++ b/agent/pom.xml
@@ -49,7 +49,7 @@
 			<name>Universal Permissive License Version 1.0</name>
 			<url>http://oss.oracle.com/licenses/upl</url>
 			<distribution>repo</distribution>
-			<comments>Copyright (c) 2018, 2023, Oracle and/or its affiliates. Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.</comments>
+			<comments>Copyright (c) 2018, 2024, Oracle and/or its affiliates. Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.</comments>
 		</license>
 	</licenses>
 	<organization>


### PR DESCRIPTION
Addresses JMC-7948 (Update ASM version in the agent).

The agent currently uses a very old version of ASM that doesn't support more recent JDK versions (most notably JDK17).

This PR bumps the ASM version up to 9.7 which was released in March and supports up to JDK23. It also bumps the agent build up to JDK17.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JMC-7948](https://bugs.openjdk.org/browse/JMC-7948): Update ASM version in the Agent (**Enhancement** - P4)


### Reviewers
 * [Alex Macdonald](https://openjdk.org/census#aptmac) (@aptmac - **Reviewer**)
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmc.git pull/561/head:pull/561` \
`$ git checkout pull/561`

Update a local copy of the PR: \
`$ git checkout pull/561` \
`$ git pull https://git.openjdk.org/jmc.git pull/561/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 561`

View PR using the GUI difftool: \
`$ git pr show -t 561`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmc/pull/561.diff">https://git.openjdk.org/jmc/pull/561.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jmc/pull/561#issuecomment-2088788014)