### PR TITLE
8251: Add missing hook in plugin from Jolokia discovery

### DIFF
--- a/application/org.openjdk.jmc.jolokia/plugin.xml
+++ b/application/org.openjdk.jmc.jolokia/plugin.xml
@@ -56,4 +56,10 @@
                class="org.openjdk.jmc.jolokia.preferences.PreferenceInitializer">
          </initializer>
       </extension>
+            <extension
+         point="org.openjdk.jmc.rjmx.descriptorProvider">
+      <provider
+            class="org.openjdk.jmc.jolokia.JolokiaDiscoveryListener">
+      </provider>
+   </extension>
 </plugin>

--- a/application/org.openjdk.jmc.jolokia/plugin.xml
+++ b/application/org.openjdk.jmc.jolokia/plugin.xml
@@ -34,29 +34,29 @@
 -->
 <?eclipse version="3.4"?>
 <plugin>
-      <extension
+   <extension
          point="org.openjdk.jmc.rjmx.jmxProtocols">
       <client
             class="org.openjdk.jmc.jolokia.JmcJolokiaJmxConnectionProvider" protocol="jolokia">
-            <sysproperty name="running.in.jmc" include="true" />
+         <sysproperty name="running.in.jmc" include="true" />
       </client>
    </extension>
-      <extension
-            point="org.eclipse.ui.preferencePages">
-         <page
-               category="org.openjdk.jmc.browser.preferences.BrowserPreferencePage"
-               class="org.openjdk.jmc.jolokia.preferences.JolokiaPreferencePage"
-               id="org.openjdk.jmc.jolokia.preferences.JolokiaPreferencePage"
-               name="%page.name">
-         </page>
-      </extension>
-      <extension
-            point="org.eclipse.core.runtime.preferences">
-         <initializer
-               class="org.openjdk.jmc.jolokia.preferences.PreferenceInitializer">
-         </initializer>
-      </extension>
-            <extension
+   <extension
+         point="org.eclipse.ui.preferencePages">
+      <page
+            category="org.openjdk.jmc.browser.preferences.BrowserPreferencePage"
+            class="org.openjdk.jmc.jolokia.preferences.JolokiaPreferencePage"
+            id="org.openjdk.jmc.jolokia.preferences.JolokiaPreferencePage"
+            name="%page.name">
+      </page>
+   </extension>
+  <extension
+        point="org.eclipse.core.runtime.preferences">
+     <initializer
+           class="org.openjdk.jmc.jolokia.preferences.PreferenceInitializer">
+     </initializer>
+   </extension>
+   <extension
          point="org.openjdk.jmc.rjmx.descriptorProvider">
       <provider
             class="org.openjdk.jmc.jolokia.JolokiaDiscoveryListener">

--- a/application/org.openjdk.jmc.jolokia/plugin.xml
+++ b/application/org.openjdk.jmc.jolokia/plugin.xml
@@ -50,7 +50,7 @@
             name="%page.name">
       </page>
    </extension>
-  <extension
+   <extension
         point="org.eclipse.core.runtime.preferences">
      <initializer
            class="org.openjdk.jmc.jolokia.preferences.PreferenceInitializer">


### PR DESCRIPTION
This got left out of #570 . All the test runs fine, but the mechansim was not properly plugged in :facepalm: 
cc: @aptmac

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JMC-8251](https://bugs.openjdk.org/browse/JMC-8251): Add missing hook in plugin from Jolokia discovery (**Bug** - P4)


### Reviewers
 * [Alex Macdonald](https://openjdk.org/census#aptmac) (@aptmac - **Reviewer**) ⚠️ Review applies to [fb70cb4b](https://git.openjdk.org/jmc/pull/583/files/fb70cb4b59d68a48de65f525f2e81f7d7fa6dc48)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmc.git pull/583/head:pull/583` \
`$ git checkout pull/583`

Update a local copy of the PR: \
`$ git checkout pull/583` \
`$ git pull https://git.openjdk.org/jmc.git pull/583/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 583`

View PR using the GUI difftool: \
`$ git pr show -t 583`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmc/pull/583.diff">https://git.openjdk.org/jmc/pull/583.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jmc/pull/583#issuecomment-2330817449)