### PR TITLE
8396: OptionsCheckRule has doesn't recognize HeapDumpOnOutOfMemoryError

### DIFF
--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/general/OptionsCheckRule.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/general/OptionsCheckRule.java
@@ -244,7 +244,7 @@ public class OptionsCheckRule implements IRule {
 			"MaxTrivialSize", "OptimizeStringConcat", "PrintAssembly", "PrintCompilation", "PrintInlining",
 			"ReservedCodeCacheSize", "RTMAbortRatio", "RTMRetryCount", "TieredCompilation", "UseAES",
 			"UseAESIntrinsics", "UseCodeCacheFlushing", "UseCondCardMark", "UseRTMDeopt", "UseRTMLocking", "UseSHA",
-			"UseSHA1Intrinsics", "UseSHA256Intrinsics", "UseSHA512Intrinsics", "UseSuperWord", "HeapDumpOnOutOfMemory",
+			"UseSHA1Intrinsics", "UseSHA256Intrinsics", "UseSHA512Intrinsics", "UseSuperWord", "HeapDumpOnOutOfMemoryError",
 			"HeapDumpPath", "LogFile", "PrintClassHistogram", "PrintConcurrentLocks", "UnlockDiagnosticVMOptions",
 			"AggressiveHeap", "AlwaysPreTouch", "CMSClassUnloadingEnabled", "CMSExpAvgFactor",
 			"CMSInitiatingOccupancyFraction", "CMSScavengeBeforeRemark", "CMSTriggerRatio", "ConcGCThreads",


### PR DESCRIPTION
I noticed that `HeapDumpOnOutOfMemoryError` was showing up as an undocumented rule, and that seemed a bit surprising.

On a closer look, it's even documented on the exact link https://docs.oracle.com/javase/8/docs/technotes/tools/windows/java.html used as the source for the `JAVA_8_DOCUMENTED_XX`.

I googled and I don't think this option ever had another name, so it looks like a copy-paste accident or something like that?

I've submitted the needed docs for the OCA so I'm opening the PR for now and hopefully that will all be in good shape soon.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JMC-8396](https://bugs.openjdk.org/browse/JMC-8396): OptionsCheckRule has doesn't recognize HeapDumpOnOutOfMemoryError (**Task** - P5)


### Reviewers
 * [Henrik Dafgård](https://openjdk.org/census#hdafgard) (@Gunde - **Reviewer**)
 * [Marcus Hirt](https://openjdk.org/census#hirt) (@thegreystone - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmc.git pull/646/head:pull/646` \
`$ git checkout pull/646`

Update a local copy of the PR: \
`$ git checkout pull/646` \
`$ git pull https://git.openjdk.org/jmc.git pull/646/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 646`

View PR using the GUI difftool: \
`$ git pr show -t 646`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmc/pull/646.diff">https://git.openjdk.org/jmc/pull/646.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jmc/pull/646#issuecomment-3008787200)
</details>
