### PR TITLE
8219: Missing coverage in application reports

### DIFF
--- a/application/coverage/pom.xml
+++ b/application/coverage/pom.xml
@@ -124,86 +124,6 @@
 		</dependency>
 		<dependency>
 			<groupId>org.openjdk.jmc</groupId>
-			<artifactId>org.openjdk.jmc.docs</artifactId>
-			<version>${project.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>org.openjdk.jmc</groupId>
-			<artifactId>org.openjdk.jmc.feature.console</artifactId>
-			<version>${project.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>org.openjdk.jmc</groupId>
-			<artifactId>org.openjdk.jmc.feature.console.ui.subscriptions</artifactId>
-			<version>0.0.3-SNAPSHOT</version>
-		</dependency>
-		<dependency>
-			<groupId>org.openjdk.jmc</groupId>
-			<artifactId>org.openjdk.jmc.feature.core</artifactId>
-			<version>${project.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>org.openjdk.jmc</groupId>
-			<artifactId>org.openjdk.jmc.feature.flightrecorder</artifactId>
-			<version>${project.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>org.openjdk.jmc</groupId>
-			<artifactId>org.openjdk.jmc.feature.flightrecorder.ext.g1</artifactId>
-			<version>1.0.0-SNAPSHOT</version>
-		</dependency>
-		<dependency>
-			<groupId>org.openjdk.jmc</groupId>
-			<artifactId>org.openjdk.jmc.feature.flightrecorder.ext.jfx</artifactId>
-			<version>${project.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>org.openjdk.jmc</groupId>
-			<artifactId>org.openjdk.jmc.feature.flightrecorder.metadata</artifactId>
-			<version>${project.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>org.openjdk.jmc</groupId>
-			<artifactId>org.openjdk.jmc.feature.ide</artifactId>
-			<version>${project.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>org.openjdk.jmc</groupId>
-			<artifactId>org.openjdk.jmc.feature.ide.launch</artifactId>
-			<version>0.0.4-SNAPSHOT</version>
-		</dependency>
-		<dependency>
-			<groupId>org.openjdk.jmc</groupId>
-			<artifactId>org.openjdk.jmc.feature.jconsole</artifactId>
-			<version>${project.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>org.openjdk.jmc</groupId>
-			<artifactId>org.openjdk.jmc.feature.joverflow</artifactId>
-			<version>1.0.1-SNAPSHOT</version>
-		</dependency>
-		<dependency>
-			<groupId>org.openjdk.jmc</groupId>
-			<artifactId>org.openjdk.jmc.feature.license</artifactId>
-			<version>${project.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>org.openjdk.jmc</groupId>
-			<artifactId>org.openjdk.jmc.feature.pde</artifactId>
-			<version>2.0.0-SNAPSHOT</version>
-		</dependency>
-		<dependency>
-			<groupId>org.openjdk.jmc</groupId>
-			<artifactId>org.openjdk.jmc.feature.rcp</artifactId>
-			<version>${project.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>org.openjdk.jmc</groupId>
-			<artifactId>org.openjdk.jmc.feature.rcp.update</artifactId>
-			<version>${project.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>org.openjdk.jmc</groupId>
 			<artifactId>org.openjdk.jmc.flightrecorder.controlpanel.ui</artifactId>
 			<version>${project.version}</version>
 		</dependency>
@@ -214,12 +134,32 @@
 		</dependency>
 		<dependency>
 			<groupId>org.openjdk.jmc</groupId>
+			<artifactId>org.openjdk.jmc.flightrecorder.dependencyview</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.openjdk.jmc</groupId>
 			<artifactId>org.openjdk.jmc.flightrecorder.ext.g1</artifactId>
 			<version>1.0.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.openjdk.jmc</groupId>
 			<artifactId>org.openjdk.jmc.flightrecorder.ext.jfx</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.openjdk.jmc</groupId>
+			<artifactId>org.openjdk.jmc.flightrecorder.flamegraph</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.openjdk.jmc</groupId>
+			<artifactId>org.openjdk.jmc.flightrecorder.graphview</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.openjdk.jmc</groupId>
+			<artifactId>org.openjdk.jmc.flightrecorder.heatmap</artifactId>
 			<version>${project.version}</version>
 		</dependency>
 		<dependency>
@@ -270,12 +210,12 @@
 		<dependency>
 			<groupId>org.openjdk.jmc</groupId>
 			<artifactId>org.openjdk.jmc.joverflow</artifactId>
-			<version>1.0.0-SNAPSHOT</version>
+			<version>${project.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.openjdk.jmc</groupId>
 			<artifactId>org.openjdk.jmc.joverflow.ui</artifactId>
-			<version>1.0.1-SNAPSHOT</version>
+			<version>${project.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.openjdk.jmc</groupId>
@@ -285,7 +225,7 @@
 		<dependency>
 			<groupId>org.openjdk.jmc</groupId>
 			<artifactId>org.openjdk.jmc.pde</artifactId>
-			<version>1.0.2-SNAPSHOT</version>
+			<version>${project.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.openjdk.jmc</groupId>
@@ -295,17 +235,6 @@
 		<dependency>
 			<groupId>org.openjdk.jmc</groupId>
 			<artifactId>org.openjdk.jmc.rcp.intro</artifactId>
-			<version>${project.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>org.openjdk.jmc</groupId>
-			<artifactId>org.openjdk.jmc.rcp.product</artifactId>
-			<version>${project.version}</version>
-			<type>pom</type>
-		</dependency>
-		<dependency>
-			<groupId>org.openjdk.jmc</groupId>
-			<artifactId>org.openjdk.jmc.rcp.product.feature</artifactId>
 			<version>${project.version}</version>
 		</dependency>
 		<dependency>
@@ -327,18 +256,6 @@
 			<groupId>org.openjdk.jmc</groupId>
 			<artifactId>org.openjdk.jmc.rjmx.ui</artifactId>
 			<version>${project.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>org.openjdk.jmc</groupId>
-			<artifactId>org.openjdk.jmc.updatesite.ide</artifactId>
-			<version>${revision}${changelist}</version>
-			<type>pom</type>
-		</dependency>
-		<dependency>
-			<groupId>org.openjdk.jmc</groupId>
-			<artifactId>org.openjdk.jmc.updatesite.rcp</artifactId>
-			<version>${revision}${changelist}</version>
-			<type>pom</type>
 		</dependency>
 		<dependency>
 			<groupId>org.openjdk.jmc</groupId>
@@ -365,6 +282,12 @@
 		<dependency>
 			<groupId>org.openjdk.jmc</groupId>
 			<artifactId>org.openjdk.jmc.flightrecorder.ext.jfx.test</artifactId>
+			<scope>test</scope>
+			<version>${project.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.openjdk.jmc</groupId>
+			<artifactId>org.openjdk.jmc.flightrecorder.graphview.test</artifactId>
 			<scope>test</scope>
 			<version>${project.version}</version>
 		</dependency>

--- a/application/tests/org.openjdk.jmc.flightrecorder.controlpanel.ui.test/pom.xml
+++ b/application/tests/org.openjdk.jmc.flightrecorder.controlpanel.ui.test/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-   Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+   Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
 
    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
@@ -50,7 +50,7 @@
 				<artifactId>tycho-surefire-plugin</artifactId>
 				<version>${tycho.version}</version>
 				<configuration>
-					<argLine>-Dcom.sun.management.jmxremote.port=9999 -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Djava.rmi.server.hostname=localhost -Djmc.test.rjmx.serviceURL=service:jmx:rmi:///jndi/rmi://localhost:9999/jmxrmi ${jfr.vmargs}</argLine>
+					<argLine>${surefireArgLine} -Dcom.sun.management.jmxremote.port=9999 -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Djava.rmi.server.hostname=localhost -Djmc.test.rjmx.serviceURL=service:jmx:rmi:///jndi/rmi://localhost:9999/jmxrmi ${jfr.vmargs}</argLine>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/application/tests/org.openjdk.jmc.flightrecorder.controlpanel.ui.test/pom.xml
+++ b/application/tests/org.openjdk.jmc.flightrecorder.controlpanel.ui.test/pom.xml
@@ -50,7 +50,7 @@
 				<artifactId>tycho-surefire-plugin</artifactId>
 				<version>${tycho.version}</version>
 				<configuration>
-					<argLine>${surefireArgLine} -Dcom.sun.management.jmxremote.port=9999 -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Djava.rmi.server.hostname=localhost -Djmc.test.rjmx.serviceURL=service:jmx:rmi:///jndi/rmi://localhost:9999/jmxrmi ${jfr.vmargs}</argLine>
+					<argLine>${tycho.testArgLine.local} -Dcom.sun.management.jmxremote.port=9999 -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Djava.rmi.server.hostname=localhost -Djmc.test.rjmx.serviceURL=service:jmx:rmi:///jndi/rmi://localhost:9999/jmxrmi ${jfr.vmargs}</argLine>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/application/tests/org.openjdk.jmc.jolokia.test/pom.xml
+++ b/application/tests/org.openjdk.jmc.jolokia.test/pom.xml
@@ -74,8 +74,7 @@
 					<includes>${test.includes}</includes>
 					<!-- Start jolokia on a random free port to avoid requiring specific ports to run test -->
 					<!-- Agent version may differ from client version, in fact it may be a good test -->
-					<argLine>
-						-javaagent:${settings.localRepository}/org/jolokia/jolokia-agent-jvm/${jolokia.agent.version}/jolokia-agent-jvm-${jolokia.agent.version}-javaagent.jar=port=0,discoveryEnabled=true</argLine>
+					<argLine>${tycho.testArgLine.local} -javaagent:${settings.localRepository}/org/jolokia/jolokia-jvm/${jolokia.agent.version}/jolokia-jvm-${jolokia.agent.version}.jar=port=0,discover=true</argLine>
 				</configuration>
 			</plugin>
 

--- a/application/tests/org.openjdk.jmc.jolokia.test/pom.xml
+++ b/application/tests/org.openjdk.jmc.jolokia.test/pom.xml
@@ -74,7 +74,7 @@
 					<includes>${test.includes}</includes>
 					<!-- Start jolokia on a random free port to avoid requiring specific ports to run test -->
 					<!-- Agent version may differ from client version, in fact it may be a good test -->
-					<argLine>${tycho.testArgLine.local} -javaagent:${settings.localRepository}/org/jolokia/jolokia-jvm/${jolokia.agent.version}/jolokia-jvm-${jolokia.agent.version}.jar=port=0,discover=true</argLine>
+					<argLine>${tycho.testArgLine.local} -javaagent:${settings.localRepository}/org/jolokia/jolokia-agent-jvm/${jolokia.agent.version}/jolokia-agent-jvm-${jolokia.agent.version}-javaagent.jar=port=0,discoveryEnabled=true</argLine>
 				</configuration>
 			</plugin>
 

--- a/application/tests/org.openjdk.jmc.rjmx.services.jfr.test/pom.xml
+++ b/application/tests/org.openjdk.jmc.rjmx.services.jfr.test/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-   Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+   Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
 
    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
@@ -50,7 +50,7 @@
 				<artifactId>tycho-surefire-plugin</artifactId>
 				<version>${tycho.version}</version>
 				<configuration>
-					<argLine>-Dcom.sun.management.jmxremote.port=9999 -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Djava.rmi.server.hostname=localhost -Djmc.test.rjmx.serviceURL=service:jmx:rmi:///jndi/rmi://localhost:9999/jmxrmi ${jfr.vmargs}</argLine>
+					<argLine>${surefireArgLine} -Dcom.sun.management.jmxremote.port=9999 -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Djava.rmi.server.hostname=localhost -Djmc.test.rjmx.serviceURL=service:jmx:rmi:///jndi/rmi://localhost:9999/jmxrmi ${jfr.vmargs}</argLine>
 					<failIfNoTests>false</failIfNoTests>
 				</configuration>
 			</plugin>

--- a/application/tests/org.openjdk.jmc.rjmx.services.jfr.test/pom.xml
+++ b/application/tests/org.openjdk.jmc.rjmx.services.jfr.test/pom.xml
@@ -50,7 +50,7 @@
 				<artifactId>tycho-surefire-plugin</artifactId>
 				<version>${tycho.version}</version>
 				<configuration>
-					<argLine>${surefireArgLine} -Dcom.sun.management.jmxremote.port=9999 -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Djava.rmi.server.hostname=localhost -Djmc.test.rjmx.serviceURL=service:jmx:rmi:///jndi/rmi://localhost:9999/jmxrmi ${jfr.vmargs}</argLine>
+					<argLine>${tycho.testArgLine.local} -Dcom.sun.management.jmxremote.port=9999 -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Djava.rmi.server.hostname=localhost -Djmc.test.rjmx.serviceURL=service:jmx:rmi:///jndi/rmi://localhost:9999/jmxrmi ${jfr.vmargs}</argLine>
 					<failIfNoTests>false</failIfNoTests>
 				</configuration>
 			</plugin>

--- a/application/tests/org.openjdk.jmc.rjmx.test/pom.xml
+++ b/application/tests/org.openjdk.jmc.rjmx.test/pom.xml
@@ -50,7 +50,7 @@
 				<artifactId>tycho-surefire-plugin</artifactId>
 				<version>${tycho.version}</version>
 				<configuration>
-					<argLine>${surefireArgLine} -Dcom.sun.management.jmxremote.port=9999 -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Djava.rmi.server.hostname=localhost -Djmc.test.rjmx.serviceURL=service:jmx:rmi:///jndi/rmi://localhost:9999/jmxrmi</argLine>
+					<argLine>${tycho.testArgLine.local} -Dcom.sun.management.jmxremote.port=9999 -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Djava.rmi.server.hostname=localhost -Djmc.test.rjmx.serviceURL=service:jmx:rmi:///jndi/rmi://localhost:9999/jmxrmi</argLine>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/application/tests/org.openjdk.jmc.rjmx.test/pom.xml
+++ b/application/tests/org.openjdk.jmc.rjmx.test/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-   Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+   Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
 
    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
@@ -50,7 +50,7 @@
 				<artifactId>tycho-surefire-plugin</artifactId>
 				<version>${tycho.version}</version>
 				<configuration>
-					<argLine>-Dcom.sun.management.jmxremote.port=9999 -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Djava.rmi.server.hostname=localhost -Djmc.test.rjmx.serviceURL=service:jmx:rmi:///jndi/rmi://localhost:9999/jmxrmi</argLine>
+					<argLine>${surefireArgLine} -Dcom.sun.management.jmxremote.port=9999 -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Djava.rmi.server.hostname=localhost -Djmc.test.rjmx.serviceURL=service:jmx:rmi:///jndi/rmi://localhost:9999/jmxrmi</argLine>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/application/tests/pom.xml
+++ b/application/tests/pom.xml
@@ -59,6 +59,7 @@
 		<test.excludes.default>**/*$*</test.excludes.default>
 		<fail.if.no.tests>true</fail.if.no.tests>
 		<jmc.config.path>${project.basedir}/../../configuration</jmc.config.path>
+		<tycho.testArgLine.local></tycho.testArgLine.local>
 	</properties>
 	<profiles>
 		<profile>
@@ -107,6 +108,9 @@
 		</profile>
 		<profile>
 			<id>coverage</id>
+			<properties>
+				<tycho.testArgLine.local>${tycho.testArgLine}</tycho.testArgLine.local>
+			</properties>
 			<build>
 				<plugins>
 					<plugin>
@@ -119,9 +123,6 @@
 								<goals>
 									<goal>prepare-agent</goal>
 								</goals>
-								<configuration>
-									<propertyName>surefireArgLine</propertyName>
-								</configuration>
 							</execution>
 							<execution>
 								<id>post-unit-test</id>
@@ -150,7 +151,6 @@
 				<artifactId>tycho-surefire-plugin</artifactId>
 				<version>${tycho.version}</version>
 				<configuration>
-					<argLine>${surefireArgLine}</argLine>
 					<appArgLine>-nl en</appArgLine>
 					<includes>${test.includes}</includes>
 					<excludes>

--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,7 @@
 		<download.maven.plugin.version>1.6.8</download.maven.plugin.version>
 		<maven.deploy.version>3.1.1</maven.deploy.version>
 		<spotbugs.version>4.7.3.5</spotbugs.version>
-		<jacoco.plugin.version>0.8.7</jacoco.plugin.version>
+		<jacoco.plugin.version>0.8.10</jacoco.plugin.version>
 	</properties>
 	<scm>
 		<connection>${scmConnection}</connection>


### PR DESCRIPTION
This PR fixes (&cleans up) the coverage reports under jmc/application.

The argLine was being set in a handful of the application test packages without the surefireArgLine that's required to have jacoco run coverage.

Additionally I've removed a bunch of the feature packages from the report (as there isn't anything to scan), and included missing packages that have been added in the last few years. There were also a handful of versions that needed to be updated as well.

The Jacoco version in core was bumped to 8.0.10, but the application version stayed at 8.0.7, this has been updated.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JMC-8219](https://bugs.openjdk.org/browse/JMC-8219): Missing coverage in application reports (**Bug** - P4)


### Reviewers
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**) ⚠️ Review applies to [29b13465](https://git.openjdk.org/jmc/pull/562/files/29b134656c212e1da22769b461d800a8aa612c82)
 * [Marcus Hirt](https://openjdk.org/census#hirt) (@thegreystone - **Reviewer**) ⚠️ Review applies to [4a5ba2b7](https://git.openjdk.org/jmc/pull/562/files/4a5ba2b753da3e479cf1e104ca4f1b7c0bb75633)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmc.git pull/562/head:pull/562` \
`$ git checkout pull/562`

Update a local copy of the PR: \
`$ git checkout pull/562` \
`$ git pull https://git.openjdk.org/jmc.git pull/562/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 562`

View PR using the GUI difftool: \
`$ git pr show -t 562`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmc/pull/562.diff">https://git.openjdk.org/jmc/pull/562.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jmc/pull/562#issuecomment-2093223712)
</details>
