### PR TITLE
8239: Errors installing JMC 9.0.0 as an Eclipse plugin via update site

### DIFF
--- a/application/org.openjdk.jmc.feature.core/feature.xml
+++ b/application/org.openjdk.jmc.feature.core/feature.xml
@@ -236,4 +236,33 @@
          install-size="0"
          version="0.0.0"
          unpack="false"/>
+
+   <plugin
+         id="org.jolokia.client-jmx-adapter.standalone"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.jolokia.service.discovery"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.jolokia.server.core"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.osgi.service.servlet"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
 </feature>

--- a/application/org.openjdk.jmc.feature.ide/feature.xml
+++ b/application/org.openjdk.jmc.feature.ide/feature.xml
@@ -203,4 +203,46 @@
          version="0.0.0"
          unpack="false"/>
 
+   <plugin
+         id="org.eclipse.jetty.ee9.security"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.jetty.ee9.server"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.jetty.ee9.servlet"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.jetty.ee9.websocket.api"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.jetty.ee9.websocket.common"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.jetty.ee9.websocket.server"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
 </feature>

--- a/application/org.openjdk.jmc.feature.license/feature.properties
+++ b/application/org.openjdk.jmc.feature.license/feature.properties
@@ -1,5 +1,5 @@
 #
-#  Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+#  Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
 #
 #  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
@@ -32,7 +32,7 @@
 #
 licenseUrl=http://oss.oracle.com/licenses/upl
 license=\
-Copyright (c) 2018, 2022, Oracle and/or its affiliates.\n\
+Copyright (c) 2018, 2024, Oracle and/or its affiliates.\n\
 \n\
 The Universal Permissive License (UPL), Version 1.0\n\
 \n\
@@ -70,7 +70,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE \n
 SOFTWARE.\n\
 \n\
 \n\
-Copyright (c) 2018, 2022 Oracle America, Inc.\n\
+Copyright (c) 2018, 2024 Oracle America, Inc.\n\
 \n\
 Redistribution and use in source and binary forms, with or without \n\
 modification, are permitted provided that the following conditions are met:\n\

--- a/application/org.openjdk.jmc.flightrecorder.ui/META-INF/MANIFEST.MF
+++ b/application/org.openjdk.jmc.flightrecorder.ui/META-INF/MANIFEST.MF
@@ -27,8 +27,8 @@ Require-Bundle: org.openjdk.jmc.rjmx,
  org.eclipse.jetty.ee9.websocket.servlet,
  org.eclipse.jetty.ee9.server,
  org.eclipse.jetty.server,
- org.eclipse.jetty.ee9.websocket.server;bundle-version="12.0.6",
- org.eclipse.jetty.servlet-api;bundle-version="5.0.2"
+ org.eclipse.jetty.ee9.websocket.server,
+ org.eclipse.jetty.servlet-api
 Bundle-ActivationPolicy: lazy
 Bundle-Activator: org.openjdk.jmc.flightrecorder.ui.FlightRecorderUI
 Export-Package: org.openjdk.jmc.flightrecorder.ui,

--- a/application/org.openjdk.jmc.jolokia/META-INF/MANIFEST.MF
+++ b/application/org.openjdk.jmc.jolokia/META-INF/MANIFEST.MF
@@ -7,7 +7,7 @@ Automatic-Module-Name: org.openjdk.jmc.jolokia
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.ui,
- org.jolokia.client-jmx-adapter.standalone,
+ org.jolokia.client-jmx-adapter.standalone;visibility:=reexport,
  org.openjdk.jmc.common,
  org.openjdk.jmc.rjmx,
  org.openjdk.jmc.ui,

--- a/application/org.openjdk.jmc.jolokia/META-INF/MANIFEST.MF
+++ b/application/org.openjdk.jmc.jolokia/META-INF/MANIFEST.MF
@@ -7,12 +7,12 @@ Automatic-Module-Name: org.openjdk.jmc.jolokia
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.ui,
- org.jolokia.client-jmx-adapter.standalone;bundle-version="2.0.2";visibility:=reexport,
+ org.jolokia.client-jmx-adapter.standalone,
  org.openjdk.jmc.common,
  org.openjdk.jmc.rjmx,
  org.openjdk.jmc.ui,
- org.jolokia.service.discovery;bundle-version="2.0.2",
- org.jolokia.server.core;bundle-version="2.0.2"
+ org.jolokia.service.discovery,
+ org.jolokia.server.core
 Export-Package:  org.openjdk.jmc.jolokia,
  org.openjdk.jmc.jolokia.preferences
 Bundle-Activator: org.openjdk.jmc.jolokia.JmcJolokiaPlugin


### PR DESCRIPTION
Added the missing plugin dependencies for newly added feature (Jolokia) and updated Jetty dependencies. With these changes, JMC 9.1.0 can be installed on Eclipse 2024-06 and 2024-09. It is not breaking Eclipse Icons and about dialog. 

JMC 9.0.0 can be installed on Eclipse 2024-06, but as @cimi, mentioned in JIRA issue that Eclipse branding breaks, including the actual Eclipse application icon and the about dialog. 

For the newer version of eclipse verification can be done after the release.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JMC-8239](https://bugs.openjdk.org/browse/JMC-8239): Errors installing JMC 9.0.0 as an Eclipse plugin via update site (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmc.git pull/610/head:pull/610` \
`$ git checkout pull/610`

Update a local copy of the PR: \
`$ git checkout pull/610` \
`$ git pull https://git.openjdk.org/jmc.git pull/610/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 610`

View PR using the GUI difftool: \
`$ git pr show -t 610`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmc/pull/610.diff">https://git.openjdk.org/jmc/pull/610.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jmc/pull/610#issuecomment-2480692376)
</details>
