### PR TITLE
8437: JDP Tests are failing on macOS-15 Github Actions runner due to local network privacy restrictions

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -138,6 +138,26 @@
 				<module>coverage</module>
 			</modules>
 		</profile>
+		<profile>
+			<id>skip-jdp-multicast-tests-on-mac</id>
+			<activation>
+				<os>
+					<family>mac</family>
+				</os>
+			</activation>
+			<build>
+				<plugins>
+					<plugin>
+						<artifactId>maven-surefire-plugin</artifactId>
+						<configuration>
+							<systemPropertyVariables>
+								<skipJDPMulticastTests>true</skipJDPMulticastTests>
+							</systemPropertyVariables>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
 	</profiles>
 	<distributionManagement>
 		<repository>


### PR DESCRIPTION
Skipped the execution of JDP tests requiring multicast which is not supported on macOS-15 runner

This was the result of moving macOS-latest from 14 to 15

Similar issues are mentioned in the following links : 
https://github.com/orgs/community/discussions/170669
https://github.com/actions/runner-images/issues/10924