### PR TITLE
7490: Trigger action does not return error message on failure.

### DIFF
--- a/application/org.openjdk.jmc.alert/src/main/java/org/openjdk/jmc/alert/AlertPlugin.java
+++ b/application/org.openjdk.jmc.alert/src/main/java/org/openjdk/jmc/alert/AlertPlugin.java
@@ -148,7 +148,9 @@ public class AlertPlugin extends MCAbstractUIPlugin {
 					new Object[] {df1.format(d), df2.format(d)}));
 		}
 		builder.append(NLS.bind(Messages.AlertPlugin_MESSAGE_EXCEPTION_INVOKING_ACTION, rule.getName()));
-		builder.append("\n" + triggerMessage + "\n");
+		if (triggerMessage != null) {
+			builder.append("\n" + triggerMessage + "\n");
+		}
 		builder.append(NLS.bind(Messages.AlertPlugin_MESSAGE_EXCEPTION_INVOKING_ACTION_MESSAGE_CAPTION,
 				exception.getLocalizedMessage()));
 		builder.append(Messages.AlertPlugin_MESSAGE_EXCEPTION_INVOKING_ACTION_MESSAGE_MORE_INFORMATION);

--- a/application/org.openjdk.jmc.alert/src/main/java/org/openjdk/jmc/alert/AlertPlugin.java
+++ b/application/org.openjdk.jmc.alert/src/main/java/org/openjdk/jmc/alert/AlertPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -139,7 +139,7 @@ public class AlertPlugin extends MCAbstractUIPlugin {
 		}
 	}
 
-	private String createExceptionMessage(Date d, Throwable exception, TriggerRule rule) {
+	private String createExceptionMessage(Date d, Throwable exception, TriggerRule rule, String triggerMessage) {
 		StringBuilder builder = new StringBuilder();
 		if (d != null) {
 			DateFormat df1 = DateFormat.getDateInstance(DateFormat.SHORT);
@@ -148,6 +148,7 @@ public class AlertPlugin extends MCAbstractUIPlugin {
 					new Object[] {df1.format(d), df2.format(d)}));
 		}
 		builder.append(NLS.bind(Messages.AlertPlugin_MESSAGE_EXCEPTION_INVOKING_ACTION, rule.getName()));
+		builder.append("\n" + triggerMessage + "\n");
 		builder.append(NLS.bind(Messages.AlertPlugin_MESSAGE_EXCEPTION_INVOKING_ACTION_MESSAGE_CAPTION,
 				exception.getLocalizedMessage()));
 		builder.append(Messages.AlertPlugin_MESSAGE_EXCEPTION_INVOKING_ACTION_MESSAGE_MORE_INFORMATION);
@@ -183,8 +184,7 @@ public class AlertPlugin extends MCAbstractUIPlugin {
 			DisplayToolkit.safeAsyncExec(PlatformUI.getWorkbench().getDisplay(), new Runnable() {
 				@Override
 				public void run() {
-					Display display = PlatformUI.getWorkbench().getDisplay();
-					Shell shell = display.getActiveShell();
+					Shell shell = PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell();
 					if (shell != null && !shell.isDisposed()) {
 						if (!hasDialog()) {
 							dialog = createDialog(shell);
@@ -214,9 +214,8 @@ public class AlertPlugin extends MCAbstractUIPlugin {
 
 	public static AlertDialog createDialog(Shell shell) {
 		Display display = PlatformUI.getWorkbench().getDisplay();
-		if (display != null && !display.isDisposed() && display.getActiveShell() != null
-				&& !display.getActiveShell().isDisposed()) {
-			return new AlertDialog(display.getActiveShell());
+		if (display != null && !display.isDisposed()) {
+			return new AlertDialog(shell);
 		} else {
 			return null;
 		}
@@ -241,7 +240,8 @@ public class AlertPlugin extends MCAbstractUIPlugin {
 		reg.put(IMAGE_ALERT_BANNER, getImageDescriptor("icons/trigger-alerts-wiz.gif").createImage()); //$NON-NLS-1$
 	}
 
-	public synchronized void addException(IConnectionHandle connectionHandle, TriggerRule rule, Throwable throwable) {
+	public synchronized void addException(
+		IConnectionHandle connectionHandle, TriggerRule rule, Throwable throwable, String triggerMessage) {
 		// FIXME: JMC-4270 - Server time approximation is not reliable
 //		IMBeanHelperService mhs = connectionHandle.getServiceOrNull(IMBeanHelperService.class);
 //		long timestamp = 0;
@@ -253,6 +253,6 @@ public class AlertPlugin extends MCAbstractUIPlugin {
 //		Date creationDate = new Date(timestamp);
 		Date creationDate = new Date();
 		addAlertObject(new AlertObject(creationDate, connectionHandle.getServerDescriptor().getDisplayName(), rule,
-				createExceptionMessage(creationDate, throwable, rule), throwable));
+				createExceptionMessage(creationDate, throwable, rule, triggerMessage), throwable));
 	}
 }

--- a/application/org.openjdk.jmc.alert/src/main/java/org/openjdk/jmc/alert/ExceptionHandler.java
+++ b/application/org.openjdk.jmc.alert/src/main/java/org/openjdk/jmc/alert/ExceptionHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -38,7 +38,8 @@ import org.openjdk.jmc.rjmx.triggers.TriggerRule;
 
 public class ExceptionHandler implements IExceptionHandler {
 	@Override
-	public void handleException(IConnectionHandle connectionHandle, TriggerRule rule, Throwable throwable) {
-		AlertPlugin.getDefault().addException(connectionHandle, rule, throwable);
+	public void handleException(
+		IConnectionHandle connectionHandle, TriggerRule rule, Throwable throwable, String triggerMessage) {
+		AlertPlugin.getDefault().addException(connectionHandle, rule, throwable, triggerMessage);
 	}
 }

--- a/application/org.openjdk.jmc.alert/src/main/java/org/openjdk/jmc/alert/TriggerActionThreadStackDump.java
+++ b/application/org.openjdk.jmc.alert/src/main/java/org/openjdk/jmc/alert/TriggerActionThreadStackDump.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -81,7 +81,7 @@ public class TriggerActionThreadStackDump extends TriggerAction {
 				data += "\n\n"; //$NON-NLS-1$
 			}
 			InputStream stream = new ByteArrayInputStream(data.getBytes(StandardCharsets.UTF_8));
-			IDESupportToolkit.writeAsJob(jobName, file, stream, isAppend());
+			IDESupportToolkit.writeAsJob(jobName, file, stream, isAppend(), data);
 		} else {
 			LOGGER.info(data);
 		}

--- a/application/org.openjdk.jmc.console.ui.notification/plugin.xml
+++ b/application/org.openjdk.jmc.console.ui.notification/plugin.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--   
-   Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+   Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
    
    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
    
@@ -87,7 +87,7 @@
             name="%TRIGGER_ACTION_DUMP_JFR_NAME">
          <file
                description="%TRIGGER_ACTION_DUMP_JFR_FILE_DESCRIPTION"
-               id="file"
+               id="dumpfilename"
                name="%TRIGGER_ACTION_DUMP_JFR_FILE"
                value="automaticallyTriggeredRecording.jfr"/>
          <timerange
@@ -127,7 +127,7 @@
 	  	    value="My Recording"/>
       <file
             description="%TRIGGER_ACTION_START_TIME_JFR_FILE_DESCRIPTION"
-            id="file"
+            id="recordingfilename"
             name="%TRIGGER_ACTION_START_TIME_JFR_FILE"
             value="automaticallyTriggeredRecording.jfr"/>
 	  <timerange

--- a/application/org.openjdk.jmc.console.ui.notification/src/main/java/org/openjdk/jmc/console/ui/notification/action/TriggerActionDumpRecording.java
+++ b/application/org.openjdk.jmc.console.ui.notification/src/main/java/org/openjdk/jmc/console/ui/notification/action/TriggerActionDumpRecording.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -85,7 +85,7 @@ public class TriggerActionDumpRecording extends TriggerAction {
 	}
 
 	protected Job createDumpFlightRecordingJob(final TriggerEvent event, final IFlightRecorderService service) {
-		MCFile path = IDESupportToolkit.createFileResource(getSetting("file").getFileName()); //$NON-NLS-1$
+		MCFile path = IDESupportToolkit.createFileResource(getSetting("dumpfilename").getFileName()); //$NON-NLS-1$
 		IQuantity timerange = getSetting("timerange").getQuantity(); //$NON-NLS-1$
 		Boolean open = getSetting("open").getBoolean(); //$NON-NLS-1$
 		return new WriteAndOpenRecordingJob(

--- a/application/org.openjdk.jmc.console.ui.notification/src/main/java/org/openjdk/jmc/console/ui/notification/action/WriteAndOpenRecordingJob.java
+++ b/application/org.openjdk.jmc.console.ui.notification/src/main/java/org/openjdk/jmc/console/ui/notification/action/WriteAndOpenRecordingJob.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -53,6 +53,7 @@ import org.openjdk.jmc.flightrecorder.configuration.IRecordingDescriptor;
 import org.openjdk.jmc.rjmx.RJMXPlugin;
 import org.openjdk.jmc.rjmx.common.services.jfr.FlightRecorderToolkit;
 import org.openjdk.jmc.rjmx.triggers.TriggerEvent;
+import org.openjdk.jmc.rjmx.triggers.internal.NotificationToolkit;
 import org.openjdk.jmc.ui.MCPathEditorInput;
 import org.openjdk.jmc.ui.WorkbenchToolkit;
 import org.openjdk.jmc.ui.common.idesupport.IDESupportToolkit;
@@ -80,6 +81,7 @@ public class WriteAndOpenRecordingJob extends Job {
 	@Override
 	protected IStatus run(IProgressMonitor monitor) {
 		String recordingName;
+		String triggerMessage = NotificationToolkit.prettyPrint(event);
 		try {
 			IRecordingDescriptor descriptor = findRecording();
 			if (descriptor == null) {
@@ -98,8 +100,9 @@ public class WriteAndOpenRecordingJob extends Job {
 			// Want non-localized message in the log!
 			RJMXPlugin.getDefault().getLogger().log(Level.SEVERE, "Could not dump recording. Faulty rule in console?", //$NON-NLS-1$
 					e);
-			return new Status(IStatus.ERROR, NotificationPlugin.PLUGIN_ID,
-					NLS.bind(Messages.WriteAndOpenRecordingJob_ERROR_MESSAGE_DUMPING_RECORDING, serverName), e);
+			return new Status(IStatus.ERROR, NotificationPlugin.PLUGIN_ID, NLS.bind(
+					"\n" + triggerMessage + "\n" + Messages.WriteAndOpenRecordingJob_ERROR_MESSAGE_DUMPING_RECORDING,
+					serverName), e);
 		}
 		return new Status(IStatus.OK, NotificationPlugin.PLUGIN_ID,
 				NLS.bind(Messages.WriteAndOpenRecordingJob_MESSAGE_SUCCESSFUL_DUMP, recordingName));

--- a/application/org.openjdk.jmc.rjmx/META-INF/MANIFEST.MF
+++ b/application/org.openjdk.jmc.rjmx/META-INF/MANIFEST.MF
@@ -7,7 +7,8 @@ Bundle-Version: 9.1.0.qualifier
 Bundle-Activator: org.openjdk.jmc.rjmx.RJMXPlugin
 Eclipse-BuddyPolicy: app
 Import-Package: jakarta.mail,
- jakarta.mail.internet
+ jakarta.mail.internet,
+ org.eclipse.swt.widgets
 Export-Package: org.openjdk.jmc.rjmx,
  org.openjdk.jmc.rjmx.actionprovider;
   x-friends:="org.openjdk.jmc.console.ui,

--- a/application/org.openjdk.jmc.rjmx/plugin.xml
+++ b/application/org.openjdk.jmc.rjmx/plugin.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--   
-   Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+   Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
    
    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
    
@@ -362,7 +362,7 @@
             id="org.openjdk.jmc.rjmx.triggers.actions.internal.TriggerActionLogToFile">
          <file
                description="%TRIGGER_ACTION_LOG_TO_FILE_FILENAME_DESCRIPTION"
-               id="filename"
+               id="logfilename"
                name="%TRIGGER_ACTION_LOG_TO_FILE_FILENAME_NAME"
                value="log.txt">
          </file>

--- a/application/org.openjdk.jmc.rjmx/src/main/java/org/openjdk/jmc/rjmx/triggers/IExceptionHandler.java
+++ b/application/org.openjdk.jmc.rjmx/src/main/java/org/openjdk/jmc/rjmx/triggers/IExceptionHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -35,5 +35,6 @@ package org.openjdk.jmc.rjmx.triggers;
 import org.openjdk.jmc.rjmx.common.IConnectionHandle;
 
 public interface IExceptionHandler {
-	void handleException(IConnectionHandle connectionHandle, TriggerRule rule, Throwable throwable);
+	void handleException(
+		IConnectionHandle connectionHandle, TriggerRule rule, Throwable throwable, String triggerMessage);
 }

--- a/application/org.openjdk.jmc.rjmx/src/main/java/org/openjdk/jmc/rjmx/triggers/actions/internal/Messages.java
+++ b/application/org.openjdk.jmc.rjmx/src/main/java/org/openjdk/jmc/rjmx/triggers/actions/internal/Messages.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -46,6 +46,8 @@ public class Messages extends NLS {
 	public static String TriggerActionMail_SUBJECT_TRIGGERED;
 	public static String TriggerActionSystemOut_FOOTER;
 	public static String TriggerActionSystemOut_HEADER;
+	public static String TriggerActionValidator_INVALID_PATH;
+	public static String TriggerActionValidator_INVALID_EMAIL;
 
 	static {
 		NLS.initializeMessages(BUNDLE_NAME, Messages.class);

--- a/application/org.openjdk.jmc.rjmx/src/main/java/org/openjdk/jmc/rjmx/triggers/actions/internal/TriggerActionDiagnosticCommand.java
+++ b/application/org.openjdk.jmc.rjmx/src/main/java/org/openjdk/jmc/rjmx/triggers/actions/internal/TriggerActionDiagnosticCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -40,6 +40,7 @@ import org.openjdk.jmc.rjmx.common.IConnectionHandle;
 import org.openjdk.jmc.rjmx.common.services.IDiagnosticCommandService;
 import org.openjdk.jmc.rjmx.triggers.TriggerAction;
 import org.openjdk.jmc.rjmx.triggers.TriggerEvent;
+import org.openjdk.jmc.rjmx.triggers.internal.NotificationToolkit;
 import org.openjdk.jmc.ui.common.idesupport.IDESupportToolkit;
 import org.openjdk.jmc.ui.common.resource.MCFile;
 
@@ -52,12 +53,13 @@ public class TriggerActionDiagnosticCommand extends TriggerAction {
 		String result = (e.getSource().getServiceOrThrow(IDiagnosticCommandService.class))
 				.runCtrlBreakHandlerWithResult(command);
 		InputStream stream = new ByteArrayInputStream(result.getBytes(StandardCharsets.UTF_8));
+		String triggerMessage = NotificationToolkit.prettyPrint(e);
 
 		synchronized (this) {
 			MCFile file = IDESupportToolkit.createFileResource(getLogFileName());
 			String jobName = append ? Messages.TriggerActionDiagnosticCommand_APPEND_ACTION_TEXT
 					: Messages.TriggerActionDiagnosticCommand_WRITE_ACTION_TEXT;
-			IDESupportToolkit.writeAsJob(jobName, file, stream, append);
+			IDESupportToolkit.writeAsJob(jobName, file, stream, append, triggerMessage);
 		}
 	}
 

--- a/application/org.openjdk.jmc.rjmx/src/main/java/org/openjdk/jmc/rjmx/triggers/actions/internal/TriggerActionLogToFile.java
+++ b/application/org.openjdk.jmc.rjmx/src/main/java/org/openjdk/jmc/rjmx/triggers/actions/internal/TriggerActionLogToFile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -56,11 +56,12 @@ public class TriggerActionLogToFile extends TriggerAction {
 	 */
 	@Override
 	public void handleNotificationEvent(TriggerEvent e) {
-		String fileName = getSetting("filename").getFileName(); //$NON-NLS-1$
+		String fileName = getSetting("logfilename").getFileName(); //$NON-NLS-1$
 		MCFile file = IDESupportToolkit.createFileResource(fileName);
+		String triggerMessage = NotificationToolkit.prettyPrint(e);
 		InputStream stream = new ByteArrayInputStream(getString(e).getBytes(StandardCharsets.UTF_8));
 		String jobName = NLS.bind(Messages.TriggerActionLogToFile_JOBNAME, file.getPath());
-		IDESupportToolkit.writeAsJob(jobName, file, stream, true);
+		IDESupportToolkit.writeAsJob(jobName, file, stream, true, triggerMessage);
 	}
 
 	/**

--- a/application/org.openjdk.jmc.rjmx/src/main/java/org/openjdk/jmc/rjmx/triggers/actions/internal/TriggerActionValidator.java
+++ b/application/org.openjdk.jmc.rjmx/src/main/java/org/openjdk/jmc/rjmx/triggers/actions/internal/TriggerActionValidator.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * 
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * The contents of this file are subject to the terms of either the Universal Permissive License
+ * v 1.0 as shown at http://oss.oracle.com/licenses/upl
+ *
+ * or the following license:
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted
+ * provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions
+ * and the following disclaimer.
+ * 
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other materials provided with
+ * the distribution.
+ * 
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to
+ * endorse or promote products derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+ * WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.openjdk.jmc.rjmx.triggers.actions.internal;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Status;
+import org.eclipse.core.runtime.jobs.Job;
+import org.eclipse.osgi.util.NLS;
+import org.eclipse.swt.widgets.Display;
+import org.openjdk.jmc.rjmx.triggers.fields.internal.Field;
+import org.openjdk.jmc.ui.common.CorePlugin;
+
+public class TriggerActionValidator extends Job {
+
+	private final String name;
+	private final Field field;
+
+	public TriggerActionValidator(String name, Field field) {
+		super(name);
+		this.name = name;
+		this.field = field;
+	}
+
+	@Override
+	protected IStatus run(IProgressMonitor monitor) {
+		if (this.name.equals("PathValidation")) {
+			Path filePath = Paths.get(field.getValue());
+			Path root = filePath.getRoot();
+			if (root != null) {
+				File driveFile = new File(root.toString());
+				if (!driveFile.exists()) {
+					setDefaultValue();
+					return new Status(IStatus.ERROR, CorePlugin.PLUGIN_ID,
+							NLS.bind(Messages.TriggerActionValidator_INVALID_PATH, field.getValue()),
+							new Exception(NLS.bind(Messages.TriggerActionValidator_INVALID_PATH, field.getValue())));
+				}
+			}
+		} else if (this.name.equals("EmailValidation")) {
+			String value = field.getValue();
+			if (!value.isEmpty()) {
+				String[] split = value.split(",|;|\\s");
+				for (String sp : split) {
+					String REGEX = "^[a-zA-Z0-9_+&*-]+(?:\\.[a-zA-Z0-9_+&*-]+)*@(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,7}$";
+					boolean matches = sp.trim().matches(REGEX);
+					if (!matches) {
+						setDefaultValue();
+						return new Status(IStatus.ERROR, CorePlugin.PLUGIN_ID,
+								NLS.bind(Messages.TriggerActionValidator_INVALID_EMAIL, field.getValue()),
+								new Exception(
+										NLS.bind(Messages.TriggerActionValidator_INVALID_EMAIL, field.getValue())));
+					}
+				}
+			}
+		}
+		return new Status(IStatus.OK, CorePlugin.PLUGIN_ID, "");
+	}
+
+	private void setDefaultValue() {
+
+		switch (field.getId()) {
+		case "dumpfilename":
+			setDefaultValue("automaticallyTriggeredRecording.jfr");
+			break;
+
+		case "recordingfilename":
+			setDefaultValue("automaticallyTriggeredRecording.jfr");
+			break;
+
+		case "filename":
+			setDefaultValue("default.hprof");
+			break;
+
+		case "log_file":
+			setDefaultValue("command.log");
+			break;
+
+		case "logfilename":
+			setDefaultValue("log.txt");
+			break;
+
+		default:
+			setDefaultValue("");
+		}
+	}
+
+	private void setDefaultValue(String value) {
+		Display.getDefault().asyncExec(new Runnable() {
+			public void run() {
+				field.setValue(value);
+			}
+		});
+	}
+
+}

--- a/application/org.openjdk.jmc.rjmx/src/main/java/org/openjdk/jmc/rjmx/triggers/internal/DefaultExceptionHandler.java
+++ b/application/org.openjdk.jmc.rjmx/src/main/java/org/openjdk/jmc/rjmx/triggers/internal/DefaultExceptionHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -41,7 +41,8 @@ import org.openjdk.jmc.rjmx.triggers.TriggerRule;
 
 public class DefaultExceptionHandler implements IExceptionHandler {
 	@Override
-	public void handleException(IConnectionHandle connectionHandle, TriggerRule rule, Throwable throwable) {
+	public void handleException(
+		IConnectionHandle connectionHandle, TriggerRule rule, Throwable throwable, String triggerMessage) {
 		RJMXPlugin.getDefault().getLogger().log(Level.SEVERE, "Could not invoke the action for the rule " //$NON-NLS-1$
 				+ rule.toString(), throwable);
 	}

--- a/application/org.openjdk.jmc.rjmx/src/main/java/org/openjdk/jmc/rjmx/triggers/internal/NotificationTrigger.java
+++ b/application/org.openjdk.jmc.rjmx/src/main/java/org/openjdk/jmc/rjmx/triggers/internal/NotificationTrigger.java
@@ -238,7 +238,7 @@ public class NotificationTrigger implements ITrigger {
 			if (stateStore.m_lastTriggerErrorTimestamp == null || (aspectEvent.getTimestamp()
 					- stateStore.m_lastTriggerErrorTimestamp >= TRIGGER_ERROR_HANDLING_LIMIT_TIME_MS)) {
 				stateStore.m_lastTriggerErrorTimestamp = aspectEvent.getTimestamp();
-				handleException(connectionHandle, rule, e, "");
+				handleException(connectionHandle, rule, e, null);
 			}
 			return;
 		}

--- a/application/org.openjdk.jmc.rjmx/src/main/java/org/openjdk/jmc/rjmx/triggers/internal/NotificationTrigger.java
+++ b/application/org.openjdk.jmc.rjmx/src/main/java/org/openjdk/jmc/rjmx/triggers/internal/NotificationTrigger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -238,7 +238,7 @@ public class NotificationTrigger implements ITrigger {
 			if (stateStore.m_lastTriggerErrorTimestamp == null || (aspectEvent.getTimestamp()
 					- stateStore.m_lastTriggerErrorTimestamp >= TRIGGER_ERROR_HANDLING_LIMIT_TIME_MS)) {
 				stateStore.m_lastTriggerErrorTimestamp = aspectEvent.getTimestamp();
-				handleException(connectionHandle, rule, e);
+				handleException(connectionHandle, rule, e, "");
 			}
 			return;
 		}
@@ -324,19 +324,21 @@ public class NotificationTrigger implements ITrigger {
 		stateStore.m_triggerState = triggState;
 		if (notificationEnabled) {
 			stateStore.m_lastTriggerEventTimestamp = aspectEvent.getTimestamp();
+			String triggerMessage = NotificationToolkit.prettyPrint(event);
 			// FIXME: The invocation of the actions should be added to a queue and dispatched in a separate thread
 			try {
 				rule.getAction().handleNotificationEvent(event);
 			} catch (Throwable e) {
-				handleException(connectionHandle, rule, e);
+				handleException(connectionHandle, rule, e, triggerMessage);
 			}
 		}
 	}
 
-	private void handleException(IConnectionHandle connectionHandle, TriggerRule rule, Throwable e) {
+	private void handleException(
+		IConnectionHandle connectionHandle, TriggerRule rule, Throwable e, String triggerMessage) {
 		IExceptionHandler[] handlers = getExceptionHandlers();
 		for (IExceptionHandler handler : handlers) {
-			handler.handleException(connectionHandle, rule, e);
+			handler.handleException(connectionHandle, rule, e, triggerMessage);
 		}
 	}
 

--- a/application/org.openjdk.jmc.rjmx/src/main/resources/org/openjdk/jmc/rjmx/triggers/actions/internal/messages.properties
+++ b/application/org.openjdk.jmc.rjmx/src/main/resources/org/openjdk/jmc/rjmx/triggers/actions/internal/messages.properties
@@ -1,5 +1,5 @@
 #
-#  Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+#  Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
 #
 #  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
@@ -39,3 +39,5 @@ TriggerActionMail_SUBJECT_INVOKED=The rule "{0}" was invoked!
 TriggerActionSystemOut_HEADER=========== Notification Alert! ==========\n
 TriggerActionSystemOut_FOOTER==========================================\n\n
 TriggerActionLogToFile_JOBNAME=Writing notification to {0}
+TriggerActionValidator_INVALID_PATH=Invalid path {0}
+TriggerActionValidator_INVALID_EMAIL=Invalid email {0}

--- a/application/org.openjdk.jmc.ui.common/src/main/java/org/openjdk/jmc/ui/common/idesupport/IDESupportToolkit.java
+++ b/application/org.openjdk.jmc.ui.common/src/main/java/org/openjdk/jmc/ui/common/idesupport/IDESupportToolkit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -77,8 +77,9 @@ public final class IDESupportToolkit {
 	 *            {@code true} if the file should be appended, {@code false} if it should be
 	 *            overwritten
 	 */
-	public static Job writeAsJob(String jobName, MCFile file, InputStream stream, boolean append) {
-		Job writeJob = new JobFileWrite(jobName, file, stream, append);
+	public static Job writeAsJob(
+		String jobName, MCFile file, InputStream stream, boolean append, String triggerMessage) {
+		Job writeJob = new JobFileWrite(jobName, file, stream, append, triggerMessage);
 		writeJob.schedule();
 		return writeJob;
 	}

--- a/application/org.openjdk.jmc.ui.common/src/main/java/org/openjdk/jmc/ui/common/idesupport/JobFileWrite.java
+++ b/application/org.openjdk.jmc.ui.common/src/main/java/org/openjdk/jmc/ui/common/idesupport/JobFileWrite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -33,6 +33,7 @@
 package org.openjdk.jmc.ui.common.idesupport;
 
 import java.io.InputStream;
+
 import java.util.logging.Level;
 
 import org.eclipse.core.runtime.IProgressMonitor;
@@ -52,6 +53,7 @@ final class JobFileWrite extends Job {
 	private final MCFile file;
 	private final InputStream stream;
 	private final boolean append;
+	private final String triggerMessage;
 
 	/**
 	 * @param jobName
@@ -64,11 +66,12 @@ final class JobFileWrite extends Job {
 	 *            {@code true} if the file should be appended, {@code false} if it should be
 	 *            overwritten
 	 */
-	JobFileWrite(String jobName, MCFile file, InputStream stream, boolean append) {
+	JobFileWrite(String jobName, MCFile file, InputStream stream, boolean append, String triggerMessage) {
 		super(jobName);
 		this.file = file;
 		this.stream = stream;
 		this.append = append;
+		this.triggerMessage = triggerMessage;
 	}
 
 	@Override
@@ -78,8 +81,8 @@ final class JobFileWrite extends Job {
 		} catch (Exception e) {
 			// Want non-localized message in the log!
 			CorePlugin.getDefault().getLogger().log(Level.SEVERE, "Could not write the specified file!", e); //$NON-NLS-1$
-			return new Status(IStatus.ERROR, CorePlugin.PLUGIN_ID,
-					NLS.bind(Messages.JobFileWrite_ERROR_FILE_WRITE_FAILED, file.getPath()), e);
+			return new Status(IStatus.ERROR, CorePlugin.PLUGIN_ID, NLS.bind(
+					"\n" + triggerMessage + "\n" + Messages.JobFileWrite_ERROR_FILE_WRITE_FAILED, file.getPath()), e);
 		} finally {
 			IOToolkit.closeSilently(stream);
 		}


### PR DESCRIPTION
If trigger action encounters any exception/error, it does not display the trigger value. On failure with the failure message, trigger value also should be displayed for the user. 

For example, if we are writing log to the drive which does not exists. Trigger action fails with IO exception. 

<img width="563" alt="FileWriteExceptionWithoutShowingTriggerValue" src="https://github.com/user-attachments/assets/9ec6b71e-ba14-432a-b51b-3865327cdeac">

With this change, trigger value has been displayed along with IO exception.

<img width="594" alt="FileWriteExceptionShowingTriggerValue" src="https://github.com/user-attachments/assets/f026e9ca-56f7-44a1-8af9-ea2d1018f34c">


This change has been done for all the trigger actions. 


Along with this, few basic path and email validation has been added.

Path validation:

<img width="523" alt="PathValidation" src="https://github.com/user-attachments/assets/839c97eb-940f-4a90-ba22-bf1bc654e06c">

Email validation:

<img width="574" alt="EmailValidation" src="https://github.com/user-attachments/assets/1b99889a-4d3e-4a51-a990-10f24376a7c3">

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JMC-7490](https://bugs.openjdk.org/browse/JMC-7490): Trigger action does not return error message on failure. (**Bug** - P3)


### Reviewers
 * [Marcus Hirt](https://openjdk.org/census#hirt) (@thegreystone - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmc.git pull/581/head:pull/581` \
`$ git checkout pull/581`

Update a local copy of the PR: \
`$ git checkout pull/581` \
`$ git pull https://git.openjdk.org/jmc.git pull/581/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 581`

View PR using the GUI difftool: \
`$ git pr show -t 581`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmc/pull/581.diff">https://git.openjdk.org/jmc/pull/581.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jmc/pull/581#issuecomment-2325838559)