### PR TITLE
8392: Memory view on MacOS keeps reverting to aggregate trace list

### DIFF
--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/ChartAndTableUI.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/ChartAndTableUI.java
@@ -122,9 +122,10 @@ abstract class ChartAndTableUI implements IPageUI {
 		table = buildHistogram(sash, state.getChild(TABLE), classifier);
 		MCContextMenuManager mm = MCContextMenuManager.create(table.getManager().getViewer().getControl());
 		ColumnMenusFactory.addDefaultMenus(table.getManager(), mm);
-		table.getManager().getViewer().addSelectionChangedListener(e -> buildChart());
-		table.getManager().getViewer()
-				.addSelectionChangedListener(e -> pageContainer.showSelection(table.getSelection().getItems()));
+		table.getManager().getViewer().addSelectionChangedListener(e -> {
+			buildChart();
+			pageContainer.showSelection(table.getSelection().getItems());
+		});
 		SelectionStoreActionToolkit.addSelectionStoreActions(pageContainer.getSelectionStore(), table,
 				NLS.bind(Messages.ChartAndTableUI_HISTOGRAM_SELECTION, sectionTitle), mm);
 		tableFilterComponent = FilterComponent.createFilterComponent(table.getManager().getViewer().getControl(),


### PR DESCRIPTION
Annoying issue.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JMC-8392](https://bugs.openjdk.org/browse/JMC-8392): Memory view on MacOS keeps reverting to aggregate trace list (**Bug** - P4)


### Reviewers
 * [Henrik Dafgård](https://openjdk.org/census#hdafgard) (@Gunde - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmc.git pull/647/head:pull/647` \
`$ git checkout pull/647`

Update a local copy of the PR: \
`$ git checkout pull/647` \
`$ git pull https://git.openjdk.org/jmc.git pull/647/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 647`

View PR using the GUI difftool: \
`$ git pr show -t 647`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmc/pull/647.diff">https://git.openjdk.org/jmc/pull/647.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jmc/pull/647#issuecomment-2845715425)
</details>
