### PR TITLE
8311: Ensure ./build.sh --installCore respects --skipJDPMulticastTests

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -34,7 +34,7 @@ function installCore() {
     }
 
     echo "$(date +%T) installing core artifacts - logging output to ${installLog}"
-    mvn clean install --log-file "${installLog}"
+    mvn ${JVM_ARGUMENTS} clean install --log-file "${installLog}"
 
     popd 1> /dev/null || {
         err_log "could not go to project root directory"


### PR DESCRIPTION
The fix for https://bugs.openjdk.org/browse/JMC-7539 does not work as intended as the JDP multicast tests reside in core due to https://bugs.openjdk.org/browse/JMC-7069

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JMC-8311](https://bugs.openjdk.org/browse/JMC-8311): Ensure ./build.sh --installCore respects --skipJDPMulticastTests (**Bug** - P4) ⚠️ Issue is not open.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmc.git pull/619/head:pull/619` \
`$ git checkout pull/619`

Update a local copy of the PR: \
`$ git checkout pull/619` \
`$ git pull https://git.openjdk.org/jmc.git pull/619/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 619`

View PR using the GUI difftool: \
`$ git pr show -t 619`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmc/pull/619.diff">https://git.openjdk.org/jmc/pull/619.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jmc/pull/619#issuecomment-2564441608)
</details>
