### PR TITLE
6683: Mouse over for Event Thread should show the various thread IDs

### DIFF
--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/JfrPropertySheet.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/JfrPropertySheet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -71,6 +71,7 @@ import org.eclipse.ui.part.Page;
 import org.eclipse.ui.views.properties.IPropertySheetPage;
 import org.openjdk.jmc.common.IDescribable;
 import org.openjdk.jmc.common.IDisplayable;
+import org.openjdk.jmc.common.IMCThread;
 import org.openjdk.jmc.common.IState;
 import org.openjdk.jmc.common.collection.IteratorToolkit;
 import org.openjdk.jmc.common.item.Aggregators;
@@ -430,7 +431,12 @@ public class JfrPropertySheet extends Page implements IPropertySheetPage {
 			return limitedDeepToString(((Collection<?>) value).toArray(), JfrPropertySheet::getVerboseString);
 		}
 
-		return TypeHandling.getVerboseString(value);
+		String verboseString = TypeHandling.getVerboseString(value);
+		if (value instanceof IMCThread) {
+			return "(" + NLS.bind(Messages.ThreadsPage_LANE_THREAD_ID_TOOLTIP, ((IMCThread) value).getThreadId()) + ") "
+					+ verboseString;
+		}
+		return verboseString;
 	}
 
 	private TableViewer viewer;

--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/messages/internal/Messages.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/messages/internal/Messages.java
@@ -621,6 +621,7 @@ public class Messages extends NLS {
 	public static String VMOperationPage_PAGE_NAME;
 	public static String VMOperationPage_ROW_VM_OPERATIONS;
 	public static String VMOperationPage_TIMELINE_SELECTION;
+	public static String ThreadsPage_LANE_THREAD_ID_TOOLTIP;
 
 	static {
 		NLS.initializeMessages(BUNDLE_NAME, Messages.class);

--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/ThreadsPageLayoutUI.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/ThreadsPageLayoutUI.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2020, 2023, Red Hat Inc. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Red Hat Inc. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -134,6 +134,7 @@ abstract class ThreadsPageLayoutUI extends ChartAndTableUI {
 		gridData.widthHint = 180;
 		chartLegend.getControl().setLayoutData(gridData);
 		DataPageToolkit.createChartTimestampTooltip(chartCanvas);
+		DataPageToolkit.createChartTimestampTooltip(textCanvas);
 
 		chart = new XYChart(pageContainer.getRecordingRange(), RendererToolkit.empty(), X_OFFSET, Y_OFFSET,
 				timelineCanvas, controlBar, buttonGroup);

--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/resources/org/openjdk/jmc/flightrecorder/ui/messages/internal/messages.properties
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/resources/org/openjdk/jmc/flightrecorder/ui/messages/internal/messages.properties
@@ -717,3 +717,4 @@ MethodProfilingPage_PACKAGE_HISTOGRAM_SELECTION=Method Profiling Package Histogr
 MethodProfilingPage_PAGE_NAME=Method Profiling
 MethodProfilingPage_SUCCESSORS_DESCRIPTION=Successors
 MethodProfilingPage_PREDECESSORS_DESCRIPTION=Predecessors
+ThreadsPage_LANE_THREAD_ID_TOOLTIP=Thread Id: {0}

--- a/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/charts/IChartInfoVisitor.java
+++ b/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/charts/IChartInfoVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -76,6 +76,10 @@ public interface IChartInfoVisitor {
 
 		@Override
 		public void visit(ILane lane) {
+		}
+
+		@Override
+		public void setChartTextCanvas(boolean chartTextCanvas) {
 		}
 	}
 
@@ -239,4 +243,8 @@ public interface IChartInfoVisitor {
 	 * @param lane
 	 */
 	void visit(ILane lane);
+
+	void setChartTextCanvas(boolean chartTextCanvas);
+
+	boolean isChartTextCanvas();
 }

--- a/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/charts/QuantitySpanRenderer.java
+++ b/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/charts/QuantitySpanRenderer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -132,6 +132,9 @@ public class QuantitySpanRenderer implements IXDataRenderer {
 				int bucket = points.floorIndexAtX(x);
 				if (bucket < points.getSize()) {
 					Span span = new Span(bucket, offset);
+					if (visitor.isChartTextCanvas() && bucket == -1) {
+						bucket = 0;
+					}
 					while (bucket >= 0) {
 						double x2 = points.getPixelY(bucket);
 						if (x < x2) {

--- a/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/misc/ChartCanvas.java
+++ b/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/misc/ChartCanvas.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * 
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -639,6 +639,11 @@ public class ChartCanvas extends Canvas {
 					setHoveredItemData(data);
 				}
 			}
+
+			@Override
+			public boolean isChartTextCanvas() {
+				return false;
+			}
 		}, lastMouseX, lastMouseY);
 		// Attempt to reduce flicker by avoiding unnecessary updates.
 		if (!newRects.equals(highlightRects)) {
@@ -715,6 +720,11 @@ public class ChartCanvas extends Canvas {
 						range[1] = (x1 instanceof IQuantity) ? (IQuantity) x1 : null;
 					}
 				}
+
+				@Override
+				public boolean isChartTextCanvas() {
+					return false;
+				}
 			}, x, y);
 			if ((range[0] != null) || (range[1] != null)) {
 				if (!awtChart.select(range[0], range[1], p.y, p.y, true)) {
@@ -783,6 +793,7 @@ public class ChartCanvas extends Canvas {
 	public void infoAt(IChartInfoVisitor visitor, int x, int y) {
 		Point p = translateDisplayToImageCoordinates(x, y);
 		if (awtChart != null) {
+			visitor.setChartTextCanvas(false);
 			awtChart.infoAt(visitor, p.x, p.y);
 		}
 	}

--- a/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/misc/ChartTextCanvas.java
+++ b/application/org.openjdk.jmc.ui/src/main/java/org/openjdk/jmc/ui/misc/ChartTextCanvas.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2020, 2023, Red Hat Inc. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Red Hat Inc. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -424,6 +424,11 @@ public class ChartTextCanvas extends Canvas {
 					setHoveredItemData(data);
 				}
 			}
+
+			@Override
+			public boolean isChartTextCanvas() {
+				return true;
+			}
 		}, lastMouseX, lastMouseY);
 		redraw();
 		if (chartCanvas != null) {
@@ -491,6 +496,7 @@ public class ChartTextCanvas extends Canvas {
 	public void infoAt(IChartInfoVisitor visitor, int x, int y) {
 		Point p = chartCanvas.translateDisplayToImageCoordinates(x, y);
 		if (awtChart != null) {
+			visitor.setChartTextCanvas(true);
 			awtChart.infoAt(visitor, p.x, p.y);
 		}
 	}


### PR DESCRIPTION
Added "Thread Id" information for Mouse Hover on Event Thread as well as in properties view.

**Before:** No information on Hover
<img width="958" alt="EventThread_Before" src="https://github.com/user-attachments/assets/b14f2ad6-72e6-4dac-be56-fe00eaf4fb42">

**After:** Thread Id shown on Hover
<img width="959" alt="EventThread_After" src="https://github.com/user-attachments/assets/5d56d806-9741-4e8f-8945-f6ee991d25b4">

**Before:** Only Thread Description shown in properties view
<img width="957" alt="Properties_Before" src="https://github.com/user-attachments/assets/44adfc75-6c43-404b-a365-b37938962cf9">


**After:** Along with Thread Description, Thread Id also shown in properties view
<img width="958" alt="Properties_After" src="https://github.com/user-attachments/assets/4bdad8d5-ff5e-4e13-af52-72fbba2fb84c">

Could you please review the changes? Please suggest if anything more is needed with this enhancement request.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JMC-6683](https://bugs.openjdk.org/browse/JMC-6683): Mouse over for Event Thread should show the various thread IDs (**Enhancement** - P2)


### Reviewers
 * [Alex Macdonald](https://openjdk.org/census#aptmac) (@aptmac - **Reviewer**)
 * [Marcus Hirt](https://openjdk.org/census#hirt) (@thegreystone - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmc.git pull/593/head:pull/593` \
`$ git checkout pull/593`

Update a local copy of the PR: \
`$ git checkout pull/593` \
`$ git pull https://git.openjdk.org/jmc.git pull/593/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 593`

View PR using the GUI difftool: \
`$ git pr show -t 593`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmc/pull/593.diff">https://git.openjdk.org/jmc/pull/593.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jmc/pull/593#issuecomment-2422001914)
</details>
