### PR TITLE
8299: JDP Tests in core fail if multicast is not possible

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -34,7 +34,7 @@ function installCore() {
     }
 
     echo "$(date +%T) installing core artifacts - logging output to ${installLog}"
-    mvn clean install --log-file "${installLog}"
+    mvn ${JVM_ARGUMENTS} clean install --log-file "${installLog}"
 
     popd 1> /dev/null || {
         err_log "could not go to project root directory"


### PR DESCRIPTION
As 

> JDPClientTest.testChangePacket:95
> JDPClientTest.testJDPClient:73
> JDPJMXTest.testJDPClient:71

Now reside in common, installCore should skip JDP multicast test when the build file has been called with the flag to avoid JDP multicast tests

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JMC-8299](https://bugs.openjdk.org/browse/JMC-8299): JDP Tests in core fail if multicast is not possible (**Bug** - P4)


### Reviewers
 * [Marcus Hirt](https://openjdk.org/census#hirt) (@thegreystone - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmc.git pull/611/head:pull/611` \
`$ git checkout pull/611`

Update a local copy of the PR: \
`$ git checkout pull/611` \
`$ git pull https://git.openjdk.org/jmc.git pull/611/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 611`

View PR using the GUI difftool: \
`$ git pr show -t 611`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmc/pull/611.diff">https://git.openjdk.org/jmc/pull/611.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jmc/pull/611#issuecomment-2496188753)
</details>
