### PR TITLE
8421: Missing Eclipse classpath entry defaults

### DIFF
--- a/application/org.openjdk.jmc.flightrecorder.dependencyview/.classpath
+++ b/application/org.openjdk.jmc.flightrecorder.dependencyview/.classpath
@@ -6,12 +6,19 @@
 		</attributes>
 	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
-	<classpathentry kind="src" path="src/main/java/">
+	<classpathentry kind="src" output="target/classes" path="src/main/java">
 		<attributes>
+			<attribute name="optional" value="true"/>
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="src" path="src/main/resources/">
+	<classpathentry kind="src" output="target/classes" path="src/main/resources">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.m2e.MAVEN2_CLASSPATH_CONTAINER">
 		<attributes>
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>

--- a/application/org.openjdk.jmc.jolokia/.classpath
+++ b/application/org.openjdk.jmc.jolokia/.classpath
@@ -12,7 +12,13 @@
 			<accessrule kind="accessible" pattern="org/json/simple/*"/>
 		</accessrules>
 	</classpathentry>
-	<classpathentry kind="src" path="src/main/java">
+	<classpathentry kind="src" output="target/classes" path="src/main/java">
+		<attributes>
+		        <attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.m2e.MAVEN2_CLASSPATH_CONTAINER">
 		<attributes>
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>

--- a/application/tests/org.openjdk.jmc.flightrecorder.controlpanel.ui.test/.classpath
+++ b/application/tests/org.openjdk.jmc.flightrecorder.controlpanel.ui.test/.classpath
@@ -6,15 +6,20 @@
 		</attributes>
 	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
-	<classpathentry kind="src" path="src/test/java/">
+	<classpathentry kind="src" output="target/test-classes" path="src/test/java">
 		<attributes>
-			<attribute name="test" value="true"/>
+			<attribute name="optional" value="true"/>
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="src" path="src/test/resources/">
+	<classpathentry kind="src" output="target/test-classes" path="src/test/resources">
 		<attributes>
-			<attribute name="test" value="true"/>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.m2e.MAVEN2_CLASSPATH_CONTAINER">
+		<attributes>
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>
 	</classpathentry>

--- a/application/tests/org.openjdk.jmc.flightrecorder.graphview.test/.classpath
+++ b/application/tests/org.openjdk.jmc.flightrecorder.graphview.test/.classpath
@@ -6,9 +6,14 @@
 		</attributes>
 	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
-	<classpathentry kind="src" path="src/test/java/">
+	<classpathentry kind="src" output="target/test-classes" path="src/test/java">
 		<attributes>
-			<attribute name="test" value="true"/>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.m2e.MAVEN2_CLASSPATH_CONTAINER">
+		<attributes>
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>
 	</classpathentry>

--- a/application/tests/org.openjdk.jmc.jolokia.test/.classpath
+++ b/application/tests/org.openjdk.jmc.jolokia.test/.classpath
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="src" path="src/test/java">
+	<classpathentry kind="src" output="target/test-classes" path="src/test/java">
 		<attributes>
-			<attribute name="test" value="true"/>
+			<attribute name="optional" value="true"/>
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>
 	</classpathentry>
@@ -16,6 +16,17 @@
 			<accessrule kind="accessible" pattern="org/jolokia/**"/>
 			<accessrule kind="accessible" pattern="org/json/simple/*"/>
 		</accessrules>
+	</classpathentry>
+	<classpathentry kind="src" output="target/test-classes" path="src/test/resources">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.m2e.MAVEN2_CLASSPATH_CONTAINER">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
 	</classpathentry>
 	<classpathentry kind="output" path="target/test-classes"/>
 </classpath>

--- a/application/tests/org.openjdk.jmc.rjmx.services.jfr.test/.classpath
+++ b/application/tests/org.openjdk.jmc.rjmx.services.jfr.test/.classpath
@@ -6,9 +6,14 @@
 		</attributes>
 	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
-	<classpathentry kind="src" path="src/test/java/">
+	<classpathentry kind="src" output="target/test-classes" path="src/test/java">
 		<attributes>
-			<attribute name="test" value="true"/>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.m2e.MAVEN2_CLASSPATH_CONTAINER">
+		<attributes>
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>
 	</classpathentry>


### PR DESCRIPTION
Updating few missed classpath files as part of this PR.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JMC-8421](https://bugs.openjdk.org/browse/JMC-8421): Missing Eclipse classpath entry defaults (**Bug** - P4)


### Reviewers
 * [Virag Purnam](https://openjdk.org/census#vpurnam) (@viragpurnam - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmc.git pull/667/head:pull/667` \
`$ git checkout pull/667`

Update a local copy of the PR: \
`$ git checkout pull/667` \
`$ git pull https://git.openjdk.org/jmc.git pull/667/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 667`

View PR using the GUI difftool: \
`$ git pr show -t 667`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmc/pull/667.diff">https://git.openjdk.org/jmc/pull/667.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jmc/pull/667#issuecomment-3092415070)
</details>
