### PR TITLE
Fix NPE preventing some recordings from showing the JVM Internals page

### DIFF
--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/common/CompositeKeyAccessorFactory.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/common/CompositeKeyAccessorFactory.java
@@ -59,7 +59,8 @@ public class CompositeKeyAccessorFactory implements IAccessorFactory<CompositeKe
 			public CompositeKey getMember(T item) {
 				Object[] result = new Object[functions.size()];
 				for (int i = 0; i < functions.size(); i++) {
-					result[i] = functions.get(i).getMember(item);
+					IMemberAccessor<?, T> accessor = functions.get(i);
+					result[i] = accessor == null ? null : accessor.getMember(item);
 				}
 				return new CompositeKey(result);
 			}


### PR DESCRIPTION
It's not clear if we expect to get null `IMemberAccessor` instances, or if that's the bug, however there are several places which explicitly return a null accessor, so it's probably best to handle this with relative grace (I don't believe this failure is the result of that line, but rather something from `return JdkAttributes.FLAG_VALUE_NUMBER.getAccessor(type);` above):
https://github.com/openjdk/jmc/blob/4a37a5e72b5a700ce90ef27a20c633d79ecb73f2/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/JVMInformationPage.java#L155-L157

The failure occurred with the following stack trace:
```
java.lang.NullPointerException
	at java.base/jdk.internal.reflect.DirectConstructorHandleAccessor.newInstance(DirectConstructorHandleAccessor.java:67)
	at java.base/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:500)
	at java.base/java.lang.reflect.Constructor.newInstance(Constructor.java:484)
	at java.base/java.util.concurrent.ForkJoinTask.getThrowableException(ForkJoinTask.java:542)
	at java.base/java.util.concurrent.ForkJoinTask.reportException(ForkJoinTask.java:567)
	at java.base/java.util.concurrent.ForkJoinTask.invoke(ForkJoinTask.java:670)
	at java.base/java.util.stream.ReduceOps$ReduceOp.evaluateParallel(ReduceOps.java:927)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:233)
	at java.base/java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:682)
	at org.openjdk.jmc.flightrecorder.ui.common.AggregationGrid.lambda$5(AggregationGrid.java:222)
	at java.base/java.util.stream.ReferencePipeline$7$1.accept(ReferencePipeline.java:273)
	at java.base/java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:179)
	at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:197)
	at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:197)
	at java.base/java.util.Spliterators$ArraySpliterator.forEachRemaining(Spliterators.java:1006)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
	at java.base/java.util.stream.StreamSpliterators$WrappingSpliterator.forEachRemaining(StreamSpliterators.java:310)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
	at java.base/java.util.stream.ReduceOps$ReduceTask.doLeaf(ReduceOps.java:960)
	at java.base/java.util.stream.ReduceOps$ReduceTask.doLeaf(ReduceOps.java:934)
	at java.base/java.util.stream.AbstractTask.compute(AbstractTask.java:327)
	at java.base/java.util.concurrent.CountedCompleter.exec(CountedCompleter.java:754)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:387)
	at java.base/java.util.concurrent.ForkJoinTask.invoke(ForkJoinTask.java:667)
	at java.base/java.util.stream.ReduceOps$ReduceOp.evaluateParallel(ReduceOps.java:927)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:233)
	at java.base/java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:682)
	at org.openjdk.jmc.flightrecorder.ui.common.AggregationGrid.mapItems(AggregationGrid.java:224)
	at org.openjdk.jmc.flightrecorder.ui.common.AggregationGrid.buildRows(AggregationGrid.java:243)
	at org.openjdk.jmc.flightrecorder.ui.common.ItemHistogram.show(ItemHistogram.java:324)
	at org.openjdk.jmc.flightrecorder.ui.common.FilterComponent.filterChangeHelper(FilterComponent.java:244)
	at org.openjdk.jmc.flightrecorder.ui.common.FilterComponent.filterChangeHelper(FilterComponent.java:249)
	at org.openjdk.jmc.flightrecorder.ui.pages.JVMInformationPage$JVMInformationUi.onFlagsFilterChange(JVMInformationPage.java:305)
	at org.openjdk.jmc.flightrecorder.ui.common.FilterComponent.lambda$1(FilterComponent.java:218)
	at org.openjdk.jmc.ui.handlers.ActionToolkit$3.run(ActionToolkit.java:166)
	at org.openjdk.jmc.flightrecorder.ui.common.FilterComponent.loadState(FilterComponent.java:160)
	at org.openjdk.jmc.flightrecorder.ui.pages.JVMInformationPage$JVMInformationUi.<init>(JVMInformationPage.java:284)
	at org.openjdk.jmc.flightrecorder.ui.pages.JVMInformationPage.display(JVMInformationPage.java:368)
	at org.openjdk.jmc.flightrecorder.ui.JfrEditor.displayPage(JfrEditor.java:264)
	at org.openjdk.jmc.flightrecorder.ui.JfrEditor.navigateTo(JfrEditor.java:248)
	at org.openjdk.jmc.flightrecorder.ui.JfrOutlinePage.selectionChanged(JfrOutlinePage.java:449)
	at org.eclipse.jface.viewers.Viewer$1.run(Viewer.java:151)
	at org.eclipse.core.runtime.SafeRunner.run(SafeRunner.java:47)
	at org.eclipse.jface.util.SafeRunnable.run(SafeRunnable.java:174)
	at org.eclipse.jface.viewers.Viewer.fireSelectionChanged(Viewer.java:148)
	at org.eclipse.jface.viewers.StructuredViewer.updateSelection(StructuredViewer.java:2132)
	at org.eclipse.jface.viewers.ColumnViewer.updateSelection(ColumnViewer.java:1055)
	at org.eclipse.jface.viewers.StructuredViewer.handleSelect(StructuredViewer.java:1170)
	at org.eclipse.jface.viewers.StructuredViewer$4.widgetSelected(StructuredViewer.java:1199)
	at org.eclipse.jface.util.OpenStrategy.fireSelectionEvent(OpenStrategy.java:262)
	at org.eclipse.jface.util.OpenStrategy$1.handleEvent(OpenStrategy.java:420)
	at org.eclipse.swt.widgets.EventTable.sendEvent(EventTable.java:89)
	at org.eclipse.swt.widgets.Display.sendEvent(Display.java:4643)
	at org.eclipse.swt.widgets.Widget.sendEvent(Widget.java:1524)
	at org.eclipse.swt.widgets.Widget.sendEvent(Widget.java:1547)
	at org.eclipse.swt.widgets.Widget.sendEvent(Widget.java:1532)
	at org.eclipse.swt.widgets.Widget.notifyListeners(Widget.java:1325)
	at org.eclipse.swt.widgets.Display.runDeferredEvents(Display.java:4410)
	at org.eclipse.swt.widgets.Display.applicationNextEventMatchingMask(Display.java:5555)
	at org.eclipse.swt.widgets.Display.applicationProc(Display.java:5962)
	at org.eclipse.swt.internal.cocoa.OS.objc_msgSendSuper(Native Method)
	at org.eclipse.swt.widgets.Widget.callSuper(Widget.java:236)
	at org.eclipse.swt.widgets.Widget.mouseDownSuper(Widget.java:1147)
	at org.eclipse.swt.widgets.Tree.mouseDownSuper(Tree.java:2194)
	at org.eclipse.swt.widgets.Widget.mouseDown(Widget.java:1139)
	at org.eclipse.swt.widgets.Control.mouseDown(Control.java:2642)
	at org.eclipse.swt.widgets.Tree.mouseDown(Tree.java:2161)
	at org.eclipse.swt.widgets.Display.windowProc(Display.java:6268)
	at org.eclipse.swt.internal.cocoa.OS.objc_msgSendSuper(Native Method)
	at org.eclipse.swt.widgets.Widget.callSuper(Widget.java:236)
	at org.eclipse.swt.widgets.Widget.windowSendEvent(Widget.java:2264)
	at org.eclipse.swt.widgets.Shell.windowSendEvent(Shell.java:2509)
	at org.eclipse.swt.widgets.Display.windowProc(Display.java:6384)
	at org.eclipse.swt.internal.cocoa.OS.objc_msgSendSuper(Native Method)
	at org.eclipse.swt.widgets.Display.applicationSendEvent(Display.java:5688)
	at org.eclipse.swt.widgets.Display.applicationProc(Display.java:5828)
	at org.eclipse.swt.internal.cocoa.OS.objc_msgSend(Native Method)
	at org.eclipse.swt.internal.cocoa.NSApplication.sendEvent(NSApplication.java:117)
	at org.eclipse.swt.widgets.Display.readAndDispatch(Display.java:3983)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine$5.run(PartRenderingEngine.java:1151)
	at org.eclipse.core.databinding.observable.Realm.runWithDefault(Realm.java:339)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine.run(PartRenderingEngine.java:1042)
	at org.eclipse.e4.ui.internal.workbench.E4Workbench.createAndRunUI(E4Workbench.java:152)
	at org.eclipse.ui.internal.Workbench.lambda$3(Workbench.java:639)
	at org.eclipse.core.databinding.observable.Realm.runWithDefault(Realm.java:339)
	at org.eclipse.ui.internal.Workbench.createAndRunWorkbench(Workbench.java:546)
	at org.eclipse.ui.PlatformUI.createAndRunWorkbench(PlatformUI.java:173)
	at org.openjdk.jmc.rcp.application.Application.start(Application.java:64)
	at org.eclipse.equinox.internal.app.EclipseAppHandle.run(EclipseAppHandle.java:208)
	at org.eclipse.core.runtime.internal.adaptor.EclipseAppLauncher.runApplication(EclipseAppLauncher.java:143)
	at org.eclipse.core.runtime.internal.adaptor.EclipseAppLauncher.start(EclipseAppLauncher.java:109)
	at org.eclipse.core.runtime.adaptor.EclipseStarter.run(EclipseStarter.java:439)
	at org.eclipse.core.runtime.adaptor.EclipseStarter.run(EclipseStarter.java:271)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
	at java.base/java.lang.reflect.Method.invoke(Method.java:578)
	at org.eclipse.equinox.launcher.Main.invokeFramework(Main.java:651)
	at org.eclipse.equinox.launcher.Main.basicRun(Main.java:588)
	at org.eclipse.equinox.launcher.Main.run(Main.java:1459)
Caused by: java.lang.NullPointerException: Cannot invoke "org.openjdk.jmc.common.item.IMemberAccessor.getMember(Object)" because the return value of "java.util.List.get(int)" is null
	at org.openjdk.jmc.flightrecorder.ui.common.CompositeKeyAccessorFactory$1.getMember(CompositeKeyAccessorFactory.java:62)
	at org.openjdk.jmc.flightrecorder.ui.common.CompositeKeyAccessorFactory$1.getMember(CompositeKeyAccessorFactory.java:1)
	at org.openjdk.jmc.flightrecorder.ui.common.KeyedStream$MapBuilder.add(KeyedStream.java:77)
	at java.base/java.util.stream.ReduceOps$3ReducingSink.accept(ReduceOps.java:169)
	at java.base/java.util.Spliterators$ArraySpliterator.forEachRemaining(Spliterators.java:1006)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
	at java.base/java.util.stream.ReduceOps$ReduceTask.doLeaf(ReduceOps.java:960)
	at java.base/java.util.stream.ReduceOps$ReduceTask.doLeaf(ReduceOps.java:934)
	at java.base/java.util.stream.AbstractTask.compute(AbstractTask.java:327)
	at java.base/java.util.concurrent.CountedCompleter.exec(CountedCompleter.java:754)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:387)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1311)
	at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1841)
	at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1806)
	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:177)
```