### PR TITLE
8291: JVM PID is shown as N/A however the value is present in JFR

### DIFF
--- a/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/jdk/JdkAttributes.java
+++ b/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/jdk/JdkAttributes.java
@@ -482,8 +482,8 @@ public final class JdkAttributes {
 			Messages.getString(Messages.ATTR_JVM_START_TIME), TIMESTAMP);
 	public static final IAttribute<String> JVM_NAME = attr("jvmName", Messages.getString(Messages.ATTR_JVM_NAME), //$NON-NLS-1$
 			PLAIN_TEXT);
-	public static final IAttribute<IQuantity> JVM_PID = attr("pid", Messages.getString(Messages.ATTR_JVM_PID), //$NON-NLS-1$
-			NUMBER);
+	public static final IAttribute<Number> JVM_PID = attr("pid", Messages.getString(Messages.ATTR_JVM_PID), //$NON-NLS-1$
+			RAW_NUMBER);
 	public static final IAttribute<String> JVM_VERSION = attr("jvmVersion", //$NON-NLS-1$
 			Messages.getString(Messages.ATTR_JVM_VERSION), PLAIN_TEXT);
 	public static final IAttribute<String> JVM_ARGUMENTS = attr("jvmArguments", //$NON-NLS-1$

--- a/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/parser/synthetic/SyntheticAttributeExtension.java
+++ b/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/parser/synthetic/SyntheticAttributeExtension.java
@@ -46,7 +46,6 @@ import org.openjdk.jmc.common.IMCPackage;
 import org.openjdk.jmc.common.IMCStackTrace;
 import org.openjdk.jmc.common.IMCThread;
 import org.openjdk.jmc.common.item.IAttribute;
-import org.openjdk.jmc.common.unit.IQuantity;
 import org.openjdk.jmc.common.unit.UnitLookup;
 import org.openjdk.jmc.common.util.LabeledIdentifier;
 import org.openjdk.jmc.flightrecorder.JfrAttributes;
@@ -242,7 +241,7 @@ public class SyntheticAttributeExtension implements IParserExtension {
 
 		@Override
 		public void addEvent(Object[] values) {
-			IQuantity longPid = (IQuantity) values[pidIndex];
+			Number longPid = (Number) values[pidIndex];
 			if (longPid != null && values != null && values.length > 0) {
 				String pid = String.valueOf(longPid.longValue());
 				Object[] newValues = new Object[values.length];


### PR DESCRIPTION
This is a regression found during internal testing.

PID issue was fixed in [JMC-7506](https://bugs.openjdk.org/browse/JMC-7506). The pid in system process was coming as string and the pid in VM information was coming as long. Hence,  to maintain the uniformity both the considered as string and changes are done to convert JVM PID from IQuantity/Long to String.

[JMC-8244](https://bugs.openjdk.org/browse/JMC-8244) Turned off all the scientific notations for long attributes. Hence, JVM_PID is no longer IQuantity/Long. Its a Raw number.

Both these fixes overlapped and PID on JVM Internals screen started showing as N/A.

![image](https://github.com/user-attachments/assets/25e9e370-cd53-44a6-a833-b8b24639d644)

Though the value of PID is present.
![image](https://github.com/user-attachments/assets/dbf1b76a-4567-408a-9407-54e54a5b294c)


After handling the datatypes properly, the issue has been fixed:
<img width="335" alt="image" src="https://github.com/user-attachments/assets/24154a14-19c0-4594-b40e-74a198835a17">

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JMC-8291](https://bugs.openjdk.org/browse/JMC-8291): JVM PID is shown as N/A however the value is present in JFR (**Bug** - P3)


### Reviewers
 * [Alex Macdonald](https://openjdk.org/census#aptmac) (@aptmac - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmc.git pull/608/head:pull/608` \
`$ git checkout pull/608`

Update a local copy of the PR: \
`$ git checkout pull/608` \
`$ git pull https://git.openjdk.org/jmc.git pull/608/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 608`

View PR using the GUI difftool: \
`$ git pr show -t 608`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmc/pull/608.diff">https://git.openjdk.org/jmc/pull/608.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jmc/pull/608#issuecomment-2470025765)
</details>
