### PR TITLE
7506: Incorrect numeric formatting of PID by JMC

### DIFF
--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/JVMInformationPage.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/JVMInformationPage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -234,7 +234,7 @@ public class JVMInformationPage extends AbstractDataPage {
 			infoViewer = new ItemAggregateViewer(jvmInfSection, toolkit);
 			infoViewer.addAggregate(JdkAggregators.JVM_START_TIME);
 			infoViewer.addAggregate(JdkAggregators.JVM_NAME);
-			infoViewer.addAggregate(JdkAggregators.JVM_PID);
+			infoViewer.addAggregate(JdkAggregators.PID);
 			infoViewer.addAggregate(JdkAggregators.JVM_VERSION);
 			infoViewer.addAggregate(JdkAggregators.JVM_ARGUMENTS);
 			infoViewer.addAggregate(JdkAggregators.JAVA_ARGUMENTS);

--- a/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/item/Aggregators.java
+++ b/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/item/Aggregators.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/item/Aggregators.java
+++ b/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/item/Aggregators.java
@@ -1093,6 +1093,31 @@ public class Aggregators {
 		};
 	}
 
+	public static <T> IAggregator<IQuantity, ?> getJvmPid(String typeId, IAttribute<T> attribute) {
+		IAggregator<Set<T>, ?> aggregator = Aggregators.distinct(attribute);
+		aggregator = filter(aggregator, ItemFilters.type(typeId));
+		return Aggregators.valueBuilderAggregator(aggregator, new IValueBuilder<IQuantity, Set<T>>() {
+			@Override
+			public IType<? super IQuantity> getValueType() {
+				return UnitLookup.NUMBER;
+			}
+
+			@Override
+			public IQuantity getValue(Set<T> source) {
+				Long value = 0L;
+				if (source.isEmpty()) {
+					return null;
+				} else {
+					Iterator<?> itr = source.iterator();
+					while (itr.hasNext()) {
+						value = Long.valueOf((String) itr.next());
+					}
+					return UnitLookup.NUMBER_UNITY.quantity(value);
+				}
+			}
+		}, attribute.getName(), attribute.getDescription());
+	}
+
 	public static <T> IAggregator<IQuantity, ?> countDistinct(
 		String name, String description, IAccessorFactory<T> attribute) {
 		return new SetAggregator<IQuantity, T>(name, description, attribute, UnitLookup.NUMBER) {

--- a/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/jdk/JdkAggregators.java
+++ b/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/jdk/JdkAggregators.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -115,8 +115,7 @@ public final class JdkAggregators {
 
 	// VM Info
 	public static final IAggregator<String, ?> JVM_NAME = distinctAsString(VM_INFO, JdkAttributes.JVM_NAME);
-	public static final IAggregator<IQuantity, ?> JVM_PID = min(JdkAttributes.JVM_PID.getName(), null, VM_INFO,
-			JdkAttributes.JVM_PID);
+	public static final IAggregator<String, ?> PID = distinctAsString(VM_INFO, JdkAttributes.PID);
 	public static final IAggregator<IQuantity, ?> JVM_START_TIME = min(JdkAttributes.JVM_START_TIME.getName(), null,
 			VM_INFO, JdkAttributes.JVM_START_TIME);
 	public static final IAggregator<String, ?> JVM_VERSION = distinctAsString(VM_INFO, JdkAttributes.JVM_VERSION);

--- a/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/jdk/JdkAggregators.java
+++ b/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/jdk/JdkAggregators.java
@@ -115,6 +115,8 @@ public final class JdkAggregators {
 
 	// VM Info
 	public static final IAggregator<String, ?> JVM_NAME = distinctAsString(VM_INFO, JdkAttributes.JVM_NAME);
+	@Deprecated
+	public static final IAggregator<IQuantity, ?> JVM_PID = Aggregators.getJvmPid(VM_INFO, JdkAttributes.PID);
 	public static final IAggregator<String, ?> PID = distinctAsString(VM_INFO, JdkAttributes.PID);
 	public static final IAggregator<IQuantity, ?> JVM_START_TIME = min(JdkAttributes.JVM_START_TIME.getName(), null,
 			VM_INFO, JdkAttributes.JVM_START_TIME);

--- a/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/parser/synthetic/SyntheticAttributeExtension.java
+++ b/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/parser/synthetic/SyntheticAttributeExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -46,6 +46,7 @@ import org.openjdk.jmc.common.IMCPackage;
 import org.openjdk.jmc.common.IMCStackTrace;
 import org.openjdk.jmc.common.IMCThread;
 import org.openjdk.jmc.common.item.IAttribute;
+import org.openjdk.jmc.common.unit.IQuantity;
 import org.openjdk.jmc.common.unit.UnitLookup;
 import org.openjdk.jmc.common.util.LabeledIdentifier;
 import org.openjdk.jmc.flightrecorder.JfrAttributes;
@@ -169,6 +170,23 @@ public class SyntheticAttributeExtension implements IParserExtension {
 						IEventSink moduleExportSink = new ModuleExportSink(subSink, packageIndex);
 						return moduleExportSink;
 					}
+				} else if (JdkTypeIDs.VM_INFO.equals(identifier)) {
+					// Adding a String pid, as that is what is used in the jdk.SystemProcess event.
+					int packageIndex = -1;
+					for (int i = 0; i < dataStructure.size(); i++) {
+						ValueField vf = dataStructure.get(i);
+						if (vf.matches(JdkAttributes.JVM_PID)) {
+							packageIndex = i;
+							break;
+						}
+					}
+					if (packageIndex != -1) {
+						List<ValueField> newDataStructure = new ArrayList<>(dataStructure);
+						newDataStructure.set(packageIndex, new ValueField(JdkAttributes.PID));
+						IEventSink subSink = sf.create(identifier, label, category, description, newDataStructure);
+						IEventSink moduleExportSink = new LongAsStringSink(subSink, packageIndex);
+						return moduleExportSink;
+					}
 				}
 				return sf.create(identifier, label, category, description, dataStructure);
 			}
@@ -208,6 +226,28 @@ public class SyntheticAttributeExtension implements IParserExtension {
 				Object[] newValues = new Object[values.length + 1];
 				System.arraycopy(values, 0, newValues, 0, values.length);
 				newValues[values.length] = exportingModule;
+				subSink.addEvent(newValues);
+			}
+		}
+	}
+
+	private static class LongAsStringSink implements IEventSink {
+		private final IEventSink subSink;
+		private final int pidIndex;
+
+		public LongAsStringSink(IEventSink subSink, int pidIndex) {
+			this.subSink = subSink;
+			this.pidIndex = pidIndex;
+		}
+
+		@Override
+		public void addEvent(Object[] values) {
+			IQuantity longPid = (IQuantity) values[pidIndex];
+			if (longPid != null && values != null && values.length > 0) {
+				String pid = String.valueOf(longPid.longValue());
+				Object[] newValues = new Object[values.length];
+				System.arraycopy(values, 0, newValues, 0, values.length - 1);
+				newValues[pidIndex] = pid;
 				subSink.addEvent(newValues);
 			}
 		}


### PR DESCRIPTION
This PR is to fix the formatting issue of the JVM PID on JVM information screen. JVM PID attribute is received as NUMBER from JFR and hence the JMC application is treating is as number. When the number is smaller , the PID is displayed using commas and when the number is larger, its converted to exponential format. This is a long pending bug in product.

The PID (Process Id) attribute is present in JMC as part of System Process event also where the data type is correct i.e. String. So in order to maintain consistency, we have made the content type of PID attribute of JVM Information event also as String. We are converting the number value of PID to string and then storing it. 

We have also introduced a new aggregator PID which will contain the value of Identifier in plain text format instead of number format. This new aggregator is displayed on JVM Information page.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JMC-7506](https://bugs.openjdk.org/browse/JMC-7506): Incorrect numeric formatting of PID by JMC (**Bug** - P3)


### Reviewers
 * [Brice Dutheil](https://openjdk.org/census#bdutheil) (@bric3 - Committer)
 * [Virag Purnam](https://openjdk.org/census#vpurnam) (@viragpurnam - Committer) ⚠️ Review applies to [9ed2439d](https://git.openjdk.org/jmc/pull/565/files/9ed2439d6906bac53c4ffbb587078b80897ff95a)
 * [Marcus Hirt](https://openjdk.org/census#hirt) (@thegreystone - **Reviewer**)


### Contributors
 * Marcus Hirt `<hirt@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmc.git pull/565/head:pull/565` \
`$ git checkout pull/565`

Update a local copy of the PR: \
`$ git checkout pull/565` \
`$ git pull https://git.openjdk.org/jmc.git pull/565/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 565`

View PR using the GUI difftool: \
`$ git pr show -t 565`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmc/pull/565.diff">https://git.openjdk.org/jmc/pull/565.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jmc/pull/565#issuecomment-2131475912)