### PR TITLE
8284: Fix Jolokia discovery issues

### DIFF
--- a/application/org.openjdk.jmc.flightrecorder.graphview/.classpath
+++ b/application/org.openjdk.jmc.flightrecorder.graphview/.classpath
@@ -1,8 +1,27 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
-	<classpathentry kind="src" path="src/main/java/"/>
-	<classpathentry kind="src" path="src/main/resources/"/>
+	<classpathentry kind="src" output="target/classes" path="src/main/java">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" output="target/classes" path="src/main/resources">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.m2e.MAVEN2_CLASSPATH_CONTAINER">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/application/org.openjdk.jmc.flightrecorder.graphview/.classpath
+++ b/application/org.openjdk.jmc.flightrecorder.graphview/.classpath
@@ -1,27 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER">
-		<attributes>
-			<attribute name="maven.pomderived" value="true"/>
-		</attributes>
-	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
-	<classpathentry kind="src" output="target/classes" path="src/main/java">
-		<attributes>
-			<attribute name="optional" value="true"/>
-			<attribute name="maven.pomderived" value="true"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="src" output="target/classes" path="src/main/resources">
-		<attributes>
-			<attribute name="optional" value="true"/>
-			<attribute name="maven.pomderived" value="true"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="con" path="org.eclipse.m2e.MAVEN2_CLASSPATH_CONTAINER">
-		<attributes>
-			<attribute name="maven.pomderived" value="true"/>
-		</attributes>
-	</classpathentry>
+	<classpathentry kind="src" path="src/main/java/"/>
+	<classpathentry kind="src" path="src/main/resources/"/>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/application/org.openjdk.jmc.jolokia/src/main/java/org/openjdk/jmc/jolokia/JolokiaAgentDescriptor.java
+++ b/application/org.openjdk.jmc.jolokia/src/main/java/org/openjdk/jmc/jolokia/JolokiaAgentDescriptor.java
@@ -34,48 +34,30 @@
 package org.openjdk.jmc.jolokia;
 
 import java.io.IOException;
-import java.lang.management.ManagementFactory;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
-import javax.management.Attribute;
-import javax.management.AttributeList;
-import javax.management.InstanceNotFoundException;
-import javax.management.MalformedObjectNameException;
-import javax.management.ObjectName;
-import javax.management.openmbean.CompositeDataSupport;
-import javax.management.openmbean.TabularDataSupport;
 import javax.management.remote.JMXServiceURL;
 
-import org.jolokia.client.jmxadapter.RemoteJmxAdapter;
-import org.openjdk.jmc.common.jvm.Connectable;
-import org.openjdk.jmc.common.jvm.JVMArch;
 import org.openjdk.jmc.common.jvm.JVMDescriptor;
-import org.openjdk.jmc.common.jvm.JVMType;
 
 /**
  * Provide data about JVMs accessed over Jolokia for the JVM browser
  */
 public class JolokiaAgentDescriptor implements ServerConnectionDescriptor {
 
-	public static final JVMDescriptor NULL_DESCRIPTOR = new JVMDescriptor(null, null, null, null, null, null, null,
-			null, false, Connectable.UNKNOWN);
 	private final JMXServiceURL serviceUrl;
 	private final Map<String, ?> agentData;
-	private final JVMDescriptor jvmDescriptor;
 
-	public JolokiaAgentDescriptor(Map<String, ?> agentData, JVMDescriptor jvmDescriptor)
-			throws URISyntaxException, MalformedURLException {
+	public JolokiaAgentDescriptor(Map<String, ?> agentData) throws URISyntaxException, MalformedURLException {
 		super();
 		URI uri = new URI((String) agentData.get("url")); //$NON-NLS-1$
 		this.serviceUrl = new JMXServiceURL(
 				String.format("service:jmx:jolokia://%s:%s%s", uri.getHost(), uri.getPort(), uri.getPath())); //$NON-NLS-1$
 		this.agentData = agentData;
-		this.jvmDescriptor = jvmDescriptor;
 	}
 
 	JMXServiceURL getServiceUrl() {
@@ -94,86 +76,10 @@ public class JolokiaAgentDescriptor implements ServerConnectionDescriptor {
 
 	@Override
 	public JVMDescriptor getJvmInfo() {
-		return this.jvmDescriptor;
-	}
-
-	/**
-	 * Best effort to extract JVM information from a connection if everything works. Can be adjusted
-	 * to support different flavors of JVM.
-	 */
-	public static JVMDescriptor attemptToGetJvmInfo(RemoteJmxAdapter adapter) {
-		try {
-			AttributeList attributes = adapter.getAttributes(new ObjectName(ManagementFactory.RUNTIME_MXBEAN_NAME),
-					new String[] {"Pid", "Name", "InputArguments", "SystemProperties"}); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-			Integer pid = null;
-			String arguments = null, javaCommand = null, javaVersion = null, vmName = null, vmVendor = null;
-			boolean isDebug = false;
-			JVMType type = JVMType.UNKNOWN;
-			JVMArch arch = JVMArch.UNKNOWN;
-			for (Attribute attribute : attributes.asList()) {
-				// newer JVM have pid as separate attribute, older have to parse from name
-				if (attribute.getName().equalsIgnoreCase("Pid")) { //$NON-NLS-1$
-					try {
-						pid = Integer.valueOf(String.valueOf(attribute.getValue()));
-					} catch (NumberFormatException ignore) {
-					}
-				} else if (attribute.getName().equalsIgnoreCase("Name") && pid == null) { //$NON-NLS-1$
-					String pidAndHost = String.valueOf(attribute.getValue());
-					int separator = pidAndHost.indexOf('@');
-					if (separator > 0) {
-						try {
-							pid = Integer.valueOf(pidAndHost.substring(0, separator));
-						} catch (NumberFormatException e) {
-						}
-					}
-				} else if (attribute.getName().equalsIgnoreCase("InputArguments")) { //$NON-NLS-1$
-
-					if (attribute.getValue() instanceof String[]) {
-						arguments = Arrays.toString((String[]) attribute.getValue());
-					} else {
-						arguments = String.valueOf(attribute.getValue());
-					}
-					if (arguments.contains("-agentlib:jdwp")) { //$NON-NLS-1$
-						isDebug = true;
-					}
-				} else if (attribute.getName().equalsIgnoreCase("SystemProperties") //$NON-NLS-1$
-						&& attribute.getValue() instanceof TabularDataSupport) {
-					TabularDataSupport systemProperties = (TabularDataSupport) attribute.getValue();
-
-					// quite clumsy: iterate over properties as we need to use the exact key, which is non trivial
-					// to reproduce
-					for (Object entry : systemProperties.values()) {
-						String key = ((CompositeDataSupport) entry).get("key").toString(); //$NON-NLS-1$
-						String value = ((CompositeDataSupport) entry).get("value").toString(); //$NON-NLS-1$
-						if (key.equalsIgnoreCase("sun.management.compiler")) { //$NON-NLS-1$
-							if (value.toLowerCase().contains("hotspot")) { //$NON-NLS-1$
-								type = JVMType.HOTSPOT;
-							}
-						} else if (key.equalsIgnoreCase("sun.arch.data.model")) { //$NON-NLS-1$
-							String archIndicator = value;
-							if (archIndicator.contains("64")) { //$NON-NLS-1$
-								arch = JVMArch.BIT64;
-							} else if (archIndicator.contains("32")) { //$NON-NLS-1$
-								arch = JVMArch.BIT32;
-							}
-						} else if (key.equalsIgnoreCase("sun.java.command")) { //$NON-NLS-1$
-							javaCommand = value;
-						} else if (key.equalsIgnoreCase("java.version")) { //$NON-NLS-1$
-							javaVersion = value;
-						} else if (key.equalsIgnoreCase("java.vm.name")) { //$NON-NLS-1$
-							vmName = value;
-						} else if (key.equalsIgnoreCase("java.vm.vendor")) { //$NON-NLS-1$
-							vmVendor = value;
-						}
-					}
-				}
-			}
-			return new JVMDescriptor(javaVersion, type, arch, javaCommand, arguments, vmName, vmVendor, pid, isDebug,
-					Connectable.UNKNOWN);
-
-		} catch (RuntimeException | IOException | InstanceNotFoundException | MalformedObjectNameException ignore) {
-			return NULL_DESCRIPTOR;
-		}
+		//Note: From discovery we may know a bit about the target JVM, however the presence of JVM info
+		//is interpreted as a local JVM by AgentJmxHelper.isLocalJvm() hence the JMC Agent will be available 
+		//which does not make sense over this protocol
+		return null;
 	}
 
 	@Override

--- a/application/org.openjdk.jmc.jolokia/src/main/java/org/openjdk/jmc/jolokia/JolokiaDiscoveryListener.java
+++ b/application/org.openjdk.jmc.jolokia/src/main/java/org/openjdk/jmc/jolokia/JolokiaDiscoveryListener.java
@@ -49,10 +49,13 @@ import org.openjdk.jmc.jolokia.preferences.PreferenceConstants;
  */
 public class JolokiaDiscoveryListener extends AbstractCachedDescriptorProvider implements PreferenceConstants {
 
-	JolokiaDiscoverySettings settings;
+	private JolokiaDiscoverySettings settings;
+	private final JolokiaDiscovery jolokiaDiscovery;
 
 	public JolokiaDiscoveryListener(JolokiaDiscoverySettings settings) {
 		this.settings = settings;
+		jolokiaDiscovery = new JolokiaDiscovery();
+		jolokiaDiscovery.init(this.settings.getJolokiaContext());
 	}
 
 	public JolokiaDiscoveryListener() {
@@ -66,8 +69,6 @@ public class JolokiaDiscoveryListener extends AbstractCachedDescriptorProvider i
 			return found;
 		}
 		try {
-			JolokiaDiscovery jolokiaDiscovery = new JolokiaDiscovery();
-			jolokiaDiscovery.init(this.settings.getJolokiaContext());
 			for (Object object : jolokiaDiscovery.lookupAgentsWithTimeoutAndMulticastAddress(
 					this.settings.getDiscoveryTimeout(), this.settings.getMulticastGroup(),
 					this.settings.getMulticastPort())) {

--- a/application/org.openjdk.jmc.jolokia/src/main/java/org/openjdk/jmc/jolokia/JolokiaDiscoveryListener.java
+++ b/application/org.openjdk.jmc.jolokia/src/main/java/org/openjdk/jmc/jolokia/JolokiaDiscoveryListener.java
@@ -38,9 +38,7 @@ import java.net.URISyntaxException;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.jolokia.client.jmxadapter.RemoteJmxAdapter;
 import org.jolokia.service.discovery.JolokiaDiscovery;
-import org.openjdk.jmc.common.jvm.JVMDescriptor;
 import org.openjdk.jmc.jolokia.preferences.PreferenceConstants;
 
 /**
@@ -75,14 +73,7 @@ public class JolokiaDiscoveryListener extends AbstractCachedDescriptorProvider i
 				try {
 					@SuppressWarnings("unchecked")
 					Map<String, ?> response = (Map<String, ?>) object;
-					JVMDescriptor jvmInfo;
-					try {// if it is connectable, see if we can get info from connection
-						jvmInfo = JolokiaAgentDescriptor
-								.attemptToGetJvmInfo(new RemoteJmxAdapter(String.valueOf(response.get("url")))); //$NON-NLS-1$
-					} catch (Exception ignore) {
-						jvmInfo = JolokiaAgentDescriptor.NULL_DESCRIPTOR;
-					}
-					JolokiaAgentDescriptor agentDescriptor = new JolokiaAgentDescriptor(response, jvmInfo);
+					JolokiaAgentDescriptor agentDescriptor = new JolokiaAgentDescriptor(response);
 					found.put(agentDescriptor.getGUID(), agentDescriptor);
 
 				} catch (URISyntaxException ignore) {


### PR DESCRIPTION
This fixes two bugs with Jolokia discovery:
1. serious : repeated discovery runs crash. Runing repeatedly in the background is the whole point
2. more of an annoyance: the PR disables JMC agent by omitting JVM info in the descriptor (as presence is interpreted as a local JVM)
Both tested OK.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JMC-8284](https://bugs.openjdk.org/browse/JMC-8284): Fix Jolokia discovery issues (**Bug** - P2)


### Reviewers
 * [Alex Macdonald](https://openjdk.org/census#aptmac) (@aptmac - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmc.git pull/597/head:pull/597` \
`$ git checkout pull/597`

Update a local copy of the PR: \
`$ git checkout pull/597` \
`$ git pull https://git.openjdk.org/jmc.git pull/597/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 597`

View PR using the GUI difftool: \
`$ git pr show -t 597`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmc/pull/597.diff">https://git.openjdk.org/jmc/pull/597.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jmc/pull/597#issuecomment-2450265088)
</details>
