### PR TITLE
6679: JMC should support project Loom JFR changes

### DIFF
--- a/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/internal/parser/v1/StructTypes.java
+++ b/core/org.openjdk.jmc.flightrecorder/src/main/java/org/openjdk/jmc/flightrecorder/internal/parser/v1/StructTypes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2026, Oracle and/or its affiliates. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -75,6 +75,7 @@ class StructTypes {
 		public Object javaThreadId;
 		public Object javaName;
 		public Object group;
+		public Object virtual;
 
 		@Override
 		public Long getThreadId() {
@@ -100,12 +101,13 @@ class StructTypes {
 
 		@Override
 		public int hashCode() {
-			return Objects.hashCode(osThreadId);
+			return Objects.hashCode(javaThreadId);
 		}
 
 		@Override
 		public boolean equals(Object obj) {
-			return this == obj || obj instanceof JfrThread && Objects.equals(osThreadId, ((JfrThread) obj).osThreadId);
+			return this == obj
+					|| obj instanceof JfrThread && Objects.equals(javaThreadId, ((JfrThread) obj).javaThreadId);
 		}
 	}
 


### PR DESCRIPTION
This PR :
- adds the **virtual** attribute to the Thread structure 
- makes hashCode and equals use the **javaThreadId** instead of osThreadId as virtual threads will be attached to the osThreadId = 0

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JMC-6679](https://bugs.openjdk.org/browse/JMC-6679): JMC should support project Loom JFR changes (**New Feature** - P2)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmc.git pull/716/head:pull/716` \
`$ git checkout pull/716`

Update a local copy of the PR: \
`$ git checkout pull/716` \
`$ git pull https://git.openjdk.org/jmc.git pull/716/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 716`

View PR using the GUI difftool: \
`$ git pr show -t 716`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmc/pull/716.diff">https://git.openjdk.org/jmc/pull/716.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jmc/pull/716#issuecomment-4243470815)
</details>
