### PR TITLE
8245: Improve XML processing

### DIFF
--- a/application/org.openjdk.jmc.console.agent/src/main/java/org/openjdk/jmc/console/agent/manager/model/Preset.java
+++ b/application/org.openjdk.jmc.console.agent/src/main/java/org/openjdk/jmc/console/agent/manager/model/Preset.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2020, 2021, Red Hat Inc. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Red Hat Inc. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -163,6 +163,7 @@ public class Preset implements IPreset {
 			factory.setFeature(XML_PARSER_DISALLOW_DOCTYPE_ATTRIBUTE, true);
 			factory.setXIncludeAware(false);
 			factory.setExpandEntityReferences(false);
+			factory.setValidating(true);
 			builder = factory.newDocumentBuilder();
 		} catch (ParserConfigurationException e) {
 			// This should not happen anyway
@@ -260,6 +261,7 @@ public class Preset implements IPreset {
 		try {
 			tf.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
 			tf.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
+			tf.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
 			transformer = tf.newTransformer();
 		} catch (TransformerConfigurationException e) {
 			// This should not happen anyway

--- a/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/util/XmlToolkit.java
+++ b/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/util/XmlToolkit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -198,6 +198,7 @@ public final class XmlToolkit {
 			throws SAXNotRecognizedException, SAXNotSupportedException, ParserConfigurationException {
 		SAXParserFactory factory = SAXParserFactory.newInstance();
 		factory.setFeature(XML_PARSER_DISALLOW_DOCTYPE_ATTRIBUTE, true);
+		factory.setValidating(true);
 		return factory;
 	}
 
@@ -213,6 +214,7 @@ public final class XmlToolkit {
 	public static DocumentBuilderFactory createDocumentBuildFactoryInstance() throws ParserConfigurationException {
 		DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
 		dbf.setFeature(XML_PARSER_DISALLOW_DOCTYPE_ATTRIBUTE, true);
+		dbf.setValidating(true);
 		return dbf;
 	}
 

--- a/core/org.openjdk.jmc.flightrecorder.configuration/src/main/java/org/openjdk/jmc/flightrecorder/configuration/model/xml/XMLModel.java
+++ b/core/org.openjdk.jmc.flightrecorder.configuration/src/main/java/org/openjdk/jmc/flightrecorder/configuration/model/xml/XMLModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -218,6 +218,7 @@ public final class XMLModel extends Observable {
 
 		try {
 			SAXParserFactory factory = XmlToolkit.createSAXParserFactory();
+			factory.setValidating(false);
 			factory.setNamespaceAware(true);
 			factory.setSchema(schema);
 

--- a/core/tests/org.openjdk.jmc.flightrecorder.rules.jdk.test/src/main/java/org/openjdk/jmc/flightrecorder/test/rules/jdk/TestRulesWithJfr.java
+++ b/core/tests/org.openjdk.jmc.flightrecorder.rules.jdk.test/src/main/java/org/openjdk/jmc/flightrecorder/test/rules/jdk/TestRulesWithJfr.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -51,6 +51,7 @@ import java.util.TreeMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.RunnableFuture;
 
+import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
@@ -106,6 +107,7 @@ import org.xml.sax.SAXException;
  */
 @SuppressWarnings("nls")
 public class TestRulesWithJfr {
+	private static final String XML_PARSER_DISALLOW_DOCTYPE_ATTRIBUTE = "http://apache.org/xml/features/disallow-doctype-decl"; //$NON-NLS-1$
 	private static final String JFR_RULE_BASELINE_JFR = "JfrRuleBaseline.xml";
 	private static final String BASELINE_DIR = "baseline";
 	static final String RECORDINGS_DIR = "jfr";
@@ -199,6 +201,9 @@ public class TestRulesWithJfr {
 	private static void writeDomToStream(Document doc, OutputStream os) {
 		try {
 			TransformerFactory transformerFactory = TransformerFactory.newInstance();
+			transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+			transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
+			transformerFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
 			Transformer transformer = transformerFactory.newTransformer();
 			transformer.setOutputProperty(OutputKeys.INDENT, "yes");
 			DOMSource source = new DOMSource(doc);
@@ -216,6 +221,8 @@ public class TestRulesWithJfr {
 			File dir = TestToolkit.materialize(TestRulesWithJfr.class, directory, fileName);
 			File file = new File(dir, fileName);
 			DocumentBuilderFactory docFactory = DocumentBuilderFactory.newInstance();
+			docFactory.setFeature(XML_PARSER_DISALLOW_DOCTYPE_ATTRIBUTE, true);
+			docFactory.setValidating(true);
 			DocumentBuilder docBuilder = docFactory.newDocumentBuilder();
 			Document baselineDoc = docBuilder.parse(file);
 			collection = ReportCollection.fromXml(baselineDoc, reportName);

--- a/releng/tools/org.openjdk.jmc.util.listversions/src/org/openjdk/jmc/util/listversions/ListVersions.java
+++ b/releng/tools/org.openjdk.jmc.util.listversions/src/org/openjdk/jmc/util/listversions/ListVersions.java
@@ -47,6 +47,7 @@ import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
 public class ListVersions {
+	private static final String XML_PARSER_DISALLOW_DOCTYPE_ATTRIBUTE = "http://apache.org/xml/features/disallow-doctype-decl"; //$NON-NLS-1$
 
 	public static void main(String[] args) throws IOException {
 		if (args.length != 1) {
@@ -63,6 +64,8 @@ public class ListVersions {
 			compositeZipStream.getNextEntry();
 
 			DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
+			dbFactory.setFeature(XML_PARSER_DISALLOW_DOCTYPE_ATTRIBUTE, true);
+			dbFactory.setValidating(true);
 			DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
 			Document compositeDoc = dBuilder.parse(compositeZipStream);
 

--- a/releng/tools/org.openjdk.jmc.util.releasenotes/src/org/openjdk/jmc/utils/releasenotes/Transform.java
+++ b/releng/tools/org.openjdk.jmc.util.releasenotes/src/org/openjdk/jmc/utils/releasenotes/Transform.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -115,6 +115,7 @@ public class Transform {
 		TransformerFactory transformerFactory = TransformerFactory.newInstance();
 		transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
 		transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
+		transformerFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
 		try (InputStream xslIn = newInputStream(sylesheetFile);
 				InputStream in = newInputStream(inputFile);
 				OutputStream out = newOutputStream(outputFile)) {


### PR DESCRIPTION
Improve XML processing.
Static code analyzer tool flags some issues in below classes for XML processing.

- ListVersions.java
- Preset.java
- StateToolkit.java
- TestRulesWithJfr.java
- XmlToolkit.java
- Transform.java

I have fixed all the issues by adding some attributes and features to **DocumentBuilderFactory**, **SAXParserFactory** and **TransformerFactory**.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JMC-8245](https://bugs.openjdk.org/browse/JMC-8245): Improve XML processing (**Bug** - P2)


### Reviewers
 * [Alex Macdonald](https://openjdk.org/census#aptmac) (@aptmac - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmc.git pull/574/head:pull/574` \
`$ git checkout pull/574`

Update a local copy of the PR: \
`$ git checkout pull/574` \
`$ git pull https://git.openjdk.org/jmc.git pull/574/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 574`

View PR using the GUI difftool: \
`$ git pr show -t 574`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmc/pull/574.diff">https://git.openjdk.org/jmc/pull/574.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jmc/pull/574#issuecomment-2257456485)