### PR TITLE
8295: Shutdown event type id is not properly translated for Oracle JDK 8

### DIFF
--- a/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/parser/synthetic/OracleJdkTypeIDsPre11.java
+++ b/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/parser/synthetic/OracleJdkTypeIDsPre11.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -176,6 +176,7 @@ public final class OracleJdkTypeIDsPre11 {
 	private final static String JAVA_THREAD_START = JVM_EVENT_ID_ROOT + "java/thread_start";
 	private final static String JAVA_THREAD_END = JVM_EVENT_ID_ROOT + "java/thread_end";
 	private final static String VM_OPERATIONS = JVM_EVENT_ID_ROOT + "vm/runtime/execute_vm_operation";
+	private final static String VM_SHUTDOWN = JVM_EVENT_ID_ROOT + "vm/runtime/shutdown";
 
 	private final static String THREAD_STATISTICS = JVM_EVENT_ID_ROOT + "java/statistics/threads";
 	private final static String CONTEXT_SWITCH_RATE = JVM_EVENT_ID_ROOT + "os/processor/context_switch_rate";
@@ -369,6 +370,8 @@ public final class OracleJdkTypeIDsPre11 {
 			return JdkTypeIDs.JAVA_THREAD_END;
 		case VM_OPERATIONS:
 			return JdkTypeIDs.VM_OPERATIONS;
+		case VM_SHUTDOWN:
+			return JdkTypeIDs.VM_SHUTDOWN;
 		case THREAD_STATISTICS:
 			return JdkTypeIDs.THREAD_STATISTICS;
 		case CONTEXT_SWITCH_RATE:


### PR DESCRIPTION
The conversion from the legacy jfr 0.9 id wasn't happening for the VM shutdown event.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JMC-8295](https://bugs.openjdk.org/browse/JMC-8295): Shutdown event type id is not properly translated for Oracle JDK 8 (**Bug** - P4)


### Reviewers
 * [Virag Purnam](https://openjdk.org/census#vpurnam) (@viragpurnam - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmc.git pull/614/head:pull/614` \
`$ git checkout pull/614`

Update a local copy of the PR: \
`$ git checkout pull/614` \
`$ git pull https://git.openjdk.org/jmc.git pull/614/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 614`

View PR using the GUI difftool: \
`$ git pr show -t 614`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmc/pull/614.diff">https://git.openjdk.org/jmc/pull/614.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jmc/pull/614#issuecomment-2515776459)
</details>
