### PR TITLE
8220: Make LocalJVMToolkit reflective

### DIFF
--- a/application/org.openjdk.jmc.browser.attach/src/main/java/org/openjdk/jmc/browser/attach/LocalJVMToolkit.java
+++ b/application/org.openjdk.jmc.browser.attach/src/main/java/org/openjdk/jmc/browser/attach/LocalJVMToolkit.java
@@ -125,6 +125,7 @@ public class LocalJVMToolkit {
 			CLASS_HOTSPOT_VIRTUAL_MACHINE = Class.forName("sun.tools.attach.HotSpotVirtualMachine");
 		} catch (ClassNotFoundException e) {
 			CLASS_HOTSPOT_VIRTUAL_MACHINE = null;
+			BrowserAttachPlugin.getPluginLogger().log(Level.WARNING, MonitoredHostWrapper.ERROR_MESSAGE_ATTACH, e); //$NON-NLS-1$
 		}
 	}
 
@@ -403,10 +404,12 @@ public class LocalJVMToolkit {
 								try {
 									// try to force finish init the attached JVM
 									// to ensure properties are correctly populated
-									// see JMC-4454 for details
-									Method methodStartLocalManagementAgent = CLASS_HOTSPOT_VIRTUAL_MACHINE
-											.getMethod("startLocalManagementAgent");
-									methodStartLocalManagementAgent.invoke(vm);
+									// see JMC-4454 for details. Best effort.
+									if (CLASS_HOTSPOT_VIRTUAL_MACHINE != null) {
+										Method methodStartLocalManagementAgent = CLASS_HOTSPOT_VIRTUAL_MACHINE
+												.getMethod("startLocalManagementAgent");
+										methodStartLocalManagementAgent.invoke(vm);
+									}
 								} catch (Exception ex) {
 									// swallow exceptions
 								}

--- a/application/org.openjdk.jmc.browser.attach/src/main/java/org/openjdk/jmc/browser/attach/LocalJVMToolkit.java
+++ b/application/org.openjdk.jmc.browser.attach/src/main/java/org/openjdk/jmc/browser/attach/LocalJVMToolkit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -39,7 +39,7 @@ import static org.openjdk.jmc.common.jvm.Connectable.NO;
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.Thread.State;
-import java.net.URISyntaxException;
+import java.lang.reflect.Method;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -48,12 +48,12 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.WeakHashMap;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;
 
 import javax.management.remote.JMXServiceURL;
@@ -63,6 +63,8 @@ import org.eclipse.jface.util.IPropertyChangeListener;
 import org.eclipse.jface.util.PropertyChangeEvent;
 import org.openjdk.jmc.attach.AttachToolkit;
 import org.openjdk.jmc.browser.attach.internal.ExecuteTunnler;
+import org.openjdk.jmc.browser.attach.internal.MonitoredHostWrapper;
+import org.openjdk.jmc.browser.attach.internal.MonitoredVmWrapper;
 import org.openjdk.jmc.browser.attach.preferences.PreferenceConstants;
 import org.openjdk.jmc.common.jvm.Connectable;
 import org.openjdk.jmc.common.jvm.JVMArch;
@@ -77,15 +79,6 @@ import com.sun.tools.attach.AgentLoadException;
 import com.sun.tools.attach.AttachNotSupportedException;
 import com.sun.tools.attach.VirtualMachine;
 import com.sun.tools.attach.VirtualMachineDescriptor;
-
-import sun.jvmstat.monitor.HostIdentifier;
-import sun.jvmstat.monitor.MonitorException;
-import sun.jvmstat.monitor.MonitoredHost;
-import sun.jvmstat.monitor.MonitoredVm;
-import sun.jvmstat.monitor.MonitoredVmUtil;
-import sun.jvmstat.monitor.StringMonitor;
-import sun.jvmstat.monitor.VmIdentifier;
-import sun.tools.attach.HotSpotVirtualMachine;
 
 /**
  * The activator class controls the plug-in life cycle
@@ -109,6 +102,7 @@ public class LocalJVMToolkit {
 		}
 	}
 
+	private static Class<?> CLASS_HOTSPOT_VIRTUAL_MACHINE;
 	private static long SEQ_NUMBER = 0;
 	private static boolean isErrorMessageSent = false;
 	private static boolean isPreferenceStoreListenerEnabled;
@@ -125,6 +119,14 @@ public class LocalJVMToolkit {
 	static final String JAVA_COMMAND_PROP = "sun.java.command"; //$NON-NLS-1$
 
 	private static final int TIMEOUT_THRESHOLD = 5;
+
+	static {
+		try {
+			CLASS_HOTSPOT_VIRTUAL_MACHINE = Class.forName("sun.tools.attach.HotSpotVirtualMachine");
+		} catch (ClassNotFoundException e) {
+			CLASS_HOTSPOT_VIRTUAL_MACHINE = null;
+		}
+	}
 
 	private LocalJVMToolkit() {
 		// Toolkit
@@ -162,13 +164,11 @@ public class LocalJVMToolkit {
 	}
 
 	private static void populateMonitoredVMs(HashMap<Object, DiscoveryEntry> map, boolean includeUnconnectables) {
-		MonitoredHost host = getMonitoredHost();
-		Set<?> vms;
-		try {
-			vms = host.activeVms();
-		} catch (MonitorException mx) {
-			throw new InternalError(mx.getMessage());
+		MonitoredHostWrapper monitoredHost = MonitoredHostWrapper.getMonitoredHost();
+		if (monitoredHost == null) {
+			return;
 		}
+		Set<?> vms = monitoredHost.activeVms();
 		for (Object vmid : vms) {
 			if (vmid instanceof Integer) {
 				// Check if the map already contains a descriptor for this
@@ -178,7 +178,7 @@ public class LocalJVMToolkit {
 				// Check if we already have a descriptor *first*, to avoid unnecessary attach which may leak handles
 				DiscoveryEntry connDesc = last.get(vmid);
 				if (connDesc == null) {
-					connDesc = createMonitoredJvmDescriptor(host, (Integer) vmid);
+					connDesc = createMonitoredJvmDescriptor(monitoredHost, (Integer) vmid);
 				}
 
 				if ((includeUnconnectables && connDesc != null)
@@ -189,7 +189,7 @@ public class LocalJVMToolkit {
 		}
 	}
 
-	private static DiscoveryEntry createMonitoredJvmDescriptor(MonitoredHost host, Integer vmid) {
+	private static DiscoveryEntry createMonitoredJvmDescriptor(MonitoredHostWrapper host, Integer vmid) {
 		try {
 			// Enforce a timeout here to make sure we don't block forever if the JVM is busy/suspended. See JMC-5398
 			ExecutorService service = Executors.newSingleThreadExecutor();
@@ -211,47 +211,29 @@ public class LocalJVMToolkit {
 
 					try {
 						// This used to leak one \BaseNamedObjects\hsperfdata_* Section handle on Windows
-						MonitoredVm mvm = host.getMonitoredVm(new VmIdentifier(name));
+						MonitoredVmWrapper mvm = host.getMonitoredVm(name);
 						try {
 							// use the command line as the display name
-							name = MonitoredVmUtil.commandLine(mvm);
-							jvmArgs = MonitoredVmUtil.jvmArgs(mvm);
-							StringMonitor sm = (StringMonitor) mvm.findByName("java.property.java.vm.name"); //$NON-NLS-1$
-							if (sm != null) {
-								jvmName = sm.stringValue();
-								type = JVMType.getJVMType(sm.stringValue());
-							}
-
-							sm = (StringMonitor) mvm.findByName("java.property.java.version"); //$NON-NLS-1$
-							if (sm != null) {
-								version = sm.stringValue();
-							}
+							name = mvm.commandLine();
+							jvmArgs = mvm.jvmArgs();
+							jvmName = mvm.jvmName();
+							type = JVMType.getJVMType(jvmName);
+							version = mvm.javaVersion();
 
 							if (version == null) {
 								// Use java.vm.version when java.version is not exposed as perfcounter (HotSpot 1.5 and JRockit)
-								sm = (StringMonitor) mvm.findByName("java.property.java.vm.version"); //$NON-NLS-1$
-								if (sm != null) {
-									String vmVersion = sm.stringValue();
-									if (type == JVMType.JROCKIT) {
-										version = JavaVMVersionToolkit.decodeJavaVersion(vmVersion);
-									} else {
-										version = JavaVMVersionToolkit.parseJavaVersion(vmVersion);
-									}
+								String vmVersion = mvm.jvmVersion();
+								if (type == JVMType.JROCKIT) {
+									version = JavaVMVersionToolkit.decodeJavaVersion(vmVersion);
+								} else {
+									version = JavaVMVersionToolkit.parseJavaVersion(vmVersion);
 								}
 							}
 							if (version == null) {
 								version = "0"; //$NON-NLS-1$
 							}
-
-							if (sm != null) {
-								isDebug = isDebug(sm.stringValue());
-							}
-
-							sm = (StringMonitor) mvm.findByName("java.property.java.vm.vendor"); //$NON-NLS-1$
-							if (sm != null) {
-								jvmVendor = sm.stringValue();
-							}
-
+							isDebug = isDebug(version);
+							jvmVendor = mvm.jvmVendor();
 							// NOTE: isAttachable seems to return true even if a real attach is not possible.
 							// attachable = MonitoredVmUtil.isAttachable(mvm);
 
@@ -422,7 +404,9 @@ public class LocalJVMToolkit {
 									// try to force finish init the attached JVM
 									// to ensure properties are correctly populated
 									// see JMC-4454 for details
-									((HotSpotVirtualMachine) vm).startLocalManagementAgent();
+									Method methodStartLocalManagementAgent = CLASS_HOTSPOT_VIRTUAL_MACHINE
+											.getMethod("startLocalManagementAgent");
+									methodStartLocalManagementAgent.invoke(vm);
 								} catch (Exception ex) {
 									// swallow exceptions
 								}
@@ -475,16 +459,6 @@ public class LocalJVMToolkit {
 				isErrorMessageSent = true;
 			}
 			return null;
-		}
-	}
-
-	private static MonitoredHost getMonitoredHost() {
-		try {
-			return MonitoredHost.getMonitoredHost(new HostIdentifier((String) null));
-		} catch (MonitorException e) {
-			throw new InternalError(e.getMessage());
-		} catch (URISyntaxException e) {
-			throw new InternalError(e.getMessage());
 		}
 	}
 
@@ -604,8 +578,7 @@ public class LocalJVMToolkit {
 	public static String executeCommandForPid(
 		VirtualMachine vm, String pid, String command, boolean throwCausingException)
 			throws AttachNotSupportedException, IOException, AgentLoadException {
-		HotSpotVirtualMachine hvm = (HotSpotVirtualMachine) vm;
-		InputStream in = ExecuteTunnler.execute(hvm, "jcmd", new Object[] {command}, throwCausingException); //$NON-NLS-1$
+		InputStream in = ExecuteTunnler.execute(vm, "jcmd", new Object[] {command}, throwCausingException); //$NON-NLS-1$
 		byte b[] = new byte[256];
 		int n;
 		StringBuffer buf = new StringBuffer();

--- a/application/org.openjdk.jmc.browser.attach/src/main/java/org/openjdk/jmc/browser/attach/internal/ExecuteTunnler.java
+++ b/application/org.openjdk.jmc.browser.attach/src/main/java/org/openjdk/jmc/browser/attach/internal/ExecuteTunnler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -41,10 +41,10 @@ import org.openjdk.jmc.browser.attach.BrowserAttachPlugin;
 
 import com.sun.tools.attach.AgentLoadException;
 
-import sun.tools.attach.HotSpotVirtualMachine;
+import com.sun.tools.attach.VirtualMachine;
 
 /**
- * Ugly ass class needed for us to work better with Sun.
+ * This is class is required to for example execute diagnostic commands.
  */
 public class ExecuteTunnler {
 	private final static String ERROR_MESSAGE_PROBLEM = "Problem executing command on local JVM"; //$NON-NLS-1$
@@ -64,14 +64,13 @@ public class ExecuteTunnler {
 	 * @throws AgentLoadException
 	 * @throws IOException
 	 */
-	public static InputStream execute(
-		HotSpotVirtualMachine hsvm, String command, Object[] args, boolean throwCausingException)
+	public static InputStream execute(VirtualMachine hsvm, String command, Object[] args, boolean throwCausingException)
 			throws AgentLoadException, IOException {
 		return invoke(hsvm, command, args, throwCausingException);
 	}
 
-	private static InputStream invoke(
-		HotSpotVirtualMachine hsvm, String command, Object[] args, boolean throwCausingException) throws IOException {
+	private static InputStream invoke(VirtualMachine hsvm, String command, Object[] args, boolean throwCausingException)
+			throws IOException {
 		Method m;
 		try {
 			m = hsvm.getClass().getDeclaredMethod("execute", //$NON-NLS-1$

--- a/application/org.openjdk.jmc.browser.attach/src/main/java/org/openjdk/jmc/browser/attach/internal/MonitoredHostWrapper.java
+++ b/application/org.openjdk.jmc.browser.attach/src/main/java/org/openjdk/jmc/browser/attach/internal/MonitoredHostWrapper.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, Datadog, Inc. All rights reserved.
+ * 
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * The contents of this file are subject to the terms of either the Universal Permissive License
+ * v 1.0 as shown at http://oss.oracle.com/licenses/upl
+ *
+ * or the following license:
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted
+ * provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions
+ * and the following disclaimer.
+ * 
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other materials provided with
+ * the distribution.
+ * 
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to
+ * endorse or promote products derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+ * WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.openjdk.jmc.browser.attach.internal;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Collections;
+import java.util.Set;
+import java.util.logging.Level;
+
+import org.openjdk.jmc.browser.attach.BrowserAttachPlugin;
+
+public class MonitoredHostWrapper {
+	static final String ERROR_MESSAGE_ATTACH = "Could not find attach related classes. This can affect discovery of locally running JVMs.";
+
+	private static Class<?> CLASS_HOST_IDENTIFIER;
+	private static Class<?> CLASS_VM_IDENTIFIER;
+	static Class<?> CLASS_MONITORED_HOST;
+
+	private Object host;
+
+	static {
+		try {
+			CLASS_MONITORED_HOST = Class.forName("sun.jvmstat.monitor.MonitoredHost");
+			CLASS_HOST_IDENTIFIER = Class.forName("sun.jvmstat.monitor.HostIdentifier");
+			CLASS_VM_IDENTIFIER = Class.forName("sun.jvmstat.monitor.VmIdentifier");
+		} catch (ClassNotFoundException e) {
+			CLASS_MONITORED_HOST = null;
+			CLASS_HOST_IDENTIFIER = null;
+			CLASS_VM_IDENTIFIER = null;
+			BrowserAttachPlugin.getPluginLogger().log(Level.WARNING, ERROR_MESSAGE_ATTACH, e);
+		}
+	}
+
+	public static MonitoredHostWrapper getMonitoredHost() {
+		return new MonitoredHostWrapper();
+	}
+
+	public MonitoredHostWrapper() {
+		if (CLASS_MONITORED_HOST != null) {
+			try {
+				Object hostIdentifier = createHostIdentifier(null);
+				Method method;
+				method = CLASS_MONITORED_HOST.getMethod("getMonitoredHost", CLASS_HOST_IDENTIFIER);
+				host = method.invoke(null, hostIdentifier);
+			} catch (NoSuchMethodException
+					| SecurityException
+					| IllegalAccessException
+					| IllegalArgumentException
+					| InvocationTargetException
+					| InstantiationException e) {
+				BrowserAttachPlugin.getPluginLogger().log(Level.FINEST,
+						"Could not create monitored host. This could make local attach problematic.", e);
+			}
+		}
+	}
+
+	private Object createHostIdentifier(String id) throws NoSuchMethodException, SecurityException,
+			InstantiationException, IllegalAccessException, IllegalArgumentException, InvocationTargetException {
+		Constructor<?> constructor = CLASS_HOST_IDENTIFIER.getConstructor(String.class);
+		return constructor.newInstance(id);
+	}
+
+	public Set<?> activeVms() {
+		if (host != null) {
+			Method method;
+			try {
+				method = CLASS_MONITORED_HOST.getMethod("activeVms");
+				return (Set<?>) method.invoke(host);
+			} catch (NoSuchMethodException
+					| SecurityException
+					| IllegalAccessException
+					| IllegalArgumentException
+					| InvocationTargetException e) {
+				BrowserAttachPlugin.getPluginLogger().log(Level.WARNING,
+						"Problem getting active VMs. This could make local attach problematic.", e);
+			}
+		}
+		return Collections.emptySet();
+	}
+
+	public MonitoredVmWrapper getMonitoredVm(String name) {
+		if (host != null) {
+			if (CLASS_VM_IDENTIFIER != null) {
+				Constructor<?> constructor;
+				try {
+					constructor = CLASS_VM_IDENTIFIER.getConstructor(String.class);
+					Object vmIdentifier = constructor.newInstance(name);
+					Method getMonitoredVm = CLASS_MONITORED_HOST.getMethod("getMonitoredVm", CLASS_VM_IDENTIFIER);
+					Object mvm = getMonitoredVm.invoke(host, vmIdentifier);
+					if (mvm != null) {
+						return new MonitoredVmWrapper(mvm);
+					}
+				} catch (InstantiationException
+						| IllegalAccessException
+						| IllegalArgumentException
+						| InvocationTargetException
+						| NoSuchMethodException
+						| SecurityException e) {
+					BrowserAttachPlugin.getPluginLogger().log(Level.WARNING, MonitoredHostWrapper.ERROR_MESSAGE_ATTACH,
+							e);
+				}
+			}
+		}
+		return null;
+	}
+}

--- a/application/org.openjdk.jmc.browser.attach/src/main/java/org/openjdk/jmc/browser/attach/internal/MonitoredHostWrapper.java
+++ b/application/org.openjdk.jmc.browser.attach/src/main/java/org/openjdk/jmc/browser/attach/internal/MonitoredHostWrapper.java
@@ -44,7 +44,7 @@ import java.util.logging.Level;
 import org.openjdk.jmc.browser.attach.BrowserAttachPlugin;
 
 public class MonitoredHostWrapper {
-	static final String ERROR_MESSAGE_ATTACH = "Could not find attach related classes. This can affect discovery of locally running JVMs.";
+	public static final String ERROR_MESSAGE_ATTACH = "Could not find attach related classes. This can affect discovery of locally running JVMs.";
 
 	private static Class<?> CLASS_HOST_IDENTIFIER;
 	private static Class<?> CLASS_VM_IDENTIFIER;

--- a/application/org.openjdk.jmc.browser.attach/src/main/java/org/openjdk/jmc/browser/attach/internal/MonitoredHostWrapper.java
+++ b/application/org.openjdk.jmc.browser.attach/src/main/java/org/openjdk/jmc/browser/attach/internal/MonitoredHostWrapper.java
@@ -105,7 +105,7 @@ public class MonitoredHostWrapper {
 					| IllegalAccessException
 					| IllegalArgumentException
 					| InvocationTargetException e) {
-				BrowserAttachPlugin.getPluginLogger().log(Level.WARNING,
+				BrowserAttachPlugin.getPluginLogger().log(Level.FINEST,
 						"Problem getting active VMs. This could make local attach problematic.", e);
 			}
 		}
@@ -130,7 +130,7 @@ public class MonitoredHostWrapper {
 						| InvocationTargetException
 						| NoSuchMethodException
 						| SecurityException e) {
-					BrowserAttachPlugin.getPluginLogger().log(Level.WARNING, MonitoredHostWrapper.ERROR_MESSAGE_ATTACH,
+					BrowserAttachPlugin.getPluginLogger().log(Level.FINEST, MonitoredHostWrapper.ERROR_MESSAGE_ATTACH,
 							e);
 				}
 			}

--- a/application/org.openjdk.jmc.browser.attach/src/main/java/org/openjdk/jmc/browser/attach/internal/MonitoredVmWrapper.java
+++ b/application/org.openjdk.jmc.browser.attach/src/main/java/org/openjdk/jmc/browser/attach/internal/MonitoredVmWrapper.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, Datadog, Inc. All rights reserved.
+ * 
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * The contents of this file are subject to the terms of either the Universal Permissive License
+ * v 1.0 as shown at http://oss.oracle.com/licenses/upl
+ *
+ * or the following license:
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted
+ * provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions
+ * and the following disclaimer.
+ * 
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other materials provided with
+ * the distribution.
+ * 
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to
+ * endorse or promote products derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+ * WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.openjdk.jmc.browser.attach.internal;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.logging.Level;
+
+import org.openjdk.jmc.browser.attach.BrowserAttachPlugin;
+
+public class MonitoredVmWrapper {
+	private static Class<?> CLASS_MONITORED_VM;
+	private static Class<?> CLASS_MONITORED_VM_UTIL;
+	private static Class<?> CLASS_STRING_MONITOR;
+
+	private Object monitoredVm;
+
+	static {
+		try {
+			CLASS_MONITORED_VM = Class.forName("sun.jvmstat.monitor.MonitoredVm"); //$NON-NLS-1$
+			CLASS_MONITORED_VM_UTIL = Class.forName("sun.jvmstat.monitor.MonitoredVmUtil"); //$NON-NLS-1$
+			CLASS_STRING_MONITOR = Class.forName("sun.jvmstat.monitor.StringMonitor"); //$NON-NLS-1$
+		} catch (ClassNotFoundException e) {
+			CLASS_MONITORED_VM = null;
+			CLASS_MONITORED_VM_UTIL = null;
+			CLASS_STRING_MONITOR = null;
+			BrowserAttachPlugin.getPluginLogger().log(Level.WARNING, MonitoredHostWrapper.ERROR_MESSAGE_ATTACH, e);
+		}
+	}
+
+	public MonitoredVmWrapper(Object monitoredVm) {
+		this.monitoredVm = monitoredVm;
+	}
+
+	public String commandLine() {
+		if (CLASS_MONITORED_VM_UTIL != null) {
+			Method methodCommandLine;
+			try {
+				methodCommandLine = CLASS_MONITORED_VM_UTIL.getMethod("commandLine", CLASS_MONITORED_VM); //$NON-NLS-1$
+				Object commandLine = methodCommandLine.invoke(null, monitoredVm);
+				return String.valueOf(commandLine);
+			} catch (NoSuchMethodException
+					| SecurityException
+					| IllegalAccessException
+					| IllegalArgumentException
+					| InvocationTargetException e) {
+				BrowserAttachPlugin.getPluginLogger().log(Level.FINEST, "Could not read command line!", e); //$NON-NLS-1$
+			}
+		}
+		return null;
+	}
+
+	public String jvmArgs() {
+		if (CLASS_MONITORED_VM_UTIL != null) {
+			Method methodCommandLine;
+			try {
+				methodCommandLine = CLASS_MONITORED_VM_UTIL.getMethod("jvmArgs", CLASS_MONITORED_VM); //$NON-NLS-1$
+				Object commandLine = methodCommandLine.invoke(null, monitoredVm);
+				return String.valueOf(commandLine);
+			} catch (NoSuchMethodException
+					| SecurityException
+					| IllegalAccessException
+					| IllegalArgumentException
+					| InvocationTargetException e) {
+				BrowserAttachPlugin.getPluginLogger().log(Level.FINEST, "Could not read command line!", e); //$NON-NLS-1$
+			}
+		}
+		return null;
+	}
+
+	public String jvmName() {
+		return getPropertyStringValue("java.property.java.vm.name"); //$NON-NLS-1$
+	}
+
+	public String javaVersion() {
+		return getPropertyStringValue("java.property.java.version"); //$NON-NLS-1$
+	}
+
+	public String jvmVersion() {
+		return getPropertyStringValue("java.property.java.vm.version"); //$NON-NLS-1$
+	}
+
+	public String jvmVendor() {
+		return getPropertyStringValue("java.property.java.vm.vendor");
+	}
+
+	public void detach() {
+		try {
+			Method methodDetach = CLASS_MONITORED_VM.getMethod("detach");
+			methodDetach.invoke(monitoredVm);
+		} catch (NoSuchMethodException
+				| SecurityException
+				| IllegalAccessException
+				| IllegalArgumentException
+				| InvocationTargetException e) {
+			BrowserAttachPlugin.getPluginLogger().log(Level.FINEST, "Could not detach from monitored VM", e); //$NON-NLS-1$
+		}
+	}
+
+	private String getPropertyStringValue(String propertyName) {
+		Method methodFindByName;
+		try {
+			methodFindByName = CLASS_MONITORED_VM.getMethod("findByName", String.class); //$NON-NLS-1$
+			Object stringMonitor = methodFindByName.invoke(monitoredVm, propertyName);
+			Method methodStringValue = CLASS_STRING_MONITOR.getMethod("stringValue"); //$NON-NLS-1$
+			return String.valueOf(methodStringValue.invoke(stringMonitor));
+		} catch (NoSuchMethodException
+				| SecurityException
+				| IllegalAccessException
+				| IllegalArgumentException
+				| InvocationTargetException e) {
+			BrowserAttachPlugin.getPluginLogger().log(Level.FINEST, "Could not read StringMonitor " + propertyName, e); //$NON-NLS-1$
+		}
+		return null;
+	}
+}


### PR DESCRIPTION
Less painful from within Eclipse.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JMC-8220](https://bugs.openjdk.org/browse/JMC-8220): Make LocalJVMToolkit reflective (**Bug** - P2)


### Reviewers
 * [Alex Macdonald](https://openjdk.org/census#aptmac) (@aptmac - **Reviewer**) ⚠️ Review applies to [5f1b51b5](https://git.openjdk.org/jmc/pull/563/files/5f1b51b59a499c464f1172c29ae8685c75754215)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmc.git pull/563/head:pull/563` \
`$ git checkout pull/563`

Update a local copy of the PR: \
`$ git checkout pull/563` \
`$ git pull https://git.openjdk.org/jmc.git pull/563/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 563`

View PR using the GUI difftool: \
`$ git pr show -t 563`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmc/pull/563.diff">https://git.openjdk.org/jmc/pull/563.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jmc/pull/563#issuecomment-2101597261)