### PR TITLE
8114: Verify fixed uitests in ControlRecordingsTest on jdk 17

### DIFF
--- a/application/uitests/org.openjdk.jmc.flightrecorder.uitest/src/test/java/org/openjdk/jmc/flightrecorder/uitest/ControlRecordingsTest.java
+++ b/application/uitests/org.openjdk.jmc.flightrecorder.uitest/src/test/java/org/openjdk/jmc/flightrecorder/uitest/ControlRecordingsTest.java
@@ -35,7 +35,6 @@ package org.openjdk.jmc.flightrecorder.uitest;
 import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.openjdk.jmc.test.jemmy.MCJemmyTestBase;
@@ -248,7 +247,6 @@ public class ControlRecordingsTest extends MCJemmyTestBase {
 	/**
 	 * Verifies that recording events can be added/removed on the fly
 	 */
-	@Ignore("Requires a jdk17 backport of JDK-8286740")
 	@Test
 	public void modifyRecordingEvents() {
 		// Dump the test recording to get the current event settings (combined from, possibly multiple recordings)
@@ -294,7 +292,6 @@ public class ControlRecordingsTest extends MCJemmyTestBase {
 	/**
 	 * Verifies that recording event threshold settings can be modified on the fly
 	 */
-	@Ignore("Requires a jdk17 backport of JDK-8286740")
 	@Test
 	public void modifyEventThreshold() {
 		// Dump the test recording to get the current event settings (combined from, possibly multiple recordings)
@@ -333,7 +330,6 @@ public class ControlRecordingsTest extends MCJemmyTestBase {
 	/**
 	 * Verifies that recording event period settings can be modified on the fly
 	 */
-	@Ignore("Requires a jdk17 backport of JDK-8286740")
 	@Test
 	public void modifyEventPeriod() {
 		// FIXME: JMC-5207 - Remove the assume call once the GTK3 related bug has been fixed


### PR DESCRIPTION
JMC-8114 (https://bugs.openjdk.org/browse/JMC-8114) is a follow-up to JMC-8175 (https://bugs.openjdk.org/browse/JMC-8175).

There were a handful of uitests in ControlRecordingsTest that were failing, and were ignored until this backport was released in 17.0.12: https://bugs.openjdk.org/browse/JDK-8328159.

They're passing again now, so the tests can be un-ignored and run again.

Having said that, I'm running into different flightrecorder uitest failures now, but can address that in a different issue.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JMC-8114](https://bugs.openjdk.org/browse/JMC-8114): Verify fixed uitests in ControlRecordingsTest on jdk 17 (**Bug** - P4)


### Reviewers
 * [Virag Purnam](https://openjdk.org/census#vpurnam) (@viragpurnam - Committer)
 * [Marcus Hirt](https://openjdk.org/census#hirt) (@thegreystone - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmc.git pull/575/head:pull/575` \
`$ git checkout pull/575`

Update a local copy of the PR: \
`$ git checkout pull/575` \
`$ git pull https://git.openjdk.org/jmc.git pull/575/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 575`

View PR using the GUI difftool: \
`$ git pr show -t 575`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmc/pull/575.diff">https://git.openjdk.org/jmc/pull/575.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jmc/pull/575#issuecomment-2258712129)