### PR TITLE
6515: Show virtualization information in JMC

### DIFF
--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/messages/internal/Messages.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/messages/internal/Messages.java
@@ -587,6 +587,7 @@ public class Messages extends NLS {
 	public static String SystemPage_SECTION_CPU;
 	public static String SystemPage_SECTION_MEMORY;
 	public static String SystemPage_SECTION_OS;
+	public static String SystemPage_SECTION_VIRTUALIZATION;
 	public static String SystemPropertiesPage_PAGE_NAME;
 	public static String TABLECOMPONENT_COMBINE_GROUP_BY;
 	public static String TABLECOMPONENT_GROUP_BY;

--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/SystemPage.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/pages/SystemPage.java
@@ -97,6 +97,8 @@ public class SystemPage extends AbstractDataPage {
 		infoViewer.addAggregate(JdkAggregators.MIN_TOTAL_MEMORY);
 		infoViewer.addCaption(Messages.SystemPage_SECTION_OS);
 		infoViewer.addAggregate(JdkAggregators.OS_VERSION);
+		infoViewer.addCaption(Messages.SystemPage_SECTION_VIRTUALIZATION);
+		infoViewer.addAggregate(JdkAggregators.VIRTUALIZATION_NAME);
 
 		infoViewer.setValues(getDataSource().getItems());
 

--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/resources/org/openjdk/jmc/flightrecorder/ui/messages/internal/messages.properties
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/resources/org/openjdk/jmc/flightrecorder/ui/messages/internal/messages.properties
@@ -545,6 +545,7 @@ SystemPage_PAGE_NAME=Environment
 SystemPage_SECTION_CPU=CPU
 SystemPage_SECTION_MEMORY=Memory
 SystemPage_SECTION_OS=Operating System
+SystemPage_SECTION_VIRTUALIZATION=Virtualization
 SystemPropertiesPage_PAGE_NAME=System Properties
 
 TABLECOMPONENT_GROUP_BY=Group By

--- a/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/jdk/JdkAggregators.java
+++ b/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/jdk/JdkAggregators.java
@@ -96,6 +96,7 @@ import static org.openjdk.jmc.flightrecorder.jdk.JdkTypeIDs.SOCKET_READ;
 import static org.openjdk.jmc.flightrecorder.jdk.JdkTypeIDs.SOCKET_WRITE;
 import static org.openjdk.jmc.flightrecorder.jdk.JdkTypeIDs.ULONG_FLAG;
 import static org.openjdk.jmc.flightrecorder.jdk.JdkTypeIDs.VM_INFO;
+import static org.openjdk.jmc.flightrecorder.jdk.JdkTypeIDs.VIRTUALIZATION_INFORMATION;
 
 import java.text.MessageFormat;
 
@@ -138,6 +139,8 @@ public final class JdkAggregators {
 	public static final IAggregator<String, ?> CPU_DESCRIPTION = distinctAsString(CPU_INFORMATION,
 			JdkAttributes.CPU_DESCRIPTION);
 	public static final IAggregator<String, ?> CPU_TYPE = distinctAsString(CPU_INFORMATION, JdkAttributes.CPU_TYPE);
+	public static final IAggregator<String, ?> VIRTUALIZATION_NAME = distinctAsString(VIRTUALIZATION_INFORMATION,
+			JdkAttributes.VIRTUALIZATION_NAME);
 	// OS info
 	public static final IAggregator<String, ?> OS_VERSION = distinctAsString(OS_INFORMATION, JdkAttributes.OS_VERSION);
 	public static final IAggregator<IQuantity, ?> MAX_USED_MEMORY = max(

--- a/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/jdk/JdkAttributes.java
+++ b/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/jdk/JdkAttributes.java
@@ -1346,6 +1346,8 @@ public final class JdkAttributes {
 			PLAIN_TEXT);
 	public static final IAttribute<String> CPU_TYPE = attr("cpu", Messages.getString(Messages.ATTR_CPU_TYPE), //$NON-NLS-1$
 			PLAIN_TEXT);
+	public static final IAttribute<String> VIRTUALIZATION_NAME = attr("name", //$NON-NLS-1$
+			Messages.getString(Messages.ATTR_VIRTUALIZATION_NAME), PLAIN_TEXT);
 	public static final IAttribute<IQuantity> NUMBER_OF_CORES = attr("cores", //$NON-NLS-1$
 			Messages.getString(Messages.ATTR_NUMBER_OF_CORES), Messages.getString(Messages.ATTR_NUMBER_OF_CORES_DESC),
 			NUMBER);

--- a/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/jdk/JdkTypeIDs.java
+++ b/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/jdk/JdkTypeIDs.java
@@ -58,6 +58,7 @@ public final class JdkTypeIDs {
 	public static final String OS_MEMORY_SUMMARY = PREFIX + "PhysicalMemory";
 	public static final String OS_INFORMATION = PREFIX + "OSInformation";
 	public static final String CPU_INFORMATION = PREFIX + "CPUInformation";
+	public static final String VIRTUALIZATION_INFORMATION = PREFIX + "VirtualizationInformation";
 	public static final String THREAD_ALLOCATION_STATISTICS = PREFIX + "ThreadAllocationStatistics";
 	public static final String HEAP_CONF = PREFIX + "GCHeapConfiguration";
 	public static final String GC_CONF = PREFIX + "GCConfiguration";

--- a/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/jdk/messages/internal/Messages.java
+++ b/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/jdk/messages/internal/Messages.java
@@ -269,6 +269,7 @@ public class Messages {
 	public static final String ATTR_CPU_DESCRIPTION = "ATTR_CPU_DESCRIPTION"; //$NON-NLS-1$
 	public static final String ATTR_CPU_DESCRIPTION_DESC = "ATTR_CPU_DESCRIPTION_DESC"; //$NON-NLS-1$
 	public static final String ATTR_CPU_TYPE = "ATTR_CPU_TYPE"; //$NON-NLS-1$
+	public static final String ATTR_VIRTUALIZATION_NAME = "ATTR_VIRTUALIZATION_NAME"; //$NON-NLS-1$
 	public static final String ATTR_DISABLE_BIASING = "ATTR_DISABLE_BIASING"; //$NON-NLS-1$
 	public static final String ATTR_DUMP_REASON = "ATTR_DUMP_REASON"; //$NON-NLS-1$
 	public static final String ATTR_DUMP_REASON_DESC = "ATTR_DUMP_REASON_DESC"; //$NON-NLS-1$

--- a/core/org.openjdk.jmc.flightrecorder/src/main/resources/org/openjdk/jmc/flightrecorder/jdk/messages/internal/messages.properties
+++ b/core/org.openjdk.jmc.flightrecorder/src/main/resources/org/openjdk/jmc/flightrecorder/jdk/messages/internal/messages.properties
@@ -305,6 +305,7 @@ ATTR_NUMBER_OF_SOCKETS_DESC=The number of cpu sockets on the motherboard
 ATTR_CPU_DESCRIPTION=CPU Description
 ATTR_CPU_DESCRIPTION_DESC=CPU Details and Features
 ATTR_CPU_TYPE=CPU Type
+ATTR_VIRTUALIZATION_NAME=Virtualization Name
 ATTR_NUMBER_OF_CORES=Number of Cores
 ATTR_NUMBER_OF_CORES_DESC=The total number of cores on all sockets
 ATTR_BLOCKING=Blocking


### PR DESCRIPTION
This PR adds Virtualization Information i.e. name (as this is the only information we have as of now) on Environment screen.

The screen looks like this:

<img width="959" height="486" alt="image" src="https://github.com/user-attachments/assets/a05ba14d-c60b-40f3-8432-c1cf57307af4" />


When jdk.VirtualizationInformation event exists:

<img width="226" height="37" alt="image" src="https://github.com/user-attachments/assets/728fc44f-d094-467c-b5b6-3946669859e6" />

When jdk.VirtualizationInformation event doesn't exists:

<img width="161" height="38" alt="image" src="https://github.com/user-attachments/assets/19299a60-ba9d-422f-b31f-894520aebe2c" />

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JMC-6515](https://bugs.openjdk.org/browse/JMC-6515): Show virtualization information in JMC (**Enhancement** - P3)


### Reviewers
 * [Alex Macdonald](https://openjdk.org/census#aptmac) (@aptmac - **Reviewer**)
 * [Marcus Hirt](https://openjdk.org/census#hirt) (@thegreystone - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmc.git pull/666/head:pull/666` \
`$ git checkout pull/666`

Update a local copy of the PR: \
`$ git checkout pull/666` \
`$ git pull https://git.openjdk.org/jmc.git pull/666/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 666`

View PR using the GUI difftool: \
`$ git pr show -t 666`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmc/pull/666.diff">https://git.openjdk.org/jmc/pull/666.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jmc/pull/666#issuecomment-3082773835)
</details>
