### PR TITLE
8394: Views should not be named view

### DIFF
--- a/application/org.openjdk.jmc.flightrecorder.dependencyview/plugin.xml
+++ b/application/org.openjdk.jmc.flightrecorder.dependencyview/plugin.xml
@@ -8,7 +8,7 @@
           class="org.openjdk.jmc.flightrecorder.dependencyview.DependencyView"
           icon="icons/chord.png"
           id="org.openjdk.jmc.flightrecorder.dependencyview"
-          name="Dependency View"
+          name="Dependency Graph"
           restorable="true">
 		</view>
 	</extension>

--- a/application/org.openjdk.jmc.flightrecorder.graphview/plugin.xml
+++ b/application/org.openjdk.jmc.flightrecorder.graphview/plugin.xml
@@ -41,7 +41,7 @@
           class="org.openjdk.jmc.flightrecorder.graphview.views.GraphView"
           icon="icons/graph.png"
           id="org.openjdk.jmc.flightrecorder.graphview"
-          name="Graph View"
+          name="Call Graph"
           restorable="true">
 		</view>
 	</extension>

--- a/application/org.openjdk.jmc.flightrecorder.heatmap/plugin.xml
+++ b/application/org.openjdk.jmc.flightrecorder.heatmap/plugin.xml
@@ -8,7 +8,7 @@
           class="org.openjdk.jmc.flightrecorder.heatmap.views.HeatmapView"
           icon="icons/heatmap.png"
           id="org.openjdk.jmc.flightrecorder.heatmap"
-          name="Heatmap View"
+          name="Heatmap"
           restorable="true">
 		</view>
 	</extension>


### PR DESCRIPTION
Generally speaking I know of only one view in Eclipse named *View - the Progress View, and that one should probably be renamed too.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JMC-8394](https://bugs.openjdk.org/browse/JMC-8394): Views should not be named view (**Enhancement** - P5)


### Reviewers
 * [Henrik Dafgård](https://openjdk.org/census#hdafgard) (@Gunde - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmc.git pull/649/head:pull/649` \
`$ git checkout pull/649`

Update a local copy of the PR: \
`$ git checkout pull/649` \
`$ git pull https://git.openjdk.org/jmc.git pull/649/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 649`

View PR using the GUI difftool: \
`$ git pr show -t 649`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmc/pull/649.diff">https://git.openjdk.org/jmc/pull/649.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jmc/pull/649#issuecomment-2892136995)
</details>
