### PR TITLE
8223: Copyright script is failing

### DIFF
--- a/scripts/checkcopyrightyear.sh
+++ b/scripts/checkcopyrightyear.sh
@@ -24,6 +24,15 @@ do
 done
 if [ $counter -ne 0 ]
 then
+    # check if the PR branch is up-to-date with upstream/master
+    # borrowed from: https://stackoverflow.com/a/39402294
+    if git merge-base --is-ancestor upstream/master @
+    then
+        echo "Branch is up-to-date."
+    else
+        echo "Branch is out of date with upstream/master. Please rebase your branch and try again."
+        exit 1
+    fi
     echo "There is a total of $counter copyright year(s) that require updating."
     exit 1
 else


### PR DESCRIPTION
This PR addresses https://bugs.openjdk.org/browse/JMC-8223.

There have been recent false positives with the copyright check script, which were happening if the PR branch was out of date with the master branch. At the moment, the script takes a diff between master and the PR branch to see what files have been changed, and then checks those files for the license header years. If a PR branch is not based ontop of upstream/master, there can be a chance that the latest master branch commits include file changes not in the PR branch, which creates a false positivie.

To give better insight as to why the script failed, I added a check in the conditional where files have been flagged as being out of date headers, to check whether or not the branch is out of date. This way it will list all the files that are affected, but then exit the script asking the user to rebase their work.

For example, I've created a branch where HEAD points at a commit before the platform-definitions were removed. As a result, doing a diff against upstream/master will flag these files: 

https://github.com/aptmac/jmc/actions/runs/9683981058/job/26720688313#step:3:39
```
Requires update: releng/platform-definitions/platform-definition-2022-09/pom.xml
Requires update: releng/platform-definitions/platform-definition-2022-09/pom.xml
Requires update: releng/platform-definitions/platform-definition-2022-12/pom.xml
Requires update: releng/platform-definitions/platform-definition-2022-12/pom.xml
Requires update: releng/platform-definitions/platform-definition-2023-03/pom.xml
Requires update: releng/platform-definitions/platform-definition-2023-03/pom.xml
Requires update: releng/platform-definitions/platform-definition-2023-09/pom.xml
Requires update: releng/platform-definitions/platform-definition-2023-09/pom.xml
Branch is out of date with upstream/master. Please rebase your branch and try again.
Error: Process completed with exit code 1.
```