### PR TITLE
8390: Wrong target platform name

### DIFF
--- a/releng/platform-definitions/platform-definition-2025-03/platform-definition-2025-03.target
+++ b/releng/platform-definitions/platform-definition-2025-03/platform-definition-2025-03.target
@@ -33,7 +33,7 @@
    WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 -->
 <?pde version="3.8"?>
-<target name="jmc-target-2024-12" sequenceNumber="47">
+<target name="jmc-target-2025-03" sequenceNumber="47">
     <locations>
         <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
             <unit id="org.eclipse.angus.jakarta.mail" version="2.0.3"/>


### PR DESCRIPTION
The 2025-03 target platform has the wrong name.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JMC-8390](https://bugs.openjdk.org/browse/JMC-8390): Wrong target platform name (**Bug** - P5)


### Reviewers
 * [Alex Macdonald](https://openjdk.org/census#aptmac) (@aptmac - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmc.git pull/643/head:pull/643` \
`$ git checkout pull/643`

Update a local copy of the PR: \
`$ git checkout pull/643` \
`$ git pull https://git.openjdk.org/jmc.git pull/643/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 643`

View PR using the GUI difftool: \
`$ git pr show -t 643`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmc/pull/643.diff">https://git.openjdk.org/jmc/pull/643.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jmc/pull/643#issuecomment-2828586430)
</details>
