### PR TITLE
5608: Include top stack trace frames in errors and exceptions rules

### DIFF
--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/messages/internal/Messages.java
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/java/org/openjdk/jmc/flightrecorder/rules/jdk/messages/internal/Messages.java
@@ -231,12 +231,15 @@ public class Messages {
 	public static final String ErrorRule_TEXT_WARN = "ErrorRule_TEXT_WARN"; //$NON-NLS-1$
 	public static final String ErrorRule_TEXT_WARN_EXCLUDED_INFO = "ErrorRule_TEXT_WARN_EXCLUDED_INFO"; //$NON-NLS-1$
 	public static final String ErrorRule_TEXT_WARN_LONG = "ErrorRule_TEXT_WARN_LONG"; //$NON-NLS-1$
+	public static final String ErrorRule_TEXT_WARN_MOST_COMMON_STACKTRACE = "ErrorRule_TEXT_WARN_MOST_COMMON_STACKTRACE"; //$NON-NLS-1$
 	public static final String ExceptionRule_CONFIG_INFO_LIMIT = "ExceptionRule_CONFIG_INFO_LIMIT"; //$NON-NLS-1$
 	public static final String ExceptionRule_CONFIG_INFO_LIMIT_LONG = "ExceptionRule_CONFIG_INFO_LIMIT_LONG"; //$NON-NLS-1$
 	public static final String ExceptionRule_CONFIG_WARN_LIMIT = "ExceptionRule_CONFIG_WARN_LIMIT"; //$NON-NLS-1$
 	public static final String ExceptionRule_CONFIG_WARN_LIMIT_LONG = "ExceptionRule_CONFIG_WARN_LIMIT_LONG"; //$NON-NLS-1$
 	public static final String ExceptionRule_RULE_NAME = "ExceptionRule_RULE_NAME"; //$NON-NLS-1$
 	public static final String ExceptionRule_TEXT_INFO_LONG = "ExceptionRule_TEXT_INFO_LONG"; //$NON-NLS-1$
+	public static final String ExceptionRule_TEXT_MOST_COMMON_EXCEPTION = "ExceptionRule_TEXT_MOST_COMMON_EXCEPTION"; //$NON-NLS-1$
+	public static final String ExceptionRule_TEXT_MOST_COMMON_STACKTRACE = "ExceptionRule_TEXT_MOST_COMMON_STACKTRACE"; //$NON-NLS-1$
 	public static final String ExceptionRule_TEXT_MESSAGE = "ExceptionRule_TEXT_MESSAGE"; //$NON-NLS-1$
 	public static final String FatalErrorRule_RULE_NAME = "FatalErrorRule_RULE_NAME"; //$NON-NLS-1$
 	public static final String FatalErrorRule_TEXT_OK = "FatalErrorRule_TEXT_OK"; //$NON-NLS-1$

--- a/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/resources/org/openjdk/jmc/flightrecorder/rules/jdk/messages/internal/messages.properties
+++ b/core/org.openjdk.jmc.flightrecorder.rules.jdk/src/main/resources/org/openjdk/jmc/flightrecorder/rules/jdk/messages/internal/messages.properties
@@ -232,14 +232,20 @@ ErrorRule_TEXT_WARN=The program generated an average of {errorRate} errors per m
 ErrorRule_TEXT_WARN_LONG={errorCount} errors were thrown in total. The most common error was ''{mostCommonError}'', which was thrown {mostCommonErrorCount} times. Investigate the thrown errors to see if they can be avoided. Errors indicate that something went wrong with the code execution and should never be used for flow control.
 # {error.exclude.regexp} is a regexp exclude string, {excludedErrors} is a number
 ErrorRule_TEXT_WARN_EXCLUDED_INFO=The following regular expression was used to exclude {excludedErrors} errors from this rule: ''{error.exclude.regexp}''.
+# {mostCommonErrorStacktrace} is a string.
+ErrorRule_TEXT_WARN_MOST_COMMON_STACKTRACE=The most common error stackrace was : \n {mostCommonErrorStacktrace}
 ExceptionRule_CONFIG_INFO_LIMIT=Exception rate info limit
 ExceptionRule_CONFIG_INFO_LIMIT_LONG=The number of thrown exceptions per second needed to trigger an info notice
 ExceptionRule_CONFIG_WARN_LIMIT=Exception rate warning limit
 ExceptionRule_CONFIG_WARN_LIMIT_LONG=The number of thrown exceptions per second needed to trigger a warning
 ExceptionRule_RULE_NAME=Thrown Exceptions
+# {mostCommonException} is an exception class name
+ExceptionRule_TEXT_MOST_COMMON_EXCEPTION=The most common exception was ''{mostCommonException}''.
 ExceptionRule_TEXT_INFO_LONG=Throwing exceptions is more expensive than normal code execution, which means that they should only be used for exceptional situations. Investigate the thrown exceptions to see if any of them can be avoided with a non-exceptional control flow.
 # {exceptionsWindow} is a time range, {exceptionsRate} is a number
 ExceptionRule_TEXT_MESSAGE=The program generated {exceptionsRate} exceptions per second during {exceptionsWindow}.
+{mostCommonExceptionStacktrace} is a string.
+ExceptionRule_TEXT_MOST_COMMON_STACKTRACE=The most common exception stacktrace was : \n {mostCommonExceptionStacktrace}
 FatalErrorRule_RULE_NAME=Fatal Errors
 FatalErrorRule_TEXT_OK=The JVM shut down in a normal way.
 FatalErrorRule_TEXT_INFO=The JVM shut down due to there being no remaining non-daemon Java threads.

--- a/core/tests/org.openjdk.jmc.flightrecorder.rules.jdk.test/src/main/resources/baseline/JfrRuleBaseline.xml
+++ b/core/tests/org.openjdk.jmc.flightrecorder.rules.jdk.test/src/main/resources/baseline/JfrRuleBaseline.xml
@@ -6289,7 +6289,18 @@ Enabling the following event types would improve the accuracy of this rule: jdk.
             <id>Errors</id>
             <severity>OK</severity>
             <summary>The program generated an average of 17 errors per minute during 9/24/2015 10:08:14.000 AM – 10:09:14 AM.</summary>
-            <explanation>17 errors were thrown in total. The most common error was ''java.lang.NoSuchMethodError'', which was thrown 13 times. Investigate the thrown errors to see if they can be avoided. Errors indicate that something went wrong with the code execution and should never be used for flow control. The following regular expression was used to exclude 381 errors from this rule: ''(com.sun.el.parser.ELParser\$LookaheadSuccess)''.</explanation>
+            <explanation>17 errors were thrown in total. The most common error was ''java.lang.NoSuchMethodError'', which was thrown 13 times. Investigate the thrown errors to see if they can be avoided. Errors indicate that something went wrong with the code execution and should never be used for flow control. The following regular expression was used to exclude 381 errors from this rule: ''(com.sun.el.parser.ELParser\$LookaheadSuccess)''.
+The most common error stackrace was : 
+ java.lang.Error.&amp;lt;init&amp;gt;(String):71
+java.lang.LinkageError.&amp;lt;init&amp;gt;(String):55
+java.lang.IncompatibleClassChangeError.&amp;lt;init&amp;gt;(String):55
+java.lang.NoSuchMethodError.&amp;lt;init&amp;gt;(String):58
+java.io.ObjectStreamClass.hasStaticInitializer(Class):-1
+java.io.ObjectStreamClass.computeDefaultSUID(Class):1743
+java.io.ObjectStreamClass.access$100(Class):72
+java.io.ObjectStreamClass$1.run():250
+java.io.ObjectStreamClass$1.run():248
+java.security.AccessController.doPrivileged(PrivilegedAction):-1</explanation>
         </rule>
         <rule>
             <id>Exceptions</id>


### PR DESCRIPTION
This PR includes : 
- Adding the most common error to the **Thrown Errors** rule
- Adding the most common exception to the **Thrown Exceptions** rule and its most common stack trace if **jdk.JavaExceptionThrow** event is enabled in recording configuration (for now the max number of stack trace frames displayed is 10)

<img width="587" height="458" alt="Screenshot 2025-09-17 at 17 30 16" src="https://github.com/user-attachments/assets/70240eef-f0c9-4231-a4e1-398e1af9f07b" />



