### PR TITLE
8401: Remove weak cipher usages in JMC Secure Store

### DIFF
--- a/application/org.openjdk.jmc.ui.common/src/main/resources/preferences.properties
+++ b/application/org.openjdk.jmc.ui.common/src/main/resources/preferences.properties
@@ -1,0 +1,34 @@
+#
+#  Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+#
+#  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+#
+#  The contents of this file are subject to the terms of either the Universal Permissive License 
+#  v 1.0 as shown at http://oss.oracle.com/licenses/upl
+#   
+#  or the following license:
+#   
+#  Redistribution and use in source and binary forms, with or without modification, are permitted
+#  provided that the following conditions are met:
+#   
+#  1. Redistributions of source code must retain the above copyright notice, this list of conditions
+#  and the following disclaimer.
+#   
+#  2. Redistributions in binary form must reproduce the above copyright notice, this list of
+#  conditions and the following disclaimer in the documentation and/or other materials provided with
+#  the distribution.
+#   
+#  3. Neither the name of the copyright holder nor the names of its contributors may be used to
+#  endorse or promote products derived from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+#  IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+#  FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+#  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+#  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+#  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+#  WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+jmc.cipherPref=PBEWithHmacSHA512AndAES_256,PBEWithHmacSHA384AndAES_256,PBEWithHmacSHA256AndAES_256,PBEWithHmacSHA512AndAES_128,PBEWithHmacSHA384AndAES_128,PBEWithHmacSHA256AndAES_128


### PR DESCRIPTION
Using stronger cipher algorithms and getting rid of weak cipher algorithms.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JMC-8401](https://bugs.openjdk.org/browse/JMC-8401): Remove weak cipher usages in JMC Secure Store (**Enhancement** - P3)


### Reviewers
 * [Marcus Hirt](https://openjdk.org/census#hirt) (@thegreystone - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmc.git pull/651/head:pull/651` \
`$ git checkout pull/651`

Update a local copy of the PR: \
`$ git checkout pull/651` \
`$ git pull https://git.openjdk.org/jmc.git pull/651/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 651`

View PR using the GUI difftool: \
`$ git pr show -t 651`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmc/pull/651.diff">https://git.openjdk.org/jmc/pull/651.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jmc/pull/651#issuecomment-2907895359)
</details>
