### PR TITLE
8236: Add support for Jolokia discovery

### DIFF
--- a/application/org.openjdk.jmc.jolokia/META-INF/MANIFEST.MF
+++ b/application/org.openjdk.jmc.jolokia/META-INF/MANIFEST.MF
@@ -10,7 +10,9 @@ Require-Bundle: org.eclipse.core.runtime,
  org.jolokia.client-jmx-adapter.standalone;bundle-version="2.0.2";visibility:=reexport,
  org.openjdk.jmc.common,
  org.openjdk.jmc.rjmx,
- org.openjdk.jmc.ui
+ org.openjdk.jmc.ui,
+ org.jolokia.service.discovery;bundle-version="2.0.2",
+ org.jolokia.server.core;bundle-version="2.0.2"
 Export-Package:  org.openjdk.jmc.jolokia,
  org.openjdk.jmc.jolokia.preferences
 Bundle-Activator: org.openjdk.jmc.jolokia.JmcJolokiaPlugin

--- a/application/org.openjdk.jmc.jolokia/plugin.xml
+++ b/application/org.openjdk.jmc.jolokia/plugin.xml
@@ -41,4 +41,19 @@
             <sysproperty name="running.in.jmc" include="true" />
       </client>
    </extension>
+      <extension
+            point="org.eclipse.ui.preferencePages">
+         <page
+               category="org.openjdk.jmc.browser.preferences.BrowserPreferencePage"
+               class="org.openjdk.jmc.jolokia.preferences.JolokiaPreferencePage"
+               id="org.openjdk.jmc.jolokia.preferences.JolokiaPreferencePage"
+               name="%page.name">
+         </page>
+      </extension>
+      <extension
+            point="org.eclipse.core.runtime.preferences">
+         <initializer
+               class="org.openjdk.jmc.jolokia.preferences.PreferenceInitializer">
+         </initializer>
+      </extension>
 </plugin>

--- a/application/org.openjdk.jmc.jolokia/src/main/java/org/openjdk/jmc/jolokia/AbstractCachedDescriptorProvider.java
+++ b/application/org.openjdk.jmc.jolokia/src/main/java/org/openjdk/jmc/jolokia/AbstractCachedDescriptorProvider.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, Kantega AS. All rights reserved.
+ * 
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * The contents of this file are subject to the terms of either the Universal Permissive License
+ * v 1.0 as shown at http://oss.oracle.com/licenses/upl
+ *
+ * or the following license:
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted
+ * provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions
+ * and the following disclaimer.
+ * 
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other materials provided with
+ * the distribution.
+ * 
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to
+ * endorse or promote products derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+ * WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.openjdk.jmc.jolokia;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import org.openjdk.jmc.rjmx.descriptorprovider.AbstractDescriptorProvider;
+import org.openjdk.jmc.rjmx.descriptorprovider.IDescriptorListener;
+
+/**
+ * The {@code AbstractCachedDescriptorProvider} keeps a list of identified JVMs that can be
+ * refreshed in the background by some means of discovering JVMs. Listeners will be notified of any
+ * changes.
+ */
+public abstract class AbstractCachedDescriptorProvider extends AbstractDescriptorProvider {
+
+	private static final long LOCAL_REFRESH_INTERVAL = 20000;
+	private Scanner scanner;
+	private Thread scannerThread;
+	/**
+	 * Map<UUID, IServerDescriptor>
+	 */
+	private final Map<String, ServerConnectionDescriptor> knownDescriptors = new HashMap<>();
+
+	/**
+	 * This is where we periodically scan and report deltas to the listeners.
+	 */
+	private class Scanner implements Runnable {
+		boolean isRunning;
+
+		@Override
+		public void run() {
+			isRunning = true;
+			while (isRunning) {
+				try {
+					scan();
+					Thread.sleep(LOCAL_REFRESH_INTERVAL);
+				} catch (InterruptedException ignore) {
+					// Don't mind being interrupted.
+				}
+			}
+		}
+
+		/**
+		 * Marks this scanner as terminated.
+		 */
+		public void shutdown() {
+			isRunning = false;
+		}
+
+		protected void scan() {
+			Map<String, ServerConnectionDescriptor> newOnes = discoverJvms();
+
+			synchronized (knownDescriptors) {
+				// Remove stale ones...
+				for (Iterator<Entry<String, ServerConnectionDescriptor>> entryIterator = knownDescriptors.entrySet()
+						.iterator(); entryIterator.hasNext();) {
+					Entry<String, ServerConnectionDescriptor> entry = entryIterator.next();
+					if (newOnes.containsKey(entry.getKey())) {
+						continue;
+					}
+					entryIterator.remove();
+					onDescriptorRemoved(entry.getKey());
+				}
+
+				// Add new ones...
+				for (Entry<String, ServerConnectionDescriptor> entry : newOnes.entrySet()) {
+					if (knownDescriptors.containsKey(entry.getKey())) {
+						continue;
+					}
+					onDescriptorDetected(entry.getValue(), entry.getValue().getPath(), entry.getValue().serviceUrl(),
+							entry.getValue());
+				}
+				knownDescriptors.clear();
+				knownDescriptors.putAll(newOnes);
+			}
+		}
+	}
+
+	/**
+	 * Sets up the thread.
+	 */
+	private void initialize() {
+		scanner = new Scanner();
+		scannerThread = new Thread(scanner, getName()); // $NON-NLS-1$
+		scannerThread.start();
+	}
+
+	protected abstract boolean isEnabled();
+
+	protected abstract Map<String, ServerConnectionDescriptor> discoverJvms();
+
+	@Override
+	public void addDescriptorListener(IDescriptorListener l) {
+		synchronized (m_descriptorListeners) {
+			if (m_descriptorListeners.size() == 0) {
+				super.addDescriptorListener(l);
+				initialize();
+			} else {
+				super.addDescriptorListener(l);
+			}
+		}
+	}
+
+	@Override
+	public void removeDescriptorListener(IDescriptorListener l) {
+		synchronized (m_descriptorListeners) {
+			super.removeDescriptorListener(l);
+			if (m_descriptorListeners.size() == 0 && scanner != null) {
+				scanner.shutdown();
+				scannerThread.interrupt();
+			}
+		}
+	}
+
+	/**
+	 * Shuts down the scanner thread.
+	 */
+	public void shutdown() {
+		if (scanner != null) {
+			scanner.shutdown();
+		}
+	}
+
+}

--- a/application/org.openjdk.jmc.jolokia/src/main/java/org/openjdk/jmc/jolokia/JmcJolokiaJmxConnectionProvider.java
+++ b/application/org.openjdk.jmc.jolokia/src/main/java/org/openjdk/jmc/jolokia/JmcJolokiaJmxConnectionProvider.java
@@ -45,8 +45,7 @@ public class JmcJolokiaJmxConnectionProvider implements JMXConnectorProvider {
 	@Override
 	public JMXConnector newJMXConnector(JMXServiceURL serviceURL, Map<String, ?> environment) throws IOException {
 		if (!"jolokia".equals(serviceURL.getProtocol())) { //$NON-NLS-1$
-			throw new MalformedURLException(Messages
-					.getString("JmcJolokiaJmxConnectionProvider.JMC_JOLOKIA_JMX_CONNECTION_PROVIDER_EXCEPTION_MSG")); //$NON-NLS-1$
+			throw new MalformedURLException(Messages.JmcJolokiaJmxConnectionProvider_UnsupportedUrlMessage);
 		}
 		return new JmcJolokiaJmxConnector(serviceURL, environment);
 	}

--- a/application/org.openjdk.jmc.jolokia/src/main/java/org/openjdk/jmc/jolokia/JolokiaAgentDescriptor.java
+++ b/application/org.openjdk.jmc.jolokia/src/main/java/org/openjdk/jmc/jolokia/JolokiaAgentDescriptor.java
@@ -1,0 +1,203 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, Kantega AS. All rights reserved.
+ * 
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * The contents of this file are subject to the terms of either the Universal Permissive License
+ * v 1.0 as shown at http://oss.oracle.com/licenses/upl
+ *
+ * or the following license:
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted
+ * provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions
+ * and the following disclaimer.
+ * 
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other materials provided with
+ * the distribution.
+ * 
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to
+ * endorse or promote products derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+ * WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.openjdk.jmc.jolokia;
+
+import java.io.IOException;
+import java.lang.management.ManagementFactory;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.management.Attribute;
+import javax.management.AttributeList;
+import javax.management.InstanceNotFoundException;
+import javax.management.MalformedObjectNameException;
+import javax.management.ObjectName;
+import javax.management.openmbean.CompositeDataSupport;
+import javax.management.openmbean.TabularDataSupport;
+import javax.management.remote.JMXServiceURL;
+
+import org.jolokia.client.jmxadapter.RemoteJmxAdapter;
+import org.openjdk.jmc.common.jvm.Connectable;
+import org.openjdk.jmc.common.jvm.JVMArch;
+import org.openjdk.jmc.common.jvm.JVMDescriptor;
+import org.openjdk.jmc.common.jvm.JVMType;
+
+/**
+ * Provide data about JVMs accessed over Jolokia for the JVM browser
+ */
+public class JolokiaAgentDescriptor implements ServerConnectionDescriptor {
+
+	public static final JVMDescriptor NULL_DESCRIPTOR = new JVMDescriptor(null, null, null, null, null, null, null,
+			null, false, Connectable.UNKNOWN);
+	private final JMXServiceURL serviceUrl;
+	private final Map<String, ?> agentData;
+	private final JVMDescriptor jvmDescriptor;
+
+	public JolokiaAgentDescriptor(Map<String, ?> agentData, JVMDescriptor jvmDescriptor)
+			throws URISyntaxException, MalformedURLException {
+		super();
+		URI uri = new URI((String) agentData.get("url")); //$NON-NLS-1$
+		this.serviceUrl = new JMXServiceURL(
+				String.format("service:jmx:jolokia://%s:%s%s", uri.getHost(), uri.getPort(), uri.getPath())); //$NON-NLS-1$
+		this.agentData = agentData;
+		this.jvmDescriptor = jvmDescriptor;
+	}
+
+	JMXServiceURL getServiceUrl() {
+		return serviceUrl;
+	}
+
+	@Override
+	public String getGUID() {
+		return String.valueOf(agentData.get("agent_id")); //$NON-NLS-1$
+	}
+
+	@Override
+	public String getDisplayName() {
+		return String.valueOf(agentData.get("agent_id")); //$NON-NLS-1$
+	}
+
+	@Override
+	public JVMDescriptor getJvmInfo() {
+		return this.jvmDescriptor;
+	}
+
+	/**
+	 * Best effort to extract JVM information from a connection if everything works. Can be adjusted
+	 * to support different flavors of JVM.
+	 */
+	public static JVMDescriptor attemptToGetJvmInfo(RemoteJmxAdapter adapter) {
+
+		try {
+			AttributeList attributes = adapter.getAttributes(new ObjectName(ManagementFactory.RUNTIME_MXBEAN_NAME),
+					new String[] {"Pid", "Name", "InputArguments", "SystemProperties"}); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+			Integer pid = null;
+			String arguments = null, javaCommand = null, javaVersion = null, vmName = null, vmVendor = null;
+			boolean isDebug = false;
+			JVMType type = JVMType.UNKNOWN;
+			JVMArch arch = JVMArch.UNKNOWN;
+			for (Attribute attribute : attributes.asList()) {
+				// newer JVM have pid as separate attribute, older have to parse from name
+				if (attribute.getName().equalsIgnoreCase("Pid")) { //$NON-NLS-1$
+					try {
+						pid = Integer.valueOf(String.valueOf(attribute.getValue()));
+					} catch (NumberFormatException ignore) {
+					}
+				} else if (attribute.getName().equalsIgnoreCase("Name") && pid == null) { //$NON-NLS-1$
+					String pidAndHost = String.valueOf(attribute.getValue());
+					int separator = pidAndHost.indexOf('@');
+					if (separator > 0) {
+						try {
+							pid = Integer.valueOf(pidAndHost.substring(0, separator));
+						} catch (NumberFormatException e) {
+						}
+					}
+				} else if (attribute.getName().equalsIgnoreCase("InputArguments")) { //$NON-NLS-1$
+
+					if (attribute.getValue() instanceof String[]) {
+						arguments = Arrays.toString((String[]) attribute.getValue());
+					} else {
+						arguments = String.valueOf(attribute.getValue());
+					}
+					if (arguments.contains("-agentlib:jdwp")) { //$NON-NLS-1$
+						isDebug = true;
+					}
+				} else if (attribute.getName().equalsIgnoreCase("SystemProperties") //$NON-NLS-1$
+						&& attribute.getValue() instanceof TabularDataSupport) {
+					TabularDataSupport systemProperties = (TabularDataSupport) attribute.getValue();
+
+					// quite clumsy: iterate over properties as we need to use the exact key, which is non trivial
+					// to reproduce
+					for (Object entry : systemProperties.values()) {
+						String key = ((CompositeDataSupport) entry).get("key").toString(); //$NON-NLS-1$
+						String value = ((CompositeDataSupport) entry).get("value").toString(); //$NON-NLS-1$
+						if (key.equalsIgnoreCase("sun.management.compiler")) { //$NON-NLS-1$
+							if (value.toLowerCase().contains("hotspot")) { //$NON-NLS-1$
+								type = JVMType.HOTSPOT;
+							}
+						} else if (key.equalsIgnoreCase("sun.arch.data.model")) { //$NON-NLS-1$
+							String archIndicator = value;
+							if (archIndicator.contains("64")) { //$NON-NLS-1$
+								arch = JVMArch.BIT64;
+							} else if (archIndicator.contains("32")) { //$NON-NLS-1$
+								arch = JVMArch.BIT32;
+							}
+						} else if (key.equalsIgnoreCase("sun.java.command")) { //$NON-NLS-1$
+							javaCommand = value;
+						} else if (key.equalsIgnoreCase("java.version")) { //$NON-NLS-1$
+							javaVersion = value;
+						} else if (key.equalsIgnoreCase("java.vm.name")) { //$NON-NLS-1$
+							vmName = value;
+						} else if (key.equalsIgnoreCase("java.vm.vendor")) { //$NON-NLS-1$
+							vmVendor = value;
+						}
+					}
+
+				}
+
+			}
+			return new JVMDescriptor(javaVersion, type, arch, javaCommand, arguments, vmName, vmVendor, pid, isDebug,
+					Connectable.UNKNOWN);
+
+		} catch (RuntimeException | IOException | InstanceNotFoundException | MalformedObjectNameException ignore) {
+			return NULL_DESCRIPTOR;
+		}
+
+	}
+
+	@Override
+	public JMXServiceURL createJMXServiceURL() throws IOException {
+		return serviceUrl;
+	}
+
+	@Override
+	public Map<String, Object> getEnvironment() {
+		return new HashMap<>();
+	}
+
+	@Override
+	public String getPath() {
+		return null;
+	}
+
+	@Override
+	public JMXServiceURL serviceUrl() {
+		return this.serviceUrl;
+	}
+
+}

--- a/application/org.openjdk.jmc.jolokia/src/main/java/org/openjdk/jmc/jolokia/JolokiaAgentDescriptor.java
+++ b/application/org.openjdk.jmc.jolokia/src/main/java/org/openjdk/jmc/jolokia/JolokiaAgentDescriptor.java
@@ -102,7 +102,6 @@ public class JolokiaAgentDescriptor implements ServerConnectionDescriptor {
 	 * to support different flavors of JVM.
 	 */
 	public static JVMDescriptor attemptToGetJvmInfo(RemoteJmxAdapter adapter) {
-
 		try {
 			AttributeList attributes = adapter.getAttributes(new ObjectName(ManagementFactory.RUNTIME_MXBEAN_NAME),
 					new String[] {"Pid", "Name", "InputArguments", "SystemProperties"}); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
@@ -167,9 +166,7 @@ public class JolokiaAgentDescriptor implements ServerConnectionDescriptor {
 							vmVendor = value;
 						}
 					}
-
 				}
-
 			}
 			return new JVMDescriptor(javaVersion, type, arch, javaCommand, arguments, vmName, vmVendor, pid, isDebug,
 					Connectable.UNKNOWN);
@@ -177,7 +174,6 @@ public class JolokiaAgentDescriptor implements ServerConnectionDescriptor {
 		} catch (RuntimeException | IOException | InstanceNotFoundException | MalformedObjectNameException ignore) {
 			return NULL_DESCRIPTOR;
 		}
-
 	}
 
 	@Override

--- a/application/org.openjdk.jmc.jolokia/src/main/java/org/openjdk/jmc/jolokia/JolokiaDiscoveryListener.java
+++ b/application/org.openjdk.jmc.jolokia/src/main/java/org/openjdk/jmc/jolokia/JolokiaDiscoveryListener.java
@@ -72,7 +72,6 @@ public class JolokiaDiscoveryListener extends AbstractCachedDescriptorProvider i
 					this.settings.getDiscoveryTimeout(), this.settings.getMulticastGroup(),
 					this.settings.getMulticastPort())) {
 				try {
-
 					@SuppressWarnings("unchecked")
 					Map<String, ?> response = (Map<String, ?>) object;
 					JVMDescriptor jvmInfo;

--- a/application/org.openjdk.jmc.jolokia/src/main/java/org/openjdk/jmc/jolokia/JolokiaDiscoveryListener.java
+++ b/application/org.openjdk.jmc.jolokia/src/main/java/org/openjdk/jmc/jolokia/JolokiaDiscoveryListener.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, Kantega AS. All rights reserved.
+ * 
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * The contents of this file are subject to the terms of either the Universal Permissive License
+ * v 1.0 as shown at http://oss.oracle.com/licenses/upl
+ *
+ * or the following license:
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted
+ * provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions
+ * and the following disclaimer.
+ * 
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other materials provided with
+ * the distribution.
+ * 
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to
+ * endorse or promote products derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+ * WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.openjdk.jmc.jolokia;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.jolokia.client.jmxadapter.RemoteJmxAdapter;
+import org.jolokia.service.discovery.JolokiaDiscovery;
+import org.openjdk.jmc.common.jvm.JVMDescriptor;
+import org.openjdk.jmc.jolokia.preferences.PreferenceConstants;
+
+/**
+ * Add found Jolokia instances to the JVM browser using the Jolokia discovery mechanism.
+ * https://jolokia.org/reference/html/protocol.html#discovery
+ */
+public class JolokiaDiscoveryListener extends AbstractCachedDescriptorProvider implements PreferenceConstants {
+
+	JolokiaDiscoverySettings settings;
+
+	public JolokiaDiscoveryListener(JolokiaDiscoverySettings settings) {
+		this.settings = settings;
+	}
+
+	public JolokiaDiscoveryListener() {
+		this(JmcJolokiaPlugin.getDefault());
+	}
+
+	@Override
+	protected Map<String, ServerConnectionDescriptor> discoverJvms() {
+		Map<String, ServerConnectionDescriptor> found = new HashMap<>();
+		if (!this.settings.shouldRunDiscovery()) {
+			return found;
+		}
+		try {
+			JolokiaDiscovery jolokiaDiscovery = new JolokiaDiscovery();
+			jolokiaDiscovery.init(this.settings.getJolokiaContext());
+			for (Object object : jolokiaDiscovery.lookupAgentsWithTimeoutAndMulticastAddress(
+					this.settings.getDiscoveryTimeout(), this.settings.getMulticastGroup(),
+					this.settings.getMulticastPort())) {
+				try {
+
+					@SuppressWarnings("unchecked")
+					Map<String, ?> response = (Map<String, ?>) object;
+					JVMDescriptor jvmInfo;
+					try {// if it is connectable, see if we can get info from connection
+						jvmInfo = JolokiaAgentDescriptor
+								.attemptToGetJvmInfo(new RemoteJmxAdapter(String.valueOf(response.get("url")))); //$NON-NLS-1$
+					} catch (Exception ignore) {
+						jvmInfo = JolokiaAgentDescriptor.NULL_DESCRIPTOR;
+					}
+					JolokiaAgentDescriptor agentDescriptor = new JolokiaAgentDescriptor(response, jvmInfo);
+					found.put(agentDescriptor.getGUID(), agentDescriptor);
+
+				} catch (URISyntaxException ignore) {
+				}
+			}
+		} catch (IOException ignore) {
+		}
+		return found;
+	}
+
+	@Override
+	public String getDescription() {
+		return Messages.JolokiaDiscoveryListener_Description;
+	}
+
+	@Override
+	public String getName() {
+		return "jolokia"; //$NON-NLS-1$
+	}
+
+	@Override
+	protected boolean isEnabled() {
+		return true;
+	}
+
+}

--- a/application/org.openjdk.jmc.jolokia/src/main/java/org/openjdk/jmc/jolokia/JolokiaDiscoverySettings.java
+++ b/application/org.openjdk.jmc.jolokia/src/main/java/org/openjdk/jmc/jolokia/JolokiaDiscoverySettings.java
@@ -1,3 +1,36 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, Kantega AS. All rights reserved.
+ *
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * The contents of this file are subject to the terms of either the Universal Permissive License
+ * v 1.0 as shown at http://oss.oracle.com/licenses/upl
+ *
+ * or the following license:
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted
+ * provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions
+ * and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other materials provided with
+ * the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to
+ * endorse or promote products derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+ * WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 package org.openjdk.jmc.jolokia;
 
 import org.jolokia.server.core.service.api.JolokiaContext;

--- a/application/org.openjdk.jmc.jolokia/src/main/java/org/openjdk/jmc/jolokia/JolokiaDiscoverySettings.java
+++ b/application/org.openjdk.jmc.jolokia/src/main/java/org/openjdk/jmc/jolokia/JolokiaDiscoverySettings.java
@@ -1,0 +1,16 @@
+package org.openjdk.jmc.jolokia;
+
+import org.jolokia.server.core.service.api.JolokiaContext;
+
+public interface JolokiaDiscoverySettings {
+	boolean shouldRunDiscovery();
+
+	JolokiaContext getJolokiaContext();
+
+	String getMulticastGroup();
+
+	int getMulticastPort();
+
+	int getDiscoveryTimeout();
+
+}

--- a/application/org.openjdk.jmc.jolokia/src/main/java/org/openjdk/jmc/jolokia/Messages.java
+++ b/application/org.openjdk.jmc.jolokia/src/main/java/org/openjdk/jmc/jolokia/Messages.java
@@ -35,25 +35,13 @@ package org.openjdk.jmc.jolokia;
 
 import org.eclipse.osgi.util.NLS;
 
-import java.util.MissingResourceException;
-import java.util.ResourceBundle;
-
 public class Messages extends NLS {
 	private static final String BUNDLE_NAME = Messages.class.getPackageName() + ".messages"; //$NON-NLS-1$
-	private static final ResourceBundle RESOURCE_BUNDLE = ResourceBundle.getBundle(BUNDLE_NAME);
-
+	public static String JmcJolokiaJmxConnectionProvider_UnsupportedUrlMessage;
 	public static String JolokiaDiscoveryListener_Description;
 	static {
 		// initialize resource bundle
 		NLS.initializeMessages(BUNDLE_NAME, Messages.class);
-	}
-
-	public static String getString(String key) {
-		try {
-			return RESOURCE_BUNDLE.getString(key);
-		} catch (MissingResourceException e) {
-			return '!' + key + '!';
-		}
 	}
 
 	private Messages() {

--- a/application/org.openjdk.jmc.jolokia/src/main/java/org/openjdk/jmc/jolokia/ServerConnectionDescriptor.java
+++ b/application/org.openjdk.jmc.jolokia/src/main/java/org/openjdk/jmc/jolokia/ServerConnectionDescriptor.java
@@ -33,29 +33,16 @@
  */
 package org.openjdk.jmc.jolokia;
 
-import org.eclipse.osgi.util.NLS;
+import javax.management.remote.JMXServiceURL;
 
-import java.util.MissingResourceException;
-import java.util.ResourceBundle;
+import org.openjdk.jmc.rjmx.common.IConnectionDescriptor;
+import org.openjdk.jmc.rjmx.common.IServerDescriptor;
 
-public class Messages extends NLS {
-	private static final String BUNDLE_NAME = Messages.class.getPackageName() + ".messages"; //$NON-NLS-1$
-	private static final ResourceBundle RESOURCE_BUNDLE = ResourceBundle.getBundle(BUNDLE_NAME);
+/**
+ * Describes the JVM and how to connect to it.
+ */
+public interface ServerConnectionDescriptor extends IServerDescriptor, IConnectionDescriptor {
+	String getPath();
 
-	public static String JolokiaDiscoveryListener_Description;
-	static {
-		// initialize resource bundle
-		NLS.initializeMessages(BUNDLE_NAME, Messages.class);
-	}
-
-	public static String getString(String key) {
-		try {
-			return RESOURCE_BUNDLE.getString(key);
-		} catch (MissingResourceException e) {
-			return '!' + key + '!';
-		}
-	}
-
-	private Messages() {
-	}
+	JMXServiceURL serviceUrl();
 }

--- a/application/org.openjdk.jmc.jolokia/src/main/java/org/openjdk/jmc/jolokia/messages.properties
+++ b/application/org.openjdk.jmc.jolokia/src/main/java/org/openjdk/jmc/jolokia/messages.properties
@@ -1,1 +1,2 @@
 JmcJolokiaJmxConnectionProvider.JMC_JOLOKIA_JMX_CONNECTION_PROVIDER_EXCEPTION_MSG=I only serve Jolokia connections
+JolokiaDiscoveryListener_Description=Uses Jolokia Discovery to report any active JVMs with Jolokia broadcasting

--- a/application/org.openjdk.jmc.jolokia/src/main/java/org/openjdk/jmc/jolokia/messages.properties
+++ b/application/org.openjdk.jmc.jolokia/src/main/java/org/openjdk/jmc/jolokia/messages.properties
@@ -1,2 +1,2 @@
-JmcJolokiaJmxConnectionProvider.JMC_JOLOKIA_JMX_CONNECTION_PROVIDER_EXCEPTION_MSG=I only serve Jolokia connections
+JmcJolokiaJmxConnectionProvider_UnsupportedUrlMessage=I only serve Jolokia connections
 JolokiaDiscoveryListener_Description=Uses Jolokia Discovery to report any active JVMs with Jolokia broadcasting

--- a/application/org.openjdk.jmc.jolokia/src/main/java/org/openjdk/jmc/jolokia/preferences/JolokiaPreferencePage.java
+++ b/application/org.openjdk.jmc.jolokia/src/main/java/org/openjdk/jmc/jolokia/preferences/JolokiaPreferencePage.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, Kantega AS. All rights reserved.
+ * 
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * The contents of this file are subject to the terms of either the Universal Permissive License
+ * v 1.0 as shown at http://oss.oracle.com/licenses/upl
+ *
+ * or the following license:
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted
+ * provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions
+ * and the following disclaimer.
+ * 
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other materials provided with
+ * the distribution.
+ * 
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to
+ * endorse or promote products derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+ * WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.openjdk.jmc.jolokia.preferences;
+
+import java.util.Map;
+import java.util.WeakHashMap;
+
+import org.eclipse.jface.preference.BooleanFieldEditor;
+import org.eclipse.jface.preference.FieldEditor;
+import org.eclipse.jface.preference.FieldEditorPreferencePage;
+import org.eclipse.jface.preference.IntegerFieldEditor;
+import org.eclipse.jface.preference.StringFieldEditor;
+import org.eclipse.swt.widgets.Control;
+import org.eclipse.swt.widgets.Text;
+import org.eclipse.ui.IWorkbench;
+import org.eclipse.ui.IWorkbenchPreferencePage;
+import org.openjdk.jmc.jolokia.JmcJolokiaPlugin;
+
+public class JolokiaPreferencePage extends FieldEditorPreferencePage
+		implements IWorkbenchPreferencePage, PreferenceConstants {
+
+	private Map<Control, Object> dependantControls = new WeakHashMap<>();
+
+	public JolokiaPreferencePage() {
+		super(GRID);
+		setPreferenceStore(JmcJolokiaPlugin.getDefault().getPreferenceStore());
+		setDescription(Messages.JolokiaPreferencePage_Description);
+	}
+
+	public void createFieldEditors() {
+		BooleanFieldEditor mainEnabler = new BooleanFieldEditor(P_SCAN, Messages.JolokiaPreferencePage_Label,
+				getFieldEditorParent()) {
+			@Override
+			protected void valueChanged(boolean oldValue, boolean newValue) {
+				super.valueChanged(oldValue, newValue);
+				enableDependantFields(newValue);
+			}
+		};
+		addField(mainEnabler);
+		this.addTextField(new StringFieldEditor(P_MULTICAST_GROUP, Messages.JolokiaPreferencePage_MulticastGroupLabel,
+				getFieldEditorParent()), Messages.JolokiaPreferencePage_MulticastGroupTooltip);
+		this.addTextField(new IntegerFieldEditor(P_MULTICAST_PORT, Messages.JolokiaPreferencePage_MulticastPortLabel,
+				getFieldEditorParent()), Messages.JolokiaPreferencePage_MulticastPortTooltip);
+		this.addDependantField(new IntegerFieldEditor(P_DISCOVER_TIMEOUT,
+				Messages.JolokiaPreferencePage_DiscoverTimeoutLabel, getFieldEditorParent()), getControl());
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * 
+	 * @see org.eclipse.ui.IWorkbenchPreferencePage#init(org.eclipse.ui.IWorkbench)
+	 */
+	public void init(IWorkbench workbench) {
+	}
+
+	private void addTextField(StringFieldEditor field, String tooltip) {
+		Text textControl = field.getTextControl(getFieldEditorParent());
+		this.addDependantField(field, textControl);
+		textControl.setToolTipText(tooltip);
+		field.getLabelControl(getFieldEditorParent()).setToolTipText(tooltip);
+
+	}
+
+	private void addDependantField(FieldEditor field, Control control) {
+		this.dependantControls.put(control, null);
+		addField(field);
+	}
+
+	private void enableDependantFields(boolean enabled) {
+		for (Control field : this.dependantControls.keySet()) {
+			field.setEnabled(enabled);
+		}
+	}
+}

--- a/application/org.openjdk.jmc.jolokia/src/main/java/org/openjdk/jmc/jolokia/preferences/Messages.java
+++ b/application/org.openjdk.jmc.jolokia/src/main/java/org/openjdk/jmc/jolokia/preferences/Messages.java
@@ -31,29 +31,22 @@
  * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
  * WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.openjdk.jmc.jolokia;
+package org.openjdk.jmc.jolokia.preferences;
 
 import org.eclipse.osgi.util.NLS;
 
-import java.util.MissingResourceException;
-import java.util.ResourceBundle;
-
 public class Messages extends NLS {
-	private static final String BUNDLE_NAME = Messages.class.getPackageName() + ".messages"; //$NON-NLS-1$
-	private static final ResourceBundle RESOURCE_BUNDLE = ResourceBundle.getBundle(BUNDLE_NAME);
-
-	public static String JolokiaDiscoveryListener_Description;
+	private static final String BUNDLE_NAME = "org.openjdk.jmc.jolokia.preferences.messages"; //$NON-NLS-1$
+	public static String JolokiaPreferencePage_Description;
+	public static String JolokiaPreferencePage_DiscoverTimeoutLabel;
+	public static String JolokiaPreferencePage_Label;
+	public static String JolokiaPreferencePage_MulticastGroupLabel;
+	public static String JolokiaPreferencePage_MulticastGroupTooltip;
+	public static String JolokiaPreferencePage_MulticastPortLabel;
+	public static String JolokiaPreferencePage_MulticastPortTooltip;
 	static {
 		// initialize resource bundle
 		NLS.initializeMessages(BUNDLE_NAME, Messages.class);
-	}
-
-	public static String getString(String key) {
-		try {
-			return RESOURCE_BUNDLE.getString(key);
-		} catch (MissingResourceException e) {
-			return '!' + key + '!';
-		}
 	}
 
 	private Messages() {

--- a/application/org.openjdk.jmc.jolokia/src/main/java/org/openjdk/jmc/jolokia/preferences/PreferenceConstants.java
+++ b/application/org.openjdk.jmc.jolokia/src/main/java/org/openjdk/jmc/jolokia/preferences/PreferenceConstants.java
@@ -31,31 +31,15 @@
  * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
  * WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.openjdk.jmc.jolokia;
+package org.openjdk.jmc.jolokia.preferences;
 
-import org.eclipse.osgi.util.NLS;
+/**
+ * Constant definitions for plug-in preferences.
+ */
+public interface PreferenceConstants {
 
-import java.util.MissingResourceException;
-import java.util.ResourceBundle;
-
-public class Messages extends NLS {
-	private static final String BUNDLE_NAME = Messages.class.getPackageName() + ".messages"; //$NON-NLS-1$
-	private static final ResourceBundle RESOURCE_BUNDLE = ResourceBundle.getBundle(BUNDLE_NAME);
-
-	public static String JolokiaDiscoveryListener_Description;
-	static {
-		// initialize resource bundle
-		NLS.initializeMessages(BUNDLE_NAME, Messages.class);
-	}
-
-	public static String getString(String key) {
-		try {
-			return RESOURCE_BUNDLE.getString(key);
-		} catch (MissingResourceException e) {
-			return '!' + key + '!';
-		}
-	}
-
-	private Messages() {
-	}
+	public static final String P_SCAN = "discoverJolokia"; //$NON-NLS-1$
+	public static final String P_MULTICAST_GROUP = "multicastGroup";//$NON-NLS-1$
+	public static final String P_MULTICAST_PORT = "multicastPort";//$NON-NLS-1$
+	public static final String P_DISCOVER_TIMEOUT = "discoverTimeout";//$NON-NLS-1$ 
 }

--- a/application/org.openjdk.jmc.jolokia/src/main/java/org/openjdk/jmc/jolokia/preferences/PreferenceInitializer.java
+++ b/application/org.openjdk.jmc.jolokia/src/main/java/org/openjdk/jmc/jolokia/preferences/PreferenceInitializer.java
@@ -31,31 +31,30 @@
  * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
  * WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.openjdk.jmc.jolokia;
+package org.openjdk.jmc.jolokia.preferences;
 
-import org.eclipse.osgi.util.NLS;
+import org.eclipse.core.runtime.preferences.AbstractPreferenceInitializer;
+import org.eclipse.jface.preference.IPreferenceStore;
+import org.openjdk.jmc.jolokia.JmcJolokiaPlugin;
+import org.jolokia.server.core.config.ConfigKey;
 
-import java.util.MissingResourceException;
-import java.util.ResourceBundle;
+/**
+ * Class used to initialize default preference values.
+ */
+public class PreferenceInitializer extends AbstractPreferenceInitializer implements PreferenceConstants {
 
-public class Messages extends NLS {
-	private static final String BUNDLE_NAME = Messages.class.getPackageName() + ".messages"; //$NON-NLS-1$
-	private static final ResourceBundle RESOURCE_BUNDLE = ResourceBundle.getBundle(BUNDLE_NAME);
-
-	public static String JolokiaDiscoveryListener_Description;
-	static {
-		// initialize resource bundle
-		NLS.initializeMessages(BUNDLE_NAME, Messages.class);
+	/*
+	 * (non-Javadoc)
+	 * 
+	 * @see org.eclipse.core.runtime.preferences.AbstractPreferenceInitializer#
+	 * initializeDefaultPreferences()
+	 */
+	public void initializeDefaultPreferences() {
+		IPreferenceStore store = JmcJolokiaPlugin.getDefault().getPreferenceStore();
+		store.setDefault(P_SCAN, false);
+		store.setDefault(P_MULTICAST_GROUP, ConfigKey.MULTICAST_GROUP.getDefaultValue());
+		store.setDefault(P_MULTICAST_PORT, ConfigKey.MULTICAST_PORT.getDefaultValue());
+		store.setDefault(P_DISCOVER_TIMEOUT, 1000);
 	}
 
-	public static String getString(String key) {
-		try {
-			return RESOURCE_BUNDLE.getString(key);
-		} catch (MissingResourceException e) {
-			return '!' + key + '!';
-		}
-	}
-
-	private Messages() {
-	}
 }

--- a/application/org.openjdk.jmc.jolokia/src/main/java/org/openjdk/jmc/jolokia/preferences/messages.properties
+++ b/application/org.openjdk.jmc.jolokia/src/main/java/org/openjdk/jmc/jolokia/preferences/messages.properties
@@ -1,0 +1,11 @@
+JolokiaPreferencePage_Description=Discover Jolokia Agents\n\nhttps://jolokia.org/reference/html/protocol.html\#discovery\n\n
+JolokiaPreferencePage_DiscoverTimeoutLabel=Discovery timeout (ms)
+JolokiaPreferencePage_Label=&Discover Jolokia agents
+JolokiaPreferencePage_MulticastGroupLabel=Multicast Group
+JolokiaPreferencePage_MulticastGroupTooltip=Multicast group used by Jolokia discovery to detect instances.
+JolokiaPreferencePage_MulticastPortLabel=Multicast Port
+JolokiaPreferencePage_MulticastPortTooltip=Port number used by Jolokia discovery to detect instances.
+JolokiaPreferencePage.MulticastAddressLabel=Jolokia Discovery Multicast Address.
+JolokiaPreferencePage.MulticastAddressTooltip=Address used for broadcast messages that available Jolokia agents should respond to.
+JolokiaPreferencePage.MulticastPortLabel=Jolokia Discovery Multicast Address.
+JolokiaPreferencePage.MulticastPortTooltip=Port used for broadcast messages that available Jolokia agents should respond to.

--- a/application/org.openjdk.jmc.jolokia/src/main/java/org/openjdk/jmc/jolokia/preferences/messages.properties
+++ b/application/org.openjdk.jmc.jolokia/src/main/java/org/openjdk/jmc/jolokia/preferences/messages.properties
@@ -1,4 +1,4 @@
-JolokiaPreferencePage_Description=Discover Jolokia Agents\n\nhttps://jolokia.org/reference/html/protocol.html\#discovery\n\n
+JolokiaPreferencePage_Description=These are the preferences for Jolokia agent discovery.\n\nhttps://jolokia.org/reference/html/protocol.html\#discovery\n\n
 JolokiaPreferencePage_DiscoverTimeoutLabel=Discovery timeout (ms)
 JolokiaPreferencePage_Label=&Discover Jolokia agents
 JolokiaPreferencePage_MulticastGroupLabel=Multicast Group

--- a/application/tests/org.openjdk.jmc.jolokia.test/META-INF/MANIFEST.MF
+++ b/application/tests/org.openjdk.jmc.jolokia.test/META-INF/MANIFEST.MF
@@ -13,5 +13,6 @@ Require-Bundle: org.junit,
  org.openjdk.jmc.rjmx,
  org.eclipse.ui,
  org.awaitility,
- org.hamcrest
+ org.hamcrest,
+ org.osgi.service.servlet;bundle-version="2.0.0"
 Automatic-Module-Name: org.openjdk.jmc.jolokia.test

--- a/application/tests/org.openjdk.jmc.jolokia.test/pom.xml
+++ b/application/tests/org.openjdk.jmc.jolokia.test/pom.xml
@@ -46,7 +46,7 @@
 
 	<properties>
 		<jmc.config.path>${project.basedir}/../../../configuration</jmc.config.path>
-		<jolokia.agent.version>1.7.2</jolokia.agent.version>
+		<jolokia.agent.version>2.0.2</jolokia.agent.version>
 	</properties>
 
 	<dependencies>
@@ -57,9 +57,10 @@
 		</dependency>
 		<dependency>
 			<groupId>org.jolokia</groupId>
-			<artifactId>jolokia-jvm</artifactId>
+			<artifactId>jolokia-agent-jvm</artifactId>
 			<version>${jolokia.agent.version}</version>
 			<scope>test</scope>
+			<classifier>javaagent</classifier>
 		</dependency>
 	</dependencies>
 
@@ -74,7 +75,7 @@
 					<!-- Start jolokia on a random free port to avoid requiring specific ports to run test -->
 					<!-- Agent version may differ from client version, in fact it may be a good test -->
 					<argLine>
-						-javaagent:${settings.localRepository}/org/jolokia/jolokia-jvm/${jolokia.agent.version}/jolokia-jvm-${jolokia.agent.version}.jar=port=0,discover=true</argLine>
+						-javaagent:${settings.localRepository}/org/jolokia/jolokia-agent-jvm/${jolokia.agent.version}/jolokia-agent-jvm-${jolokia.agent.version}-javaagent.jar=port=0,discoveryEnabled=true</argLine>
 				</configuration>
 			</plugin>
 

--- a/releng/platform-definitions/platform-definition-2024-03/platform-definition-2024-03.target
+++ b/releng/platform-definitions/platform-definition-2024-03/platform-definition-2024-03.target
@@ -46,6 +46,8 @@
             <unit id="org.adoptopenjdk.jemmy-core" version="2.0.0"/>
             <unit id="org.adoptopenjdk.jemmy-swt" version="2.0.0"/>
             <unit id="org.jolokia.client-jmx-adapter.standalone" version="2.0.2"/>
+            <unit id="org.jolokia.service.discovery" version="2.0.2"/>
+            <unit id="org.jolokia.server.core" version="2.0.2"/>
             <unit id="com.github.tomakehurst.wiremock-standalone" version="2.27.2"/>
             <unit id="org.eclipse.jetty.websocket.api" version="12.0.6"/>
             <unit id="org.eclipse.jetty.ee9.websocket.api" version="12.0.6"/>

--- a/releng/third-party/pom.xml
+++ b/releng/third-party/pom.xml
@@ -165,6 +165,19 @@
 									<transitive>false</transitive>
 								</artifact>
 								<artifact>
+									<id>org.jolokia:jolokia-service-discovery:${jolokia.version}</id>
+									<override>true</override>
+									<instructions>
+										<Export-Package>org.jolokia.service.discovery</Export-Package>
+									</instructions>
+								</artifact>
+								<artifact>
+									<id>org.jolokia:jolokia-server-core:${jolokia.version}</id>
+								</artifact>
+								<artifact>
+									<id>org.osgi:org.osgi.service.servlet:2.0.0</id>
+								</artifact>
+								<artifact>
 									<id>com.github.tomakehurst:wiremock-standalone:${wiremock.version}</id>
 									<transitive>false</transitive>
 								</artifact>


### PR DESCRIPTION
Jolokia comes with a discovery mechanism. It is helpful to make use of this to automatically populate the JVM browser, alongside local JVM and other discovery mechanisms.

https://jolokia.org/reference/html/manual/jolokia_protocol.html#discovery

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JMC-8236](https://bugs.openjdk.org/browse/JMC-8236): Add support for Jolokia discovery (**Enhancement** - P4)


### Reviewers
 * [Alex Macdonald](https://openjdk.org/census#aptmac) (@aptmac - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmc.git pull/570/head:pull/570` \
`$ git checkout pull/570`

Update a local copy of the PR: \
`$ git checkout pull/570` \
`$ git pull https://git.openjdk.org/jmc.git pull/570/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 570`

View PR using the GUI difftool: \
`$ git pr show -t 570`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmc/pull/570.diff">https://git.openjdk.org/jmc/pull/570.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jmc/pull/570#issuecomment-2206012640)