### PR TITLE
8577: Update asm version to 9.10.1 for agent

### DIFF
--- a/agent/pom.xml
+++ b/agent/pom.xml
@@ -91,7 +91,7 @@
 		<nexus.staging.plugin.version>1.6.13</nexus.staging.plugin.version>
 		<maven.gpg.version>3.1.0</maven.gpg.version>
 		<!-- Dependency Versions -->
-		<asm.version>9.9.1</asm.version>
+		<asm.version>9.10.1</asm.version>
 		<junit.version>4.13.2</junit.version>
 	</properties>
 	<scm>


### PR DESCRIPTION
This adds support for the upcoming JDK 27 classfile version.

- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JMC-8577](https://bugs.openjdk.org/browse/JMC-8577): Update asm version to 9.10.1 for agent (**Enhancement** - P4)


### Reviewers
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)
 * [Marcus Hirt](https://openjdk.org/census#hirt) (@thegreystone - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmc.git pull/721/head:pull/721` \
`$ git checkout pull/721`

Update a local copy of the PR: \
`$ git checkout pull/721` \
`$ git pull https://git.openjdk.org/jmc.git pull/721/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 721`

View PR using the GUI difftool: \
`$ git pr show -t 721`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmc/pull/721.diff">https://git.openjdk.org/jmc/pull/721.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jmc/pull/721#issuecomment-4609285159)
</details>
