### PR TITLE
8288: Clean up warnings

### DIFF
--- a/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/item/Aggregators.java
+++ b/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/item/Aggregators.java
@@ -140,13 +140,13 @@ public class Aggregators {
 		double sum = 0.0;
 		IUnit unit = null;
 
-		Predicate predicate;
+		Predicate<Double> predicate;
 
 		SumConsumer(IMemberAccessor<? extends IQuantity, IItem> accessor) {
 			super(accessor);
 		}
 
-		SumConsumer(IMemberAccessor<? extends IQuantity, IItem> accessor, Predicate predicate) {
+		SumConsumer(IMemberAccessor<? extends IQuantity, IItem> accessor, Predicate<Double> predicate) {
 			this(accessor);
 			this.predicate = predicate;
 		}

--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/util/DefaultIItemResultSet.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/util/DefaultIItemResultSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -155,6 +155,7 @@ final class DefaultIItemResultSet implements IItemResultSet {
 		data.addAll(processingQueue);
 	}
 
+	@SuppressWarnings("rawtypes")
 	private void checkStatusOfAllTasks(List<Future> totalAssignedTasks) {
 		int completedTask = 0;
 		for (Future future : totalAssignedTasks) {

--- a/core/tests/org.openjdk.jmc.flightrecorder.rules.jdk.test/src/main/java/org/openjdk/jmc/flightrecorder/test/rules/jdk/TestSocketReadWriteRule.java
+++ b/core/tests/org.openjdk.jmc.flightrecorder.rules.jdk.test/src/main/java/org/openjdk/jmc/flightrecorder/test/rules/jdk/TestSocketReadWriteRule.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2020, Datadog, Inc. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Datadog, Inc. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -48,7 +48,6 @@ import org.openjdk.jmc.flightrecorder.rules.ResultToolkit;
 import org.openjdk.jmc.flightrecorder.rules.jdk.io.SocketReadRule;
 import org.openjdk.jmc.flightrecorder.rules.jdk.io.SocketWriteRule;
 
-@SuppressWarnings("restriction")
 public class TestSocketReadWriteRule {
 	private static final String ADDRESS_1 = "123.45.67.78";
 	private static final String ADDRESS_2 = "123.102.103.104";

--- a/core/tests/org.openjdk.jmc.flightrecorder.rules.jdk.test/src/main/java/org/openjdk/jmc/flightrecorder/test/rules/jdk/VerifyNoneRuleTest.java
+++ b/core/tests/org.openjdk.jmc.flightrecorder.rules.jdk.test/src/main/java/org/openjdk/jmc/flightrecorder/test/rules/jdk/VerifyNoneRuleTest.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2020, Datadog, Inc. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Datadog, Inc. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -45,7 +45,6 @@ import org.openjdk.jmc.flightrecorder.rules.ResultProvider;
 import org.openjdk.jmc.flightrecorder.rules.ResultToolkit;
 import org.openjdk.jmc.flightrecorder.rules.jdk.general.VerifyNoneRule;
 
-@SuppressWarnings("restriction")
 public class VerifyNoneRuleTest {
 
 	@Test

--- a/core/tests/org.openjdk.jmc.flightrecorder.rules.jdk.test/src/main/java/org/openjdk/jmc/flightrecorder/test/rules/jdk/general/PasswordsInArgumentsRuleTest.java
+++ b/core/tests/org.openjdk.jmc.flightrecorder.rules.jdk.test/src/main/java/org/openjdk/jmc/flightrecorder/test/rules/jdk/general/PasswordsInArgumentsRuleTest.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2020, Datadog, Inc. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Datadog, Inc. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -49,7 +49,6 @@ import org.openjdk.jmc.flightrecorder.test.rules.jdk.MockEventCollection;
 import org.openjdk.jmc.flightrecorder.test.rules.jdk.TestEvent;
 import org.openjdk.jmc.flightrecorder.test.rules.jdk.VMInfoTestEvent;
 
-@SuppressWarnings("restriction")
 public class PasswordsInArgumentsRuleTest {
 
 	@Test

--- a/core/tests/org.openjdk.jmc.flightrecorder.rules.jdk.test/src/main/java/org/openjdk/jmc/flightrecorder/test/rules/jdk/general/PasswordsInEnvironmentRuleTest.java
+++ b/core/tests/org.openjdk.jmc.flightrecorder.rules.jdk.test/src/main/java/org/openjdk/jmc/flightrecorder/test/rules/jdk/general/PasswordsInEnvironmentRuleTest.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2020, Datadog, Inc. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Datadog, Inc. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -48,7 +48,6 @@ import org.openjdk.jmc.flightrecorder.rules.jdk.general.PasswordsInEnvironmentRu
 import org.openjdk.jmc.flightrecorder.test.rules.jdk.MockEventCollection;
 import org.openjdk.jmc.flightrecorder.test.rules.jdk.TestEvent;
 
-@SuppressWarnings("restriction")
 public class PasswordsInEnvironmentRuleTest {
 
 	@Test

--- a/core/tests/org.openjdk.jmc.flightrecorder.rules.jdk.test/src/main/java/org/openjdk/jmc/flightrecorder/test/rules/jdk/general/PasswordsInSystemPropertiesRuleTest.java
+++ b/core/tests/org.openjdk.jmc.flightrecorder.rules.jdk.test/src/main/java/org/openjdk/jmc/flightrecorder/test/rules/jdk/general/PasswordsInSystemPropertiesRuleTest.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2020, Datadog, Inc. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Datadog, Inc. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -48,7 +48,6 @@ import org.openjdk.jmc.flightrecorder.rules.jdk.general.PasswordsInSystemPropert
 import org.openjdk.jmc.flightrecorder.test.rules.jdk.MockEventCollection;
 import org.openjdk.jmc.flightrecorder.test.rules.jdk.TestEvent;
 
-@SuppressWarnings("restriction")
 public class PasswordsInSystemPropertiesRuleTest {
 
 	@Test

--- a/core/tests/org.openjdk.jmc.flightrecorder.test/src/main/java/org/openjdk/jmc/flightrecorder/test/CharAttributeTest.java
+++ b/core/tests/org.openjdk.jmc.flightrecorder.test/src/main/java/org/openjdk/jmc/flightrecorder/test/CharAttributeTest.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2022, 2023 Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2022, 2023 Red Hat, Inc. All rights reserved.
+ * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2024, Red Hat, Inc. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -57,7 +57,6 @@ import jdk.jfr.Recording;
 /**
  * Test for making sure events with {@code char} attributes can be parsed.
  */
-@SuppressWarnings("restriction")
 public class CharAttributeTest {
 
 	@Test

--- a/core/tests/org.openjdk.jmc.flightrecorder.writer.test/src/main/java/org/openjdk/jmc/flightrecorder/writer/AnnotationTest.java
+++ b/core/tests/org.openjdk.jmc.flightrecorder.writer.test/src/main/java/org/openjdk/jmc/flightrecorder/writer/AnnotationTest.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2021, Datadog, Inc. All rights reserved.
+ * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024, Datadog, Inc. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -43,7 +43,6 @@ import org.junit.jupiter.api.Test;
 import org.openjdk.jmc.flightrecorder.writer.api.Annotation;
 import org.openjdk.jmc.flightrecorder.writer.api.Types;
 
-@SuppressWarnings("restriction")
 class AnnotationTest {
 	private TypesImpl types;
 

--- a/core/tests/org.openjdk.jmc.flightrecorder.writer.test/src/main/java/org/openjdk/jmc/flightrecorder/writer/BuiltinTypeTest.java
+++ b/core/tests/org.openjdk.jmc.flightrecorder.writer.test/src/main/java/org/openjdk/jmc/flightrecorder/writer/BuiltinTypeTest.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2021, Datadog, Inc. All rights reserved.
+ * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024, Datadog, Inc. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/core/tests/org.openjdk.jmc.flightrecorder.writer.test/src/main/java/org/openjdk/jmc/flightrecorder/writer/BuiltinTypeTest.java
+++ b/core/tests/org.openjdk.jmc.flightrecorder.writer.test/src/main/java/org/openjdk/jmc/flightrecorder/writer/BuiltinTypeTest.java
@@ -51,7 +51,6 @@ import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 
-@SuppressWarnings("restriction")
 class BuiltinTypeTest {
 	private static final long TYPE_ID = 1L;
 	private BuiltinType instance;

--- a/core/tests/org.openjdk.jmc.flightrecorder.writer.test/src/main/java/org/openjdk/jmc/flightrecorder/writer/ChunkComplexTest.java
+++ b/core/tests/org.openjdk.jmc.flightrecorder.writer.test/src/main/java/org/openjdk/jmc/flightrecorder/writer/ChunkComplexTest.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2021, Datadog, Inc. All rights reserved.
+ * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024, Datadog, Inc. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -62,7 +62,6 @@ import org.openjdk.jmc.flightrecorder.writer.api.TypedField;
 import org.openjdk.jmc.flightrecorder.writer.api.TypedValue;
 import org.openjdk.jmc.flightrecorder.writer.api.Types;
 
-@SuppressWarnings("restriction")
 class ChunkComplexTest {
 	private Recording recording;
 	private Path jfrPath;

--- a/core/tests/org.openjdk.jmc.flightrecorder.writer.test/src/main/java/org/openjdk/jmc/flightrecorder/writer/ChunkTest.java
+++ b/core/tests/org.openjdk.jmc.flightrecorder.writer.test/src/main/java/org/openjdk/jmc/flightrecorder/writer/ChunkTest.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2021, Datadog, Inc. All rights reserved.
+ * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024, Datadog, Inc. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -45,7 +45,6 @@ import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 
-@SuppressWarnings("restriction")
 class ChunkTest {
 	private Chunk instance;
 	private LEB128Writer writer;

--- a/core/tests/org.openjdk.jmc.flightrecorder.writer.test/src/main/java/org/openjdk/jmc/flightrecorder/writer/CompositeTypeImplTest.java
+++ b/core/tests/org.openjdk.jmc.flightrecorder.writer.test/src/main/java/org/openjdk/jmc/flightrecorder/writer/CompositeTypeImplTest.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2021, 2023, Datadog, Inc. All rights reserved.
+ * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024, Datadog, Inc. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -46,7 +46,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openjdk.jmc.flightrecorder.writer.api.Annotation;
 
-@SuppressWarnings("restriction")
 class CompositeTypeImplTest {
 	private static final String TYPE_NAME = "test.Type";
 	private static final String FIELD_NAME = "field1";

--- a/core/tests/org.openjdk.jmc.flightrecorder.writer.test/src/main/java/org/openjdk/jmc/flightrecorder/writer/ConstantPoolTest.java
+++ b/core/tests/org.openjdk.jmc.flightrecorder.writer.test/src/main/java/org/openjdk/jmc/flightrecorder/writer/ConstantPoolTest.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2021, Datadog, Inc. All rights reserved.
+ * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024, Datadog, Inc. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -44,7 +44,6 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 
-@SuppressWarnings("restriction")
 class ConstantPoolTest {
 	private ConstantPool instance;
 

--- a/core/tests/org.openjdk.jmc.flightrecorder.writer.test/src/main/java/org/openjdk/jmc/flightrecorder/writer/ConstantPoolWriterTest.java
+++ b/core/tests/org.openjdk.jmc.flightrecorder.writer.test/src/main/java/org/openjdk/jmc/flightrecorder/writer/ConstantPoolWriterTest.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2021, Datadog, Inc. All rights reserved.
+ * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024, Datadog, Inc. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -38,7 +38,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-@SuppressWarnings("restriction")
 class ConstantPoolWriterTest {
 	private ConstantPools constantPools;
 	private TypesImpl types;

--- a/core/tests/org.openjdk.jmc.flightrecorder.writer.test/src/main/java/org/openjdk/jmc/flightrecorder/writer/ConstantPoolsTest.java
+++ b/core/tests/org.openjdk.jmc.flightrecorder.writer.test/src/main/java/org/openjdk/jmc/flightrecorder/writer/ConstantPoolsTest.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2021, 2023, Datadog, Inc. All rights reserved.
+ * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024, Datadog, Inc. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -49,7 +49,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
-@SuppressWarnings("restriction")
 class ConstantPoolsTest {
 	private ConstantPools instance;
 	private TypeImpl type1;

--- a/core/tests/org.openjdk.jmc.flightrecorder.writer.test/src/main/java/org/openjdk/jmc/flightrecorder/writer/InvalidType.java
+++ b/core/tests/org.openjdk.jmc.flightrecorder.writer.test/src/main/java/org/openjdk/jmc/flightrecorder/writer/InvalidType.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2021, Datadog, Inc. All rights reserved.
+ * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024, Datadog, Inc. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -41,7 +41,6 @@ import org.openjdk.jmc.flightrecorder.writer.api.NamedType;
 import org.openjdk.jmc.flightrecorder.writer.api.Type;
 import org.openjdk.jmc.flightrecorder.writer.api.TypedValueBuilder;
 
-@SuppressWarnings("restriction")
 final class InvalidType implements TypeImpl {
 	@Override
 	public long getId() {

--- a/core/tests/org.openjdk.jmc.flightrecorder.writer.test/src/main/java/org/openjdk/jmc/flightrecorder/writer/MetadataImplTest.java
+++ b/core/tests/org.openjdk.jmc.flightrecorder.writer.test/src/main/java/org/openjdk/jmc/flightrecorder/writer/MetadataImplTest.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2021, Datadog, Inc. All rights reserved.
+ * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024, Datadog, Inc. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -47,7 +47,6 @@ import java.util.function.Supplier;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-@SuppressWarnings("restriction")
 public class MetadataImplTest {
 	private static final String TYPE_NAME = "dummy.Type";
 

--- a/core/tests/org.openjdk.jmc.flightrecorder.writer.test/src/main/java/org/openjdk/jmc/flightrecorder/writer/RecordingImplTest.java
+++ b/core/tests/org.openjdk.jmc.flightrecorder.writer.test/src/main/java/org/openjdk/jmc/flightrecorder/writer/RecordingImplTest.java
@@ -79,7 +79,6 @@ import org.openjdk.jmc.flightrecorder.writer.api.RecordingSettings;
 import org.openjdk.jmc.flightrecorder.writer.api.TypedField;
 import org.openjdk.jmc.flightrecorder.writer.api.Types;
 
-@SuppressWarnings("restriction")
 class RecordingImplTest {
 	@Label("Simple Test Event")
 	@Registered(true)

--- a/core/tests/org.openjdk.jmc.flightrecorder.writer.test/src/main/java/org/openjdk/jmc/flightrecorder/writer/ResolvableTypeTest.java
+++ b/core/tests/org.openjdk.jmc.flightrecorder.writer.test/src/main/java/org/openjdk/jmc/flightrecorder/writer/ResolvableTypeTest.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2021, 2023, Datadog, Inc. All rights reserved.
+ * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024, Datadog, Inc. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -48,7 +48,6 @@ import org.mockito.Mockito;
 import org.openjdk.jmc.flightrecorder.writer.api.TypedValue;
 import org.openjdk.jmc.flightrecorder.writer.api.Types;
 
-@SuppressWarnings("restriction")
 class ResolvableTypeTest {
 	private static final String FIELD_1_NAME = "field_1";
 	private static final String FIELD_2_NAME = "field_2";

--- a/core/tests/org.openjdk.jmc.flightrecorder.writer.test/src/main/java/org/openjdk/jmc/flightrecorder/writer/SelfTypeTest.java
+++ b/core/tests/org.openjdk.jmc.flightrecorder.writer.test/src/main/java/org/openjdk/jmc/flightrecorder/writer/SelfTypeTest.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2021, 2023, Datadog, Inc. All rights reserved.
+ * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024, Datadog, Inc. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -37,7 +37,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.api.Test;
 
-@SuppressWarnings("restriction")
 class SelfTypeTest {
 	@Test
 	void isBuiltin() {

--- a/core/tests/org.openjdk.jmc.flightrecorder.writer.test/src/main/java/org/openjdk/jmc/flightrecorder/writer/TestType.java
+++ b/core/tests/org.openjdk.jmc.flightrecorder.writer.test/src/main/java/org/openjdk/jmc/flightrecorder/writer/TestType.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2021, Datadog, Inc. All rights reserved.
+ * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024, Datadog, Inc. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -37,7 +37,6 @@ import org.openjdk.jmc.flightrecorder.writer.api.Annotation;
 
 import java.util.List;
 
-@SuppressWarnings("restriction")
 abstract class TestType extends BaseType {
 	public TestType(long id, String name, String supertype, ConstantPools constantPools, TypesImpl types) {
 		super(id, name, supertype, constantPools, types);

--- a/core/tests/org.openjdk.jmc.flightrecorder.writer.test/src/main/java/org/openjdk/jmc/flightrecorder/writer/TypeByUsageComparatorTest.java
+++ b/core/tests/org.openjdk.jmc.flightrecorder.writer.test/src/main/java/org/openjdk/jmc/flightrecorder/writer/TypeByUsageComparatorTest.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2021, Datadog, Inc. All rights reserved.
+ * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024, Datadog, Inc. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -38,7 +38,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-@SuppressWarnings("restriction")
 class TypeByUsageComparatorTest {
 	private TypesImpl types;
 	private org.openjdk.jmc.flightrecorder.writer.util.TypeByUsageComparator instance;

--- a/core/tests/org.openjdk.jmc.flightrecorder.writer.test/src/main/java/org/openjdk/jmc/flightrecorder/writer/TypeStructureBuilderImplTest.java
+++ b/core/tests/org.openjdk.jmc.flightrecorder.writer.test/src/main/java/org/openjdk/jmc/flightrecorder/writer/TypeStructureBuilderImplTest.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2021, Datadog, Inc. All rights reserved.
+ * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024, Datadog, Inc. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -47,7 +47,6 @@ import org.openjdk.jmc.flightrecorder.writer.api.Annotation;
 import org.openjdk.jmc.flightrecorder.writer.api.TypeStructure;
 import org.openjdk.jmc.flightrecorder.writer.api.TypedField;
 
-@SuppressWarnings("restriction")
 class TypeStructureBuilderImplTest {
 	private static final String FIELD_NAME = "field";
 	private static final String CUSTOM_TYPE_NAME = "test.Type";

--- a/core/tests/org.openjdk.jmc.flightrecorder.writer.test/src/main/java/org/openjdk/jmc/flightrecorder/writer/TypedFieldBuilderImplTest.java
+++ b/core/tests/org.openjdk.jmc.flightrecorder.writer.test/src/main/java/org/openjdk/jmc/flightrecorder/writer/TypedFieldBuilderImplTest.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2021, Datadog, Inc. All rights reserved.
+ * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024, Datadog, Inc. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -47,7 +47,6 @@ import org.mockito.Mockito;
 import org.openjdk.jmc.flightrecorder.writer.api.Annotation;
 import org.openjdk.jmc.flightrecorder.writer.api.Types;
 
-@SuppressWarnings("restriction")
 class TypedFieldBuilderImplTest {
 	private static final String FIELD_NAME = "field";
 	private static final String CUSTOM_TYPE_NAME = "test.Type";

--- a/core/tests/org.openjdk.jmc.flightrecorder.writer.test/src/main/java/org/openjdk/jmc/flightrecorder/writer/TypedFieldImplTest.java
+++ b/core/tests/org.openjdk.jmc.flightrecorder.writer.test/src/main/java/org/openjdk/jmc/flightrecorder/writer/TypedFieldImplTest.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2021, Datadog, Inc. All rights reserved.
+ * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024, Datadog, Inc. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -45,7 +45,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@SuppressWarnings("restriction")
 class TypedFieldImplTest {
 	private static final String FIELD_NAME = "instance";
 

--- a/core/tests/org.openjdk.jmc.flightrecorder.writer.test/src/main/java/org/openjdk/jmc/flightrecorder/writer/TypedFieldValueTest.java
+++ b/core/tests/org.openjdk.jmc.flightrecorder.writer.test/src/main/java/org/openjdk/jmc/flightrecorder/writer/TypedFieldValueTest.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2021, 2023, Datadog, Inc. All rights reserved.
+ * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024, Datadog, Inc. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -41,7 +41,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-@SuppressWarnings("restriction")
 class TypedFieldValueTest {
 	private TypesImpl types;
 

--- a/core/tests/org.openjdk.jmc.flightrecorder.writer.test/src/main/java/org/openjdk/jmc/flightrecorder/writer/TypedValueBuilderImplTest.java
+++ b/core/tests/org.openjdk.jmc.flightrecorder.writer.test/src/main/java/org/openjdk/jmc/flightrecorder/writer/TypedValueBuilderImplTest.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2021, 2023, Datadog, Inc. All rights reserved.
+ * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024, Datadog, Inc. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -50,7 +50,6 @@ import org.openjdk.jmc.flightrecorder.writer.api.TypedFieldBuilder;
 import org.openjdk.jmc.flightrecorder.writer.api.TypedFieldValue;
 import org.openjdk.jmc.flightrecorder.writer.api.Types;
 
-@SuppressWarnings("restriction")
 class TypedValueBuilderImplTest {
 	private static final String CUSTOM_FIELD_NAME = "custom_field";
 	private static final String CUSTOM_FIELD_ARRAY_NAME = "custom_field_arr";

--- a/core/tests/org.openjdk.jmc.flightrecorder.writer.test/src/main/java/org/openjdk/jmc/flightrecorder/writer/TypedValueImplTest.java
+++ b/core/tests/org.openjdk.jmc.flightrecorder.writer.test/src/main/java/org/openjdk/jmc/flightrecorder/writer/TypedValueImplTest.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2021, 2023, Datadog, Inc. All rights reserved.
+ * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024, Datadog, Inc. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -48,7 +48,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 
-@SuppressWarnings("restriction")
 class TypedValueImplTest {
 	private ConstantPools constantPools;
 	private MetadataImpl metadata;


### PR DESCRIPTION
Cleaning up some of the warnings in core in preparation for hack-commit-push (https://switzerland2024.hack-commit-pu.sh/). The ones related to the security manager being deprecated will be taken care of in JMC 10 (https://bugs.openjdk.org/browse/JMC-8289).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JMC-8288](https://bugs.openjdk.org/browse/JMC-8288): Clean up warnings (**Enhancement** - P5)


### Reviewers
 * [Alex Macdonald](https://openjdk.org/census#aptmac) (@aptmac - **Reviewer**) ⚠️ Review applies to [57110e06](https://git.openjdk.org/jmc/pull/604/files/57110e06f21784540cfa183139e141305ec4f0b0)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmc.git pull/604/head:pull/604` \
`$ git checkout pull/604`

Update a local copy of the PR: \
`$ git checkout pull/604` \
`$ git pull https://git.openjdk.org/jmc.git pull/604/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 604`

View PR using the GUI difftool: \
`$ git pr show -t 604`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmc/pull/604.diff">https://git.openjdk.org/jmc/pull/604.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jmc/pull/604#issuecomment-2455023541)
</details>
