### PR TITLE
8257: Stacktrace Percentage Column Tooltip throwing Exception

### DIFF
--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/messages/internal/Messages.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/messages/internal/Messages.java
@@ -542,6 +542,8 @@ public class Messages extends NLS {
 	public static String STACKTRACE_VIEW_TRACE_IN_GROUP;
 	public static String STACKTRACE_VIEW_TRACE_IN_GROUPS;
 	public static String STACKTRACE_VIEW_TRACE_OF_TOTAL;
+	public static String STACKTRACE_VIEW_TRACE_OF_TOTAL_COUNT;
+	public static String STACKTRACE_VIEW_TRACES_OF_TOTAL_COUNT;
 	public static String STORED_SELECTIONS_SIZE_LESS_THAN_ZERO;
 	public static String STORED_SELECTIONS_SIZE_PREF;
 	public static String STORED_SELECTIONS_SIZE_UNPARSABLE;
@@ -628,9 +630,9 @@ public class Messages extends NLS {
 	public static String stackTraceMessage(int itemCount, int totalCount, String frameFraction) {
 		String message;
 		if (itemCount == 1) {
-			message = Messages.STACKTRACE_VIEW_TRACE_OF_TOTAL;
+			message = Messages.STACKTRACE_VIEW_TRACE_OF_TOTAL_COUNT;
 		} else {
-			message = Messages.STACKTRACE_VIEW_TRACES_OF_TOTAL;
+			message = Messages.STACKTRACE_VIEW_TRACES_OF_TOTAL_COUNT;
 		}
 		return NLS.bind(message, new Object[] {itemCount, frameFraction, totalCount});
 	}

--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/resources/org/openjdk/jmc/flightrecorder/ui/messages/internal/messages.properties
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/resources/org/openjdk/jmc/flightrecorder/ui/messages/internal/messages.properties
@@ -525,6 +525,8 @@ STACKTRACE_VIEW_TRACE_IN_GROUPS={0} stack trace in {1} sibling groups
 STACKTRACE_VIEW_TRACES_IN_GROUP={0} stack traces in {1} sibling group
 STACKTRACE_VIEW_TRACES_IN_GROUPS={0} stack traces in {1} sibling groups
 # {0}, {1} and {2} are numbers
+STACKTRACE_VIEW_TRACE_OF_TOTAL_COUNT={0} stack trace ({1} of total {2})
+STACKTRACE_VIEW_TRACES_OF_TOTAL_COUNT={0} stack traces ({1} of total {2})
 STACKTRACE_VIEW_TRACE_OF_TOTAL={0} {1} stack trace ({2} of total {3} {4})
 STACKTRACE_VIEW_TRACES_OF_TOTAL={0} {1} stack traces ({2} of total {3} {4})
 SystemPage_PAGE_NAME=Environment


### PR DESCRIPTION
Open Thread page. Click on any thread. Stacktrace view gets populated with the results. Mouse hover on percentage column values. The tooltip doesnt get populated.

While debugging I found an exception in the console.

This PR is to fix the issue.

After the fix the tooltip is populating properly and there is no exception in console.

<img width="749" alt="8257_TooltipFixed" src="https://github.com/user-attachments/assets/b56329cc-653a-438f-9568-8f3010d4cc23">

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JMC-8257](https://bugs.openjdk.org/browse/JMC-8257): Stacktrace Percentage Column Tooltip throwing Exception (**Bug** - P4)


### Reviewers
 * [Alex Macdonald](https://openjdk.org/census#aptmac) (@aptmac - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmc.git pull/589/head:pull/589` \
`$ git checkout pull/589`

Update a local copy of the PR: \
`$ git checkout pull/589` \
`$ git pull https://git.openjdk.org/jmc.git pull/589/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 589`

View PR using the GUI difftool: \
`$ git pr show -t 589`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmc/pull/589.diff">https://git.openjdk.org/jmc/pull/589.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jmc/pull/589#issuecomment-2351594635)