### PR TITLE
6626: The halt rule result should have a table of the VM operations

### DIFF
--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/messages/internal/Messages.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/messages/internal/Messages.java
@@ -647,6 +647,7 @@ public class Messages {
 	public static final String VMOperationRule_CONFIG_WARNING_LIMIT = "VMOperationRule_CONFIG_WARNING_LIMIT"; //$NON-NLS-1$
 	public static final String VMOperationRule_CONFIG_WARNING_LIMIT_LONG = "VMOperationRule_CONFIG_WARNING_LIMIT_LONG"; //$NON-NLS-1$
 	public static final String VMOperations_RULE_NAME = "VMOperations_RULE_NAME"; //$NON-NLS-1$
+	public static final String VMOperations_Duration_Operation = "VMOperations_Duration_Operation"; //$NON-NLS-1$
 	public static final String VerifyNoneRule_RULE_NAME = "VerifyNoneRule_RULE_NAME"; //$NON-NLS-1$
 	public static final String VerifyNoneRule_TEXT_INFO = "VerifyNoneRule_TEXT_INFO"; //$NON-NLS-1$
 	public static final String VerifyNoneRule_TEXT_INFO_LONG = "VerifyNoneRule_TEXT_INFO_LONG"; //$NON-NLS-1$

--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/resources/org/openjdk/jmc/flightrecorder/rules/jdk/messages/internal/messages.properties
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/resources/org/openjdk/jmc/flightrecorder/rules/jdk/messages/internal/messages.properties
@@ -729,6 +729,7 @@ TlabAllocationRatioRuleFactory_TEXT_OK_NO_OUTSIDE=No object allocations outside 
 UnlockExperimentalVMOptionsRuleFactory_TEXT_INFO=The recording was performed on a JVM that had Experimental VM Options enabled.
 UnlockExperimentalVMOptionsRuleFactory_TEXT_INFO_LONG=Experimental VM options may be unreliable and should not be used in a production environment. Unless you have to use an experimental option, you should avoid the '-XX:+UnlockExperimentalVMOptions' command line option.
 VMOperations_RULE_NAME=VMOperation Peak Duration
+VMOperations_Duration_Operation=  Duration  |   VM Operation
 VMOperationRule_CONFIG_WARNING_LIMIT=Blocking VM operation duration warning limit
 VMOperationRule_CONFIG_WARNING_LIMIT_LONG=The minimum duration for a blocking VM operation needed to trigger a warning
 # {longestOperationDuration} is a time period


### PR DESCRIPTION
Added top 5 vm operations (ordered by max time), including the thread that initiated them.
Since the halt rule was pointing to VM operation rule in its description, hence i have added the table to vm opertion rule itself where it was more related to.

The rule looks something like this now.
<img width="345" alt="image" src="https://github.com/user-attachments/assets/11ffd276-8411-470d-9faf-00e2e4803fc3">

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JMC-6626](https://bugs.openjdk.org/browse/JMC-6626): The halt rule result should have a table of the VM operations (**Enhancement** - P2)


### Reviewers
 * [Alex Macdonald](https://openjdk.org/census#aptmac) (@aptmac - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmc.git pull/596/head:pull/596` \
`$ git checkout pull/596`

Update a local copy of the PR: \
`$ git checkout pull/596` \
`$ git pull https://git.openjdk.org/jmc.git pull/596/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 596`

View PR using the GUI difftool: \
`$ git pr show -t 596`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmc/pull/596.diff">https://git.openjdk.org/jmc/pull/596.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jmc/pull/596#issuecomment-2446050227)
</details>
