### PR TITLE
8260: Warnings and errors logged during XML processing

### DIFF
--- a/application/org.openjdk.jmc.console.agent/src/main/java/org/openjdk/jmc/console/agent/manager/model/Preset.java
+++ b/application/org.openjdk.jmc.console.agent/src/main/java/org/openjdk/jmc/console/agent/manager/model/Preset.java
@@ -165,6 +165,7 @@ public class Preset implements IPreset {
 			factory.setExpandEntityReferences(false);
 			factory.setValidating(true);
 			builder = factory.newDocumentBuilder();
+			builder.setErrorHandler(null);
 		} catch (ParserConfigurationException e) {
 			// This should not happen anyway
 			throw new RuntimeException(e);

--- a/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/util/XmlToolkit.java
+++ b/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/util/XmlToolkit.java
@@ -170,8 +170,9 @@ public final class XmlToolkit {
 			InputSource xml = new InputSource(
 					new StringReader("<?xml version=\"1.0\" encoding=\"UTF-8\"?><" + rootElementName + "/>")); //$NON-NLS-1$ //$NON-NLS-2$
 			DocumentBuilderFactory dbf = createDocumentBuildFactoryInstance();
-
-			doc = dbf.newDocumentBuilder().parse(xml);
+			DocumentBuilder documentBuilder = dbf.newDocumentBuilder();
+			documentBuilder.setErrorHandler(null);
+			doc = documentBuilder.parse(xml);
 		} catch (IOException e) {
 			// just rethrow
 			throw e;
@@ -380,6 +381,7 @@ public final class XmlToolkit {
 		try {
 			DocumentBuilderFactory factory = createDocumentBuildFactoryInstance();
 			docBuilder = factory.newDocumentBuilder();
+			docBuilder.setErrorHandler(null);
 		} catch (ParserConfigurationException e) {
 			// This shouldn't happen since all configuration is done within XmlToolkit
 			LOGGER.log(Level.WARNING, "Parser configuration error", e); //$NON-NLS-1$

--- a/core/org.openjdk.jmc.flightrecorder.configuration/src/main/java/org/openjdk/jmc/flightrecorder/configuration/model/xml/XMLModel.java
+++ b/core/org.openjdk.jmc.flightrecorder.configuration/src/main/java/org/openjdk/jmc/flightrecorder/configuration/model/xml/XMLModel.java
@@ -157,6 +157,7 @@ public final class XMLModel extends Observable {
 			SAXParser sp = spf.newSAXParser();
 			XMLReader xr = sp.getXMLReader();
 			XMLModelBuilder dataHandler = new XMLModelBuilder(dummyRoot);
+			xr.setErrorHandler(null);
 			xr.setContentHandler(dataHandler);
 			xr.parse(input);
 			List<XMLTagInstance> instances = dummyRoot.getTagsInstances();

--- a/core/tests/org.openjdk.jmc.flightrecorder.rules.jdk.test/src/main/java/org/openjdk/jmc/flightrecorder/test/rules/jdk/TestRulesWithJfr.java
+++ b/core/tests/org.openjdk.jmc.flightrecorder.rules.jdk.test/src/main/java/org/openjdk/jmc/flightrecorder/test/rules/jdk/TestRulesWithJfr.java
@@ -224,6 +224,7 @@ public class TestRulesWithJfr {
 			docFactory.setFeature(XML_PARSER_DISALLOW_DOCTYPE_ATTRIBUTE, true);
 			docFactory.setValidating(true);
 			DocumentBuilder docBuilder = docFactory.newDocumentBuilder();
+			docBuilder.setErrorHandler(null);
 			Document baselineDoc = docBuilder.parse(file);
 			collection = ReportCollection.fromXml(baselineDoc, reportName);
 		} catch (ParserConfigurationException | SAXException | IOException e) {

--- a/releng/tools/org.openjdk.jmc.util.listversions/src/org/openjdk/jmc/util/listversions/ListVersions.java
+++ b/releng/tools/org.openjdk.jmc.util.listversions/src/org/openjdk/jmc/util/listversions/ListVersions.java
@@ -48,6 +48,7 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
+import org.xml.sax.ErrorHandler;
 
 public class ListVersions {
 	private static final String XML_PARSER_DISALLOW_DOCTYPE_ATTRIBUTE = "http://apache.org/xml/features/disallow-doctype-decl"; //$NON-NLS-1$
@@ -100,6 +101,7 @@ public class ListVersions {
 			dbFactory.setFeature(XML_PARSER_DISALLOW_DOCTYPE_ATTRIBUTE, true);
 			dbFactory.setValidating(true);
 			DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
+			dBuilder.setErrorHandler(null);
 			Document compositeDoc = dBuilder.parse(compositeZipStream);
 
 			NodeList childrenList = compositeDoc.getElementsByTagName("child");


### PR DESCRIPTION
We have several xml files in JMC. To remove fortify scan issue about XML Validation, **DocumentBuilderFactory.setValidating(true)** had been added. Because of that validation was triggered during the parsing of XML. We do not have **xsd files** against all the xml files and so it shows errors and warning.  
We can either create **xsd files** or **disable the ErrorValidator**. 
I think at this point disabling the default ErrorValidator is better option, and I have done the same in this PR. 
Could you please review the changes. Thanks.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JMC-8260](https://bugs.openjdk.org/browse/JMC-8260): Warnings and errors logged during XML processing (**Bug** - P5)


### Reviewers
 * [Marcus Hirt](https://openjdk.org/census#hirt) (@thegreystone - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmc.git pull/592/head:pull/592` \
`$ git checkout pull/592`

Update a local copy of the PR: \
`$ git checkout pull/592` \
`$ git pull https://git.openjdk.org/jmc.git pull/592/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 592`

View PR using the GUI difftool: \
`$ git pr show -t 592`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmc/pull/592.diff">https://git.openjdk.org/jmc/pull/592.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jmc/pull/592#issuecomment-2407873075)