### PR TITLE
7263: JMC displaying long value in scientific notation

### DIFF
--- a/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/internal/parser/v1/TypeManager.java
+++ b/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/internal/parser/v1/TypeManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -482,7 +482,8 @@ class TypeManager {
 				if (JfrInternalConstants.LINE_NUMBER_ID.equals(f.fieldIdentifier)
 						|| JfrInternalConstants.BCI_ID.equals(f.fieldIdentifier)
 						|| JfrInternalConstants.MODIFIERS_ID.equals(f.fieldIdentifier)
-						|| JfrInternalConstants.JAVA_THREAD_ID_ID.equals(f.fieldIdentifier)) {
+						|| JfrInternalConstants.JAVA_THREAD_ID_ID.equals(f.fieldIdentifier)
+						|| JfrInternalConstants.CERTIFICATE_ID_ID.equals(f.fieldIdentifier)) {
 					reader = new PrimitiveReader(typeIdentifier);
 				} else {
 					IUnit unit = UnitLookup.getUnitOrNull(valueType);

--- a/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/internal/util/JfrInternalConstants.java
+++ b/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/internal/util/JfrInternalConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -44,4 +44,5 @@ public final class JfrInternalConstants {
 	public static final String BCI_ID = "bytecodeIndex"; //$NON-NLS-1$
 	public static final String MODIFIERS_ID = "modifiers"; //$NON-NLS-1$
 	public static final String JAVA_THREAD_ID_ID = "javaThreadId"; //$NON-NLS-1$
+	public static final String CERTIFICATE_ID_ID = "certificateId"; //$NON-NLS-1$
 }


### PR DESCRIPTION
This PR addresses the formatting issue for the certificate Ids for X509 Certificate and X509 Validation events.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JMC-7263](https://bugs.openjdk.org/browse/JMC-7263): JMC displaying long value in scientific notation (**Bug** - P4)


### Reviewers
 * [Virag Purnam](https://openjdk.org/census#vpurnam) (@viragpurnam - Committer)
 * [Marcus Hirt](https://openjdk.org/census#hirt) (@thegreystone - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmc.git pull/564/head:pull/564` \
`$ git checkout pull/564`

Update a local copy of the PR: \
`$ git checkout pull/564` \
`$ git pull https://git.openjdk.org/jmc.git pull/564/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 564`

View PR using the GUI difftool: \
`$ git pr show -t 564`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmc/pull/564.diff">https://git.openjdk.org/jmc/pull/564.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jmc/pull/564#issuecomment-2131458814)