### PR TITLE
8303: NPE at org.openjdk.jmc.flightrecorder.rules.report.JfrRulesReport.addReport

### DIFF
--- a/core/org.openjdk.jmc.flightrecorder.rules/src/main/java/org/openjdk/jmc/flightrecorder/rules/report/JfrRulesReport.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules/src/main/java/org/openjdk/jmc/flightrecorder/rules/report/JfrRulesReport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -329,8 +329,9 @@ public class JfrRulesReport {
 								Element itemNode = parent.getOwnerDocument().createElement("item"); //$NON-NLS-1$
 								itemsNode.appendChild(itemNode);
 								for (IMemberAccessor<?, IItem> a : accessors) {
-									itemNode.appendChild(createValueNode(parent.getOwnerDocument(), "value", //$NON-NLS-1$
-											toString(a.getMember(item))));
+									if (a != null)
+										itemNode.appendChild(createValueNode(parent.getOwnerDocument(), "value", //$NON-NLS-1$
+												toString(a.getMember(item))));
 								}
 							}
 						}

--- a/core/org.openjdk.jmc.flightrecorder.rules/src/main/java/org/openjdk/jmc/flightrecorder/rules/report/JfrRulesReport.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules/src/main/java/org/openjdk/jmc/flightrecorder/rules/report/JfrRulesReport.java
@@ -331,12 +331,13 @@ public class JfrRulesReport {
 								Element itemNode = parent.getOwnerDocument().createElement("item"); //$NON-NLS-1$
 								itemsNode.appendChild(itemNode);
 								for (IMemberAccessor<?, IItem> a : accessors) {
-									if (a != null)
+									if (a != null) {
 										itemNode.appendChild(createValueNode(parent.getOwnerDocument(), "value", //$NON-NLS-1$
 												toString(a.getMember(item))));
-									else
+									} else {
 										Logger.getLogger(JfrRulesReport.class.getName()).log(Level.WARNING,
 												"Accessor is null: " + item.getType()); //$NON-NLS-1$
+									}
 								}
 							}
 						}

--- a/core/org.openjdk.jmc.flightrecorder.rules/src/main/java/org/openjdk/jmc/flightrecorder/rules/report/JfrRulesReport.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules/src/main/java/org/openjdk/jmc/flightrecorder/rules/report/JfrRulesReport.java
@@ -45,6 +45,8 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.concurrent.Future;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -332,6 +334,9 @@ public class JfrRulesReport {
 									if (a != null)
 										itemNode.appendChild(createValueNode(parent.getOwnerDocument(), "value", //$NON-NLS-1$
 												toString(a.getMember(item))));
+									else
+										Logger.getLogger(JfrRulesReport.class.getName()).log(Level.WARNING,
+												"Accessor is null: " + item.getType()); //$NON-NLS-1$
 								}
 							}
 						}

--- a/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/jdk/JdkQueries.java
+++ b/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/jdk/JdkQueries.java
@@ -153,8 +153,8 @@ public final class JdkQueries {
 			.select(ALLOC_INSIDE_TLAB_AVG).select(ALLOC_INSIDE_TLAB_SUM).groupBy(ALLOCATION_CLASS).build();
 	public static final IItemQuery ALLOC_INSIDE_TLAB_BY_THREAD = fromWhere(JdkFilters.ALLOC_INSIDE_TLAB)
 			.select(ALLOC_INSIDE_TLAB_AVG).select(ALLOC_INSIDE_TLAB_SUM).groupBy(EVENT_THREAD).build();
-	public static final IItemQuery JFR_DATA_LOST = fromWhere(JdkFilters.JFR_DATA_LOST)
-			.select(END_TIME, EVENT_THREAD, FLR_DATA_LOST).build();
+	public static final IItemQuery JFR_DATA_LOST = fromWhere(JdkFilters.JFR_DATA_LOST).select(END_TIME, FLR_DATA_LOST)
+			.build();
 	public static final IItemQuery CLASS_LOAD = fromWhere(JdkFilters.CLASS_LOAD)
 			.select(CLASS_LOADED, CLASS_DEFINING_CLASSLOADER, CLASS_INITIATING_CLASSLOADER, EVENT_THREAD, DURATION)
 			.build();


### PR DESCRIPTION
One of our customers is trying to generate XML report using below mentioned command.

java -cp ".\common-9.1.0-SNAPSHOT.jar;.\flightrecorder-9.1.0-SNAPSHOT.jar;.\flightrecorder.rules-9.1.0-SNAPSHOT.jar;.\flightrecorder.rules.jdk-9.1.0-SNAPSHOT.jar;.\lz4-java_1.8.0.jar;.\org.owasp.encoder_1.2.3.jar" org.openjdk.jmc.flightrecorder.rules.report.JfrRulesReport JFRFileName.jfr -verbose -format xml > XmlFileName.xml

The report is not generated and the console is showing NullPointerException as below:

Caused by: java.lang.NullPointerException: Cannot invoke "org.openjdk.jmc.common.item.IMemberAccessor.getMember(Object)" because "a" is null
at org.openjdk.jmc.flightrecorder.rules.report.JfrRulesReport.addReport(JfrRulesReport.java:331)
at com.oracle.psr.pcl.analyzers.jmc.JMCParserProcess.call(JMCParserProcess.java:82)
at com.oracle.psr.pcl.analyzers.jmc.JMCParserProcess.call(JMCParserProcess.java:36)
at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
at java.base/java.lang.Thread.run(Thread.java:842) 

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JMC-8303](https://bugs.openjdk.org/browse/JMC-8303): NPE at org.openjdk.jmc.flightrecorder.rules.report.JfrRulesReport.addReport (**Bug** - P3)


### Reviewers
 * [Marcus Hirt](https://openjdk.org/census#hirt) (@thegreystone - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmc.git pull/616/head:pull/616` \
`$ git checkout pull/616`

Update a local copy of the PR: \
`$ git checkout pull/616` \
`$ git pull https://git.openjdk.org/jmc.git pull/616/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 616`

View PR using the GUI difftool: \
`$ git pr show -t 616`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmc/pull/616.diff">https://git.openjdk.org/jmc/pull/616.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jmc/pull/616#issuecomment-2537925296)
</details>
