### PR TITLE
8297: OptionsCheckRule jvm arguments

### DIFF
--- a/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/version/JavaVersionSupport.java
+++ b/core/org.openjdk.jmc.common/src/main/java/org/openjdk/jmc/common/version/JavaVersionSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -75,4 +75,7 @@ public class JavaVersionSupport {
 	public static final JavaVersion JDK_19 = new JavaVersion(19, 0);
 	public static final JavaVersion JDK_20 = new JavaVersion(20, 0);
 	public static final JavaVersion JDK_21 = new JavaVersion(21, 0);
+	public static final JavaVersion JDK_22 = new JavaVersion(22, 0);
+	public static final JavaVersion JDK_23 = new JavaVersion(23, 0);
+	public static final JavaVersion JDK_24 = new JavaVersion(24, 0);
 }

--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/general/OptionsCheckRule.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/general/OptionsCheckRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -278,9 +278,10 @@ public class OptionsCheckRule implements IRule {
 			new DeprecatedOption("AllowTransitionalJSR292", null, JavaVersionSupport.JDK_7, JavaVersionSupport.JDK_8), //$NON-NLS-1$
 			// Deprecated in 8
 			// http://hg.openjdk.java.net/jdk8/jdk8/hotspot/file/87ee5ee27509/src/share/vm/runtime/arguments.cpp#l1979
-			new DeprecatedOption("MaxGCMinorPauseMillis", JavaVersionSupport.JDK_8, null, null), //$NON-NLS-1$
-			new DeprecatedOption("DefaultMaxRAMFraction", JavaVersionSupport.JDK_8, null, null, //$NON-NLS-1$
-					Messages.getString(Messages.OptionsCheckRule_TEXT_USE_MAXRAMFRACTION)),
+			new DeprecatedOption("MaxGCMinorPauseMillis", JavaVersionSupport.JDK_8, JavaVersionSupport.JDK_23, //$NON-NLS-1$
+					JavaVersionSupport.JDK_24),
+			new DeprecatedOption("DefaultMaxRAMFraction", JavaVersionSupport.JDK_8, JavaVersionSupport.JDK_23, //$NON-NLS-1$
+					JavaVersionSupport.JDK_24, Messages.getString(Messages.OptionsCheckRule_TEXT_USE_MAXRAMFRACTION)),
 			new DeprecatedOption("UseCMSCompactAtFullCollection", JavaVersionSupport.JDK_8, null, null), //$NON-NLS-1$
 			new DeprecatedOption("CMSFullGCsBeforeCompaction", JavaVersionSupport.JDK_8, null, null),
 			new DeprecatedOption("UseCMSCollectionPassing", JavaVersionSupport.JDK_8, null, null),
@@ -364,42 +365,66 @@ public class OptionsCheckRule implements IRule {
 			new DeprecatedOption("UseNewReflection", null, JavaVersionSupport.JDK_9, null),
 			new DeprecatedOption("UseOldInlining", null, JavaVersionSupport.JDK_9, null),
 			new DeprecatedOption("VerifyReflectionBytecodes", null, JavaVersionSupport.JDK_9, null),
-			new DeprecatedOption("InitialRAMFraction", JavaVersionSupport.JDK_10, null, null),
-			new DeprecatedOption("MaxRAMFraction", JavaVersionSupport.JDK_10, null, null),
-			new DeprecatedOption("MinRAMFraction", JavaVersionSupport.JDK_10, null, null),
-			new DeprecatedOption("AggressiveOpts", JavaVersionSupport.JDK_11, null, JavaVersionSupport.JDK_13),
+			new DeprecatedOption("InitialRAMFraction", JavaVersionSupport.JDK_10, JavaVersionSupport.JDK_23,
+					JavaVersionSupport.JDK_24),
+			new DeprecatedOption("MaxRAMFraction", JavaVersionSupport.JDK_10, JavaVersionSupport.JDK_23,
+					JavaVersionSupport.JDK_24),
+			new DeprecatedOption("MinRAMFraction", JavaVersionSupport.JDK_10, JavaVersionSupport.JDK_23,
+					JavaVersionSupport.JDK_24),
+			new DeprecatedOption("AggressiveOpts", JavaVersionSupport.JDK_11, JavaVersionSupport.JDK_12,
+					JavaVersionSupport.JDK_13),
 			new DeprecatedOption("UnlockCommercialFeatures", JavaVersionSupport.JDK_11, null, null),
 			new DeprecatedOption("UseContainerCpuShares", JavaVersionSupport.JDK_11_0_17, null, null),
-			new DeprecatedOption("MonitorInUseLists", null, JavaVersionSupport.JDK_12, null),
-			new DeprecatedOption("UseConcMarkSweepGC", null, JavaVersionSupport.JDK_14, null),
-			new DeprecatedOption("CMSClassUnloadingEnabled", null, JavaVersionSupport.JDK_14, null),
-			new DeprecatedOption("CMSExpAvgFactor", null, JavaVersionSupport.JDK_14, null),
-			new DeprecatedOption("CMSInitiatingOccupancyFraction", null, JavaVersionSupport.JDK_14, null),
-			new DeprecatedOption("CMSScavengeBeforeRemark", null, JavaVersionSupport.JDK_14, null),
-			new DeprecatedOption("CMSTriggerRatio", null, JavaVersionSupport.JDK_14, null),
-			new DeprecatedOption("UseParallelOldGC", JavaVersionSupport.JDK_14, null, null),
-			new DeprecatedOption("UseAdaptiveGCBoundary", null, JavaVersionSupport.JDK_15, null),
-			new DeprecatedOption("ForceNUMA", JavaVersionSupport.JDK_15, null, null),
-			new DeprecatedOption("UseBiasedLocking", JavaVersionSupport.JDK_15, JavaVersionSupport.JDK_18, null),
+			new DeprecatedOption("MonitorInUseLists", null, JavaVersionSupport.JDK_12, JavaVersionSupport.JDK_13),
+			new DeprecatedOption("UseConcMarkSweepGC", null, JavaVersionSupport.JDK_14, JavaVersionSupport.JDK_15),
+			new DeprecatedOption("CMSClassUnloadingEnabled", null, JavaVersionSupport.JDK_14,
+					JavaVersionSupport.JDK_15),
+			new DeprecatedOption("CMSExpAvgFactor", null, JavaVersionSupport.JDK_14, JavaVersionSupport.JDK_15),
+			new DeprecatedOption("CMSInitiatingOccupancyFraction", null, JavaVersionSupport.JDK_14,
+					JavaVersionSupport.JDK_15),
+			new DeprecatedOption("CMSScavengeBeforeRemark", null, JavaVersionSupport.JDK_14, JavaVersionSupport.JDK_15),
+			new DeprecatedOption("CMSTriggerRatio", null, JavaVersionSupport.JDK_14, JavaVersionSupport.JDK_15),
+			new DeprecatedOption("UseParallelOldGC", JavaVersionSupport.JDK_14, JavaVersionSupport.JDK_15,
+					JavaVersionSupport.JDK_16),
+			new DeprecatedOption("UseAdaptiveGCBoundary", null, JavaVersionSupport.JDK_15, JavaVersionSupport.JDK_16),
+			new DeprecatedOption("ForceNUMA", JavaVersionSupport.JDK_15, JavaVersionSupport.JDK_16,
+					JavaVersionSupport.JDK_17),
+			new DeprecatedOption("UseBiasedLocking", JavaVersionSupport.JDK_15, JavaVersionSupport.JDK_18,
+					JavaVersionSupport.JDK_19),
 			new DeprecatedOption("BiasedLockingStartupDelay", JavaVersionSupport.JDK_15, JavaVersionSupport.JDK_18,
-					null),
-			new DeprecatedOption("TraceClassLoading", JavaVersionSupport.JDK_9, JavaVersionSupport.JDK_16, null),
-			new DeprecatedOption("TraceClassUnloading", JavaVersionSupport.JDK_9, JavaVersionSupport.JDK_16, null),
-			new DeprecatedOption("TraceExceptions", JavaVersionSupport.JDK_9, JavaVersionSupport.JDK_16, null),
-			new DeprecatedOption("UseContainerCpuShares", JavaVersionSupport.JDK_17, null, null),
-			new DeprecatedOption("G1RSetRegionEntries", null, JavaVersionSupport.JDK_18, null),
-			new DeprecatedOption("G1RSetSparseRegionEntries", null, JavaVersionSupport.JDK_18, null),
+					JavaVersionSupport.JDK_19),
+			new DeprecatedOption("TraceClassLoading", JavaVersionSupport.JDK_9, JavaVersionSupport.JDK_16,
+					JavaVersionSupport.JDK_17),
+			new DeprecatedOption("TraceClassUnloading", JavaVersionSupport.JDK_9, JavaVersionSupport.JDK_16,
+					JavaVersionSupport.JDK_17),
+			new DeprecatedOption("TraceExceptions", JavaVersionSupport.JDK_9, JavaVersionSupport.JDK_16,
+					JavaVersionSupport.JDK_17),
+			new DeprecatedOption("UseContainerCpuShares", JavaVersionSupport.JDK_17, JavaVersionSupport.JDK_18, null),
+			new DeprecatedOption("G1RSetRegionEntries", null, JavaVersionSupport.JDK_18, JavaVersionSupport.JDK_19),
+			new DeprecatedOption("G1RSetSparseRegionEntries", null, JavaVersionSupport.JDK_18,
+					JavaVersionSupport.JDK_19),
 			new DeprecatedOption("GCParallelVerificationEnabled", null, null, JavaVersionSupport.JDK_19),
-			new DeprecatedOption("G1UseAdaptiveConcRefinement", null, JavaVersionSupport.JDK_20, null),
-			new DeprecatedOption("G1ConcRefinementGreenZone", null, JavaVersionSupport.JDK_20, null),
-			new DeprecatedOption("G1ConcRefinementYellowZone", null, JavaVersionSupport.JDK_20, null),
-			new DeprecatedOption("G1ConcRefinementRedZone", null, JavaVersionSupport.JDK_20, null),
-			new DeprecatedOption("G1ConcRefinementThresholdStep", null, JavaVersionSupport.JDK_20, null),
-			new DeprecatedOption("G1ConcRefinementServiceIntervalMillis", null, JavaVersionSupport.JDK_20, null),
-			new DeprecatedOption("G1ConcRSLogCacheSize", null, JavaVersionSupport.JDK_21, null),
-			new DeprecatedOption("G1ConcRSHotCardLimit", null, JavaVersionSupport.JDK_21, null),
+			new DeprecatedOption("G1UseAdaptiveConcRefinement", null, JavaVersionSupport.JDK_20,
+					JavaVersionSupport.JDK_24),
+			new DeprecatedOption("G1ConcRefinementGreenZone", null, JavaVersionSupport.JDK_20,
+					JavaVersionSupport.JDK_24),
+			new DeprecatedOption("G1ConcRefinementYellowZone", null, JavaVersionSupport.JDK_20,
+					JavaVersionSupport.JDK_24),
+			new DeprecatedOption("G1ConcRefinementRedZone", null, JavaVersionSupport.JDK_20, JavaVersionSupport.JDK_24),
+			new DeprecatedOption("G1ConcRefinementThresholdStep", null, JavaVersionSupport.JDK_20,
+					JavaVersionSupport.JDK_24),
+			new DeprecatedOption("G1ConcRefinementServiceIntervalMillis", null, JavaVersionSupport.JDK_20,
+					JavaVersionSupport.JDK_24),
+			new DeprecatedOption("G1ConcRSLogCacheSize", null, JavaVersionSupport.JDK_21, JavaVersionSupport.JDK_24),
+			new DeprecatedOption("G1ConcRSHotCardLimit", null, JavaVersionSupport.JDK_21, JavaVersionSupport.JDK_24),
 			new DeprecatedOption("EnableWaitForParallelLoad", null, null, JavaVersionSupport.JDK_21),
-			new DeprecatedOption("MetaspaceReclaimPolicy", null, JavaVersionSupport.JDK_21, null)};
+			new DeprecatedOption("MetaspaceReclaimPolicy", null, JavaVersionSupport.JDK_21, null),
+			new DeprecatedOption("RegisterFinalizersAtInit", JavaVersionSupport.JDK_22, JavaVersionSupport.JDK_23,
+					JavaVersionSupport.JDK_24),
+			new DeprecatedOption("PreserveAllAnnotations", JavaVersionSupport.JDK_23, JavaVersionSupport.JDK_24, null),
+			new DeprecatedOption("DontYieldALot", JavaVersionSupport.JDK_23, JavaVersionSupport.JDK_24, null),
+			new DeprecatedOption("UseEmptySlotsInSupers", JavaVersionSupport.JDK_23, JavaVersionSupport.JDK_24, null),
+			new DeprecatedOption("UseNotificationThread", JavaVersionSupport.JDK_23, JavaVersionSupport.JDK_24, null),};
 
 	@SuppressWarnings("nls")
 	private static final DeprecatedOption[] DEPRECATED_OPTIONS_X = {
@@ -409,7 +434,9 @@ public class OptionsCheckRule implements IRule {
 			new DeprecatedOption("run", JavaVersionSupport.JDK_8, null, JavaVersionSupport.JDK_9),
 			new DeprecatedOption("verify:none", JavaVersionSupport.JDK_13, null, null),
 			new DeprecatedOption("concgc", null, JavaVersionSupport.JDK_14, null),
-			new DeprecatedOption("noconcgc", null, JavaVersionSupport.JDK_14, null)};
+			new DeprecatedOption("noconcgc", null, JavaVersionSupport.JDK_14, null),
+			new DeprecatedOption("noagent", JavaVersionSupport.JDK_22, null, JavaVersionSupport.JDK_23),
+			new DeprecatedOption("debug", JavaVersionSupport.JDK_22, null, null),};
 
 	private static final Map<String, EventAvailability> REQUIRED_EVENTS = RequiredEventsBuilder.create()
 			.addEventType(JdkTypeIDs.VM_INFO, EventAvailability.AVAILABLE).build();

--- a/core/tests/org.openjdk.jmc.flightrecorder.rules.jdk.test/src/main/resources/baseline/JfrRuleBaseline.xml
+++ b/core/tests/org.openjdk.jmc.flightrecorder.rules.jdk.test/src/main/resources/baseline/JfrRuleBaseline.xml
@@ -5437,7 +5437,7 @@ Enabling the following event types would improve the accuracy of this rule: jdk.
             <id>Options</id>
             <severity>OK</severity>
             <summary>Deprecated option flags were detected.</summary>
-            <explanation>The following option flags are or will be deprecated. &lt;ul&gt;&lt;li&gt;-XX:+UseParallelOldGC: Deprecated in Java 14.&lt;/li&gt;&lt;li&gt;-XX:+UnlockCommercialFeatures: Deprecated in Java 11.&lt;/li&gt;&lt;/ul&gt; Deprecated option flags should be avoided. In some cases they enable legacy code and in other cases they are ignored completely. They will usually be removed in a later Java release.</explanation>
+            <explanation>The following option flags are or will be deprecated. &lt;ul&gt;&lt;li&gt;-XX:+UseParallelOldGC: Deprecated in Java 14, ignored in Java 15, and removed in Java 16.&lt;/li&gt;&lt;li&gt;-XX:+UnlockCommercialFeatures: Deprecated in Java 11.&lt;/li&gt;&lt;/ul&gt; Deprecated option flags should be avoided. In some cases they enable legacy code and in other cases they are ignored completely. They will usually be removed in a later Java release.</explanation>
         </rule>
         <rule>
             <id>OverAggressiveRecordingSetting</id>


### PR DESCRIPTION
New cli-options were added for JDK release 22, 23 based on the official release notes (removed part and deprecated path)
https://www.oracle.com/java/technologies/javase/22-relnote-issues.html
https://www.oracle.com/java/technologies/javase/23-relnote-issues.html 

I also updated existing depcrecated options in the array based on 
this file in the jdk https://github.com/openjdk/jdk/blob/master/src/hotspot/share/runtime/arguments.cpp#L516 which is regularly updated, i switched between git tags to find earlier options when they were part of the array. I did this to jdk10, but not before jdk version 10 for everything i could find. I can also update the arguments, which were obsoleted in jdk9.

Any feedback appreciated, thank you.