### PR TITLE
8618: Update Fireplace to 0.0.1.rc10

### DIFF
--- a/application/org.openjdk.jmc.flightrecorder.flamegraph/src/main/java/org/openjdk/jmc/flightrecorder/flamegraph/views/ButterflyView.java
+++ b/application/org.openjdk.jmc.flightrecorder.flamegraph/src/main/java/org/openjdk/jmc/flightrecorder/flamegraph/views/ButterflyView.java
@@ -114,6 +114,7 @@ import org.openjdk.jmc.ui.misc.PatternFly.Palette;
 
 import io.github.bric3.fireplace.core.ui.Colors;
 import io.github.bric3.fireplace.flamegraph.ColorMapper;
+import io.github.bric3.fireplace.flamegraph.DefaultFrameRenderer;
 import io.github.bric3.fireplace.flamegraph.DimmingFrameColorProvider;
 import io.github.bric3.fireplace.flamegraph.FlamegraphView;
 import io.github.bric3.fireplace.flamegraph.FlamegraphView.HoverListener;
@@ -438,16 +439,18 @@ public class ButterflyView extends ViewPart implements ISelectionListener {
 		fg.putClientProperty(FlamegraphView.SHOW_STATS, false);
 		fg.setShowMinimap(false);
 
-		fg.setRenderConfiguration(
+		fg.setFrameRender(new DefaultFrameRenderer<>(
 				FrameTextsProvider.of(
 						frame -> frame.isRoot() ? "" : frame.actualNode.getFrame().getHumanReadableShortString(),
 						frame -> frame.isRoot() ? ""
 								: FormatToolkit.getHumanReadable(frame.actualNode.getFrame().getMethod(), false, false,
 										false, false, true, false),
 						frame -> frame.isRoot() ? "" : frame.actualNode.getFrame().getMethod().getMethodName()),
-				new DimmingFrameColorProvider<>(frame -> ColorMapper.ofObjectHashUsing(Colors.Palette.DATADOG.colors())
-						.apply(frame.actualNode.getFrame().getMethod().getType().getPackage())),
-				FrameFontProvider.defaultFontProvider());
+				new DimmingFrameColorProvider<Node>(
+						frame -> ColorMapper.ofObjectHashUsing(Colors.Palette.DATADOG.colors())
+								.apply(frame.actualNode.getFrame().getMethod().getType().getPackage()))
+										.withDimNonFocusedFlame(true),
+				FrameFontProvider.defaultFontProvider()));
 
 		fg.setHoverListener(new HoverListener<Node>() {
 			@Override

--- a/application/org.openjdk.jmc.flightrecorder.flamegraph/src/main/java/org/openjdk/jmc/flightrecorder/flamegraph/views/FlamegraphSwingView.java
+++ b/application/org.openjdk.jmc.flightrecorder.flamegraph/src/main/java/org/openjdk/jmc/flightrecorder/flamegraph/views/FlamegraphSwingView.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023, 2025, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2023, 2025, Datadog, Inc. All rights reserved.
+ * Copyright (c) 2023, 2026, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2026, Datadog, Inc. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -142,6 +142,7 @@ import org.openjdk.jmc.ui.misc.DisplayToolkit;
 
 import io.github.bric3.fireplace.core.ui.Colors;
 import io.github.bric3.fireplace.flamegraph.ColorMapper;
+import io.github.bric3.fireplace.flamegraph.DefaultFrameRenderer;
 import io.github.bric3.fireplace.flamegraph.DimmingFrameColorProvider;
 import io.github.bric3.fireplace.flamegraph.FlamegraphImage;
 import io.github.bric3.fireplace.flamegraph.FlamegraphView;
@@ -704,16 +705,18 @@ public class FlamegraphSwingView extends ViewPart implements ISelectionListener 
 		fg.putClientProperty(FlamegraphView.SHOW_STATS, false);
 		fg.setShowMinimap(false);
 
-		fg.setRenderConfiguration(
+		fg.setFrameRender(new DefaultFrameRenderer<>(
 				FrameTextsProvider.of(
 						frame -> frame.isRoot() ? "" : frame.actualNode.getFrame().getHumanReadableShortString(),
 						frame -> frame.isRoot() ? ""
 								: FormatToolkit.getHumanReadable(frame.actualNode.getFrame().getMethod(), false, false,
 										false, false, true, false),
 						frame -> frame.isRoot() ? "" : frame.actualNode.getFrame().getMethod().getMethodName()),
-				new DimmingFrameColorProvider<>(frame -> ColorMapper.ofObjectHashUsing(Colors.Palette.DATADOG.colors())
-						.apply(frame.actualNode.getFrame().getMethod().getType().getPackage())),
-				FrameFontProvider.defaultFontProvider());
+				new DimmingFrameColorProvider<Node>(
+						frame -> ColorMapper.ofObjectHashUsing(Colors.Palette.DATADOG.colors())
+								.apply(frame.actualNode.getFrame().getMethod().getType().getPackage()))
+										.withDimNonFocusedFlame(true),
+				FrameFontProvider.defaultFontProvider()));
 		fg.setHoverListener(new HoverListener<Node>() {
 			@Override
 			public void onStopHover(FrameBox<Node> frameBox, Rectangle frameRect, MouseEvent mouseEvent) {

--- a/releng/platform-definitions/platform-definition-2024-12/platform-definition-2024-12.target
+++ b/releng/platform-definitions/platform-definition-2024-12/platform-definition-2024-12.target
@@ -57,9 +57,9 @@
             <unit id="org.eclipse.jetty.websocket.server" version="12.1.9"/>
             <unit id="jakarta.annotation-api" version="3.0.0"/>
             <unit id="org.apache.aries.spifly.dynamic.bundle" version="1.3.7"/>
-            <unit id="fireplace-swing" version="0.0.1.rc9"/>
-            <unit id="fireplace-swt-awt-bridge" version="0.0.1.rc9"/>
-            <unit id="fireplace-swing-animation" version="0.0.1.rc9"/>
+            <unit id="fireplace-swing" version="0.0.1.rc10"/>
+            <unit id="fireplace-swt-awt-bridge" version="0.0.1.rc10"/>
+            <unit id="fireplace-swing-animation" version="0.0.1.rc10"/>
             <unit id="radiance-animation" version="8.5.0"/>
             <unit id="org.awaitility" version="4.0.0"/>
             <repository location="http://localhost:8080/site"/>

--- a/releng/platform-definitions/platform-definition-2025-03/platform-definition-2025-03.target
+++ b/releng/platform-definitions/platform-definition-2025-03/platform-definition-2025-03.target
@@ -58,9 +58,9 @@
             <unit id="org.eclipse.jetty.websocket.server" version="12.1.9"/>
             <unit id="jakarta.annotation-api" version="3.0.0"/>
             <unit id="org.apache.aries.spifly.dynamic.bundle" version="1.3.7"/>
-            <unit id="fireplace-swing" version="0.0.1.rc9"/>
-            <unit id="fireplace-swt-awt-bridge" version="0.0.1.rc9"/>
-            <unit id="fireplace-swing-animation" version="0.0.1.rc9"/>
+            <unit id="fireplace-swing" version="0.0.1.rc10"/>
+            <unit id="fireplace-swt-awt-bridge" version="0.0.1.rc10"/>
+            <unit id="fireplace-swing-animation" version="0.0.1.rc10"/>
             <unit id="radiance-animation" version="8.5.0"/>
             <unit id="org.awaitility" version="4.0.0"/>
             <repository location="http://localhost:8080/site"/>

--- a/releng/platform-definitions/platform-definition-2025-06/platform-definition-2025-06.target
+++ b/releng/platform-definitions/platform-definition-2025-06/platform-definition-2025-06.target
@@ -57,9 +57,9 @@
             <unit id="org.eclipse.jetty.websocket.server" version="12.1.9"/>
             <unit id="jakarta.annotation-api" version="3.0.0"/>
             <unit id="org.apache.aries.spifly.dynamic.bundle" version="1.3.7"/>
-            <unit id="fireplace-swing" version="0.0.1.rc9"/>
-            <unit id="fireplace-swt-awt-bridge" version="0.0.1.rc9"/>
-            <unit id="fireplace-swing-animation" version="0.0.1.rc9"/>
+            <unit id="fireplace-swing" version="0.0.1.rc10"/>
+            <unit id="fireplace-swt-awt-bridge" version="0.0.1.rc10"/>
+            <unit id="fireplace-swing-animation" version="0.0.1.rc10"/>
             <unit id="radiance-animation" version="8.5.0"/>
             <unit id="org.awaitility" version="4.0.0"/>
             <repository location="http://localhost:8080/site"/>

--- a/releng/platform-definitions/platform-definition-2025-09/platform-definition-2025-09.target
+++ b/releng/platform-definitions/platform-definition-2025-09/platform-definition-2025-09.target
@@ -56,9 +56,9 @@
             <unit id="org.eclipse.jetty.websocket.server" version="12.1.9"/>
             <unit id="jakarta.annotation-api" version="3.0.0"/>
             <unit id="org.apache.aries.spifly.dynamic.bundle" version="1.3.7"/>
-            <unit id="fireplace-swing" version="0.0.1.rc9"/>
-            <unit id="fireplace-swt-awt-bridge" version="0.0.1.rc9"/>
-            <unit id="fireplace-swing-animation" version="0.0.1.rc9"/>
+            <unit id="fireplace-swing" version="0.0.1.rc10"/>
+            <unit id="fireplace-swt-awt-bridge" version="0.0.1.rc10"/>
+            <unit id="fireplace-swing-animation" version="0.0.1.rc10"/>
             <unit id="radiance-animation" version="8.5.0"/>
             <unit id="org.awaitility" version="4.0.0"/>
             <repository location="http://localhost:8080/site"/>

--- a/releng/platform-definitions/platform-definition-2025-12/platform-definition-2025-12.target
+++ b/releng/platform-definitions/platform-definition-2025-12/platform-definition-2025-12.target
@@ -57,9 +57,9 @@
             <unit id="org.eclipse.jetty.websocket.server" version="12.1.9"/>
             <unit id="jakarta.annotation-api" version="3.0.0"/>
             <unit id="org.apache.aries.spifly.dynamic.bundle" version="1.3.7"/>
-            <unit id="fireplace-swing" version="0.0.1.rc9"/>
-            <unit id="fireplace-swt-awt-bridge" version="0.0.1.rc9"/>
-            <unit id="fireplace-swing-animation" version="0.0.1.rc9"/>
+            <unit id="fireplace-swing" version="0.0.1.rc10"/>
+            <unit id="fireplace-swt-awt-bridge" version="0.0.1.rc10"/>
+            <unit id="fireplace-swing-animation" version="0.0.1.rc10"/>
             <unit id="radiance-animation" version="8.5.0"/>
             <unit id="org.awaitility" version="4.0.0"/>
             <repository location="http://localhost:8080/site"/>

--- a/releng/platform-definitions/platform-definition-2026-03/platform-definition-2026-03.target
+++ b/releng/platform-definitions/platform-definition-2026-03/platform-definition-2026-03.target
@@ -57,9 +57,9 @@
             <unit id="org.eclipse.jetty.websocket.server" version="12.1.9"/>
             <unit id="jakarta.annotation-api" version="3.0.0"/>
             <unit id="org.apache.aries.spifly.dynamic.bundle" version="1.3.7"/>
-            <unit id="fireplace-swing" version="0.0.1.rc9"/>
-            <unit id="fireplace-swt-awt-bridge" version="0.0.1.rc9"/>
-            <unit id="fireplace-swing-animation" version="0.0.1.rc9"/>
+            <unit id="fireplace-swing" version="0.0.1.rc10"/>
+            <unit id="fireplace-swt-awt-bridge" version="0.0.1.rc10"/>
+            <unit id="fireplace-swing-animation" version="0.0.1.rc10"/>
             <unit id="radiance-animation" version="8.5.0"/>
             <unit id="org.awaitility" version="4.0.0"/>
             <repository location="http://localhost:8080/site"/>

--- a/releng/platform-definitions/platform-definition-2026-06/platform-definition-2026-06.target
+++ b/releng/platform-definitions/platform-definition-2026-06/platform-definition-2026-06.target
@@ -57,9 +57,9 @@
             <unit id="org.eclipse.jetty.websocket.server" version="12.1.9"/>
             <unit id="jakarta.annotation-api" version="3.0.0"/>
             <unit id="org.apache.aries.spifly.dynamic.bundle" version="1.3.7"/>
-            <unit id="fireplace-swing" version="0.0.1.rc9"/>
-            <unit id="fireplace-swt-awt-bridge" version="0.0.1.rc9"/>
-            <unit id="fireplace-swing-animation" version="0.0.1.rc9"/>
+            <unit id="fireplace-swing" version="0.0.1.rc10"/>
+            <unit id="fireplace-swt-awt-bridge" version="0.0.1.rc10"/>
+            <unit id="fireplace-swing-animation" version="0.0.1.rc10"/>
             <unit id="radiance-animation" version="8.5.0"/>
             <unit id="org.awaitility" version="4.0.0"/>
             <repository location="http://localhost:8080/site"/>

--- a/releng/third-party/pom.xml
+++ b/releng/third-party/pom.xml
@@ -63,7 +63,7 @@
 		<spifly.version>1.3.7</spifly.version>
 		<jolokia.version>2.5.1</jolokia.version>
 		<wiremock.version>2.27.2</wiremock.version>
-		<fireplace.version>0.0.1-rc.9</fireplace.version>
+		<fireplace.version>0.0.1-rc.10</fireplace.version>
 		<radiance.version>8.5.0</radiance.version>
 		<jakarta.inject.version>2.0.1</jakarta.inject.version>
 		<jakarta.annotation.version>3.0.0</jakarta.annotation.version>


### PR DESCRIPTION
This PR:
- bumps Fireplace to 0.0.1.rc10.
- Adjusts the Flamegraph/Butterfly integration for the updated Fireplace API.

- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JMC-8618](https://bugs.openjdk.org/browse/JMC-8618): Update Fireplace to 0.0.1.rc10 (**Task** - P3)


### Reviewers
 * [Marcus Hirt](https://openjdk.org/census#hirt) (@thegreystone - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jmc.git pull/728/head:pull/728` \
`$ git checkout pull/728`

Update a local copy of the PR: \
`$ git checkout pull/728` \
`$ git pull https://git.openjdk.org/jmc.git pull/728/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 728`

View PR using the GUI difftool: \
`$ git pr show -t 728`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jmc/pull/728.diff">https://git.openjdk.org/jmc/pull/728.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jmc/pull/728#issuecomment-5529830530)
</details>
