### PR TITLE
8287: Fix the JMX protocol extenders

### DIFF
--- a/application/org.openjdk.jmc.rjmx.ext/META-INF/MANIFEST.MF
+++ b/application/org.openjdk.jmc.rjmx.ext/META-INF/MANIFEST.MF
@@ -4,6 +4,9 @@ Bundle-Name: RJMX extensions
 Bundle-SymbolicName: org.openjdk.jmc.rjmx.ext;singleton:=true
 Bundle-Version: 9.1.0.qualifier
 Bundle-Vendor: Oracle Corporation
-Fragment-Host: org.openjdk.jmc.rjmx
+Fragment-Host: org.openjdk.jmc.rjmx.common
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Automatic-Module-Name: org.openjdk.jmc.rjmx.ext
+Require-Bundle: org.eclipse.equinox.common,
+ org.eclipse.osgi,
+ org.eclipse.core.runtime


### PR DESCRIPTION
This PR addresses [JMC-8287](https://bugs.openjdk.org/browse/JMC-8287), in which the JMX protocol extenders were not running due to rjmx.ext not being visible by rjmx.common.

This bug would have originated from the movement of rjmx code from application to core last year.

Making rjmx.ext specify Fragment-Host on rjmx.common fixes the visiblity issue, and the protocol extenders both run as expected. This also fixes use-cases where plugins were expecting to have their protocols used but were failing due to the protocols not being picked up properly:
```
org.openjdk.jmc.rjmx.common.ConnectionException caused by java.net.MalformedURLException: Unsupported protocol:
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JMC-8287](https://bugs.openjdk.org/browse/JMC-8287): Fix the JMX protocol extenders (**Bug** - P3)


### Reviewers
 * [Marcus Hirt](https://openjdk.org/census#hirt) (@thegreystone - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmc.git pull/602/head:pull/602` \
`$ git checkout pull/602`

Update a local copy of the PR: \
`$ git checkout pull/602` \
`$ git pull https://git.openjdk.org/jmc.git pull/602/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 602`

View PR using the GUI difftool: \
`$ git pr show -t 602`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmc/pull/602.diff">https://git.openjdk.org/jmc/pull/602.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jmc/pull/602#issuecomment-2451933634)
</details>
