### PR TITLE
8231: Add version to build tarball names

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -209,6 +209,18 @@
 			</plugin>
 			<plugin>
 				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-p2-director-plugin</artifactId>
+				<version>${tycho.version}</version>
+				<configuration>
+				<products>
+					<product>
+						<archiveFileName>${groupId}-${project.version}</archiveFileName>
+					</product>
+				</products>
+				</configuration>
+			 </plugin>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
 				<artifactId>tycho-p2-repository-plugin</artifactId>
 				<version>${tycho.version}</version>
 				<configuration>


### PR DESCRIPTION
This PR addresses https://bugs.openjdk.org/browse/JMC-8231, in which it would be nice for the built tarballs to print what version of the product they are.

Before:
```bash
aptmac@fedora ~/w/j/t/products (master)> ll
total 449M
drwxr-xr-x. 1 aptmac aptmac  32 Jun 26 12:11 org.openjdk.jmc/
-rw-r--r--. 1 aptmac aptmac 88M Jun 26 12:12 org.openjdk.jmc-linux.gtk.aarch64.tar.gz
-rw-r--r--. 1 aptmac aptmac 89M Jun 26 12:12 org.openjdk.jmc-linux.gtk.x86_64.tar.gz
-rw-r--r--. 1 aptmac aptmac 92M Jun 26 12:12 org.openjdk.jmc-macosx.cocoa.aarch64.tar.gz
-rw-r--r--. 1 aptmac aptmac 92M Jun 26 12:12 org.openjdk.jmc-macosx.cocoa.x86_64.tar.gz
-rw-r--r--. 1 aptmac aptmac 90M Jun 26 12:12 org.openjdk.jmc-win32.win32.x86_64.zip

```
After:
```bash
aptmac@fedora ~/w/j/t/products (8231)> ll
total 449M
drwxr-xr-x. 1 aptmac aptmac  32 Jun 26 12:27 org.openjdk.jmc/
-rw-r--r--. 1 aptmac aptmac 89M Jun 26 12:28 org.openjdk.jmc-9.1.0-SNAPSHOT-linux.gtk.aarch64.tar.gz
-rw-r--r--. 1 aptmac aptmac 89M Jun 26 12:28 org.openjdk.jmc-9.1.0-SNAPSHOT-linux.gtk.x86_64.tar.gz
-rw-r--r--. 1 aptmac aptmac 92M Jun 26 12:28 org.openjdk.jmc-9.1.0-SNAPSHOT-macosx.cocoa.aarch64.tar.gz
-rw-r--r--. 1 aptmac aptmac 92M Jun 26 12:28 org.openjdk.jmc-9.1.0-SNAPSHOT-macosx.cocoa.x86_64.tar.gz
-rw-r--r--. 1 aptmac aptmac 90M Jun 26 12:28 org.openjdk.jmc-9.1.0-SNAPSHOT-win32.win32.x86_64.zip
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JMC-8231](https://bugs.openjdk.org/browse/JMC-8231): Add version to build tarball names (**Bug** - P4)


### Reviewers
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmc.git pull/568/head:pull/568` \
`$ git checkout pull/568`

Update a local copy of the PR: \
`$ git checkout pull/568` \
`$ git pull https://git.openjdk.org/jmc.git pull/568/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 568`

View PR using the GUI difftool: \
`$ git pr show -t 568`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmc/pull/568.diff">https://git.openjdk.org/jmc/pull/568.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jmc/pull/568#issuecomment-2192169537)