### PR TITLE
8395: Thread ID is not properly visible on hover for Mac

### DIFF
--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/common/ChartToolTipProvider.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/common/ChartToolTipProvider.java
@@ -148,9 +148,9 @@ public class ChartToolTipProvider implements IChartInfoVisitor {
 
 	protected void appendThreadId(Long threadId) {
 		if (text.indexOf(threadId.toString()) == -1) {
-			text.append("<p><b>") //$NON-NLS-1$
+			text.append("<p><span nowrap='true'>") //$NON-NLS-1$
 					.append(htmlify(NLS.bind(Messages.ThreadsPage_LANE_THREAD_ID_TOOLTIP, threadId.toString())))
-					.append("</b></p>"); //$NON-NLS-1$
+					.append("</span></p>"); //$NON-NLS-1$
 		}
 	}
 


### PR DESCRIPTION
In MAC, thread ID is not visible when user hover on thread name. 
Disabled the text wrap to fix the issue.

**Issue:**
<img width="1401" alt="8395_Bug" src="https://github.com/user-attachments/assets/e1c34a23-195e-4cd0-b1ec-c37f0b512b89" />

**Fix:**
<img width="1420" alt="8395_Fix" src="https://github.com/user-attachments/assets/8994ee05-2066-4d79-bfb0-cc1b8d0dc46c" />

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JMC-8395](https://bugs.openjdk.org/browse/JMC-8395): Thread ID is not properly visible on hover for Mac (**Bug** - P3)


### Reviewers
 * [Marcus Hirt](https://openjdk.org/census#hirt) (@thegreystone - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmc.git pull/648/head:pull/648` \
`$ git checkout pull/648`

Update a local copy of the PR: \
`$ git checkout pull/648` \
`$ git pull https://git.openjdk.org/jmc.git pull/648/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 648`

View PR using the GUI difftool: \
`$ git pr show -t 648`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmc/pull/648.diff">https://git.openjdk.org/jmc/pull/648.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jmc/pull/648#issuecomment-2854092651)
</details>
