### PR TITLE
Fix incorrect option name for `HeapDumpOnOutOfMemoryError`

### DIFF
--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/general/OptionsCheckRule.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/general/OptionsCheckRule.java
@@ -244,7 +244,7 @@ public class OptionsCheckRule implements IRule {
 			"MaxTrivialSize", "OptimizeStringConcat", "PrintAssembly", "PrintCompilation", "PrintInlining",
 			"ReservedCodeCacheSize", "RTMAbortRatio", "RTMRetryCount", "TieredCompilation", "UseAES",
 			"UseAESIntrinsics", "UseCodeCacheFlushing", "UseCondCardMark", "UseRTMDeopt", "UseRTMLocking", "UseSHA",
-			"UseSHA1Intrinsics", "UseSHA256Intrinsics", "UseSHA512Intrinsics", "UseSuperWord", "HeapDumpOnOutOfMemory",
+			"UseSHA1Intrinsics", "UseSHA256Intrinsics", "UseSHA512Intrinsics", "UseSuperWord", "HeapDumpOnOutOfMemoryError",
 			"HeapDumpPath", "LogFile", "PrintClassHistogram", "PrintConcurrentLocks", "UnlockDiagnosticVMOptions",
 			"AggressiveHeap", "AlwaysPreTouch", "CMSClassUnloadingEnabled", "CMSExpAvgFactor",
 			"CMSInitiatingOccupancyFraction", "CMSScavengeBeforeRemark", "CMSTriggerRatio", "ConcGCThreads",


### PR DESCRIPTION
I noticed that `HeapDumpOnOutOfMemoryError` was showing up as an undocumented rule, and that seemed a bit surprising.

On a closer look, it's even documented on the exact link https://docs.oracle.com/javase/8/docs/technotes/tools/windows/java.html used as the source for the `JAVA_8_DOCUMENTED_XX`.

I googled and I don't think this option ever had another name, so it looks like a copy-paste accident or something like that?

I'm contributing this fix on behalf of my employer, Datadog. I believe since [Datadog is already on the list of OCA Signatories](https://oca.opensource.oracle.com/?ojr=contrib-list) that I'm "good to go", but let me know if I missed a step :)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Commit message must refer to an issue
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmc.git pull/645/head:pull/645` \
`$ git checkout pull/645`

Update a local copy of the PR: \
`$ git checkout pull/645` \
`$ git pull https://git.openjdk.org/jmc.git pull/645/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 645`

View PR using the GUI difftool: \
`$ git pr show -t 645`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmc/pull/645.diff">https://git.openjdk.org/jmc/pull/645.diff</a>

</details>
