### PR TITLE
8336: Socket Read rule should filter jfr recordings

### DIFF
--- a/application/org.openjdk.jmc.feature.console.ui.subscriptions/feature.properties
+++ b/application/org.openjdk.jmc.feature.console.ui.subscriptions/feature.properties
@@ -32,6 +32,6 @@
 #
 name=Subscriptions Tab
 provider=Oracle Corporation
-copyright=Copyright \u00A9 2018, 2022, Oracle and/or its affiliates.
+copyright=Copyright \u00A9 2018, 2025, Oracle and/or its affiliates.
 description=This feature adds a tab for monitoring existing subscriptions from within the JDK Mission Control Console.
 descriptionUrl=http://www.oracle.com/missioncontrol

--- a/application/org.openjdk.jmc.feature.console.ui.subscriptions/feature.properties
+++ b/application/org.openjdk.jmc.feature.console.ui.subscriptions/feature.properties
@@ -1,5 +1,5 @@
 #
-#  Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+#  Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
 #
 #  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #

--- a/application/org.openjdk.jmc.feature.flightrecorder.ext.jfx/feature.properties
+++ b/application/org.openjdk.jmc.feature.flightrecorder.ext.jfx/feature.properties
@@ -1,5 +1,5 @@
 #
-#  Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+#  Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
 #
 #  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
@@ -32,6 +32,6 @@
 #
 name=JavaFX Page
 provider=Oracle Corporation
-copyright=Copyright \u00A9 2018, 2022, Oracle and/or its affiliates.
+copyright=Copyright \u00A9 2018, 2025, Oracle and/or its affiliates.
 description=This feature adds a page for viewing JDK Flight Recorder data produced by JavaFX.
 descriptionUrl=http://www.oracle.com/missioncontrol

--- a/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/item/ItemFilters.java
+++ b/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/item/ItemFilters.java
@@ -472,7 +472,7 @@ public class ItemFilters {
 			return PredicateToolkit.not(PredicateToolkit.endsWith(accessor, substring));
 		}
 	}
-	
+
 	public static class Contains extends AttributeValue<String> {
 		Contains(String substring, ICanonicalAccessorFactory<String> attribute) {
 			super(Kind.CONTAINS, attribute, substring);
@@ -620,7 +620,7 @@ public class ItemFilters {
 	public static IItemFilter notEndsWith(ICanonicalAccessorFactory<String> attribute, String substring) {
 		return new NotEndsWith(substring, attribute);
 	}
-	
+
 	public static IItemFilter notMatches(ICanonicalAccessorFactory<String> attribute, String regexp) {
 		return new NotMatches(regexp, attribute);
 	}

--- a/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/item/ItemFilters.java
+++ b/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/item/ItemFilters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -451,6 +451,28 @@ public class ItemFilters {
 		}
 	}
 
+	public static class EndsWith extends AttributeValue<String> {
+		EndsWith(String substring, ICanonicalAccessorFactory<String> attribute) {
+			super(Kind.ENDS_WITH, attribute, substring);
+		}
+
+		@Override
+		protected Predicate<IItem> getPredicate(IMemberAccessor<? extends String, IItem> accessor, String substring) {
+			return PredicateToolkit.endsWith(accessor, substring);
+		}
+	}
+
+	public static class NotEndsWith extends AttributeValue<String> {
+		NotEndsWith(String substring, ICanonicalAccessorFactory<String> attribute) {
+			super(Kind.NOT_ENDS_WITH, attribute, substring);
+		}
+
+		@Override
+		protected Predicate<IItem> getPredicate(IMemberAccessor<? extends String, IItem> accessor, String substring) {
+			return PredicateToolkit.not(PredicateToolkit.endsWith(accessor, substring));
+		}
+	}
+	
 	public static class Contains extends AttributeValue<String> {
 		Contains(String substring, ICanonicalAccessorFactory<String> attribute) {
 			super(Kind.CONTAINS, attribute, substring);
@@ -591,6 +613,14 @@ public class ItemFilters {
 		return new Contains(substring, attribute);
 	}
 
+	public static IItemFilter endsWith(ICanonicalAccessorFactory<String> attribute, String substring) {
+		return new EndsWith(substring, attribute);
+	}
+
+	public static IItemFilter notEndsWith(ICanonicalAccessorFactory<String> attribute, String substring) {
+		return new NotEndsWith(substring, attribute);
+	}
+	
 	public static IItemFilter notMatches(ICanonicalAccessorFactory<String> attribute, String regexp) {
 		return new NotMatches(regexp, attribute);
 	}

--- a/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/item/PersistableItemFilter.java
+++ b/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/item/PersistableItemFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -75,6 +75,8 @@ public abstract class PersistableItemFilter implements IItemFilter, IStateful {
 		NOT_MATCHES(MATCHES),
 		CONTAINS,
 		NOT_CONTAINS(CONTAINS),
+		ENDS_WITH,
+		NOT_ENDS_WITH(ENDS_WITH),
 		LESS,
 		LESS_OR_EQUAL,
 		MORE(LESS_OR_EQUAL),
@@ -161,6 +163,10 @@ public abstract class PersistableItemFilter implements IItemFilter, IStateful {
 			return ItemFilters.matches(readStringAttribute(memento), memento.getAttribute(KEY_VALUE));
 		case NOT_MATCHES:
 			return ItemFilters.notMatches(readStringAttribute(memento), memento.getAttribute(KEY_VALUE));
+		case ENDS_WITH:
+			return ItemFilters.endsWith(readStringAttribute(memento), memento.getAttribute(KEY_VALUE));
+		case NOT_ENDS_WITH:
+			return ItemFilters.notEndsWith(readStringAttribute(memento), memento.getAttribute(KEY_VALUE));
 		case CONTAINS:
 			return ItemFilters.contains(readStringAttribute(memento), memento.getAttribute(KEY_VALUE));
 		case NOT_CONTAINS:

--- a/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/util/PredicateToolkit.java
+++ b/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/util/PredicateToolkit.java
@@ -640,7 +640,7 @@ public class PredicateToolkit {
 			}
 		};
 	}
-	
+
 	/**
 	 * Create a predicate that checks if a string value ends with a specified substring.
 	 * <p>

--- a/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/util/PredicateToolkit.java
+++ b/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/util/PredicateToolkit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -637,6 +637,29 @@ public class PredicateToolkit {
 			public boolean test(T o) {
 				String value = valueAccessor.getMember(o);
 				return value == null ? false : value.contains(substring);
+			}
+		};
+	}
+	
+	/**
+	 * Create a predicate that checks if a string value ends with a specified substring.
+	 * <p>
+	 * The predicate takes an input object as argument but the value that is checked is extracted
+	 * from the input object using a member accessor.
+	 *
+	 * @param valueAccessor
+	 *            string accessor used to get the value to check from the input type
+	 * @param substring
+	 *            the substring to look for
+	 * @return a predicate that tests to {@code true} if the string value contains the substring
+	 */
+	public static <T> Predicate<T> endsWith(
+		final IMemberAccessor<? extends String, T> valueAccessor, final String substring) {
+		return new Predicate<T>() {
+			@Override
+			public boolean test(T o) {
+				String value = valueAccessor.getMember(o);
+				return value == null ? false : value.endsWith(substring);
 			}
 		};
 	}

--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/io/FileReadRule.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/io/FileReadRule.java
@@ -111,7 +111,8 @@ public class FileReadRule implements IRule {
 		IQuantity infoLimit = warningLimit.multiply(0.5);
 		String excludedFiles = vp.getPreferenceValue(EXCLUDED_FILES);
 
-		IItemCollection fileReadEvents = items.apply(ItemFilters.and(JdkFilters.FILE_READ, createExcludeFilter(excludedFiles)));
+		IItemCollection fileReadEvents = items
+				.apply(ItemFilters.and(JdkFilters.FILE_READ, createExcludeFilter(excludedFiles)));
 		IItem longestEvent = fileReadEvents.getAggregate(Aggregators.itemWithMax(JfrAttributes.DURATION));
 
 		// Aggregate of all file read events - if null, then we had no events
@@ -152,10 +153,10 @@ public class FileReadRule implements IRule {
 
 	private IItemFilter createExcludeFilter(String excludedFiles) {
 		if (excludedFiles.isBlank()) {
-			return ItemFilters.all();			
+			return ItemFilters.all();
 		}
-		String [] files = excludedFiles.split(",");
-		IItemFilter [] filters = new IItemFilter[files.length];
+		String[] files = excludedFiles.split(",");
+		IItemFilter[] filters = new IItemFilter[files.length];
 		for (int i = 0; i < files.length; i++) {
 			filters[i] = ItemFilters.notEndsWith(JdkAttributes.IO_PATH, files[i].trim());
 		}

--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/messages/internal/Messages.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/messages/internal/Messages.java
@@ -271,6 +271,8 @@ public class Messages {
 	public static final String FileReadRuleFactory_TEXT_WARN_LONG = "FileReadRuleFactory_TEXT_WARN_LONG"; //$NON-NLS-1$
 	public static final String FileReadRule_CONFIG_WARNING_LIMIT = "FileReadRule_CONFIG_WARNING_LIMIT"; //$NON-NLS-1$
 	public static final String FileReadRule_CONFIG_WARNING_LIMIT_LONG = "FileReadRule_CONFIG_WARNING_LIMIT_LONG"; //$NON-NLS-1$
+	public static final String FileReadRule_CONFIG_EXCLUDED_FILES = "FileReadRule_CONFIG_EXCLUDED_FILES"; //$NON-NLS-1$
+	public static final String FileReadRule_CONFIG_EXCLUDED_FILES_LONG = "FileReadRule_CONFIG_EXCLUDED_FILES_LONG"; //$NON-NLS-1$
 	public static final String FileWriteRuleFactory_RULE_NAME = "FileWriteRuleFactory_RULE_NAME"; //$NON-NLS-1$
 	public static final String FileWriteRuleFactory_TEXT_NO_EVENTS = "FileWriteRuleFactory_TEXT_NO_EVENTS"; //$NON-NLS-1$
 	public static final String FileWriteRuleFactory_TEXT_OK = "FileWriteRuleFactory_TEXT_OK"; //$NON-NLS-1$

--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/messages/internal/Messages.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/messages/internal/Messages.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/resources/org/openjdk/jmc/flightrecorder/rules/jdk/messages/internal/messages.properties
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/resources/org/openjdk/jmc/flightrecorder/rules/jdk/messages/internal/messages.properties
@@ -271,6 +271,8 @@ FewSampledThreadsRule_TEXT_INFO=There are fewer sampled threads than the total n
 FewSampledThreadsRule_TEXT_INFO_LONG={threadsWithEnoughSamples} threads with at least {min.sample.count.per.thread} method samples were found, but the machine has {hwThreads} hardware threads (cores). The application might benefit from a higher level of parallelism. This could also be caused by threads doing something else than running Java code, for example running native code or spending time in the JVM internals.
 FileReadRule_CONFIG_WARNING_LIMIT=File read duration warning limit
 FileReadRule_CONFIG_WARNING_LIMIT_LONG=The shortest file read duration that should trigger a warning
+FileReadRule_CONFIG_EXCLUDED_FILES=Files to exclude
+FileReadRule_CONFIG_EXCLUDED_FILES_LONG=The files to exclude. Will do an endsWith check, so can use extensions like .jfr.
 FileReadRuleFactory_RULE_NAME=File Read Peak Duration
 # {longestReadTime} is a time period
 FileReadRuleFactory_TEXT_OK=No long file read pauses were found in this recording (the longest was {longestReadTime}).

--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/resources/org/openjdk/jmc/flightrecorder/rules/jdk/messages/internal/messages.properties
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/resources/org/openjdk/jmc/flightrecorder/rules/jdk/messages/internal/messages.properties
@@ -1,5 +1,5 @@
 #
-#  Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
+#  Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
 #
 #  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #


### PR DESCRIPTION
Also filtering /proc/self/smap as that is also a very "serviceability tool" thing to do.