### PR TITLE
8372: Add UnitLookup.TIMESPAN to AttributeSelection to be able to use the attribute in FlameGraph for IO

### DIFF
--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/common/AttributeSelection.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/common/AttributeSelection.java
@@ -76,7 +76,8 @@ public class AttributeSelection extends Action implements IMenuCreator {
 			if (eventIterable.getType().hasAttribute(JfrAttributes.EVENT_STACKTRACE)) {
 				for (IAttribute<?> attr : attributes) {
 					ContentType<?> contentType = attr.getContentType();
-					if (contentType == UnitLookup.NUMBER || contentType == UnitLookup.MEMORY) {
+					if (contentType == UnitLookup.NUMBER || contentType == UnitLookup.MEMORY
+							|| contentType == UnitLookup.TIMESPAN) {
 						compatibleAttr.add(new Pair<>(attr.getName(), (IAttribute<IQuantity>) attr));
 					}
 				}


### PR DESCRIPTION
Add UnitLookup.TIMESPAN to AttributeSelection to be able to use the attribute in FlameGraph for IO

https://ibb.co/mrBQpYbQ

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JMC-8372](https://bugs.openjdk.org/browse/JMC-8372): Add UnitLookup.TIMESPAN to AttributeSelection to be able to use the attribute in FlameGraph for IO (**Enhancement** - P4)


### Reviewers
 * [Marcus Hirt](https://openjdk.org/census#hirt) (@thegreystone - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmc.git pull/634/head:pull/634` \
`$ git checkout pull/634`

Update a local copy of the PR: \
`$ git checkout pull/634` \
`$ git pull https://git.openjdk.org/jmc.git pull/634/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 634`

View PR using the GUI difftool: \
`$ git pr show -t 634`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmc/pull/634.diff">https://git.openjdk.org/jmc/pull/634.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jmc/pull/634#issuecomment-2758367107)
</details>
