### PR TITLE
8439: ArithmeticException thrown when plotting event count histogram with maxDuration set to 0

### DIFF
--- a/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/views/histogram/HDRHistogramView.java
+++ b/application/org.openjdk.jmc.flightrecorder.ui/src/main/java/org/openjdk/jmc/flightrecorder/ui/views/histogram/HDRHistogramView.java
@@ -269,7 +269,7 @@ public class HDRHistogramView extends ViewPart implements ISelectionListener {
 
 			// Get the maximum duration to set chart bounds
 			IQuantity maxDuration = itemsWithDuration.getAggregate(JdkAggregators.LONGEST_EVENT);
-			if (maxDuration == null || maxDuration.doubleValueIn(UnitLookup.MILLISECOND) == 0.0) {
+			if (maxDuration == null || maxDuration.clampedLongValueIn(UnitLookup.NANOSECOND) == 0L) {
 				maxDuration = UnitLookup.MILLISECOND.quantity(100);
 			} else {
 				maxDuration = UnitLookup.MILLISECOND.quantity(maxDuration.doubleValueIn(UnitLookup.MILLISECOND) * 1.1);


### PR DESCRIPTION
When plotting event count histogram and all event durations are set to 0, the duration range will be evaluated to 0, leading to an ArithmeticException (divid by 0), which stops JMC from plotting that histogram.

This can be shown on the attached screenshot, where only the percentile table is shown and the histogram chart is missing

<img width="1506" height="865" alt="missing-histogram" src="https://github.com/user-attachments/assets/7a02b705-83f3-45e9-9feb-91c5904064e7" />

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JMC-8439](https://bugs.openjdk.org/browse/JMC-8439): ArithmeticException thrown when plotting event count histogram with maxDuration set to 0 (**Bug** - P3)


### Reviewers
 * [Marcus Hirt](https://openjdk.org/census#hirt) (@thegreystone - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmc.git pull/675/head:pull/675` \
`$ git checkout pull/675`

Update a local copy of the PR: \
`$ git checkout pull/675` \
`$ git pull https://git.openjdk.org/jmc.git pull/675/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 675`

View PR using the GUI difftool: \
`$ git pr show -t 675`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmc/pull/675.diff">https://git.openjdk.org/jmc/pull/675.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jmc/pull/675#issuecomment-3323321947)
</details>
