### PR TITLE
8254: Allow primitive types in converters

### DIFF
--- a/agent/src/main/java/org/openjdk/jmc/agent/impl/ResolvedConvertable.java
+++ b/agent/src/main/java/org/openjdk/jmc/agent/impl/ResolvedConvertable.java
@@ -136,6 +136,25 @@ public final class ResolvedConvertable extends AbstractConvertable implements Co
 	}
 
 	private static Class<?> getClassFromType(Type type) throws MalformedConverterException {
+		switch (type.getClassName()) {
+		case "boolean":
+			return boolean.class;
+		case "byte":
+			return byte.class;
+		case "short":
+			return short.class;
+		case "char":
+			return char.class;
+		case "int":
+			return int.class;
+		case "float":
+			return float.class;
+		case "long":
+			return long.class;
+		case "double":
+			return double.class;
+		}
+
 		try {
 			return Class.forName(type.getClassName());
 		} catch (ClassNotFoundException e) {

--- a/agent/src/main/java/org/openjdk/jmc/agent/impl/ResolvedConvertable.java
+++ b/agent/src/main/java/org/openjdk/jmc/agent/impl/ResolvedConvertable.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2020, Datadog, Inc. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Datadog, Inc. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/agent/src/test/java/org/openjdk/jmc/agent/converters/test/GurkMultiDefaultConverter.java
+++ b/agent/src/test/java/org/openjdk/jmc/agent/converters/test/GurkMultiDefaultConverter.java
@@ -78,7 +78,7 @@ public class GurkMultiDefaultConverter {
 	}
 
 	public static String convert(char c) {
-		return "" + c;
+		return String.valueOf(c);
 	}
 
 	public static long convert(int i) {
@@ -86,7 +86,7 @@ public class GurkMultiDefaultConverter {
 	}
 
 	public static int convert(float f) {
-		return (int) f;
+		return Math.round(f);
 	}
 
 	public static String convert(long l) {

--- a/agent/src/test/java/org/openjdk/jmc/agent/converters/test/GurkMultiDefaultConverter.java
+++ b/agent/src/test/java/org/openjdk/jmc/agent/converters/test/GurkMultiDefaultConverter.java
@@ -33,6 +33,8 @@
  */
 package org.openjdk.jmc.agent.converters.test;
 
+import java.util.Date;
+
 import org.openjdk.jmc.agent.test.Gurka;
 
 /**
@@ -61,5 +63,37 @@ public class GurkMultiDefaultConverter {
 
 	public static int convert(Long value) {
 		return value.intValue();
+	}
+
+	public static String convert(boolean b) {
+		return Boolean.toString(b);
+	}
+
+	public static String convert(byte b) {
+		return Byte.toString(b);
+	}
+
+	public static String convert(short s) {
+		return Short.toString(s);
+	}
+
+	public static String convert(char c) {
+		return "" + c;
+	}
+
+	public static long convert(int i) {
+		return i;
+	}
+
+	public static int convert(float f) {
+		return (int) f;
+	}
+
+	public static String convert(long l) {
+		return new Date(l).toString();
+	}
+
+	public static String convert(double d) {
+		return Integer.toString((int) d);
 	}
 }

--- a/agent/src/test/java/org/openjdk/jmc/agent/converters/test/GurkMultiDefaultConverter.java
+++ b/agent/src/test/java/org/openjdk/jmc/agent/converters/test/GurkMultiDefaultConverter.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2020, Datadog, Inc. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Datadog, Inc. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/agent/src/test/java/org/openjdk/jmc/agent/converters/test/InstrumentMeConverter.java
+++ b/agent/src/test/java/org/openjdk/jmc/agent/converters/test/InstrumentMeConverter.java
@@ -77,6 +77,14 @@ public class InstrumentMeConverter {
 					printClassGurka(Gurka.createGurka());
 					innerClass.switchGurka();
 					innerClass.instrumentationPoint();
+					printBooleanMultiDefault((TestToolkit.randomLong() & 1) == 0);
+					printByteMultiDefault((byte) (TestToolkit.randomLong() & 255));
+					printShortMultiDefault((short) (TestToolkit.randomLong() & 255));
+					printCharMultiDefault(Double.toString(TestToolkit.randomLong()).charAt(0));
+					printIntMultiDefault((int) TestToolkit.randomLong());
+					printFloatMultiDefault((float) Math.random());
+					printLongMultiDefault(System.currentTimeMillis());
+					printDoubleMultiDefault(Math.random() * 500 - 250);
 				} catch (InterruptedException e) {
 				} catch (URISyntaxException e) {
 				}
@@ -171,6 +179,46 @@ public class InstrumentMeConverter {
 
 	public static void printClassGurka(Gurka createGurka) throws InterruptedException {
 		System.out.println("C The class of Gurka is: " + createGurka.getClass().getName());
+		Thread.sleep(SLEEP_TIME);
+	}
+
+	public static void printBooleanMultiDefault(boolean b) throws InterruptedException {
+		System.out.println("C boolean MC: " + b);
+		Thread.sleep(SLEEP_TIME);
+	}
+
+	public static void printByteMultiDefault(byte b) throws InterruptedException {
+		System.out.println("C byte MC: " + b);
+		Thread.sleep(SLEEP_TIME);
+	}
+
+	public static void printShortMultiDefault(short s) throws InterruptedException {
+		System.out.println("C short MC: " + s);
+		Thread.sleep(SLEEP_TIME);
+	}
+
+	public static void printCharMultiDefault(char c) throws InterruptedException {
+		System.out.println("C char MC: " + c);
+		Thread.sleep(SLEEP_TIME);
+	}
+
+	public static void printFloatMultiDefault(float f) throws InterruptedException {
+		System.out.println("C float MC: " + f);
+		Thread.sleep(SLEEP_TIME);
+	}
+
+	public static void printIntMultiDefault(int i) throws InterruptedException {
+		System.out.println("C int MC: " + i);
+		Thread.sleep(SLEEP_TIME);
+	}
+
+	public static void printLongMultiDefault(long l) throws InterruptedException {
+		System.out.println("C long MC: " + l);
+		Thread.sleep(SLEEP_TIME);
+	}
+
+	public static void printDoubleMultiDefault(double d) throws InterruptedException {
+		System.out.println("C double MC: " + d);
 		Thread.sleep(SLEEP_TIME);
 	}
 }

--- a/agent/src/test/java/org/openjdk/jmc/agent/converters/test/InstrumentMeConverter.java
+++ b/agent/src/test/java/org/openjdk/jmc/agent/converters/test/InstrumentMeConverter.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2020, 2021, Datadog, Inc. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Datadog, Inc. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/agent/src/test/resources/org/openjdk/jmc/agent/converters/test/jfrprobes_template.xml
+++ b/agent/src/test/resources/org/openjdk/jmc/agent/converters/test/jfrprobes_template.xml
@@ -344,8 +344,8 @@
 			</method>
 			<location>WRAP</location>
 		</event>
-		<event id="demo.jfr.convertertest.ConverterEventMultiDefaultPrimBoolean">
-			<label>ConverterEventMultiDefaultPrimBoolean</label>
+		<event id="demo.jfr.convertertest.ConverterEventMultiDefaultPrimitiveBoolean">
+			<label>ConverterEventMultiDefaultPrimitiveBoolean</label>
 			<description>Testing picking the right method.
 			</description>
 			<path>demo/converterevents</path>
@@ -367,8 +367,8 @@
 			</method>
 			<location>WRAP</location>
 		</event>
-		<event id="demo.jfr.convertertest.ConverterEventMultiDefaultPrimByte">
-			<label>ConverterEventMultiDefaultPrimByte</label>
+		<event id="demo.jfr.convertertest.ConverterEventMultiDefaultPrimitiveByte">
+			<label>ConverterEventMultiDefaultPrimitiveByte</label>
 			<description>Testing picking the right method.
 			</description>
 			<path>demo/converterevents</path>
@@ -390,8 +390,8 @@
 			</method>
 			<location>WRAP</location>
 		</event>
-		<event id="demo.jfr.convertertest.ConverterEventMultiDefaultPrimShort">
-			<label>ConverterEventMultiDefaultPrimShort</label>
+		<event id="demo.jfr.convertertest.ConverterEventMultiDefaultPrimitiveShort">
+			<label>ConverterEventMultiDefaultPrimitiveShort</label>
 			<description>Testing picking the right method.
 			</description>
 			<path>demo/converterevents</path>
@@ -413,8 +413,8 @@
 			</method>
 			<location>WRAP</location>
 		</event>
-		<event id="demo.jfr.convertertest.ConverterEventMultiDefaultPrimChar">
-			<label>ConverterEventMultiDefaultPrimChar</label>
+		<event id="demo.jfr.convertertest.ConverterEventMultiDefaultPrimitiveChar">
+			<label>ConverterEventMultiDefaultPrimitiveChar</label>
 			<description>Testing picking the right method.
 			</description>
 			<path>demo/converterevents</path>
@@ -436,8 +436,8 @@
 			</method>
 			<location>WRAP</location>
 		</event>
-		<event id="demo.jfr.convertertest.ConverterEventMultiDefaultPrimInt">
-			<label>ConverterEventMultiDefaultPrimInt</label>
+		<event id="demo.jfr.convertertest.ConverterEventMultiDefaultPrimitiveInt">
+			<label>ConverterEventMultiDefaultPrimitiveInt</label>
 			<description>Testing picking the right method.
 			</description>
 			<path>demo/converterevents</path>
@@ -459,8 +459,8 @@
 			</method>
 			<location>WRAP</location>
 		</event>
-		<event id="demo.jfr.convertertest.ConverterEventMultiDefaultPrimFloat">
-			<label>ConverterEventMultiDefaultPrimFloat</label>
+		<event id="demo.jfr.convertertest.ConverterEventMultiDefaultPrimitiveFloat">
+			<label>ConverterEventMultiDefaultPrimitiveFloat</label>
 			<description>Testing picking the right method.
 			</description>
 			<path>demo/converterevents</path>
@@ -482,8 +482,8 @@
 			</method>
 			<location>WRAP</location>
 		</event>
-		<event id="demo.jfr.convertertest.ConverterEventMultiDefaultPrimLong">
-			<label>ConverterEventMultiDefaultPrimLong</label>
+		<event id="demo.jfr.convertertest.ConverterEventMultiDefaultPrimitiveLong">
+			<label>ConverterEventMultiDefaultPrimitiveLong</label>
 			<description>Testing picking the right method.
 			</description>
 			<path>demo/converterevents</path>
@@ -505,8 +505,8 @@
 			</method>
 			<location>WRAP</location>
 		</event>
-		<event id="demo.jfr.convertertest.ConverterEventMultiDefaultPrimDouble">
-			<label>ConverterEventMultiDefaultPrimDouble</label>
+		<event id="demo.jfr.convertertest.ConverterEventMultiDefaultPrimitiveDouble">
+			<label>ConverterEventMultiDefaultPrimitiveDouble</label>
 			<description>Testing picking the right method.
 			</description>
 			<path>demo/converterevents</path>

--- a/agent/src/test/resources/org/openjdk/jmc/agent/converters/test/jfrprobes_template.xml
+++ b/agent/src/test/resources/org/openjdk/jmc/agent/converters/test/jfrprobes_template.xml
@@ -331,11 +331,195 @@
 			</class>
 			<method>
 				<name>printDoubleMultiDefault</name>
-				<descriptor>(Ljava/lang/Double;)V</descriptor>
+				<descriptor>(Ljava/lang/Double;)Z</descriptor>
 				<parameters>
 					<parameter index="0">
 						<name>Double as Int</name>
 						<description>The converted Double-parameter</description>
+						<contenttype>None</contenttype>
+						<converter>org.openjdk.jmc.agent.converters.test.GurkMultiDefaultConverter
+						</converter>
+					</parameter>
+				</parameters>
+			</method>
+			<location>WRAP</location>
+		</event>
+		<event id="demo.jfr.convertertest.ConverterEventMultiDefaultPrimBoolean">
+			<label>ConverterEventMultiDefaultPrimBoolean</label>
+			<description>Testing picking the right method.
+			</description>
+			<path>demo/converterevents</path>
+			<stacktrace>true</stacktrace>
+			<class>org.openjdk.jmc.agent.converters.test.InstrumentMeConverter
+			</class>
+			<method>
+				<name>printBooleanMultiDefault</name>
+				<descriptor>(Z)V</descriptor>
+				<parameters>
+					<parameter index="0">
+						<name>boolean as string</name>
+						<description>The converted boolean-parameter</description>
+						<contenttype>None</contenttype>
+						<converter>org.openjdk.jmc.agent.converters.test.GurkMultiDefaultConverter
+						</converter>
+					</parameter>
+				</parameters>
+			</method>
+			<location>WRAP</location>
+		</event>
+		<event id="demo.jfr.convertertest.ConverterEventMultiDefaultPrimByte">
+			<label>ConverterEventMultiDefaultPrimByte</label>
+			<description>Testing picking the right method.
+			</description>
+			<path>demo/converterevents</path>
+			<stacktrace>true</stacktrace>
+			<class>org.openjdk.jmc.agent.converters.test.InstrumentMeConverter
+			</class>
+			<method>
+				<name>printByteMultiDefault</name>
+				<descriptor>(B)V</descriptor>
+				<parameters>
+					<parameter index="0">
+						<name>byte as string</name>
+						<description>The converted byte-parameter</description>
+						<contenttype>None</contenttype>
+						<converter>org.openjdk.jmc.agent.converters.test.GurkMultiDefaultConverter
+						</converter>
+					</parameter>
+				</parameters>
+			</method>
+			<location>WRAP</location>
+		</event>
+		<event id="demo.jfr.convertertest.ConverterEventMultiDefaultPrimShort">
+			<label>ConverterEventMultiDefaultPrimShort</label>
+			<description>Testing picking the right method.
+			</description>
+			<path>demo/converterevents</path>
+			<stacktrace>true</stacktrace>
+			<class>org.openjdk.jmc.agent.converters.test.InstrumentMeConverter
+			</class>
+			<method>
+				<name>printShortMultiDefault</name>
+				<descriptor>(S)V</descriptor>
+				<parameters>
+					<parameter index="0">
+						<name>short as string</name>
+						<description>The converted short-parameter</description>
+						<contenttype>None</contenttype>
+						<converter>org.openjdk.jmc.agent.converters.test.GurkMultiDefaultConverter
+						</converter>
+					</parameter>
+				</parameters>
+			</method>
+			<location>WRAP</location>
+		</event>
+		<event id="demo.jfr.convertertest.ConverterEventMultiDefaultPrimChar">
+			<label>ConverterEventMultiDefaultPrimChar</label>
+			<description>Testing picking the right method.
+			</description>
+			<path>demo/converterevents</path>
+			<stacktrace>true</stacktrace>
+			<class>org.openjdk.jmc.agent.converters.test.InstrumentMeConverter
+			</class>
+			<method>
+				<name>printCharMultiDefault</name>
+				<descriptor>(C)V</descriptor>
+				<parameters>
+					<parameter index="0">
+						<name>char as string</name>
+						<description>The converted char-parameter</description>
+						<contenttype>None</contenttype>
+						<converter>org.openjdk.jmc.agent.converters.test.GurkMultiDefaultConverter
+						</converter>
+					</parameter>
+				</parameters>
+			</method>
+			<location>WRAP</location>
+		</event>
+		<event id="demo.jfr.convertertest.ConverterEventMultiDefaultPrimInt">
+			<label>ConverterEventMultiDefaultPrimInt</label>
+			<description>Testing picking the right method.
+			</description>
+			<path>demo/converterevents</path>
+			<stacktrace>true</stacktrace>
+			<class>org.openjdk.jmc.agent.converters.test.InstrumentMeConverter
+			</class>
+			<method>
+				<name>printIntMultiDefault</name>
+				<descriptor>(I)V</descriptor>
+				<parameters>
+					<parameter index="0">
+						<name>int as long</name>
+						<description>The converted long-parameter</description>
+						<contenttype>None</contenttype>
+						<converter>org.openjdk.jmc.agent.converters.test.GurkMultiDefaultConverter
+						</converter>
+					</parameter>
+				</parameters>
+			</method>
+			<location>WRAP</location>
+		</event>
+		<event id="demo.jfr.convertertest.ConverterEventMultiDefaultPrimFloat">
+			<label>ConverterEventMultiDefaultPrimFloat</label>
+			<description>Testing picking the right method.
+			</description>
+			<path>demo/converterevents</path>
+			<stacktrace>true</stacktrace>
+			<class>org.openjdk.jmc.agent.converters.test.InstrumentMeConverter
+			</class>
+			<method>
+				<name>printFloatMultiDefault</name>
+				<descriptor>(F)V</descriptor>
+				<parameters>
+					<parameter index="0">
+						<name>float as int</name>
+						<description>The converted float-parameter</description>
+						<contenttype>None</contenttype>
+						<converter>org.openjdk.jmc.agent.converters.test.GurkMultiDefaultConverter
+						</converter>
+					</parameter>
+				</parameters>
+			</method>
+			<location>WRAP</location>
+		</event>
+		<event id="demo.jfr.convertertest.ConverterEventMultiDefaultPrimLong">
+			<label>ConverterEventMultiDefaultPrimLong</label>
+			<description>Testing picking the right method.
+			</description>
+			<path>demo/converterevents</path>
+			<stacktrace>true</stacktrace>
+			<class>org.openjdk.jmc.agent.converters.test.InstrumentMeConverter
+			</class>
+			<method>
+				<name>printLongMultiDefault</name>
+				<descriptor>(J)V</descriptor>
+				<parameters>
+					<parameter index="0">
+						<name>long as string</name>
+						<description>The converted long-parameter</description>
+						<contenttype>None</contenttype>
+						<converter>org.openjdk.jmc.agent.converters.test.GurkMultiDefaultConverter
+						</converter>
+					</parameter>
+				</parameters>
+			</method>
+			<location>WRAP</location>
+		</event>
+		<event id="demo.jfr.convertertest.ConverterEventMultiDefaultPrimDouble">
+			<label>ConverterEventMultiDefaultPrimDouble</label>
+			<description>Testing picking the right method.
+			</description>
+			<path>demo/converterevents</path>
+			<stacktrace>true</stacktrace>
+			<class>org.openjdk.jmc.agent.converters.test.InstrumentMeConverter
+			</class>
+			<method>
+				<name>printDoubleMultiDefault</name>
+				<descriptor>(D)V</descriptor>
+				<parameters>
+					<parameter index="0">
+						<name>double as string</name>
+						<description>The converted double-parameter</description>
 						<contenttype>None</contenttype>
 						<converter>org.openjdk.jmc.agent.converters.test.GurkMultiDefaultConverter
 						</converter>


### PR DESCRIPTION
This allows primitive types in converters.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JMC-8254](https://bugs.openjdk.org/browse/JMC-8254): Allow primitive types in converters (**Enhancement** - P4)


### Reviewers
 * [Marcus Hirt](https://openjdk.org/census#hirt) (@thegreystone - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmc.git pull/584/head:pull/584` \
`$ git checkout pull/584`

Update a local copy of the PR: \
`$ git checkout pull/584` \
`$ git pull https://git.openjdk.org/jmc.git pull/584/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 584`

View PR using the GUI difftool: \
`$ git pr show -t 584`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmc/pull/584.diff">https://git.openjdk.org/jmc/pull/584.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jmc/pull/584#issuecomment-2338270128)