### PR TITLE
8244: Turn off scientific notation in JMC for attributes with long data type

### DIFF
--- a/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/internal/parser/v1/TypeManager.java
+++ b/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/internal/parser/v1/TypeManager.java
@@ -468,6 +468,7 @@ class TypeManager {
 		TypeEntry fieldType = getTypeEntry(f.classId);
 		String typeIdentifier = fieldType.element.typeIdentifier;
 		boolean isNumeric = PrimitiveReader.isNumeric(typeIdentifier);
+		boolean isLong = PrimitiveReader.isLong(typeIdentifier);
 		IValueReader reader = fieldType.getReader();
 		if (f.ticksUnitKind == UnitLookup.TIMESPAN) {
 			reader = new QuantityReader(typeIdentifier, header.getTicksTimespanUnit(), f.unsigned);
@@ -483,7 +484,7 @@ class TypeManager {
 						|| JfrInternalConstants.BCI_ID.equals(f.fieldIdentifier)
 						|| JfrInternalConstants.MODIFIERS_ID.equals(f.fieldIdentifier)
 						|| JfrInternalConstants.JAVA_THREAD_ID_ID.equals(f.fieldIdentifier)
-						|| JfrInternalConstants.CERTIFICATE_ID_ID.equals(f.fieldIdentifier)) {
+						|| JfrInternalConstants.CERTIFICATE_ID_ID.equals(f.fieldIdentifier) || isLong) {
 					reader = new PrimitiveReader(typeIdentifier);
 				} else {
 					IUnit unit = UnitLookup.getUnitOrNull(valueType);

--- a/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/internal/parser/v1/ValueReaders.java
+++ b/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/internal/parser/v1/ValueReaders.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -406,6 +406,10 @@ class ValueReaders {
 
 		static boolean isDouble(String typeIdentifier) {
 			return DOUBLE.equals(typeIdentifier);
+		}
+
+		static boolean isLong(String typeIdentifier) {
+			return LONG.equals(typeIdentifier);
 		}
 
 		static boolean isNumeric(String typeIdentifier) {

--- a/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/jdk/JdkAttributes.java
+++ b/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/jdk/JdkAttributes.java
@@ -49,6 +49,7 @@ import static org.openjdk.jmc.common.unit.UnitLookup.THREAD;
 import static org.openjdk.jmc.common.unit.UnitLookup.TIMESPAN;
 import static org.openjdk.jmc.common.unit.UnitLookup.TIMESTAMP;
 import static org.openjdk.jmc.common.unit.UnitLookup.UNKNOWN;
+import static org.openjdk.jmc.common.unit.UnitLookup.RAW_NUMBER;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -792,9 +793,27 @@ public final class JdkAttributes {
 	public static final IAttribute<String> SHUTDOWN_REASON = attr("reason", //$NON-NLS-1$
 			Messages.getString(Messages.ATTR_SHUTDOWN_REASON), Messages.getString(Messages.ATTR_SHUTDOWN_REASON_DESC),
 			PLAIN_TEXT);
-	public static final IAttribute<IQuantity> CLASSLOADER_LOADED_COUNT = attr("loadedClassCount", //$NON-NLS-1$
+	public static final IAttribute<Number> CLASSLOADER_LOADED_COUNT_NUMBER = attr("loadedClassCount", //$NON-NLS-1$
 			Messages.getString(Messages.ATTR_CLASSLOADER_LOADED_COUNT),
-			Messages.getString(Messages.ATTR_CLASSLOADER_LOADED_COUNT_DESC), NUMBER);
+			Messages.getString(Messages.ATTR_CLASSLOADER_LOADED_COUNT_DESC), RAW_NUMBER);
+
+	public static final IAttribute<IQuantity> CLASSLOADER_LOADED_COUNT = Attribute.canonicalize(
+			new Attribute<IQuantity>("loadedClassCount", Messages.getString(Messages.ATTR_CLASSLOADER_LOADED_COUNT), //$NON-NLS-1$
+					Messages.getString(Messages.ATTR_CLASSLOADER_LOADED_COUNT_DESC), NUMBER) {
+				@Override
+				public <U> IMemberAccessor<IQuantity, U> customAccessor(IType<U> type) {
+
+					final IMemberAccessor<Number, U> accessor = CLASSLOADER_LOADED_COUNT_NUMBER.getAccessor(type);
+					return accessor == null ? null : new IMemberAccessor<IQuantity, U>() {
+						@Override
+						public IQuantity getMember(U i) {
+							Number countNumber = accessor.getMember(i);
+							return countNumber == null ? null : UnitLookup.NUMBER_UNITY.quantity(countNumber);
+						}
+					};
+				}
+			});
+
 	public static final IAttribute<IQuantity> CLASSLOADER_UNLOADED_COUNT = attr("unloadedClassCount", //$NON-NLS-1$
 			Messages.getString(Messages.ATTR_CLASSLOADER_UNLOADED_COUNT),
 			Messages.getString(Messages.ATTR_CLASSLOADER_UNLOADED_COUNT_DESC), NUMBER);
@@ -1128,9 +1147,27 @@ public final class JdkAttributes {
 	public static final IAttribute<String> ENVIRONMENT_VALUE = attr("value", //$NON-NLS-1$
 			Messages.getString(Messages.ATTR_ENVIRONMENT_VALUE), PLAIN_TEXT);
 
-	public static final IAttribute<IQuantity> EXCEPTION_THROWABLES_COUNT = attr("throwables", //$NON-NLS-1$
+	public static final IAttribute<Number> EXCEPTION_THROWABLES_COUNT_NUMBER = attr("throwables", //$NON-NLS-1$
 			Messages.getString(Messages.ATTR_EXCEPTION_THROWABLES_COUNT),
-			Messages.getString(Messages.ATTR_EXCEPTION_THROWABLES_COUNT_DESC), NUMBER);
+			Messages.getString(Messages.ATTR_EXCEPTION_THROWABLES_COUNT_DESC), RAW_NUMBER);
+
+	public static final IAttribute<IQuantity> EXCEPTION_THROWABLES_COUNT = Attribute.canonicalize(
+			new Attribute<IQuantity>("throwables", Messages.getString(Messages.ATTR_EXCEPTION_THROWABLES_COUNT), //$NON-NLS-1$
+					Messages.getString(Messages.ATTR_EXCEPTION_THROWABLES_COUNT_DESC), NUMBER) {
+				@Override
+				public <U> IMemberAccessor<IQuantity, U> customAccessor(IType<U> type) {
+
+					final IMemberAccessor<Number, U> accessor = EXCEPTION_THROWABLES_COUNT_NUMBER.getAccessor(type);
+					return accessor == null ? null : new IMemberAccessor<IQuantity, U>() {
+						@Override
+						public IQuantity getMember(U i) {
+							Number countNumber = accessor.getMember(i);
+							return countNumber == null ? null : UnitLookup.NUMBER_UNITY.quantity(countNumber);
+						}
+					};
+				}
+			});
+
 	public static final IAttribute<IMCType> EXCEPTION_THROWNCLASS = attr("thrownClass", //$NON-NLS-1$
 			Messages.getString(Messages.ATTR_EXCEPTION_THROWNCLASS), CLASS);
 	public static final IAttribute<String> EXCEPTION_THROWNCLASS_NAME = Attribute.canonicalize(
@@ -1306,9 +1343,27 @@ public final class JdkAttributes {
 	public static final IAttribute<IQuantity> SAMPLE_WEIGHT = attr("weight", //$NON-NLS-1$
 			Messages.getString(Messages.ATTR_SAMPLE_WEIGHT), MEMORY);
 
-	public static final IAttribute<IQuantity> TOTAL_FINALIZERS_RUN = attr("totalFinalizersRun", //$NON-NLS-1$
+	public static final IAttribute<Number> TOTAL_FINALIZERS_RUN_NUMBER = attr("totalFinalizersRun", //$NON-NLS-1$
 			Messages.getString(Messages.ATTR_TOTAL_FINALIZERS_RUN),
-			Messages.getString(Messages.ATTR_TOTAL_FINALIZERS_RUN_DESC), NUMBER);
+			Messages.getString(Messages.ATTR_TOTAL_FINALIZERS_RUN_DESC), RAW_NUMBER);
+
+	public static final IAttribute<IQuantity> TOTAL_FINALIZERS_RUN = Attribute.canonicalize(
+			new Attribute<IQuantity>("totalFinalizersRun", Messages.getString(Messages.ATTR_TOTAL_FINALIZERS_RUN), //$NON-NLS-1$
+					Messages.getString(Messages.ATTR_TOTAL_FINALIZERS_RUN_DESC), NUMBER) {
+				@Override
+				public <U> IMemberAccessor<IQuantity, U> customAccessor(IType<U> type) {
+
+					final IMemberAccessor<Number, U> accessor = TOTAL_FINALIZERS_RUN_NUMBER.getAccessor(type);
+					return accessor == null ? null : new IMemberAccessor<IQuantity, U>() {
+						@Override
+						public IQuantity getMember(U i) {
+							Number countNumber = accessor.getMember(i);
+							return countNumber == null ? null : UnitLookup.NUMBER_UNITY.quantity(countNumber);
+						}
+					};
+				}
+			});
+
 	public static final IAttribute<IMCType> FINALIZABLE_CLASS = attr("finalizableClass", //$NON-NLS-1$
 			Messages.getString(Messages.ATTR_FINALIZABLE_CLASS),
 			Messages.getString(Messages.ATTR_FINALIZABLE_CLASS_DESC), CLASS);


### PR DESCRIPTION
This PR resolves the issue of scientific notation display for attributes with long datatype. This was the common pain-point of several customers and we were getting repeated requests of fixing this issue as they were not able to analyze the data due to this format of display. Since there is very less difference between the values of each row, after converting it to scientific notation all values look-alike and its difficult for customers to analyze the data. We have consulted the JFR team and there was a suggestion of skipping long attributes for this format display as they have followed in JFR-tools also. Same approach I have followed in JMC too. Please provide your valuable feedbacks. 

Attaching few screenshots for better reference:

Before:
<img width="464" alt="image" src="https://github.com/user-attachments/assets/44566b32-8f40-4f14-8885-c81ebd2e1d97">

After:
<img width="473" alt="image" src="https://github.com/user-attachments/assets/788785b1-d3b1-42fc-ae52-c03d01b20da2">

Before:
<img width="394" alt="image" src="https://github.com/user-attachments/assets/32568ba2-9925-4914-91db-d949f4f6d78e">

After:
<img width="385" alt="image" src="https://github.com/user-attachments/assets/90288ce2-1565-41ba-87c3-0e1fcc28b1ad">

Before:
<img width="688" alt="image" src="https://github.com/user-attachments/assets/0968b452-8097-4e71-b951-55c9996de8f6">

After:
<img width="692" alt="image" src="https://github.com/user-attachments/assets/0388ae51-dfc4-46b4-9e64-857b81da1853">

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JMC-8244](https://bugs.openjdk.org/browse/JMC-8244): Turn off scientific notation in JMC for attributes with long data type (**Enhancement** - P3)


### Reviewers
 * [Brice Dutheil](https://openjdk.org/census#bdutheil) (@bric3 - Committer)
 * [Marcus Hirt](https://openjdk.org/census#hirt) (@thegreystone - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmc.git pull/572/head:pull/572` \
`$ git checkout pull/572`

Update a local copy of the PR: \
`$ git checkout pull/572` \
`$ git pull https://git.openjdk.org/jmc.git pull/572/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 572`

View PR using the GUI difftool: \
`$ git pr show -t 572`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmc/pull/572.diff">https://git.openjdk.org/jmc/pull/572.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jmc/pull/572#issuecomment-2254620687)